### PR TITLE
Print square brackets around the tag value in RADIUS strings

### DIFF
--- a/print-radius.c
+++ b/print-radius.c
@@ -477,7 +477,7 @@ print_attr_string(netdissect_options *ndo,
                  ND_PRINT((ndo, "%s", tstr));
                  return;
               }
-              ND_PRINT((ndo, "Tag %u", *data));
+              ND_PRINT((ndo, "Tag[%u]", *data));
               data++;
               length--;
            }


### PR DESCRIPTION
Before, VLAN attributes that had a tag 1 looked like this:

  Tunnel Medium Attribute (65), length: 6, Value: Tag[1]802
  Tunnel Private Group Attribute (81), length: 4, Value: Tag 14

With the Tunnel-Medium-Type attribute (65), it is clear where the tag ends and the value begins. With this patch, the value for a string type (like Tunnel-Private-Group-Id) looks similar:

  Tunnel Private Group Attribute (81), length: 4, Value: Tag[1]4
