### PR TITLE
print-dccp: the function 'dccp_packet_hdr_len' is never used

### DIFF
--- a/print-dccp.c
+++ b/print-dccp.c
@@ -250,24 +250,6 @@ trunc:
 	return;
 }
 
-static inline unsigned int dccp_packet_hdr_len(const u_int8_t type)
-{
-	if (type == DCCP_PKT_DATA)
-		return 0;
-	if (type == DCCP_PKT_DATAACK	||
-	    type == DCCP_PKT_ACK	||
-	    type == DCCP_PKT_SYNC	||
-	    type == DCCP_PKT_SYNCACK	||
-	    type == DCCP_PKT_CLOSE	||
-	    type == DCCP_PKT_CLOSEREQ)
-		return sizeof(struct dccp_hdr_ack_bits);
-	if (type == DCCP_PKT_REQUEST)
-		return sizeof(struct dccp_hdr_request);
-	if (type == DCCP_PKT_RESPONSE)
-		return sizeof(struct dccp_hdr_response);
-	return sizeof(struct dccp_hdr_reset);
-}
-
 static int dccp_print_option(const u_char *option);
 
 /**


### PR DESCRIPTION
This is a fix for it.
