### PR TITLE
Fixed bug in arp_print() in handling of inverse arp responses

### DIFF
--- a/print-arp.c
+++ b/print-arp.c
@@ -389,8 +389,8 @@ arp_print(netdissect_options *ndo,
 
 	case ARPOP_INVREPLY:
 		ND_PRINT((ndo,"%s at %s",
-			  linkaddr_string(ndo, THA(ap), linkaddr, HRD_LEN(ap)),
-			  ipaddr_string(ndo, TPA(ap))));
+			  linkaddr_string(ndo, SHA(ap), linkaddr, HRD_LEN(ap)),
+			  ipaddr_string(ndo, SPA(ap))));
 		break;
 
 	default:


### PR DESCRIPTION
The target's hardware and protocol address were being printed instead of the sender's hardware and protocol address.

This is now handled the same way as a ARP response.

I found this bug several years ago, but there was not an easy way for me to submit a patch.  Once I found out this project was now being hosted on GitHub, I took a look and found the bug still existed, and decided to submit a fix.
