### PR TITLE
Don't recompile filter for every file.

### DIFF
--- a/tcpdump.c
+++ b/tcpdump.c
@@ -1829,8 +1829,6 @@ main(int argc, char **argv)
 					RFileName, dlt_name,
 					pcap_datalink_val_to_description(new_dlt));
 				}
-				if (pcap_compile(pd, &fcode, cmdbuf, Oflag, netmask) < 0)
-					error("%s", pcap_geterr(pd));
 				if (pcap_setfilter(pd, &fcode) < 0)
 					error("%s", pcap_geterr(pd));
 			}


### PR DESCRIPTION
When reading multiple files using the -V option, the filter should be compiled once and reused since there is no way to change it between files.

This will substantially speed things up when operating on a large number of small pcap files with a complicated filter.