### PR TITLE
timestamps: make possible to request high precision timestamps

### DIFF
--- a/netdissect.h
+++ b/netdissect.h
@@ -126,6 +126,7 @@ struct netdissect_options {
   int ndo_Hflag;		/* dissect 802.11s draft mesh standard */
   int ndo_packet_number;	/* print a packet number in the beginning of line */
   int ndo_suppress_default_print; /* don't use default_print() for unknown packet types */
+  int ndo_tstamp_precision;   /* requested time stamp precision */
   const char *ndo_dltname;
 
   char *ndo_espsecret;

--- a/tcpdump.1.in
+++ b/tcpdump.1.in
@@ -432,6 +432,15 @@ List the supported time stamp types for the interface and exit.  If the
 time stamp type cannot be set for the interface, no time stamp types are
 listed.
 .TP
+.BI \-\-time\-stamp\-precision= tstamp_precision
+.PD
+Set the time stamp precision for the capture to
+\fItstamp_precision\fP. Currently supported are microseconds and
+nanoseconds. Note that availability of high precision time stamps (nanoseconds)
+and their actual accuracy is platform and HW dependent. Also note that when
+writing captures to the savefile, distinct magic number is used to distinguish
+savefiles which contains time stamps in nanoseconds.
+.TP
 .B \-K
 .PD 0
 .TP

--- a/util.c
+++ b/util.c
@@ -135,11 +135,14 @@ fn_printzp(netdissect_options *ndo,
  * Format the timestamp
  */
 static char *
-ts_format(register int sec, register int usec)
+ts_format(netdissect_options *ndo, int sec, int usec)
 {
-        static char buf[sizeof("00:00:00.000000")];
-        (void)snprintf(buf, sizeof(buf), "%02d:%02d:%02d.%06u",
-               sec / 3600, (sec % 3600) / 60, sec % 60, usec);
+	static char buf[sizeof("00:00:00.000000000")];
+	const char *format = ndo->ndo_tstamp_precision == PCAP_TSTAMP_PRECISION_NANO ?
+                "%02d:%02d:%02d.%09u" : "%02d:%02d:%02d.%06u";
+
+	snprintf(buf, sizeof(buf), format,
+                 sec / 3600, (sec % 3600) / 60, sec % 60, usec);
 
         return buf;
 }
@@ -163,7 +166,7 @@ ts_print(netdissect_options *ndo,
 
 	case 0: /* Default */
 		s = (tvp->tv_sec + thiszone) % 86400;
-		ND_PRINT((ndo, "%s ", ts_format(s, tvp->tv_usec)));
+		ND_PRINT((ndo, "%s ", ts_format(ndo, s, tvp->tv_usec)));
 		break;
 
 	case 1: /* No time stamp */
@@ -191,7 +194,7 @@ ts_print(netdissect_options *ndo,
                     d_sec--;
                 }
 
-                ND_PRINT((ndo, "%s ", ts_format(d_sec, d_usec)));
+                ND_PRINT((ndo, "%s ", ts_format(ndo, d_sec, d_usec)));
 
                 if (ndo->ndo_tflag == 3) { /* set timestamp for last packet */
                     b_sec = tvp->tv_sec;
@@ -208,7 +211,7 @@ ts_print(netdissect_options *ndo,
 		else
 			ND_PRINT((ndo, "%04d-%02d-%02d %s ",
                                tm->tm_year+1900, tm->tm_mon+1, tm->tm_mday,
-                               ts_format(s, tvp->tv_usec)));
+                               ts_format(ndo, s, tvp->tv_usec)));
 		break;
 	}
 }


### PR DESCRIPTION
A while ago we introduced new API in libpcap which made possible to request
timestamps with higher resolution (nanosecond). This commit aims to move things
forward and implement missing bits. It introduces new option -P.

When used for live capture tcpdump we will ask kernel for timestamp resolution
in nanoseconds and tcpdump will print fraction part of the timestamp using
nanosecond format. In the future we might support even more granular timestamp
resolution, but we should be fine to  support only microsecond and nanosecond
for now. libpcap doesn't provide anything else at the moment anyway.

When used in combination with -r/-w options then we will either write to the
savefile timestamps in nanoseconds or treat timestamps in savefile as if they
are in nanoseconds. If they are not we will scale them to nanoseconds.
