### PR TITLE
Remove "capability mode sandbox enabled" message.

### DIFF
--- a/tcpdump.c
+++ b/tcpdump.c
@@ -1686,8 +1686,6 @@ main(int argc, char **argv)
 	cansandbox = (gndo->ndo_nflag && VFileName == NULL && zflag == NULL);
 	if (cansandbox && cap_enter() < 0 && errno != ENOSYS)
 		error("unable to enter the capability mode");
-	if (cap_sandboxed())
-		fprintf(stderr, "capability mode sandbox enabled\n");
 #endif	/* HAVE_CAPSICUM */
 
 	do {


### PR DESCRIPTION
We have removed all instances of these messages in FreeBSD as they serve
little purpose and break some comsumers.