### PR TITLE
Add --limit-file-size.

### DIFF
--- a/netdissect.h
+++ b/netdissect.h
@@ -128,6 +128,7 @@ struct netdissect_options {
   int ndo_packet_number;	/* print a packet number in the beginning of line */
   int ndo_suppress_default_print; /* don't use default_print() for unknown packet types */
   int ndo_tstamp_precision;   /* requested time stamp precision */
+  long ndo_limit_file_size;    /* exit when capture file reaches this size */
   const char *ndo_dltname;
 
   char *ndo_espsecret;

--- a/tcpdump.1.in
+++ b/tcpdump.1.in
@@ -434,6 +434,12 @@ efficiency.  This is the default when printing packets rather than
 saving packets to a ``savefile'' if the packets are being printed to a
 terminal rather than to a file or pipe.
 .TP
+.BI \-\-limit\-file\-size= max_size
+.PD
+Once the capture file exceeds \fImax_size\fP do not capture any further
+packets.  Default format is bytes, but suffixes k, m, g and t can be used
+to denote kilobytes, megabytes, gigabytes and terabytes respectively.
+.TP
 .BI \-j " tstamp_type"
 .PD 0
 .TP
@@ -978,6 +984,24 @@ ping packets):
 .nf
 .B
 tcpdump 'icmp[icmptype] != icmp-echo and icmp[icmptype] != icmp-echoreply'
+.fi
+.RE
+.LP
+To capture all IP packets to a file named /tmp/capCCYYMMDDHHMMSS and switch to a
+new file every 10 seconds:
+.RS
+.nf
+.B
+tcpdump -G 10 -w /tmp/cap%Y%m%d%H%M%S ip
+.fi
+.RE
+.LP
+To capture all packets to a file named /tmp/cap and exit after capturing
+5 gigabytes
+.RS
+.nf
+.B
+tcpdump --limit-file-size 5g -w /tmp/cap
 .fi
 .RE
 .SH OUTPUT FORMAT


### PR DESCRIPTION
After reaching a specified output file size, do not write any further packets and then exit.

    $ ./tcpdump -h
    tcpdump version 4.8.0-PRE-GIT_2015_03_11
    libpcap version 1.8.0-PRE-GIT_2015_03_07
    OpenSSL 1.0.1e-fips 11 Feb 2013
    Usage: tcpdump [-aAbdDefhHIJKlLnNOpqRStuUvxX#] [ -B size ] [ -c count ]
                    [ -C file_size ] [ -E algo:secret ] [ -F file ] [ -G seconds ]
                    [ -i interface ] [ -j tstamptype ] [ --limit-file-size max_size ]
                    [ -M secret ] [ --number ]
                    [ -Q in|out|inout ]
                    [ -r file ] [ -s snaplen ] [ --time-stamp-precision precision ]
                    [ --immediate-mode ] [ -T type ] [ --version ] [ -V file ]
                    [ -w file ] [ -W filecount ] [ -y datalinktype ] [ -z command ]
                    [ -Z user ] [ expression ]
    $ ./tcpdump -r tests/mptcp.pcap -w /tmp/foo
    reading from file tests/mptcp.pcap, link-type EN10MB (Ethernet)
    $ ls -l /tmp/foo
    -rw-rw-r--. 1 usera usera 39394 Mar 11 15:48 /tmp/foo
    $ ./tcpdump -r tests/mptcp.pcap -w /tmp/foo --limit-file-size 10000
    reading from file tests/mptcp.pcap, link-type EN10MB (Ethernet)
    $ ls -l /tmp/foo
    -rw-rw-r--. 1 usera usera 10244 Mar 11 15:49 /tmp/foo
    $ ./tcpdump -r tests/mptcp.pcap -w /tmp/foo --limit-file-size 15k
    reading from file tests/mptcp.pcap, link-type EN10MB (Ethernet)
    $ ls -l /tmp/foo
    -rw-rw-r--. 1 usera usera 15424 Mar 11 15:49 /tmp/foo
    $ man -l tcpdump.1.in
    snip
           --limit-file-size=max_size
                  Once the capture file exceeds max_size do not capture any further packets.  Default format is     bytes, but suffixes k, m, g and t can be used to denote kilobytes, megabytes, gigabytes and terabytes respectively.
    snip
           To capture all packets to a file named /tmp/cap and exit after capturing 5 gigabytes
                  tcpdump --limit-file-size 5g -w /tmp/cap
    $