### PR TITLE
Free all and entire lists pcap_findalldevs() returns

### DIFF
--- a/tcpdump.c
+++ b/tcpdump.c
@@ -716,7 +716,7 @@ main(int argc, char **argv)
 	char *ret = NULL;
 	char *end;
 #ifdef HAVE_PCAP_FINDALLDEVS
-	pcap_if_t *devpointer;
+	pcap_if_t *p, *devpointer;
 	int devnum;
 #endif
 	int status;
@@ -889,13 +889,13 @@ main(int argc, char **argv)
 				 * Look for the devnum-th entry in the
 				 * list of devices (1-based).
 				 */
-				for (i = 0;
-				    i < devnum-1 && devpointer != NULL;
-				    i++, devpointer = devpointer->next)
+				for (i = 0, p = devpointer;
+				    i < devnum-1 && p != NULL;
+				    i++, p = p->next)
 					;
-				if (devpointer == NULL)
+				if (p == NULL)
 					error("Invalid adapter index");
-				device = strdup(devpointer->name);
+				device = strdup(p->name);
 				pcap_freealldevs(devpointer);
 				break;
 			}

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -299,23 +299,21 @@ show_dlts_and_exit(const char *device)
 static void
 show_devices_and_exit (void)
 {
-	pcap_if_t *devpointer;
+	pcap_if_t *p, *devpointer;
 	char ebuf[PCAP_ERRBUF_SIZE];
 	int i;
 
 	if (pcap_findalldevs(&devpointer, ebuf) < 0)
 		error("%s", ebuf);
-	else {
-		for (i = 0; devpointer != NULL; i++) {
-			printf("%d.%s", i+1, devpointer->name);
-			if (devpointer->description != NULL)
-				printf(" (%s)", devpointer->description);
-			if (devpointer->flags != 0)
-				printf(" [%s]", bittok2str(status_flags, "none", devpointer->flags));
-			printf("\n");
-			devpointer = devpointer->next;
-		}
+	for (i = 0, p = devpointer; p != NULL; i++, p = p->next) {
+		printf("%d.%s", i+1, p->name);
+		if (p->description != NULL)
+			printf(" (%s)", p->description);
+		if (p->flags != 0)
+			printf(" [%s]", bittok2str(status_flags, "none", p->flags));
+		printf("\n");
 	}
+	pcap_freealldevs(devpointer);
 	exit(0);
 }
 #endif /* HAVE_PCAP_FINDALLDEVS */


### PR DESCRIPTION
The last commit only freed the remainder of the list, starting with the interface to listen on. I also changed `show_devices_and_exit()` along the lines of the last commit to make Valgrind shut up about the leak.