### PR TITLE
Replace exit() with the new exit_tcpdump(), which calls smiExit()

### DIFF
--- a/interface.h
+++ b/interface.h
@@ -81,7 +81,7 @@ extern void warning(const char *, ...)
 #endif /* __ATTRIBUTE___FORMAT_OK */
      ;
 
-extern void tcpdump_exit(int status) __attribute__((noreturn));
+extern void exit_tcpdump(int status) __attribute__((noreturn));
 
 extern char *read_infile(char *);
 extern char *copy_argv(char **);

--- a/interface.h
+++ b/interface.h
@@ -81,6 +81,8 @@ extern void warning(const char *, ...)
 #endif /* __ATTRIBUTE___FORMAT_OK */
      ;
 
+extern void tcpdump_exit(int status) __attribute__((noreturn));
+
 extern char *read_infile(char *);
 extern char *copy_argv(char **);
 

--- a/print-esp.c
+++ b/print-esp.c
@@ -465,7 +465,7 @@ static void esp_print_decode_onesecret(netdissect_options *ndo, char *line,
 		secretfile = fopen(filename, FOPEN_READ_TXT);
 		if (secretfile == NULL) {
 			perror(filename);
-			tcpdump_exit(3);
+			exit_tcpdump(3);
 		}
 
 		while (fgets(fileline, sizeof(fileline)-1, secretfile) != NULL) {

--- a/print-esp.c
+++ b/print-esp.c
@@ -43,6 +43,7 @@
 #endif
 
 #include "netdissect.h"
+#include "interface.h"
 #include "strtoaddr.h"
 #include "extract.h"
 
@@ -464,7 +465,7 @@ static void esp_print_decode_onesecret(netdissect_options *ndo, char *line,
 		secretfile = fopen(filename, FOPEN_READ_TXT);
 		if (secretfile == NULL) {
 			perror(filename);
-			exit(3);
+			tcpdump_exit(3);
 		}
 
 		while (fgets(fileline, sizeof(fileline)-1, secretfile) != NULL) {

--- a/print.c
+++ b/print.c
@@ -35,6 +35,7 @@
 #include <netdissect-stdinc.h>
 
 #include "netdissect.h"
+#include "interface.h"
 #include "addrtoname.h"
 #include "print.h"
 
@@ -429,7 +430,7 @@ ndo_error(netdissect_options *ndo, const char *fmt, ...)
 		if (fmt[-1] != '\n')
 			(void)fputc('\n', stderr);
 	}
-	exit(1);
+	tcpdump_exit(1);
 	/* NOTREACHED */
 }
 

--- a/print.c
+++ b/print.c
@@ -430,7 +430,7 @@ ndo_error(netdissect_options *ndo, const char *fmt, ...)
 		if (fmt[-1] != '\n')
 			(void)fputc('\n', stderr);
 	}
-	tcpdump_exit(1);
+	exit_tcpdump(1);
 	/* NOTREACHED */
 }
 

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -288,7 +288,7 @@ show_tstamp_types_and_exit(const char *device)
 	if (n_tstamp_types == 0) {
 		fprintf(stderr, "Time stamp type cannot be set for %s\n",
 		    device);
-		tcpdump_exit(0);
+		exit_tcpdump(0);
 	}
 	fprintf(stderr, "Time stamp types for %s (use option -j to set):\n",
 	    device);
@@ -302,7 +302,7 @@ show_tstamp_types_and_exit(const char *device)
 		}
 	}
 	pcap_free_tstamp_types(tstamp_types);
-	tcpdump_exit(0);
+	exit_tcpdump(0);
 }
 #endif
 
@@ -355,7 +355,7 @@ show_dlts_and_exit(const char *device)
 #ifdef HAVE_PCAP_FREE_DATALINKS
 	pcap_free_datalinks(dlts);
 #endif
-	tcpdump_exit(0);
+	exit_tcpdump(0);
 }
 
 #ifdef HAVE_PCAP_FINDALLDEVS
@@ -377,7 +377,7 @@ show_devices_and_exit (void)
 		printf("\n");
 	}
 	pcap_freealldevs(devlist);
-	tcpdump_exit(0);
+	exit_tcpdump(0);
 }
 #endif /* HAVE_PCAP_FINDALLDEVS */
 
@@ -535,7 +535,7 @@ droproot(const char *username, const char *chroot_dir)
 	if (chroot_dir && !username) {
 		fprintf(stderr, "%s: Chroot without dropping root is insecure\n",
 			program_name);
-		tcpdump_exit(1);
+		exit_tcpdump(1);
 	}
 
 	pw = getpwnam(username);
@@ -544,7 +544,7 @@ droproot(const char *username, const char *chroot_dir)
 			if (chroot(chroot_dir) != 0 || chdir ("/") != 0) {
 				fprintf(stderr, "%s: Couldn't chroot/chdir to '%.64s': %s\n",
 					program_name, chroot_dir, pcap_strerror(errno));
-				tcpdump_exit(1);
+				exit_tcpdump(1);
 			}
 		}
 #ifdef HAVE_LIBCAP_NG
@@ -564,7 +564,7 @@ droproot(const char *username, const char *chroot_dir)
 				(unsigned long)pw->pw_uid,
 				(unsigned long)pw->pw_gid,
 				pcap_strerror(errno));
-			tcpdump_exit(1);
+			exit_tcpdump(1);
 		}
 		else {
 			fprintf(stderr, "dropped privs to %s\n", username);
@@ -574,7 +574,7 @@ droproot(const char *username, const char *chroot_dir)
 	else {
 		fprintf(stderr, "%s: Couldn't find user '%.32s'\n",
 			program_name, username);
-		tcpdump_exit(1);
+		exit_tcpdump(1);
 	}
 #ifdef HAVE_LIBCAP_NG
 	/* We don't need CAP_SETUID and CAP_SETGID any more. */
@@ -916,7 +916,7 @@ main(int argc, char **argv)
 
 		case 'h':
 			print_usage();
-			tcpdump_exit(0);
+			exit_tcpdump(0);
 			break;
 
 		case 'H':
@@ -1190,7 +1190,7 @@ main(int argc, char **argv)
 
 		case OPTION_VERSION:
 			print_version();
-			tcpdump_exit(0);
+			exit_tcpdump(0);
 			break;
 
 #ifdef HAVE_PCAP_SET_TSTAMP_PRECISION
@@ -1209,7 +1209,7 @@ main(int argc, char **argv)
 
 		default:
 			print_usage();
-			tcpdump_exit(1);
+			exit_tcpdump(1);
 			/* NOTREACHED */
 		}
 
@@ -1544,7 +1544,7 @@ main(int argc, char **argv)
 		pcap_close(pd);
 		free(cmdbuf);
 		pcap_freecode(&fcode);
-		tcpdump_exit(0);
+		exit_tcpdump(0);
 	}
 	init_print(ndo, localnet, netmask, timezone_offset);
 
@@ -1879,7 +1879,7 @@ main(int argc, char **argv)
 
 	free(cmdbuf);
 	pcap_freecode(&fcode);
-	tcpdump_exit(status == -1 ? 1 : 0);
+	exit_tcpdump(status == -1 ? 1 : 0);
 }
 
 /* make a clean exit on interrupts */
@@ -1919,7 +1919,7 @@ cleanup(int signo _U_)
 		(void)fflush(stdout);
 		info(1);
 	}
-	tcpdump_exit(0);
+	exit_tcpdump(0);
 #endif
 }
 
@@ -2019,7 +2019,7 @@ compress_savefile(const char *filename)
 			filename,
 			pcap_strerror(errno));
 #ifdef HAVE_FORK
-	tcpdump_exit(1);
+	exit_tcpdump(1);
 #else
 	_exit(1);
 #endif
@@ -2092,7 +2092,7 @@ dump_packet_and_trunc(u_char *user, const struct pcap_pkthdr *h, const u_char *s
 			if (Cflag == 0 && Wflag > 0 && Gflag_count >= Wflag) {
 				(void)fprintf(stderr, "Maximum file limit reached: %d\n",
 				    Wflag);
-				tcpdump_exit(0);
+				exit_tcpdump(0);
 				/* NOTREACHED */
 			}
 			if (dump_info->CurrentFileName != NULL)

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -288,7 +288,7 @@ show_tstamp_types_and_exit(const char *device)
 	if (n_tstamp_types == 0) {
 		fprintf(stderr, "Time stamp type cannot be set for %s\n",
 		    device);
-		exit(0);
+		tcpdump_exit(0);
 	}
 	fprintf(stderr, "Time stamp types for %s (use option -j to set):\n",
 	    device);
@@ -302,7 +302,7 @@ show_tstamp_types_and_exit(const char *device)
 		}
 	}
 	pcap_free_tstamp_types(tstamp_types);
-	exit(0);
+	tcpdump_exit(0);
 }
 #endif
 
@@ -355,7 +355,7 @@ show_dlts_and_exit(const char *device)
 #ifdef HAVE_PCAP_FREE_DATALINKS
 	pcap_free_datalinks(dlts);
 #endif
-	exit(0);
+	tcpdump_exit(0);
 }
 
 #ifdef HAVE_PCAP_FINDALLDEVS
@@ -377,7 +377,7 @@ show_devices_and_exit (void)
 		printf("\n");
 	}
 	pcap_freealldevs(devlist);
-	exit(0);
+	tcpdump_exit(0);
 }
 #endif /* HAVE_PCAP_FINDALLDEVS */
 
@@ -535,7 +535,7 @@ droproot(const char *username, const char *chroot_dir)
 	if (chroot_dir && !username) {
 		fprintf(stderr, "%s: Chroot without dropping root is insecure\n",
 			program_name);
-		exit(1);
+		tcpdump_exit(1);
 	}
 
 	pw = getpwnam(username);
@@ -544,7 +544,7 @@ droproot(const char *username, const char *chroot_dir)
 			if (chroot(chroot_dir) != 0 || chdir ("/") != 0) {
 				fprintf(stderr, "%s: Couldn't chroot/chdir to '%.64s': %s\n",
 					program_name, chroot_dir, pcap_strerror(errno));
-				exit(1);
+				tcpdump_exit(1);
 			}
 		}
 #ifdef HAVE_LIBCAP_NG
@@ -564,7 +564,7 @@ droproot(const char *username, const char *chroot_dir)
 				(unsigned long)pw->pw_uid,
 				(unsigned long)pw->pw_gid,
 				pcap_strerror(errno));
-			exit(1);
+			tcpdump_exit(1);
 		}
 		else {
 			fprintf(stderr, "dropped privs to %s\n", username);
@@ -574,7 +574,7 @@ droproot(const char *username, const char *chroot_dir)
 	else {
 		fprintf(stderr, "%s: Couldn't find user '%.32s'\n",
 			program_name, username);
-		exit(1);
+		tcpdump_exit(1);
 	}
 #ifdef HAVE_LIBCAP_NG
 	/* We don't need CAP_SETUID and CAP_SETGID any more. */
@@ -916,7 +916,7 @@ main(int argc, char **argv)
 
 		case 'h':
 			print_usage();
-			exit(0);
+			tcpdump_exit(0);
 			break;
 
 		case 'H':
@@ -1190,7 +1190,7 @@ main(int argc, char **argv)
 
 		case OPTION_VERSION:
 			print_version();
-			exit(0);
+			tcpdump_exit(0);
 			break;
 
 #ifdef HAVE_PCAP_SET_TSTAMP_PRECISION
@@ -1209,7 +1209,7 @@ main(int argc, char **argv)
 
 		default:
 			print_usage();
-			exit(1);
+			tcpdump_exit(1);
 			/* NOTREACHED */
 		}
 
@@ -1544,7 +1544,7 @@ main(int argc, char **argv)
 		pcap_close(pd);
 		free(cmdbuf);
 		pcap_freecode(&fcode);
-		exit(0);
+		tcpdump_exit(0);
 	}
 	init_print(ndo, localnet, netmask, timezone_offset);
 
@@ -1879,7 +1879,7 @@ main(int argc, char **argv)
 
 	free(cmdbuf);
 	pcap_freecode(&fcode);
-	exit(status == -1 ? 1 : 0);
+	tcpdump_exit(status == -1 ? 1 : 0);
 }
 
 /* make a clean exit on interrupts */
@@ -1919,7 +1919,7 @@ cleanup(int signo _U_)
 		(void)fflush(stdout);
 		info(1);
 	}
-	exit(0);
+	tcpdump_exit(0);
 #endif
 }
 
@@ -2019,7 +2019,7 @@ compress_savefile(const char *filename)
 			filename,
 			pcap_strerror(errno));
 #ifdef HAVE_FORK
-	exit(1);
+	tcpdump_exit(1);
 #else
 	_exit(1);
 #endif
@@ -2092,7 +2092,7 @@ dump_packet_and_trunc(u_char *user, const struct pcap_pkthdr *h, const u_char *s
 			if (Cflag == 0 && Wflag > 0 && Gflag_count >= Wflag) {
 				(void)fprintf(stderr, "Maximum file limit reached: %d\n",
 				    Wflag);
-				exit(0);
+				tcpdump_exit(0);
 				/* NOTREACHED */
 			}
 			if (dump_info->CurrentFileName != NULL)

--- a/util.c
+++ b/util.c
@@ -51,6 +51,11 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef USE_LIBSMI
+#include <smi.h>
+#endif
+
+
 #include "interface.h"
 
 /* VARARGS */
@@ -68,7 +73,7 @@ error(const char *fmt, ...)
 		if (fmt[-1] != '\n')
 			(void)fputc('\n', stderr);
 	}
-	exit(1);
+	tcpdump_exit(1);
 	/* NOTREACHED */
 }
 
@@ -87,6 +92,17 @@ warning(const char *fmt, ...)
 		if (fmt[-1] != '\n')
 			(void)fputc('\n', stderr);
 	}
+}
+
+
+extern void tcpdump_exit(int status)
+{
+
+#ifdef USE_LIBSMI
+    smiExit();
+#endif
+
+    exit(status);
 }
 
 /*

--- a/util.c
+++ b/util.c
@@ -73,7 +73,7 @@ error(const char *fmt, ...)
 		if (fmt[-1] != '\n')
 			(void)fputc('\n', stderr);
 	}
-	tcpdump_exit(1);
+	exit_tcpdump(1);
 	/* NOTREACHED */
 }
 
@@ -95,7 +95,7 @@ warning(const char *fmt, ...)
 }
 
 
-extern void tcpdump_exit(int status)
+extern void exit_tcpdump(int status)
 {
 
 #ifdef USE_LIBSMI


### PR DESCRIPTION
As suggested by @guyharris here - https://github.com/the-tcpdump-group/tcpdump/issues/529:

New function exit_tcpdump(), which calls smiExit()(if USE_LIBSMI is defined), introduced.
All calls to exit(), including the one in utils.c:error() replaced with call to this new function.

smiExit() is leaking one memory allocation, which libsmi team has been informed of along
with some preliminary investigation report and offer to assist.


Before calling smiExit():

> 
$ valgrind tcpdump -h 
.
.
.
==4311== 
==4311== HEAP SUMMARY:
==4311==     in use at exit: 320,870 bytes in 3,830 blocks
==4311==   total heap usage: 6,445 allocs, 2,615 frees, 586,344 bytes allocated
==4311== 
==4311== LEAK SUMMARY:
==4311==    definitely lost: 744 bytes in 53 blocks
==4311==    indirectly lost: 0 bytes in 0 blocks
==4311==      possibly lost: 0 bytes in 0 blocks
==4311==    still reachable: 320,126 bytes in 3,777 blocks
==4311==         suppressed: 0 bytes in 0 blocks
==4311== Rerun with --leak-check=full to see details of leaked memory
.
.
.


After calling smiExit():
> $ valgrind tcpdump -h 
.
.
.
==4320== 
==4320== HEAP SUMMARY:
==4320==     in use at exit: 816 bytes in 54 blocks
==4320==   total heap usage: 6,445 allocs, 6,391 frees, 586,344 bytes allocated
==4320== 
==4320== LEAK SUMMARY:
==4320==    definitely lost: 744 bytes in 53 blocks
==4320==    indirectly lost: 0 bytes in 0 blocks
==4320==      possibly lost: 0 bytes in 0 blocks
==4320==    still reachable: 72 bytes in 1 blocks
==4320==         suppressed: 0 bytes in 0 blocks
==4320== Rerun with --leak-check=full to see details of leaked memory
.
.
.
