### PR TITLE
Correct TCP option Kind value for TCP Auth and add SCPS-TP.

### DIFF
--- a/print-tcp.c
+++ b/print-tcp.c
@@ -125,8 +125,9 @@ static const struct tok tcp_option_values[] = {
         { TCPOPT_CCNEW, "ccnew" },
         { TCPOPT_CCECHO, "" },
         { TCPOPT_SIGNATURE, "md5" },
-        { TCPOPT_AUTH, "enhanced auth" },
+        { TCPOPT_SCPS, "scps" },
         { TCPOPT_UTO, "uto" },
+        { TCPOPT_AUTH, "enhanced auth" },
         { TCPOPT_MPTCP, "mptcp" },
         { TCPOPT_FASTOPEN, "tfo" },
         { TCPOPT_EXPERIMENT2, "exp" },
@@ -532,6 +533,12 @@ tcp_print(netdissect_options *ndo,
                                 for (i = 0; i < TCP_SIGLEN; ++i)
                                         ND_PRINT((ndo, "%02x", cp[i]));
 #endif
+                                break;
+
+                        case TCPOPT_SCPS:
+                                datalen = 2;
+                                LENCHECK(datalen);
+                                ND_PRINT((ndo, " cap %02x id %u", cp[0], cp[1]));
                                 break;
 
                         case TCPOPT_AUTH:

--- a/tcp.h
+++ b/tcp.h
@@ -81,9 +81,10 @@ struct tcphdr {
 #define TCPOPT_SIGNATURE	19	/* Keyed MD5 (rfc2385) */
 #define    TCPOLEN_SIGNATURE		18
 #define TCP_SIGLEN 16			/* length of an option 19 digest */
-#define TCPOPT_AUTH             20      /* Enhanced AUTH option */
+#define TCPOPT_SCPS		20	/* SCPS-TP (CCSDS 714.0-B-2) */
 #define	TCPOPT_UTO		28	/* tcp user timeout (rfc5482) */
 #define	   TCPOLEN_UTO			4
+#define TCPOPT_AUTH		29	/* Enhanced AUTH option (rfc5925) */
 #define	TCPOPT_MPTCP		30	/* MPTCP options */
 #define TCPOPT_FASTOPEN		34	/* TCP Fast Open (rfc7413) */
 #define TCPOPT_EXPERIMENT2	254	/* experimental headers (rfc4727) */


### PR DESCRIPTION
Fixes first problem in issue #516 while the second one isn't broken in tcpdump.

https://www.iana.org/assignments/tcp-parameters/tcp-parameters.xhtml

See section 3.2.3 on page 20 in http://public.ccsds.org/publications/archive/714x0b2.pdf

Review carefully because I haven't been able to test it with TCP Auth and SCPS-TP packets.
