### PR TITLE
Add CAP_FCNTL and use cap_fcntls_limit().

### DIFF
--- a/tcpdump.c
+++ b/tcpdump.c
@@ -1814,10 +1814,14 @@ main(int argc, char **argv)
 		if (p == NULL)
 			error("%s", pcap_geterr(pd));
 #ifdef HAVE_CAPSICUM
-		cap_rights_init(&rights, CAP_SEEK, CAP_WRITE);
+		cap_rights_init(&rights, CAP_SEEK, CAP_WRITE, CAP_FCNTL);
 		if (cap_rights_limit(fileno(pcap_dump_file(p)), &rights) < 0 &&
 		    errno != ENOSYS) {
 			error("unable to limit dump descriptor");
+		}
+		if (cap_fcntls_limit(fileno(pcap_dump_file(p)), CAP_FCNTL_GETFL) < 0 &&
+		    errno != ENOSYS) {
+			error("unable to limit dump descriptor fcntls");
 		}
 #endif
 		if (Cflag != 0 || Gflag != 0) {
@@ -1834,6 +1838,10 @@ main(int argc, char **argv)
 			if (cap_rights_limit(dumpinfo.dirfd, &rights) < 0 &&
 			    errno != ENOSYS) {
 				error("unable to limit directory rights");
+			}
+			if (cap_fcntls_limit(dumpinfo.dirfd, CAP_FCNTL_GETFL) < 0 &&
+			    errno != ENOSYS) {
+				error("unable to limit dump descriptor fcntls");
 			}
 #else	/* !HAVE_CAPSICUM */
 			dumpinfo.WFileName = WFileName;
@@ -2327,11 +2335,15 @@ dump_packet_and_trunc(u_char *user, const struct pcap_pkthdr *h, const u_char *s
 			if (dump_info->p == NULL)
 				error("%s", pcap_geterr(pd));
 #ifdef HAVE_CAPSICUM
-			cap_rights_init(&rights, CAP_SEEK, CAP_WRITE);
+			cap_rights_init(&rights, CAP_SEEK, CAP_WRITE, CAP_FCNTL);
 			if (cap_rights_limit(fileno(pcap_dump_file(dump_info->p)),
 			    &rights) < 0 && errno != ENOSYS) {
 				error("unable to limit dump descriptor");
 			}
+		if (cap_fcntls_limit(fileno(pcap_dump_file(dump_info->p)),
+		    CAP_FCNTL_GETFL) < 0 && errno != ENOSYS) {
+			error("unable to limit dump descriptor fcntls");
+		}
 #endif
 		}
 	}


### PR DESCRIPTION
Without these changes pcap_dump_ftell() will return -1 and set errno to
ENOTCAPABLE.

This allows you to do:

tcpdump -C 1 -W 5 -w foo.pcap

Without these changes it will never rotate to foo.pcap1 and continue writing
to foo.pcap0 forever.

Discussed at: http://unix.derkeiler.com/Mailing-Lists/FreeBSD/current/2014-09/msg00142.html