### PR TITLE
Fix possible buffer overflow while doing sscanf()

### DIFF
--- a/print-atalk.c
+++ b/print-atalk.c
@@ -540,7 +540,7 @@ ataddr_string(u_short atnet, u_char athost)
 {
 	register struct hnamemem *tp, *tp2;
 	register int i = (atnet << 8) | athost;
-	char nambuf[MAXHOSTNAMELEN + 20];
+	char nambuf[256];
 	static int first = 1;
 	FILE *fp;
 


### PR DESCRIPTION
MAXHOSTNAMELEN + 100 is only 164 which is less than 256 sscanf() buffer.
Fix it by increasing size of nambuf buffer.
