### PR TITLE
Fixes issue where statistics not reported when -G and -W options used

### DIFF
--- a/tcpdump.c
+++ b/tcpdump.c
@@ -2053,6 +2053,7 @@ dump_packet_and_trunc(u_char *user, const struct pcap_pkthdr *h, const u_char *s
 			if (Cflag == 0 && Wflag > 0 && Gflag_count >= Wflag) {
 				(void)fprintf(stderr, "Maximum file limit reached: %d\n",
 				    Wflag);
+				info(1);
 				exit(0);
 				/* NOTREACHED */
 			}


### PR DESCRIPTION
Added missing call to `info()`.

https://github.com/the-tcpdump-group/tcpdump/issues/503
