### PR TITLE
Geneve TLV Option Classes

### DIFF
--- a/print-geneve.c
+++ b/print-geneve.c
@@ -183,7 +183,7 @@ geneve_print(netdissect_options *ndo, const u_char *bp, u_int len)
 
     if (len < opts_len) {
         ND_PRINT((ndo, " truncated-geneve - %u bytes missing",
-                  len - opts_len));
+                  opts_len - len));
         return;
     }
 

--- a/print-geneve.c
+++ b/print-geneve.c
@@ -26,7 +26,7 @@
 #include "ethertype.h"
 
 /*
- * Geneve header, draft-gross-geneve-02
+ * Geneve header, draft-ietf-nvo3-geneve
  *
  *    0                   1                   2                   3
  *    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -76,12 +76,25 @@ static const struct tok geneve_flag_values[] = {
 static const char *
 format_opt_class(uint16_t opt_class)
 {
-    if (opt_class <= 0xff)
-        return "Standard";
-    else if (opt_class == 0xffff)
-        return "Experimental";
-    else
-        return "Unknown";
+    switch (opt_class) {
+    case 0x0100:
+        return "Linux";
+    case 0x0101:
+        return "Open vSwitch";
+    case 0x0102:
+        return "Open Virtual Networking (OVN)";
+    case 0x0103:
+        return "In-band Network Telemetry (INT)";
+    case 0x0104:
+        return "VMware";
+    default:
+        if (opt_class <= 0x00ff)
+            return "Standard";
+        else if (opt_class >= 0xfff0)
+            return "Experimental";
+    }
+
+    return "Unknown";
 }
 
 static void


### PR DESCRIPTION
The latest versions of the Geneve draft (https://tools.ietf.org/html/draft-ietf-nvo3-geneve-02) have additional assignments for option classes. This adds support for printing them by name instead of by hex value.