### PR TITLE
DCCP tests: more verbosity (from -v to -vv)

### DIFF
--- a/tests/TESTLIST
+++ b/tests/TESTLIST
@@ -175,5 +175,5 @@ ipv6-bad-version.pcap	ipv6-bad-version.pcap 	ipv6-bad-version.out	-t
 loopback	loopback.pcap		loopback.out		-t
 
 # DCCP partial checksums tests
-dccp_partial_csum_v4_simple	dccp_partial_csum_v4_simple.pcap	dccp_partial_csum_v4_simple.out -t -v
-dccp_partial_csum_v4_longer	dccp_partial_csum_v4_longer.pcap	dccp_partial_csum_v4_longer.out -t -v
+dccp_partial_csum_v4_simple	dccp_partial_csum_v4_simple.pcap	dccp_partial_csum_v4_simple.out -t -vv
+dccp_partial_csum_v4_longer	dccp_partial_csum_v4_longer.pcap	dccp_partial_csum_v4_longer.out -t -vv

--- a/tests/dccp_partial_csum_v4_longer.out
+++ b/tests/dccp_partial_csum_v4_longer.out
@@ -1,30 +1,30 @@
 IP (tos 0x0, ttl 64, id 65312, offset 0, flags [DF], proto DCCP (33), length 52)
-    139.133.209.176.39420 > 139.133.209.65.5001: CCVal 0, CsCov 0, cksum 0xaaf3 (correct), request (service=0) 
+    139.133.209.176.39420 > 139.133.209.65.5001: CCVal 0, CsCov 0, cksum 0xaaf3 (correct), request (service=0) seq 38464816766 <change_l ack_ratio 2, change_r ccid 2, change_l ccid 2>
 IP (tos 0x0, ttl 64, id 0, offset 0, flags [DF], proto DCCP (33), length 68)
-    139.133.209.65.5001 > 139.133.209.176.39420: CCVal 0, CsCov 0, cksum 0xb04b (correct), response (service=0) (ack=38464816766) 
+    139.133.209.65.5001 > 139.133.209.176.39420: CCVal 0, CsCov 0, cksum 0xb04b (correct), response (service=0) (ack=38464816766) seq 1960341146 <nop, nop, change_l ack_ratio 2, confirm_r ccid 2 2, confirm_l ccid 2 2, confirm_r ack_ratio 2>
 IP (tos 0x0, ttl 64, id 65313, offset 0, flags [DF], proto DCCP (33), length 56)
-    139.133.209.176.39420 > 139.133.209.65.5001: CCVal 0, CsCov 0, cksum 0xf53a (correct), ack (ack=1960341146) 
+    139.133.209.176.39420 > 139.133.209.65.5001: CCVal 0, CsCov 0, cksum 0xf53a (correct), ack (ack=1960341146) seq 38464816767 <nop, confirm_r ack_ratio 2, ack_vector0 0x00, elapsed_time 1>
 IP (tos 0x0, ttl 64, id 65314, offset 0, flags [DF], proto DCCP (33), length 152)
-    139.133.209.176.39420 > 139.133.209.65.5001: CCVal 0, CsCov 6, cksum 0x7d28 (correct), dataack (ack=1960341146) 
+    139.133.209.176.39420 > 139.133.209.65.5001: CCVal 0, CsCov 6, cksum 0x7d28 (correct), dataack (ack=1960341146) seq 38464816768 <nop, nop, ack_vector0 0x00, elapsed_time 1249, ndp_count 1>
 IP (tos 0x0, ttl 64, id 3176, offset 0, flags [DF], proto DCCP (33), length 52)
-    139.133.209.65.5001 > 139.133.209.176.39420: CCVal 0, CsCov 0, cksum 0xfc63 (correct), ack (ack=38464816768) 
+    139.133.209.65.5001 > 139.133.209.176.39420: CCVal 0, CsCov 0, cksum 0xfc63 (correct), ack (ack=38464816768) seq 1960341147 <nop, ack_vector0 0x01, elapsed_time 1>
 IP (tos 0x0, ttl 64, id 65315, offset 0, flags [DF], proto DCCP (33), length 148)
-    139.133.209.176.39420 > 139.133.209.65.5001: CCVal 0, CsCov 6, cksum 0x5e05 (correct), dataack (ack=1960341147) 
+    139.133.209.176.39420 > 139.133.209.65.5001: CCVal 0, CsCov 6, cksum 0x5e05 (correct), dataack (ack=1960341147) seq 38464816769 <nop, ack_vector0 0x00, elapsed_time 84>
 IP (tos 0x0, ttl 64, id 3177, offset 0, flags [DF], proto DCCP (33), length 52)
-    139.133.209.65.5001 > 139.133.209.176.39420: CCVal 0, CsCov 0, cksum 0x0165 (correct), ack (ack=38464816769) 
+    139.133.209.65.5001 > 139.133.209.176.39420: CCVal 0, CsCov 0, cksum 0x0165 (correct), ack (ack=38464816769) seq 1960341148 <nop, nop, ack_vector0 0x00, ndp_count 1>
 IP (tos 0x0, ttl 64, id 65316, offset 0, flags [DF], proto DCCP (33), length 148)
-    139.133.209.176.39420 > 139.133.209.65.5001: CCVal 0, CsCov 6, cksum 0x5e1e (correct), dataack (ack=1960341148) 
+    139.133.209.176.39420 > 139.133.209.65.5001: CCVal 0, CsCov 6, cksum 0x5e1e (correct), dataack (ack=1960341148) seq 38464816770 <nop, ack_vector0 0x00, elapsed_time 57>
 IP (tos 0x0, ttl 64, id 65317, offset 0, flags [DF], proto DCCP (33), length 148)
-    139.133.209.176.39420 > 139.133.209.65.5001: CCVal 0, CsCov 6, cksum 0x5e15 (correct), dataack (ack=1960341148) 
+    139.133.209.176.39420 > 139.133.209.65.5001: CCVal 0, CsCov 6, cksum 0x5e15 (correct), dataack (ack=1960341148) seq 38464816771 <nop, ack_vector0 0x00, elapsed_time 65>
 IP (tos 0x0, ttl 64, id 3178, offset 0, flags [DF], proto DCCP (33), length 56)
-    139.133.209.65.5001 > 139.133.209.176.39420: CCVal 0, CsCov 0, cksum 0xfb32 (correct), ack (ack=38464816770) 
+    139.133.209.65.5001 > 139.133.209.176.39420: CCVal 0, CsCov 0, cksum 0xfb32 (correct), ack (ack=38464816770) seq 1960341149 <nop, nop, ack_vector0 0x00, elapsed_time 1, ndp_count 2>
 IP (tos 0x0, ttl 64, id 3179, offset 0, flags [DF], proto DCCP (33), length 56)
-    139.133.209.65.5001 > 139.133.209.176.39420: CCVal 0, CsCov 0, cksum 0xfa2f (correct), ack (ack=38464816771) 
+    139.133.209.65.5001 > 139.133.209.176.39420: CCVal 0, CsCov 0, cksum 0xfa2f (correct), ack (ack=38464816771) seq 1960341150 <nop, nop, ack_vector0 0x01, elapsed_time 1, ndp_count 3>
 IP (tos 0x0, ttl 64, id 65318, offset 0, flags [DF], proto DCCP (33), length 148)
-    139.133.209.176.39420 > 139.133.209.65.5001: CCVal 0, CsCov 6, cksum 0x5e35 (correct), dataack (ack=1960341150) 
+    139.133.209.176.39420 > 139.133.209.65.5001: CCVal 0, CsCov 6, cksum 0x5e35 (correct), dataack (ack=1960341150) seq 38464816772 <nop, ack_vector0 0x00, elapsed_time 30>
 IP (tos 0x0, ttl 64, id 65319, offset 0, flags [DF], proto DCCP (33), length 52)
-    139.133.209.176.39420 > 139.133.209.65.5001: CCVal 0, CsCov 0, cksum 0xf638 (correct), close (ack=1960341150) 
+    139.133.209.176.39420 > 139.133.209.65.5001: CCVal 0, CsCov 0, cksum 0xf638 (correct), close (ack=1960341150) seq 38464816773 <nop, ack_vector0 0x00, elapsed_time 37>
 IP (tos 0x0, ttl 64, id 3180, offset 0, flags [DF], proto DCCP (33), length 56)
-    139.133.209.65.5001 > 139.133.209.176.39420: CCVal 0, CsCov 0, cksum 0xfb2c (correct), ack (ack=38464816772) 
+    139.133.209.65.5001 > 139.133.209.176.39420: CCVal 0, CsCov 0, cksum 0xfb2c (correct), ack (ack=38464816772) seq 1960341151 <nop, nop, ack_vector0 0x00, elapsed_time 1, ndp_count 4>
 IP (tos 0x0, ttl 64, id 3181, offset 0, flags [DF], proto DCCP (33), length 60)
-    139.133.209.65.5001 > 139.133.209.176.39420: CCVal 0, CsCov 0, cksum 0xef25 (correct), reset (code=closed) (ack=38464816773) 
+    139.133.209.65.5001 > 139.133.209.176.39420: CCVal 0, CsCov 0, cksum 0xef25 (correct), reset (code=closed) (ack=38464816773) seq 1960341152 <nop, nop, ack_vector0 0x01, elapsed_time 2, ndp_count 5>

--- a/tests/dccp_partial_csum_v4_simple.out
+++ b/tests/dccp_partial_csum_v4_simple.out
@@ -1,14 +1,14 @@
 IP (tos 0x0, ttl 64, id 30095, offset 0, flags [DF], proto DCCP (33), length 52)
-    139.133.209.176.52667 > 139.133.209.65.5001: CCVal 0, CsCov 0, cksum 0xa766 (correct), request (service=0) 
+    139.133.209.176.52667 > 139.133.209.65.5001: CCVal 0, CsCov 0, cksum 0xa766 (correct), request (service=0) seq 33164071488 <change_l ack_ratio 2, change_r ccid 2, change_l ccid 2>
 IP (tos 0x0, ttl 64, id 0, offset 0, flags [DF], proto DCCP (33), length 68)
-    139.133.209.65.5001 > 139.133.209.176.52667: CCVal 0, CsCov 0, cksum 0x9a1a (correct), response (service=0) (ack=33164071488) 
+    139.133.209.65.5001 > 139.133.209.176.52667: CCVal 0, CsCov 0, cksum 0x9a1a (correct), response (service=0) (ack=33164071488) seq 1925546833 <nop, nop, change_l ack_ratio 2, confirm_r ccid 2 2, confirm_l ccid 2 2, confirm_r ack_ratio 2>
 IP (tos 0x0, ttl 64, id 30096, offset 0, flags [DF], proto DCCP (33), length 56)
-    139.133.209.176.52667 > 139.133.209.65.5001: CCVal 0, CsCov 0, cksum 0xdf09 (correct), ack (ack=1925546833) 
+    139.133.209.176.52667 > 139.133.209.65.5001: CCVal 0, CsCov 0, cksum 0xdf09 (correct), ack (ack=1925546833) seq 33164071489 <nop, confirm_r ack_ratio 2, ack_vector0 0x00, elapsed_time 1>
 IP (tos 0x0, ttl 64, id 30097, offset 0, flags [DF], proto DCCP (33), length 68)
-    139.133.209.176.52667 > 139.133.209.65.5001: CCVal 0, CsCov 1, cksum 0x9dfa (correct), dataack (ack=1925546833) 
+    139.133.209.176.52667 > 139.133.209.65.5001: CCVal 0, CsCov 1, cksum 0x9dfa (correct), dataack (ack=1925546833) seq 33164071490 <nop, nop, ack_vector0 0x00, elapsed_time 70, ndp_count 1>
 IP (tos 0x0, ttl 64, id 24713, offset 0, flags [DF], proto DCCP (33), length 52)
-    139.133.209.65.5001 > 139.133.209.176.52667: CCVal 0, CsCov 0, cksum 0xe632 (correct), ack (ack=33164071490) 
+    139.133.209.65.5001 > 139.133.209.176.52667: CCVal 0, CsCov 0, cksum 0xe632 (correct), ack (ack=33164071490) seq 1925546834 <nop, ack_vector0 0x01, elapsed_time 1>
 IP (tos 0x0, ttl 64, id 30098, offset 0, flags [DF], proto DCCP (33), length 52)
-    139.133.209.176.52667 > 139.133.209.65.5001: CCVal 0, CsCov 0, cksum 0xdf8d (correct), close (ack=1925546834) 
+    139.133.209.176.52667 > 139.133.209.65.5001: CCVal 0, CsCov 0, cksum 0xdf8d (correct), close (ack=1925546834) seq 33164071491 <nop, ack_vector0 0x00, elapsed_time 166>
 IP (tos 0x0, ttl 64, id 24714, offset 0, flags [DF], proto DCCP (33), length 60)
-    139.133.209.65.5001 > 139.133.209.176.52667: CCVal 0, CsCov 0, cksum 0xd900 (correct), reset (code=closed) (ack=33164071491) 
+    139.133.209.65.5001 > 139.133.209.176.52667: CCVal 0, CsCov 0, cksum 0xd900 (correct), reset (code=closed) (ack=33164071491) seq 1925546835 <nop, nop, ack_vector0 0x00, elapsed_time 3, ndp_count 1>


### PR DESCRIPTION
To better track update problems
