### PR TITLE
support MIP (Minimal Interconnection Protocol)

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -154,6 +154,7 @@ LIBNETDISSECT_SRC=\
 	print-lwapp.c \
 	print-lwres.c \
 	print-m3ua.c \
+	print-mip.c \
 	print-mobile.c \
 	print-mpcp.c \
 	print-mpls.c \

--- a/ethertype.h
+++ b/ethertype.h
@@ -196,5 +196,8 @@
 #ifndef	ETHERTYPE_GEONET
 #define	ETHERTYPE_GEONET        0x8947  /* ETSI GeoNetworking (Official IEEE registration from Jan 2013) */
 #endif
+#ifndef	ETHERTYPE_MIP
+#define	ETHERTYPE_MIP           0xFFFF  /* MIP (Minimal Interconnect Protocol) UiO teaching material */
+#endif
 
 extern const struct tok ethertype_values[];

--- a/netdissect.h
+++ b/netdissect.h
@@ -360,6 +360,7 @@ extern int esp_print(netdissect_options *,
 		     const u_char *bp, const int length, const u_char *bp2,
 		     int *nhdr, int *padlen);
 extern void arp_print(netdissect_options *,const u_char *, u_int, u_int);
+extern void mip_print(netdissect_options *, const u_char *, const u_char *, u_int, u_int);
 extern void tipc_print(netdissect_options *, const u_char *, u_int, u_int);
 extern void msnlb_print(netdissect_options *, const u_char *);
 extern void icmp6_print(netdissect_options *ndo, const u_char *,

--- a/print-ether.c
+++ b/print-ether.c
@@ -83,6 +83,7 @@ const struct tok ethertype_values[] = {
     { ETHERTYPE_GEONET,         "GeoNet"},
     { ETHERTYPE_CALM_FAST,      "CALM FAST"},
     { ETHERTYPE_AOE,            "AoE" },
+    { ETHERTYPE_MIP,		"MIP" },
     { 0, NULL}
 };
 
@@ -422,6 +423,10 @@ ethertype_print(netdissect_options *ndo,
 
 	case ETHERTYPE_AOE:
 		aoe_print(ndo, p, length);
+		return (1);
+
+	case ETHERTYPE_MIP:
+		mip_print(ndo, p-14, p, length, caplen);
 		return (1);
 
 	case ETHERTYPE_LAT:

--- a/print-mip.c
+++ b/print-mip.c
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2013 The TCPDUMP project
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that: (1) source code
+ * distributions retain the above copyright notice and this paragraph
+ * in its entirety, and (2) distributions including binary code include
+ * the above copyright notice and this paragraph in its entirety in
+ * the documentation or other materials provided with the distribution.
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND
+ * WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, WITHOUT
+ * LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE.
+ *
+ * Original code by Ola Martin Lykkja (ola.lykkja@q-free.com)
+ */
+
+#define NETDISSECT_REWORKED
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <tcpdump-stdinc.h>
+
+#include "interface.h"
+#include "extract.h"
+#include "addrtoname.h"
+
+
+/*
+MIP student protocol.
+Header:
+	3 bits: T R A (Transport Routing Address-resolution)
+		Transport means we are transporting user data
+		Routing ???
+		Address means we are requesting someone to tell us their hardware address
+		no flags is arp response which means we are sending our hardware address back to the requester
+	4 bits: TTL
+		as in IPv4, only that this is initially 0xf
+	9 bits: len
+		you have to multiply it to get the payload length
+	8 bits: source
+	8 bits: destination
+*/
+
+#define TRA_TRANSPORT 4
+#define TRA_ROUTING   2
+#define TRA_ARP       1
+#define TRA_ARP_REP   0
+
+struct mip_hdr {
+	u_char  mip_flags1;
+	u_char  mip_flags2;
+	u_char  mip_src;
+	u_char  mip_dst;
+};
+
+#define TRA(m) (((m)->mip_flags1>>5) & 0x007)
+#define TTL(m) (((m)->mip_flags1>>1) & 0x00f)
+#define LEN(m) (((((m)->mip_flags1 & 1) << 8) | (m)->mip_flags2)*4)
+
+static const struct tok tra_values[] = {
+	{ TRA_TRANSPORT, "Transport"    },
+	{ TRA_ROUTING,   "Routing"      },
+	{ TRA_ARP,       "Arp request"  },
+	{ TRA_ARP_REP,   "Arp response" },
+	{ 0,             NULL           }
+};
+
+void mip_print(netdissect_options *ndo, const u_char *eth, const u_char *bp, u_int length, u_int caplen)
+{
+	const struct mip_hdr *mip = (const struct mip_hdr*)bp;
+	int tra, ttl, len, src, dst;
+
+	tra = TRA(mip);
+	ttl = TTL(mip);
+	len = LEN(mip);
+	src = mip->mip_src;
+	dst = mip->mip_dst;
+
+	ND_TCHECK2(*bp, 4);
+
+	ND_PRINT((ndo, "MIP %i -> %i: TTL %i, payload length %i, TRA %s", src, dst, ttl, len,  tok2str(tra_values, "unknown (%u)", tra)));
+
+	return;
+
+trunc:
+	ND_PRINT((ndo, "[|mip]"));
+}
+
+
+/*
+ * Local Variables:
+ * c-style: whitesmith
+ * c-basic-offset: 8
+ * End:
+ */

--- a/print-mip.c
+++ b/print-mip.c
@@ -12,7 +12,8 @@
  * LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
  * FOR A PARTICULAR PURPOSE.
  *
- * Original code by Ola Martin Lykkja (ola.lykkja@q-free.com)
+ * Original code by Håkon Struijk Holmen (hawken@thehawken.org) based
+ *  on work by Ola Martin Lykkja (ola.lykkja@q-free.com)
  */
 
 #define NETDISSECT_REWORKED

--- a/print-mip.c
+++ b/print-mip.c
@@ -12,7 +12,7 @@
  * LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
  * FOR A PARTICULAR PURPOSE.
  *
- * Original code by Håkon Struijk Holmen (hawken@thehawken.org) based
+ * Code by Håkon Struijk Holmen (hawken@thehawken.org) based
  *  on work by Ola Martin Lykkja (ola.lykkja@q-free.com)
  */
 


### PR DESCRIPTION
See http://www.uio.no/studier/emner/matnat/ifi/INF3190/v15/oblig/oblig.pdf

This protocol is used in at least the inf3190 data communication course in the University of Oslo. Probably not used outside the university. It's a mini-ip protocol operating on top of Ethernet with ethertype 0xffff. It has it's own ARP via a bit in the header, it has 8-bit addressing and not much more.

It would be fun if tcpdump had support for it :)