### PR TITLE
Adding support for BFD Multihop packets

### DIFF
--- a/print-bfd.c
+++ b/print-bfd.c
@@ -106,8 +106,9 @@ static const struct tok bfd_v1_authentication_values[] = {
 #define	BFD_EXTRACT_DIAG(x)     ((x)&0x1f)
 
 static const struct tok bfd_port_values[] = {
-    { BFD_CONTROL_PORT, "Control" },
-    { BFD_ECHO_PORT,    "Echo" },
+    { BFD_CONTROL_PORT,      "Control" },
+    { BFD_ECHO_PORT,         "Echo" },
+    { BFD_MHOP_CONTROL_PORT, "Multihop-Control" },
     { 0, NULL }
 };
 
@@ -166,7 +167,7 @@ bfd_print(netdissect_options *ndo, register const u_char *pptr,
         uint8_t version = 0;
 
         bfd_header = (const struct bfd_header_t *)pptr;
-        if (port == BFD_CONTROL_PORT) {
+        if (port == BFD_CONTROL_PORT || port == BFD_MHOP_CONTROL_PORT) {
             ND_TCHECK(*bfd_header);
             version = BFD_EXTRACT_VERSION(bfd_header->version_diag);
         } else if (port == BFD_ECHO_PORT) {
@@ -210,6 +211,11 @@ bfd_print(netdissect_options *ndo, register const u_char *pptr,
 
             /* BFDv1 */
         case (BFD_CONTROL_PORT << 8 | 1):
+	    /* 
+             * Fall-through. No difference between Singlehop and Multihop 
+             * control packets except UDP port numbers 
+             */
+	case (BFD_MHOP_CONTROL_PORT << 8 | 1):
             if (ndo->ndo_vflag < 1)
             {
                 ND_PRINT((ndo, "BFDv%u, %s, State %s, Flags: [%s], length: %u",

--- a/print-udp.c
+++ b/print-udp.c
@@ -620,7 +620,8 @@ udp_print(netdissect_options *ndo, register const u_char *bp, u_int length,
 		else if (IS_SRC_OR_DST_PORT(MPLS_LSP_PING_PORT))
 			lspping_print(ndo, (const u_char *)(up + 1), length);
 		else if (dport == BFD_CONTROL_PORT ||
-			 dport == BFD_ECHO_PORT )
+			 dport == BFD_ECHO_PORT || 
+			 dport == BFD_MHOP_CONTROL_PORT)
 			bfd_print(ndo, (const u_char *)(up+1), length, dport);
                 else if (IS_SRC_OR_DST_PORT(LMP_PORT))
 			lmp_print(ndo, (const u_char *)(up + 1), length);

--- a/udp.h
+++ b/udp.h
@@ -260,6 +260,9 @@ struct udphdr {
 #ifndef WB_PORT
 #define WB_PORT				4567
 #endif
+#ifndef BFD_MHOP_CONTROL_PORT
+#define BFD_MHOP_CONTROL_PORT		4784	/* RFC 5883 */
+#endif
 #ifndef VXLAN_PORT
 #define VXLAN_PORT			4789	/* RFC 7348 */
 #endif


### PR DESCRIPTION
1. RFC 5883 states BFD Multihop packets differ from Singlehop only
   in that the UDP port is 4784. Also Multihop doesn't support Echo
2. Test on IPv4 and IPv6 using crafted packets

tcpdump: listening on lo, link-type EN10MB (Ethernet), capture size 262144 bytes
13:47:28.662854 IP (tos 0x0, ttl 64, id 1, offset 0, flags [none], proto UDP (17), length 52)
    localhost.49152 > localhost.4784: [udp sum ok] BFDv1, length: 24
    Multihop-Control, State Up, Flags: [none], Diagnostic: No Diagnostic (0x00)
    Detection Timer Multiplier: 3 (150 ms Detection time), BFD Length: 24
    My Discriminator: 0x00000001, Your Discriminator: 0x0000000a
      Desired min Tx Interval:      50 ms
      Required min Rx Interval:     50 ms
      Required min Echo Interval:  100 ms
13:47:34.840662 IP6 (hlim 64, next-header UDP (17) payload length: 32)
     ip6-localhost.49152 > ip6-localhost.4784: [udp sum ok] BFDv1, length: 24
    Multihop-Control, State Up, Flags: [none], Diagnostic: No Diagnostic (0x00)
    Detection Timer Multiplier: 3 (150 ms Detection time), BFD Length: 24
    My Discriminator: 0x00000001, Your Discriminator: 0x0000000a
      Desired min Tx Interval:      50 ms
      Required min Rx Interval:     50 ms
      Required min Echo Interval:  100 ms
