### PR TITLE
For DNS messages, represent the "DNSSEC OK" bit as "DO" instead of "OK"

### DIFF
--- a/print-domain.c
+++ b/print-domain.c
@@ -528,7 +528,7 @@ ns_rprint(netdissect_options *ndo,
 	case T_OPT:
 		ND_PRINT((ndo, " UDPsize=%u", class));
 		if (opt_flags & 0x8000)
-			ND_PRINT((ndo, " OK"));
+			ND_PRINT((ndo, " DO"));
 		break;
 
 	case T_UNSPECA:		/* One long string */


### PR DESCRIPTION
"DO" is a better description of the DNSSEC OK bit in the EDNS0 OPT record.  See RFC 3225 section 3.  There may be other bits allocated in the future that call themselves "Something OK".