### PR TITLE
Fix typo in printing full name of CFM's CCM opcode value.

### DIFF
--- a/print-cfm.c
+++ b/print-cfm.c
@@ -50,7 +50,7 @@ struct cfm_common_header_t {
 #define	CFM_OPCODE_LTM 5
 
 static const struct tok cfm_opcode_values[] = {
-    { CFM_OPCODE_CCM, "Continouity Check Message"},
+    { CFM_OPCODE_CCM, "Continuity Check Message"},
     { CFM_OPCODE_LBR, "Loopback Reply"},
     { CFM_OPCODE_LBM, "Loopback Message"},
     { CFM_OPCODE_LTR, "Linktrace Reply"},


### PR DESCRIPTION
Note that the following tests fail when I run make check, it does not seem plausible that my change broke them, however in case you believe it plausible that it was my change I am including the information so you can reject it:

Failed test: pcap-invalid-version-2

1c1
\< EXIT CODE 00000100
---
\> IP6 fe80::b299:28ff:fec8:d646.6696 > ff02::1:6.6696: babel 2 (424) hello update/id request tspc hmac hmac hmac hmac hmac hmac hmac hmac
Failed test: pcap-ng-invalid-vers-2

1c1
\< EXIT CODE 00000100
---
\> IP6 fe80::20c:29ff:fe9e:c1b2 > ff02::5: OSPFv3, Hello, length 88
