### PR TITLE
Geneve: Don't abort on unknown version

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,8 +1,9 @@
-Thursday Nov. 20, 2014 guy@alum.mit.edu
+Friday Nov. 21, 2014 guy@alum.mit.edu
   Summary for 5.0.0 tcpdump release
 	Fix PPI printing
 	Radius: update Packet Type Codes and Attribute Types with RFC/IANA names
 	DCCP: update Packet Types with RFC4340/IANA names
+	Support for Generic Network Virtualization Encapsulation (Geneve).
 
 Tuesday  Sep.  2, 2014 mcr@sandelman.ca
   Summary for 4.6.2 tcpdump release

--- a/print-geneve.c
+++ b/print-geneve.c
@@ -148,10 +148,8 @@ geneve_print(netdissect_options *ndo, const u_char *bp, u_int len)
     len -= 1;
 
     version = ver_opt >> VER_SHIFT;
-    if (version != 0) {
-        ND_PRINT((ndo, " ERROR: unknown-version %u", version));
-        return;
-    }
+    if (version != 0)
+        ND_PRINT((ndo, " (unknown version %u)", version));
 
     flags = *bp;
     bp += 1;


### PR DESCRIPTION
It is slightly more futureproof if we only warn and attempt to
continue.
