### PR TITLE
Add support for libcasper library available on FreeBSD 11.0 and newer.

### DIFF
--- a/addrtoname.c
+++ b/addrtoname.c
@@ -26,6 +26,11 @@
 #include "config.h"
 #endif
 
+#ifdef HAVE_CASPER
+#include <libcasper.h>
+#include <casper/cap_dns.h>
+#endif /* HAVE_CASPER */
+
 #include <netdissect-stdinc.h>
 
 #ifdef USE_ETHER_NTOHOST
@@ -197,6 +202,9 @@ intoa(uint32_t addr)
 
 static uint32_t f_netmask;
 static uint32_t f_localnet;
+#ifdef HAVE_CASPER
+extern cap_channel_t *capdns;
+#endif
 
 /*
  * Return a name for the IP address pointed to by ap.  This address
@@ -242,7 +250,13 @@ getname(netdissect_options *ndo, const u_char *ap)
 	 */
 	if (!ndo->ndo_nflag &&
 	    (addr & f_netmask) == f_localnet) {
-		hp = gethostbyaddr((char *)&addr, 4, AF_INET);
+#ifdef HAVE_CASPER
+		if (capdns != NULL) {
+			hp = cap_gethostbyaddr(capdns, (char *)&addr, 4,
+			    AF_INET);
+		} else
+#endif
+			hp = gethostbyaddr((char *)&addr, 4, AF_INET);
 		if (hp) {
 			char *dotp;
 
@@ -297,7 +311,14 @@ getname6(netdissect_options *ndo, const u_char *ap)
 	 * Do not print names if -n was given.
 	 */
 	if (!ndo->ndo_nflag) {
-		hp = gethostbyaddr((char *)&addr, sizeof(addr), AF_INET6);
+#ifdef HAVE_CASPER
+		if (capdns != NULL) {
+			hp = cap_gethostbyaddr(capdns, (char *)&addr,
+			    sizeof(addr), AF_INET6);
+		} else
+#endif
+			hp = gethostbyaddr((char *)&addr, sizeof(addr),
+			    AF_INET6);
 		if (hp) {
 			char *dotp;
 

--- a/config.h.in
+++ b/config.h.in
@@ -12,8 +12,8 @@
 /* capsicum support available */
 #undef HAVE_CAPSICUM
 
-/* Define to 1 if you have the `cap_enter' function. */
-#undef HAVE_CAP_ENTER
+/* Casper library available */
+#undef HAVE_CASPER
 
 /* Define to 1 if you have the `cap_ioctls_limit' function. */
 #undef HAVE_CAP_IOCTLS_LIMIT

--- a/configure
+++ b/configure
@@ -4588,12 +4588,104 @@ else
 fi
 done
 
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for cap_init in -lcasper" >&5
+$as_echo_n "checking for cap_init in -lcasper... " >&6; }
+if ${ac_cv_lib_casper_cap_init+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lcasper  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char cap_init ();
+int
+main ()
+{
+return cap_init ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_casper_cap_init=yes
+else
+  ac_cv_lib_casper_cap_init=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_casper_cap_init" >&5
+$as_echo "$ac_cv_lib_casper_cap_init" >&6; }
+if test "x$ac_cv_lib_casper_cap_init" = xyes; then :
+  LIBS="$LIBS -lcasper"
+fi
+
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for cap_gethostbyaddr in -lcap_dns" >&5
+$as_echo_n "checking for cap_gethostbyaddr in -lcap_dns... " >&6; }
+if ${ac_cv_lib_cap_dns_cap_gethostbyaddr+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lcap_dns  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char cap_gethostbyaddr ();
+int
+main ()
+{
+return cap_gethostbyaddr ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_cap_dns_cap_gethostbyaddr=yes
+else
+  ac_cv_lib_cap_dns_cap_gethostbyaddr=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_cap_dns_cap_gethostbyaddr" >&5
+$as_echo "$ac_cv_lib_cap_dns_cap_gethostbyaddr" >&6; }
+if test "x$ac_cv_lib_cap_dns_cap_gethostbyaddr" = xyes; then :
+  LIBS="$LIBS -lcap_dns"
+fi
+
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to sandbox using capsicum" >&5
 $as_echo_n "checking whether to sandbox using capsicum... " >&6; }
 if test "x$ac_lbl_capsicum_function_seen" = "xyes" -a "x$ac_lbl_capsicum_function_not_seen" != "xyes"; then
 
 $as_echo "#define HAVE_CAPSICUM 1" >>confdefs.h
+
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+else
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to sandbox using Casper library" >&5
+$as_echo_n "checking whether to sandbox using Casper library... " >&6; }
+if test "x$ac_cv_lib_casper_cap_init" = "xyes" -a "x$ac_cv_lib_cap_dns_cap_gethostbyaddr" = "xyes"; then
+
+$as_echo "#define HAVE_CASPER 1" >>confdefs.h
 
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }

--- a/configure.in
+++ b/configure.in
@@ -225,10 +225,19 @@ if test ! -z "$with_sandbox-capsicum" && test "$with_sandbox-capsicum" != "no" ;
 	AC_CHECK_FUNCS(cap_enter cap_rights_limit cap_ioctls_limit openat,
 	    ac_lbl_capsicum_function_seen=yes,
 	    ac_lbl_capsicum_function_not_seen=yes)
+	AC_CHECK_LIB(casper, cap_init, LIBS="$LIBS -lcasper")
+	AC_CHECK_LIB(cap_dns, cap_gethostbyaddr, LIBS="$LIBS -lcap_dns")
 fi
 AC_MSG_CHECKING([whether to sandbox using capsicum])
 if test "x$ac_lbl_capsicum_function_seen" = "xyes" -a "x$ac_lbl_capsicum_function_not_seen" != "xyes"; then
 	AC_DEFINE(HAVE_CAPSICUM, 1, [capsicum support available])
+	AC_MSG_RESULT(yes)
+else
+	AC_MSG_RESULT(no)
+fi
+AC_MSG_CHECKING([whether to sandbox using Casper library])
+if test "x$ac_cv_lib_casper_cap_init" = "xyes" -a "x$ac_cv_lib_cap_dns_cap_gethostbyaddr" = "xyes"; then
+	AC_DEFINE(HAVE_CASPER, 1, [Casper support available])
 	AC_MSG_RESULT(yes)
 else
 	AC_MSG_RESULT(no)


### PR DESCRIPTION
The patch allows tcpdump to run sandboxed and still do name resolution.

The code is obtained from FreeBSD tree, where it was developed by

Pawel Jakub Dawidek <pjd@FreeBSD.org>
Mariusz Zaborski <oshogbo@FreeBSD.org>