### PR TITLE
Add Value 13 "VLAN" to Tunnel-Type RADIUS attribute

### DIFF
--- a/print-radius.c
+++ b/print-radius.c
@@ -37,6 +37,10 @@
  * RFC 2869:
  *      "RADIUS Extensions"
  *
+ * RFC 3580:
+ *      "IEEE 802.1X Remote Authentication Dial In User Service (RADIUS)"
+ *      "Usage Guidelines"
+ *
  * RFC 4675:
  *      "RADIUS Attributes for Virtual LAN and Priority Support"
  *
@@ -330,6 +334,7 @@ static const char *tunnel_type[]={ NULL,
                                    "GRE",
                                    "DVS",
                                    "IP-in-IP Tunneling",
+                                   "VLAN",
                                  };
 
 /* Tunnel-Medium-Type Attribute standard values */


### PR DESCRIPTION
I haven't included any unit tests, because the trivial change this is. It has been tested locally and it has been seen working there. It doesn't break any existing unit tests either.

Fun fact: this value is used to assign a VLAN to a port or WLAN user, I wouldn't be surprised if it's the most common used value for Tunnel-Type.