### PR TITLE
New feature to limit capture file size

### DIFF
--- a/tcpdump.1.in
+++ b/tcpdump.1.in
@@ -434,6 +434,12 @@ efficiency.  This is the default when printing packets rather than
 saving packets to a ``savefile'' if the packets are being printed to a
 terminal rather than to a file or pipe.
 .TP
+.BI \-\-limit\-file\-size= max_size
+.PD
+Once the capture file exceeds \fImax_size\fP do not capture any further
+packets.  Default format is bytes, but suffixes k, m and g can be used to
+denote kilobytes, megabytes and gigabytes respectively.
+.TP
 .BI \-j " tstamp_type"
 .PD 0
 .TP


### PR DESCRIPTION
I have cancelled an earlier similar pull request I made.  This pull request incorporates the suggestions concerning ambiguous else, int overflow and trailing whitespace.

    $ sudo ./tcpdump -w /tmp/foo -i eth0 --limit-file-size=2k
    tcpdump: listening on eth0, link-type EN10MB (Ethernet), capture size 262144 bytes
    $ ls -lh /tmp/foo
    -rw-rw-r--. 1 steve steve 2.2K Jun  7 14:39 /tmp/foo
    $ man -l tcpdump.1.in | grep -C 5 limit-file-size
    
           --immediate-mode
                  Capture  in "immediate mode".  In this mode, packets are delivered to tcpdump as soon     as they arrive, rather than being buffered for efficiency.  This is the default when printing packets rather than saving packets to
                  a ``savefile'' if the packets are being printed to a terminal rather than to a file or pipe.
    
           --limit-file-size=max_size
                  Once the capture file exceeds max_size do not capture any further packets.  Default     format is bytes, but suffixes k, m and g can be used to denote kilobytes, megabytes and gigabytes respectively.
    
           -j tstamp_type
           --time-stamp-type=tstamp_type
                  Set the time stamp type for the capture to tstamp_type.  The names to use for the time stamp types are given in pcap-tstamp(@MAN_MISC_INFO@); not all the types listed there will necessarily  be  valid  for  any  given
    $

