### PR TITLE
Default to correct interface on Windows

### DIFF
--- a/tcpdump.c
+++ b/tcpdump.c
@@ -1291,7 +1291,12 @@ main(int argc, char **argv)
 		 * We're doing a live capture.
 		 */
 		if (device == NULL) {
+#ifdef HAVE_PCAP_FINDALLDEVS
+			if (pcap_findalldevs(&devpointer, ebuf) >= 0 && devpointer != NULL)
+				device = devpointer->name;
+#else /* HAVE_PCAP_FINDALLDEVS */
 			device = pcap_lookupdev(ebuf);
+#endif
 			if (device == NULL)
 				error("%s", ebuf);
 		}


### PR DESCRIPTION
WinDump defaults to the wrong interface on my machine. Reproducing [my message](https://www.winpcap.org/pipermail/winpcap-bugs/2015-August/002178.html) to (unresponsive) [winpcap-bugs](mailto:winpcap-bugs@winpcap.org) for reference:
> WinDump -D prints the list of network interfaces, whereas WinDump -i 1 captures packets from the topmost entry in that list. So far, so good. According to https://www.winpcap.org/windump/docs/manual.htm, the same thing should happen if the executable is called without any arguments:
> > If unspecified, tcpdump searches the system interface list for the lowest numbered, configured up interface (excluding loopback). 
>
> This works on UNIX, but unfortunately behaves differently on Windows. The interface to listen on is determined with pcap_findalldevs in the -D/-i case, and with pcap_lookupdev otherwise. The former sorts them according to the numbers in their name. The latter's implementations differ: on UNIX it simply calls pcap_findalldevs and takes the first entry in that list, but on Windows it chooses the first interface without any further calls to pcap_findalldevs, and without any additional sorting.