### PR TITLE
Remove global netdissect_object and remove non-dissection related fields

### DIFF
--- a/netdissect.h
+++ b/netdissect.h
@@ -615,6 +615,4 @@ extern int esp_print_decrypt_buffer_by_ikev2(netdissect_options *ndo,
 extern void geonet_print(netdissect_options *ndo,const u_char *eth_hdr,const u_char *geo_pck, u_int len);
 extern void calm_fast_print(netdissect_options *ndo,const u_char *eth_hdr,const u_char *calm_pck, u_int len);
 
-extern netdissect_options *gndo;
-
 #endif  /* netdissect_h */

--- a/netdissect.h
+++ b/netdissect.h
@@ -101,7 +101,6 @@ struct netdissect_options {
   int ndo_sflag;		/* use the libsmi to translate OIDs */
   int ndo_Sflag;		/* print raw TCP sequence numbers */
   int ndo_tflag;		/* print packet arrival time */
-  int ndo_Uflag;		/* "unbuffered" output of dump files */
   int ndo_uflag;		/* Print undecoded NFS handles */
   int ndo_vflag;		/* verbose */
   int ndo_xflag;		/* print packet in hex */
@@ -109,21 +108,9 @@ struct netdissect_options {
   int ndo_Aflag;		/* print packet only in ascii observing TAB,
 				 * LF, CR and SPACE as graphical chars
 				 */
-  int ndo_Bflag;		/* buffer size */
-  int ndo_Iflag;		/* rfmon (monitor) mode */
-  int ndo_Oflag;                /* run filter code optimizer */
   int ndo_dlt;                  /* if != -1, ask libpcap for the DLT it names*/
-  int ndo_jflag;                /* packet time stamp source */
-  int ndo_pflag;                /* don't go promiscuous */
   int ndo_immediate;            /* use immediate mode */
 
-  int ndo_Cflag;                /* rotate dump files after this many bytes */
-  int ndo_Cflag_count;      /* Keep track of which file number we're writing */
-  int ndo_Gflag;            /* rotate dump files after this many seconds */
-  int ndo_Gflag_count;      /* number of files created with Gflag rotation */
-  time_t ndo_Gflag_time;    /* The last time_t the dump file was rotated. */
-  int ndo_Wflag;          /* recycle output files after this number of files */
-  int ndo_WflagChars;
   int ndo_Hflag;		/* dissect 802.11s draft mesh standard */
   int ndo_packet_number;	/* print a packet number in the beginning of line */
   int ndo_suppress_default_print; /* don't use default_print() for unknown packet types */

--- a/print.c
+++ b/print.c
@@ -247,11 +247,12 @@ static int	tcpdump_printf(netdissect_options *ndo _U_, const char *fmt, ...)
 		     ;
 
 void
-init_print(u_int32_t localnet, u_int32_t mask, uint32_t timezone_offset)
+init_print(netdissect_options *ndo, u_int32_t localnet, u_int32_t mask,
+    uint32_t timezone_offset)
 {
 
 	thiszone = timezone_offset;
-	init_addrtoname(gndo, localnet, mask);
+	init_addrtoname(ndo, localnet, mask);
 	init_checksum();
 }
 
@@ -300,17 +301,18 @@ has_printer(int type)
 }
 
 struct print_info
-get_print_info(int type)
+get_print_info(netdissect_options *ndo, int type)
 {
+	const char *dltname;
 	struct print_info printinfo;
 
-	printinfo.ndo = gndo;
+	printinfo.ndo = ndo;
 	printinfo.printer = lookup_printer(type);
 	if (printinfo.printer == NULL) {
-		gndo->ndo_dltname = pcap_datalink_val_to_name(type);
-		if (gndo->ndo_dltname != NULL)
+		dltname = pcap_datalink_val_to_name(type);
+		if (dltname != NULL)
 			error("packet printing is not supported for link type %s: use -w",
-			      gndo->ndo_dltname);
+			      dltname);
 		else
 			error("packet printing is not supported for link type %d: use -w", type);
 	}

--- a/print.h
+++ b/print.h
@@ -33,12 +33,12 @@ struct print_info {
 	if_printer printer;
 };
 
-void	init_print(u_int32_t localnet, u_int32_t mask,
+void	init_print(netdissect_options *ndo, u_int32_t localnet, u_int32_t mask,
 	    uint32_t timezone_offset);
 
 int	has_printer(int type);
 
-struct print_info	get_print_info(int type);
+struct print_info	get_print_info(netdissect_options *ndo, int type);
 
 void	pretty_print_packet(struct print_info *print_info,
 	    const struct pcap_pkthdr *h, const u_char *sp,

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -134,9 +134,6 @@ extern int SIZE_BUF;
 #define SIGNAL_REQ_INFO SIGUSR1
 #endif
 
-netdissect_options Gndo;
-netdissect_options *gndo = &Gndo;
-
 static int Cflag;			/* rotate dump files after this many bytes */
 static int Cflag_count;			/* Keep track of which file number we're writing */
 static int Dflag;			/* list available devices and exit */
@@ -738,11 +735,14 @@ main(int argc, char **argv)
 	int jflag=-1;			/* packet time stamp source */
 	int Oflag=1;			/* run filter code optimizer */
 	int pflag=0;			/* don't go promiscuous */
+	netdissect_options Gndo;
+	netdissect_options *gndo = &Gndo;
 
 #ifdef WIN32
 	if(wsockinit() != 0) return 1;
 #endif /* WIN32 */
 
+	memset(gndo, 0, sizeof(*gndo));
 	gndo->ndo_Rflag=1;
 	gndo->ndo_dlt=-1;
 	ndo_set_function_pointers(gndo);
@@ -1487,7 +1487,7 @@ main(int argc, char **argv)
 		free(cmdbuf);
 		exit(0);
 	}
-	init_print(localnet, netmask, timezone_offset);
+	init_print(gndo, localnet, netmask, timezone_offset);
 
 #ifndef WIN32
 	(void)setsignal(SIGPIPE, cleanup);
@@ -1636,7 +1636,7 @@ main(int argc, char **argv)
 #endif
 	} else {
 		type = pcap_datalink(pd);
-		printinfo = get_print_info(type);
+		printinfo = get_print_info(gndo, type);
 		callback = print_packet;
 		pcap_userdata = (u_char *)&printinfo;
 	}
@@ -1758,7 +1758,7 @@ main(int argc, char **argv)
 				new_dlt = pcap_datalink(pd);
 				if (WFileName && new_dlt != dlt)
 					error("%s: new dlt does not match original", RFileName);
-				printinfo = get_print_info(new_dlt);
+				printinfo = get_print_info(gndo, new_dlt);
 				dlt_name = pcap_datalink_val_to_name(new_dlt);
 				if (dlt_name == NULL) {
 					fprintf(stderr, "reading from file %s, link-type %u\n",

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -735,14 +735,14 @@ main(int argc, char **argv)
 	int jflag=-1;			/* packet time stamp source */
 	int Oflag=1;			/* run filter code optimizer */
 	int pflag=0;			/* don't go promiscuous */
-	netdissect_options *ndo;
+	netdissect_options Ndo;
+	netdissect_options *ndo = &Ndo;
 
 #ifdef WIN32
 	if(wsockinit() != 0) return 1;
 #endif /* WIN32 */
 
-	if((ndo = calloc(1, sizeof(*ndo))) == NULL)
-		error("malloc ndo: %s", strerror(errno));
+	memset(ndo, 0, sizeof(*ndo));
 	ndo->ndo_Rflag=1;
 	ndo->ndo_dlt=-1;
 	ndo_set_function_pointers(ndo);
@@ -1779,7 +1779,6 @@ main(int argc, char **argv)
 	while (ret != NULL);
 
 	free(cmdbuf);
-	free(ndo);
 	exit(status == -1 ? 1 : 0);
 }
 


### PR DESCRIPTION
This set of changes further improves the split between the frontend and backend by eliminating a shared global netdissect_object and removing several members from the struct that deal with frontend packet processing details.