### PR TITLE
Add --print-bytes argument so that a subset of the packet can be printed.

### DIFF
--- a/interface.h
+++ b/interface.h
@@ -224,6 +224,9 @@ extern netdissect_options *gndo;
 #define snaplen     gndo->ndo_snaplen
 #define snapend     gndo->ndo_snapend
 
+#define printstart gndo->ndo_snaplen
+#define printend gndo->ndo_snaplen
+
 extern void default_print(const u_char *, u_int);
 
 #endif

--- a/netdissect.h
+++ b/netdissect.h
@@ -116,6 +116,9 @@ struct netdissect_options {
   int ndo_jflag;                /* packet time stamp source */
   int ndo_pflag;                /* don't go promiscuous */
   int ndo_immediate;            /* use immediate mode */
+  int ndo_print_bytes_flag;     /* print subset of bytes flag */
+  uint8_t ndo_print_start;      /* print range start */
+  uint8_t ndo_print_end;        /* print range end */
 
   int ndo_Cflag;                /* rotate dump files after this many bytes */
   int ndo_Cflag_count;      /* Keep track of which file number we're writing */

--- a/tcpdump.1.in
+++ b/tcpdump.1.in
@@ -568,9 +568,9 @@ Do not run the packet-matching code optimizer.
 This is useful only
 if you suspect a bug in the optimizer.
 .TP
-.B \-\-print\-bytes " start:length"
+.B \-\-print\-bytes " start:end"
 .PD
-Used in conjunction with \-X to limit printing to packet data beyond the link level header,  between \fIstart\fP end \fIend\fP bytes.
+Used in conjunction with \-X to limit printing to packet data beyond the link level header,  from \fIstart\fP to \fIend\fP bytes.
 .TP
 .B \-p
 .PD 0

--- a/tcpdump.1.in
+++ b/tcpdump.1.in
@@ -570,7 +570,7 @@ if you suspect a bug in the optimizer.
 .TP
 .B \-\-print\-bytes " start:length"
 .PD
-Used in conjunction with \-XX to limit printing to payload data between \fIstart\fP end \fIend\fP bytes.
+Used in conjunction with \-X to limit printing to packet data beyond the link level header,  between \fIstart\fP end \fIend\fP bytes.
 .TP
 .B \-p
 .PD 0

--- a/tcpdump.1.in
+++ b/tcpdump.1.in
@@ -568,6 +568,10 @@ Do not run the packet-matching code optimizer.
 This is useful only
 if you suspect a bug in the optimizer.
 .TP
+.B \-\-print\-bytes " start:length"
+.PD
+Used in conjunction with \-XX to limit printing to payload data between \fIstart\fP end \fIend\fP bytes.
+.TP
 .B \-p
 .PD 0
 .TP

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -2490,12 +2490,7 @@ print_packet(u_char *user, const struct pcap_pkthdr *h, const u_char *sp)
 			/*
 			 * Include the link-layer header.
 			 */
-			if(ndo->ndo_print_bytes_flag) {
-				hex_and_ascii_print(ndo, "\n\t", sp + hdrlen + ndo->ndo_print_start,
-				    ndo->ndo_print_end);
-			} else {
-				hex_and_ascii_print(ndo, "\n\t", sp, h->caplen);
-			}
+			hex_and_ascii_print(ndo, "\n\t", sp, h->caplen);
 		} else {
 			/*
 			 * Don't include the link-layer header - and if
@@ -2503,8 +2498,13 @@ print_packet(u_char *user, const struct pcap_pkthdr *h, const u_char *sp)
 			 * print nothing.
 			 */
 			if (h->caplen > hdrlen)
-				hex_and_ascii_print(ndo, "\n\t", sp + hdrlen,
-				    h->caplen - hdrlen);
+				if(ndo->ndo_print_bytes_flag) {
+					hex_and_ascii_print_with_offset(ndo, "\n\t", sp + hdrlen + ndo->ndo_print_start,
+				    	ndo->ndo_print_end-ndo->ndo_print_start,ndo->ndo_print_start);
+				} else {
+					hex_and_ascii_print(ndo, "\n\t", sp + hdrlen,
+				    	h->caplen - hdrlen);
+				}
 		}
 	} else if (ndo->ndo_xflag) {
 		/*
@@ -2679,7 +2679,7 @@ print_usage(void)
 "\t\t[ -i interface ]" j_FLAG_USAGE " [ -M secret ] [ --number ]\n");
 #ifdef HAVE_PCAP_SETDIRECTION
 	(void)fprintf(stderr,
-"\t\t[ --print-bytes proto[start:end] ] [ -Q in|out|inout ]\n");
+"\t\t[ --print-bytes start:end ] [ -Q in|out|inout ]\n");
 #endif
 	(void)fprintf(stderr,
 "\t\t[ -r file ] [ -s snaplen ] ");

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -678,6 +678,7 @@ show_devices_and_exit (void)
 #define OPTION_VERSION		128
 #define OPTION_TSTAMP_PRECISION	129
 #define OPTION_IMMEDIATE_MODE	130
+#define OPTION_PRINT_BYTES	131
 
 static const struct option longopts[] = {
 #if defined(HAVE_PCAP_CREATE) || defined(WIN32)
@@ -717,7 +718,7 @@ static const struct option longopts[] = {
 #endif
 	{ "relinquish-privileges", required_argument, NULL, 'Z' },
 	{ "number", no_argument, NULL, '#' },
-	{ "print-bytes", required_argument, NULL, 'P' },
+	{ "print-bytes", required_argument, NULL, OPTION_PRINT_BYTES },
 	{ "version", no_argument, NULL, OPTION_VERSION },
 	{ NULL, 0, NULL, 0 }
 };
@@ -1276,7 +1277,7 @@ main(int argc, char **argv)
 			++pflag;
 			break;
 
-		case 'P':
+		case OPTION_PRINT_BYTES:
 			if ((colon=strchr(optarg,':')) == 0) {
 				error("bad syntax");
 			}

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -2501,7 +2501,7 @@ print_packet(u_char *user, const struct pcap_pkthdr *h, const u_char *sp)
 			if (h->caplen > hdrlen)
 				if(ndo->ndo_print_bytes_flag) {
 					hex_and_ascii_print_with_offset(ndo, "\n\t", sp + hdrlen + ndo->ndo_print_start,
-				    	ndo->ndo_print_end-ndo->ndo_print_start,ndo->ndo_print_start);
+				    	ndo->ndo_print_end-ndo->ndo_print_start+1,ndo->ndo_print_start);
 				} else {
 					hex_and_ascii_print(ndo, "\n\t", sp + hdrlen,
 				    	h->caplen - hdrlen);


### PR DESCRIPTION
Permit printing of a portion of the packet (minus link layer) when --print-bytes used with -X.

Example:

```
    $ ./tcpdump -h
    tcpdump version 4.8.0-PRE-GIT_2015_03_08
    libpcap version 1.8.0-PRE-GIT_2015_03_07
    OpenSSL 1.0.1e-fips 11 Feb 2013
    Usage: tcpdump [-aAbdDefhHIJKlLnNOpqRStuUvxX#] [ -B size ] [ -c count ]
                    [ -C file_size ] [ -E algo:secret ] [ -F file ] [ -G seconds ]
                    [ -i interface ] [ -j tstamptype ] [ -M secret ] [ --number ]
                    [ --print-bytes start:end ] [ -Q in|out|inout ]
                    [ -r file ] [ -s snaplen ] [ --time-stamp-precision precision ]
                    [ --immediate-mode ] [ -T type ] [ --version ] [ -V file ]
                    [ -w file ] [ -W filecount ] [ -y datalinktype ] [ -z command ]
                    [ -Z user ] [ expression ]
    $ ./tcpdump -r tests/mptcp.pcap -c 1 -XX
    reading from file tests/mptcp.pcap, link-type EN10MB (Ethernet)
    05:56:35.701161 IP 10.2.1.2.35961 > 10.1.1.2.ssh: Flags [S], seq 2912457561, win 14600, options         [mss 1460,sackOK,TS val 4294943152 ecr 0,nop,wscale 6,mptcp capable csum {0x9c9eabd1e46a33b2}],         length 0
            0x0000:  1651 5304 3f55 f28c f524 1b21 0800 4500  .QS.?U...$.!..E.
            0x0010:  0048 32e9 4000 4006 f1c0 0a02 0102 0a01  .H2.@.@.........
            0x0020:  0102 8c79 0016 ad98 9359 0000 0000 d002  ...y.....Y......
            0x0030:  3908 da99 0000 0204 05b4 0402 080a ffff  9...............
            0x0040:  a1b0 0000 0000 0103 0306 1e0c 0081 9c9e  ................
            0x0050:  abd1 e46a 33b2                           ...j3.
    $ ./tcpdump -r tests/mptcp.pcap -c 1 -X
    reading from file tests/mptcp.pcap, link-type EN10MB (Ethernet)
    05:56:35.701161 IP 10.2.1.2.35961 > 10.1.1.2.ssh: Flags [S], seq 2912457561, win 14600, options [mss 1460,sackOK,TS val 4294943152 ecr 0,nop,wscale 6,mptcp capable csum {0x9c9eabd1e46a33b2}], length 0
            0x0000:  4500 0048 32e9 4000 4006 f1c0 0a02 0102  E..H2.@.@.......
            0x0010:  0a01 0102 8c79 0016 ad98 9359 0000 0000  .....y.....Y....
            0x0020:  d002 3908 da99 0000 0204 05b4 0402 080a  ..9.............
            0x0030:  ffff a1b0 0000 0000 0103 0306 1e0c 0081  ................
            0x0040:  9c9e abd1 e46a 33b2                      .....j3.
    $ ./tcpdump -r tests/mptcp.pcap -c 1 -X --print-bytes 16:31
    reading from file tests/mptcp.pcap, link-type EN10MB (Ethernet)
    05:56:35.701161 IP 10.2.1.2.35961 > 10.1.1.2.ssh: Flags [S], seq 2912457561, win 14600, options [mss 1460,sackOK,TS val 4294943152 ecr 0,nop,wscale 6,mptcp capable csum {0x9c9eabd1e46a33b2}], length 0
            0x0010:  0a01 0102 8c79 0016 ad98 9359 0000 00    .....y.....Y....
    $ 
```
