### PR TITLE
Enable check with various versions of gcc (e.g. CC=gcc-4.8 ./configure)

### DIFF
--- a/tests/lmp-v.sh
+++ b/tests/lmp-v.sh
@@ -6,7 +6,7 @@
 # GCC build and must reproduce correctly on any other GCC build regardless of
 # the architecture.
 
-if grep '^CC = gcc$' ../Makefile >/dev/null
+if grep '^CC = gcc' ../Makefile >/dev/null
 then
   ./TESTonce lmp-v lmp.pcap lmp-v.out '-t -T lmp -v'
 else


### PR DESCRIPTION
This change avoid:
    lmp-v                         : TEST SKIPPED (compiler is not GCC)
