### PR TITLE
print-pptp: pptp_result_code_print(): badly placed break

### DIFF
--- a/print-pptp.c
+++ b/print-pptp.c
@@ -554,8 +554,8 @@ pptp_result_code_print(const u_int8_t *result_code, int ctrl_msg_type)
 			default:
 				printf(":?");
 				break;
-			break;
 			}
+			break;
 		default:
 			/* assertion error */
 			break;


### PR DESCRIPTION
This is a fix for it.
