### PR TITLE
Remove an unnecessicary bit shifting loop

### DIFF
--- a/util.c
+++ b/util.c
@@ -358,26 +358,14 @@ bittok2str_internal(register const struct tok *lp, register const char *fmt,
 {
         static char buf[256]; /* our stringbuffer */
         int buflen=0;
-        register int rotbit; /* this is the bit we rotate through all bitpositions */
-        register int tokval;
         const char * sepstr = "";
 
 	while (lp != NULL && lp->s != NULL) {
-            tokval=lp->v;   /* load our first value */
-            rotbit=1;
-            while (rotbit != 0) {
-                /*
-                 * lets AND the rotating bit with our token value
-                 * and see if we have got a match
-                 */
-		if (tokval == (v&rotbit)) {
-                    /* ok we have found something */
-                    buflen+=snprintf(buf+buflen, sizeof(buf)-buflen, "%s%s",
-                                     sepstr, lp->s);
-                    sepstr = sep ? ", " : "";
-                    break;
-                }
-                rotbit=rotbit<<1; /* no match - lets shift and try again */
+	    if ((lp->v & v) == lp->v) {
+		/* ok we have found something */
+		buflen+=snprintf(buf+buflen, sizeof(buf)-buflen, "%s%s",
+				 sepstr, lp->s);
+		sepstr = sep ? ", " : "";
             }
             lp++;
 	}


### PR DESCRIPTION
The inner loop serves no purpose and depends on signed integer overflow behavior which is undefined. Our compiler based on clang-3.6 miscompiles the shift operation resulting in memory corruption if multiple flags are set. I noticed the bug because our hardware enforced memory safety code trapped rather than overwriting memory.

This version passes all tests that master passes.