### PR TITLE
Fix capsicum support to work with zerocopy buffers in bpf.

### DIFF
--- a/tcpdump.c
+++ b/tcpdump.c
@@ -1555,7 +1555,7 @@ main(int argc, char **argv)
 		error("%s", pcap_geterr(pd));
 #ifdef HAVE_CAPSICUM
 	if (RFileName == NULL && VFileName == NULL) {
-		static const unsigned long cmds[] = { BIOCGSTATS };
+		static const unsigned long cmds[] = { BIOCGSTATS, BIOCROTZBUF };
 
 		cap_rights_init(&rights, CAP_IOCTL, CAP_READ);
 		if (cap_rights_limit(pcap_fileno(pd), &rights) < 0 &&


### PR DESCRIPTION
Zerocopcy buffers in bpf was broken until recently in FreeBSD and now that
it is fixed, tcpdump is failing with insuficient capabilities when trying to
use the BIOCROTZBUF ioctl.

This commit adds BIOCROTZBUF to the list of allowed ioctls.