### PR TITLE
print-olsr: do not continue parsing when length of packet is invalid

### DIFF
--- a/print-olsr.c
+++ b/print-olsr.c
@@ -359,6 +359,9 @@ olsr_print(netdissect_options *ndo,
             msg_data = tptr + sizeof(struct olsr_msg4);
         }
 
+        if (!msg_len_valid)
+            return;
+
         switch (msg_type) {
         case OLSR_HELLO_MSG:
         case OLSR_HELLO_LQ_MSG:


### PR DESCRIPTION
This commit is an attempt to fix CVE-2014-8767.
