### PR TITLE
Avoiding conditional directives that break statements

### DIFF
--- a/tcpdump.c
+++ b/tcpdump.c
@@ -1888,10 +1888,11 @@ static void
 compress_savefile(const char *filename)
 {
 # ifdef HAVE_FORK
-	if (fork())
+	#define test_fork fork()
 # else
-	if (vfork())
+	#define test_fork vfork()
 # endif
+	if(test_fork)
 		return;
 	/*
 	 * Set to lowest priority so that this doesn't disturb the capture


### PR DESCRIPTION
This change is only aesthetical, it's a suggestion based on code style guidelines from the Linux Kernel.
[Linux kernel coding style](https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892)