### PR TITLE
CDP dissector ends prematurely if a zero-length field is encountered

### DIFF
--- a/print-cdp.c
+++ b/print-cdp.c
@@ -215,7 +215,7 @@ cdp_print(netdissect_options *ndo,
                     }
                 }
 		/* avoid infinite loop */
-		if (len == 0)
+		if (len < 0)
 			break;
 		tptr = tptr+len;
 	}


### PR DESCRIPTION
A zero-length data field is acceptible. However if `len` is correctly
set to zero then we incorrectly exit the processing loop before reading
every header from the packet.

Resolves the first part of #401.
