### PR TITLE
Don't use rip_dest (a 32-bit field) to extract 16-bit.

### DIFF
--- a/print-rip.c
+++ b/print-rip.c
@@ -141,7 +141,7 @@ rip_entry_print_v2(register const struct rip_netinfo *ni, const unsigned remaini
 				putchar (isprint(*p) ? *p : '.');
 		} else if (auth_type == 3) {
 			printf("\n\t  Auth header:");
-			printf(" Packet Len %u,", EXTRACT_16BITS(&ni->rip_dest));
+			printf(" Packet Len %u,", EXTRACT_16BITS((u_int8_t *)ni + 4));
 			printf(" Key-ID %u,", *((u_int8_t *)ni + 6));
 			printf(" Auth Data Len %u,", *((u_int8_t *)ni + 7));
 			printf(" SeqNo %u,", EXTRACT_32BITS(&ni->rip_dest_mask));


### PR DESCRIPTION
Don't use rip_dest (a 32-bit field) to extract 16-bit.  Instead, explicitly use 16-bit alignment to access the packet length field.
