### PR TITLE
Fix print-dccp.c warning

### DIFF
--- a/print-dccp.c
+++ b/print-dccp.c
@@ -497,7 +497,6 @@ void dccp_print(netdissect_options *ndo, const u_char *bp, const u_char *data2,
 
 	/* process options */
 	if (hlen > fixed_hdrlen){
-		const u_char *cp;
 		u_int optlen;
 		cp = bp + fixed_hdrlen;
 		ND_PRINT((ndo, " <"));


### PR DESCRIPTION
Fix warning:
```
 print-dccp.c(500): warning C4456: declaration of 'cp' hides previous local declaration
 print-dccp.c(277): note: see declaration of 'cp'
```
