### PR TITLE
Convert README to Markdown (README.md) + typo fixes + formatting tweaks + Travis CI build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ build libpcap, also originally from LBL and now being maintained by
 tcpdump.org; see http://www.tcpdump.org/ .
 
 Once libpcap is built (either install it or make sure it's in
-`../libpcap`), you can build tcpdump using the procedure in the `INSTALL`
+`../libpcap`), you can build tcpdump using the procedure in the `INSTALL.txt`
 file.
 
 The program is loosely based on SMI's "etherfind" although none of the


### PR DESCRIPTION
Markdown renders nicely in GitHub (and allows embedding rich content like Travis CI build badge images) and it's still very readable when reading the raw text. So I renamed the README to README.md and converted to Markdown and then did some additional tweaks.

If you only want some of these changes, you can try to cherry pick or if the commits aren't granular enough, I can split stuff out that you want to merge into separate commits.

To see a preview of how the README.md looks in my fork when rendered by GitHub, look at my fork here:

https://github.com/msabramo/tcpdump/tree/README_markdown
