### PR TITLE
Fix -C with Capsicum

### DIFF
--- a/tcpdump.c
+++ b/tcpdump.c
@@ -1799,10 +1799,14 @@ main(int argc, char **argv)
 		if (p == NULL)
 			error("%s", pcap_geterr(pd));
 #ifdef HAVE_CAPSICUM
-		cap_rights_init(&rights, CAP_SEEK, CAP_WRITE);
+		cap_rights_init(&rights, CAP_SEEK, CAP_WRITE, CAP_FCNTL);
 		if (cap_rights_limit(fileno(pcap_dump_file(p)), &rights) < 0 &&
 		    errno != ENOSYS) {
 			error("unable to limit dump descriptor");
+		}
+		if (cap_fcntls_limit(fileno(pcap_dump_file(p)), CAP_FCNTL_GETFL) < 0 &&
+		    errno != ENOSYS) {
+			error("unable to limit dump descriptor fcntls");
 		}
 #endif
 		if (Cflag != 0 || Gflag != 0) {
@@ -1819,6 +1823,10 @@ main(int argc, char **argv)
 			if (cap_rights_limit(dumpinfo.dirfd, &rights) < 0 &&
 			    errno != ENOSYS) {
 				error("unable to limit directory rights");
+			}
+			if (cap_fcntls_limit(dumpinfo.dirfd, CAP_FCNTL_GETFL) < 0 &&
+		        errno != ENOSYS) {
+				error("unable to limit dump descriptor fcntls");
 			}
 #else	/* !HAVE_CAPSICUM */
 			dumpinfo.WFileName = WFileName;
@@ -2298,10 +2306,14 @@ dump_packet_and_trunc(u_char *user, const struct pcap_pkthdr *h, const u_char *s
 		if (dump_info->p == NULL)
 			error("%s", pcap_geterr(pd));
 #ifdef HAVE_CAPSICUM
-		cap_rights_init(&rights, CAP_SEEK, CAP_WRITE);
+		cap_rights_init(&rights, CAP_SEEK, CAP_WRITE, CAP_FCNTL);
 		if (cap_rights_limit(fileno(pcap_dump_file(dump_info->p)),
 		    &rights) < 0 && errno != ENOSYS) {
 			error("unable to limit dump descriptor");
+		}
+		if (cap_fcntls_limit(fileno(pcap_dump_file(dump_info->p)),
+		    CAP_FCNTL_GETFL) < 0 && errno != ENOSYS) {
+			error("unable to limit dump descriptor fcntls");
 		}
 #endif
 	}


### PR DESCRIPTION
As discussed at http://thread.gmane.org/gmane.network.tcpdump.devel/7056/focus=7057, this fixes a bug when using -C with Capsicum due to a missing capability causing pcap_dump_ftell() to return -1.