### PR TITLE
Tcp fast open

### DIFF
--- a/print-tcp.c
+++ b/print-tcp.c
@@ -239,7 +239,7 @@ tcp_print(register const u_char *bp, register u_int length,
         flags = tp->th_flags;
         printf("Flags [%s]", bittok2str_nosep(tcp_flag_values, "none", flags));
 
-        if (!Sflag && (flags & TH_ACK)) {
+        if (!Sflag && (flags & (TH_ACK | TH_SYN))) {
                 /*
                  * Find (or record) the initial sequence numbers for
                  * this conversation.  (we pick an arbitrary
@@ -335,7 +335,7 @@ tcp_print(register const u_char *bp, register u_int length,
                                            sizeof(th->addr)) == 0)
                                         break;
 
-                        if (!th->nxt || (flags & TH_SYN)) {
+                        if (!th->nxt || ((flags & TH_SYN) && !(flags & TH_ACK))) {
                                 /* didn't find it or new conversation */
                                 if (th->nxt == NULL) {
                                         th->nxt = (struct tcp_seq_hash *)
@@ -345,9 +345,14 @@ tcp_print(register const u_char *bp, register u_int length,
                                 }
                                 th->addr = tha;
                                 if (rev)
-                                        th->ack = seq, th->seq = ack - 1;
+                                        th->ack = seq, th->seq = ack;
                                 else
-                                        th->seq = seq, th->ack = ack - 1;
+                                        th->seq = seq, th->ack = ack;
+                        } else if (flags & TH_SYN) {
+                                if (rev)
+                                        th->ack = seq;
+                                else
+                                        th->seq = seq;
                         } else {
                                 if (rev)
                                         seq -= th->ack, ack -= th->seq;

--- a/tests/of10_pf5240-vv.out
+++ b/tests/of10_pf5240-vv.out
@@ -1,7 +1,7 @@
 IP (tos 0xa0, ttl 64, id 10670, offset 0, flags [DF], proto TCP (6), length 60)
     172.16.1.101.62224 > 172.16.1.51.6633: Flags [S], cksum 0x6dd0 (correct), seq 2446711727, win 2048, options [mss 1460,nop,wscale 0,nop,nop,TS val 0 ecr 0], length 0
 IP (tos 0xa0, ttl 64, id 0, offset 0, flags [DF], proto TCP (6), length 40)
-    172.16.1.51.6633 > 172.16.1.101.62224: Flags [R.], cksum 0xda97 (correct), seq 0, ack 2446711728, win 0, length 0
+    172.16.1.51.6633 > 172.16.1.101.62224: Flags [R.], cksum 0xda97 (correct), seq 0, ack 1, win 0, length 0
 IP (tos 0xa0, ttl 64, id 10673, offset 0, flags [DF], proto TCP (6), length 60)
     172.16.1.101.62221 > 172.16.1.51.6633: Flags [S], cksum 0xa14c (correct), seq 2619186670, win 2048, options [mss 1460,nop,wscale 0,nop,nop,TS val 0 ecr 0], length 0
 IP (tos 0x0, ttl 64, id 0, offset 0, flags [DF], proto TCP (6), length 60)
@@ -425,4 +425,4 @@ IP (tos 0x0, ttl 64, id 0, offset 0, flags [DF], proto TCP (6), length 52)
 IP (tos 0xa0, ttl 64, id 10710, offset 0, flags [DF], proto TCP (6), length 60)
     172.16.1.101.62216 > 172.16.1.51.6633: Flags [S], cksum 0xf0a4 (correct), seq 2928426028, win 2048, options [mss 1460,nop,wscale 0,nop,nop,TS val 0 ecr 0], length 0
 IP (tos 0xa0, ttl 64, id 0, offset 0, flags [DF], proto TCP (6), length 40)
-    172.16.1.51.6633 > 172.16.1.101.62216: Flags [R.], cksum 0x5d6c (correct), seq 0, ack 2928426029, win 0, length 0
+    172.16.1.51.6633 > 172.16.1.101.62216: Flags [R.], cksum 0x5d6c (correct), seq 0, ack 1, win 0, length 0

--- a/tests/tfo.out
+++ b/tests/tfo.out
@@ -11,4 +11,4 @@ IP 3.3.3.3.13054 > 192.168.0.100.13047: Flags [F.], seq 1, ack 2, win 1400, leng
 IP 192.168.0.100.13047 > 3.3.3.3.13054: Flags [.], ack 2, win 1400, length 0
 IP 9.9.9.9.13047 > 3.3.3.3.13054: Flags [.], ack 2, win 1400, length 0
 IP 192.168.0.100.13048 > 3.3.3.3.13054: Flags [S], seq 936732547:936732551, win 1400, options [exp-tfo cookie 090909090000,nop,nop], length 4
-IP 192.168.0.100.13048 > 3.3.3.3.13054: Flags [F.], seq 936732552, ack 0, win 1400, length 0
+IP 192.168.0.100.13048 > 3.3.3.3.13054: Flags [F.], seq 5, ack 0, win 1400, length 0


### PR DESCRIPTION
I added support for the experimental TCP fast open option in tcpdump.
https://tools.ietf.org/html/draft-ietf-tcpm-fastopen-03

I my patch was inspired by the wireshark implementation.
https://anonsvn.wireshark.org/viewvc/trunk/epan/dissectors/packet-tcp.c?r1=46723&r2=46722&pathrev=46723

I also had to fix tcpdump's handling of syn packets with with a non zero data length. 

I didn't know what kind of output formatting would work best and am open to suggestions about that.