### PR TITLE
Allow the use of pcap's immediate_mode when TPACKET_V3 is available.

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -58,6 +58,9 @@
 /* Define to 1 if you have the `rpc' library (-lrpc). */
 #undef HAVE_LIBRPC
 
+/* Define to 1 if you have the <linux/if_packet.h> header file. */
+#undef HAVE_LINUX_IF_PACKET_H
+
 /* Define to 1 if you have the <memory.h> header file. */
 #undef HAVE_MEMORY_H
 

--- a/configure
+++ b/configure
@@ -7408,6 +7408,22 @@ done
 
 CPPFLAGS="$savedcppflags"
 
+#
+# Check for TPACKET_V3 to determine if set_immediate_mode should be exposed.
+#
+for ac_header in linux/if_packet.h
+do :
+  ac_fn_c_check_header_mongrel "$LINENO" "linux/if_packet.h" "ac_cv_header_linux_if_packet_h" "$ac_includes_default"
+if test "x$ac_cv_header_linux_if_packet_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_LINUX_IF_PACKET_H 1
+_ACEOF
+
+fi
+
+done
+
+
 if test -n "$ac_tool_prefix"; then
   # Extract the first word of "${ac_tool_prefix}ranlib", so it can be a program name with args.
 set dummy ${ac_tool_prefix}ranlib; ac_word=$2

--- a/configure.in
+++ b/configure.in
@@ -1018,6 +1018,11 @@ AC_CHECK_HEADERS(pcap/nflog.h,,,[#include "tcpdump-stdinc.h"])
 AC_CHECK_HEADERS(pcap/usb.h,,,[#include "tcpdump-stdinc.h"])
 CPPFLAGS="$savedcppflags"
 
+#
+# Check for TPACKET_V3 to determine if set_immediate_mode should be exposed.
+#
+AC_CHECK_HEADERS(linux/if_packet.h,,,)
+
 AC_PROG_RANLIB
 AC_CHECK_TOOL([AR], [ar])
 

--- a/tcpdump.1.in
+++ b/tcpdump.1.in
@@ -546,6 +546,15 @@ instead of ``nic.ddn.mil''.
 .PD
 Print an optional packet number at the beginning of the line.
 .TP
+.B \-o
+.PD 0
+.TP
+.B \-\-immediate-mode
+.PD
+Output the packet as soon as it is received.
+This is only available if TPACKET_V3 is available in the kernel, in which case
+buffering may otherwise occur.
+.TP
 .B \-O
 .PD 0
 .TP

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -635,6 +635,17 @@ show_devices_and_exit (void)
 #define D_FLAG
 #endif
 
+#ifdef HAVE_LINUX_IF_PACKET_H
+#include <linux/if_packet.h>
+#ifdef TPACKET3_HDRLEN
+#define HAVE_TPACKET3
+#define o_FLAG "o"
+static int oflag = 0;
+#else
+#define o_FLAG
+#endif /* TPACKET3_HDRLEN */
+#endif /* HAVE_LINUX_IF_PACKET_H */
+
 #ifdef HAVE_PCAP_DUMP_FLUSH
 #define U_FLAG	"U"
 #else
@@ -689,6 +700,9 @@ static const struct option longopts[] = {
 #endif
 	{ "dont-verify-checksums", no_argument, NULL, 'K' },
 	{ "list-data-link-types", no_argument, NULL, 'L' },
+#ifdef HAVE_TPACKET3
+	{ "immediate-mode", no_argument, NULL, 'o' },
+#endif
 	{ "no-optimize", no_argument, NULL, 'O' },
 	{ "no-promiscuous-mode", no_argument, NULL, 'p' },
 #ifdef HAVE_PCAP_SETDIRECTION
@@ -977,7 +991,7 @@ main(int argc, char **argv)
 #endif
 
 	while (
-	    (op = getopt_long(argc, argv, "aAb" B_FLAG "c:C:d" D_FLAG "eE:fF:G:hHi:" I_FLAG j_FLAG J_FLAG "KlLm:M:nNOpq" Q_FLAG "r:Rs:StT:u" U_FLAG "vV:w:W:xXy:Yz:Z:#", longopts, NULL)) != -1)
+	    (op = getopt_long(argc, argv, "aAb" B_FLAG "c:C:d" D_FLAG "eE:fF:G:hHi:" I_FLAG j_FLAG J_FLAG "KlLm:M:nN" o_FLAG "Opq" Q_FLAG "r:Rs:StT:u" U_FLAG "vV:w:W:xXy:Yz:Z:#", longopts, NULL)) != -1)
 		switch (op) {
 
 		case 'a':
@@ -1181,6 +1195,9 @@ main(int argc, char **argv)
 			++Nflag;
 			break;
 
+		case 'o':
+			oflag = 1;
+			break;
 		case 'O':
 			Oflag = 0;
 			break;
@@ -1506,6 +1523,11 @@ main(int argc, char **argv)
 		if (Jflag)
 			show_tstamp_types_and_exit(device, pd);
 #endif
+#ifdef HAVE_TPACKET3
+		if (oflag) {
+			pcap_set_immediate_mode(pd, 1);
+		}
+#endif /* HAVE_TPACKET3 */
 #ifdef HAVE_PCAP_SET_TSTAMP_PRECISION
 		status = pcap_set_tstamp_precision(pd, gndo->ndo_tstamp_precision);
 		if (status != 0)
@@ -2518,7 +2540,7 @@ print_usage(void)
 {
 	print_version();
 	(void)fprintf(stderr,
-"Usage: %s [-aAbd" D_FLAG "efhH" I_FLAG J_FLAG "KlLnNOpqRStu" U_FLAG "vxX#]" B_FLAG_USAGE " [ -c count ]\n", program_name);
+"Usage: %s [-aAbd" D_FLAG "efhH" I_FLAG J_FLAG "KlLnN" o_FLAG "OpqRStu" U_FLAG "vxX#]" B_FLAG_USAGE " [ -c count ]\n", program_name);
 	(void)fprintf(stderr,
 "\t\t[ -C file_size ] [ -E algo:secret ] [ -F file ] [ -G seconds ]\n");
 	(void)fprintf(stderr,


### PR DESCRIPTION
If the kernel has TPACKET_V3 support, then libpcap, by default, will use it and
packets may not be delivered as soon as they're received.

This patch allows the user to provide a -o (--set-immediate-mode) flag to enable
immediate_mode in case receiving packets ASAP is required.