### PR TITLE
Make droproot say something when successful.

### DIFF
--- a/tcpdump.c
+++ b/tcpdump.c
@@ -713,6 +713,9 @@ droproot(const char *username, const char *chroot_dir)
 		if (ret < 0) {
 			fprintf(stderr, "error : ret %d\n", ret);
 		}
+		else {
+			printf("dropped privs to %s\n", username);
+		}
 		/* We don't need CAP_SETUID and CAP_SETGID */
 		capng_update(CAPNG_DROP, CAPNG_EFFECTIVE, CAP_SETUID);
 		capng_update(CAPNG_DROP, CAPNG_EFFECTIVE, CAP_SETUID);


### PR DESCRIPTION
I've seen people run into situations where they were using a command like this:

tcpdump -i eth0 -G 500 -w /root/%H%M%S.pcap

The first file would be created successfully but the second file would not
because their version of tcpdump was dropping privs. It was unclear to them
that this was going on and was causing confusion.

At least with this message in there it should become more evident that
privs are being altered and aid in debugging these kinds of problems.
