### PR TITLE
NetFlow v5: Ignore nh peer data for v5 records

### DIFF
--- a/print-cnfp.c
+++ b/print-cnfp.c
@@ -118,7 +118,7 @@ cnfp_print(netdissect_options *ndo,
 
 	ND_PRINT((ndo, "%2u recs", nrecs));
 
-	for (; nrecs-- && (const u_char *)(nr + 1) <= ndo->ndo_snapend; nr++) {
+	for (; nrecs--; nr++) {
 		char buf[20];
 		char asbuf[20];
 
@@ -183,5 +183,10 @@ cnfp_print(netdissect_options *ndo,
 		       EXTRACT_32BITS(&nr->proto_tos) & 0xff,
 		       EXTRACT_32BITS(&nr->packets),
 		       EXTRACT_32BITS(&nr->octets), buf));
+
+                /* Exclude nh peer data for v5 as it doesn't apply for v5. */
+                if (5 == ver)
+                        nr = (struct nfrec *) ((struct in_addr *) nr - 1);
+
 	}
 }


### PR DESCRIPTION
# Fix Description

```
* The nexthop peer IP address is relevant only for v6, but the same
  data structure is used for processing both v5 and v6 records.
* This patch ignores the nh peer data for v5 records.
```
