### PR TITLE
Don't accept zero -C or -W options

### DIFF
--- a/tcpdump.c
+++ b/tcpdump.c
@@ -864,7 +864,7 @@ main(int argc, char **argv)
 
 		case 'C':
 			Cflag = atoi(optarg) * 1000000;
-			if (Cflag < 0)
+			if (Cflag <= 0)
 				error("invalid file size %s", optarg);
 			break;
 
@@ -1145,7 +1145,7 @@ main(int argc, char **argv)
 
 		case 'W':
 			Wflag = atoi(optarg);
-			if (Wflag < 0)
+			if (Wflag <= 0)
 				error("invalid number of output files %s", optarg);
 			WflagChars = getWflagChars(Wflag);
 			break;


### PR DESCRIPTION
Rolling over into zero filesize makes no sense. Creating a rotating
buffer of zero files makes no sense.

Modify the checks for -C and -W to accept greater than one, not greater
than zero.

Signed-off-by: Jamie Bainbridge <jamie.bainbiridge@gmail.com>