### PR TITLE
Improvements of NTP printer

### DIFF
--- a/print-ntp.c
+++ b/print-ntp.c
@@ -309,10 +309,10 @@ ntp_print(netdissect_options *ndo,
 
 	if ( (sizeof(struct ntpdata) - length) == 16) { 	/* Optional: key-id */
 		ND_TCHECK(bp->key_id);
-		ND_PRINT((ndo, "\n\tKey id: %u", bp->key_id));
+		ND_PRINT((ndo, "\n\tKey id: %u", EXTRACT_32BITS(&bp->key_id)));
 	} else if ( (sizeof(struct ntpdata) - length) == 0) { 	/* Optional: key-id + authentication */
 		ND_TCHECK(bp->key_id);
-		ND_PRINT((ndo, "\n\tKey id: %u", bp->key_id));
+		ND_PRINT((ndo, "\n\tKey id: %u", EXTRACT_32BITS(&bp->key_id)));
 		ND_TCHECK2(bp->message_digest, sizeof (bp->message_digest));
                 ND_PRINT((ndo, "\n\tAuthentication: %08x%08x%08x%08x",
         		       EXTRACT_32BITS(bp->message_digest),

--- a/print-ntp.c
+++ b/print-ntp.c
@@ -279,7 +279,9 @@ ntp_print(netdissect_options *ndo,
 		return;
 
 	default:
-		ND_PRINT((ndo, "%s", ipaddr_string(ndo, &(bp->refid))));
+		/* In NTPv4 (RFC 5905) refid is an IPv4 address or first 32 bits of
+		   MD5 sum of IPv6 address */
+		ND_PRINT((ndo, "%08x", EXTRACT_32BITS(&bp->refid)));
 		break;
 	}
 

--- a/print-ntp.c
+++ b/print-ntp.c
@@ -126,7 +126,7 @@ struct ntpdata {
 	struct l_fixedpt rec_timestamp;
 	struct l_fixedpt xmt_timestamp;
         uint32_t key_id;
-        uint8_t  message_digest[16];
+        uint8_t  message_digest[20];
 };
 /*
  *	Leap Second Codes (high order two bits)
@@ -307,18 +307,28 @@ ntp_print(netdissect_options *ndo,
 	ND_PRINT((ndo, "\n\t    Originator - Transmit Timestamp: "));
 	p_ntp_delta(ndo, &(bp->org_timestamp), &(bp->xmt_timestamp));
 
-	if ( (sizeof(struct ntpdata) - length) == 16) { 	/* Optional: key-id */
+	if ( (sizeof(struct ntpdata) - length) == 20) { 	/* Optional: key-id (crypto-NAK) */
 		ND_TCHECK(bp->key_id);
 		ND_PRINT((ndo, "\n\tKey id: %u", EXTRACT_32BITS(&bp->key_id)));
-	} else if ( (sizeof(struct ntpdata) - length) == 0) { 	/* Optional: key-id + authentication */
+	} else if ( (sizeof(struct ntpdata) - length) == 4) { 	/* Optional: key-id + 128-bit digest */
 		ND_TCHECK(bp->key_id);
 		ND_PRINT((ndo, "\n\tKey id: %u", EXTRACT_32BITS(&bp->key_id)));
-		ND_TCHECK2(bp->message_digest, sizeof (bp->message_digest));
+		ND_TCHECK2(bp->message_digest, 16);
                 ND_PRINT((ndo, "\n\tAuthentication: %08x%08x%08x%08x",
         		       EXTRACT_32BITS(bp->message_digest),
 		               EXTRACT_32BITS(bp->message_digest + 4),
 		               EXTRACT_32BITS(bp->message_digest + 8),
 		               EXTRACT_32BITS(bp->message_digest + 12)));
+	} else if ( (sizeof(struct ntpdata) - length) == 0) { 	/* Optional: key-id + 160-bit digest */
+		ND_TCHECK(bp->key_id);
+		ND_PRINT((ndo, "\n\tKey id: %u", EXTRACT_32BITS(&bp->key_id)));
+		ND_TCHECK2(bp->message_digest, 20);
+		ND_PRINT((ndo, "\n\tAuthentication: %08x%08x%08x%08x%08x",
+		               EXTRACT_32BITS(bp->message_digest),
+		               EXTRACT_32BITS(bp->message_digest + 4),
+		               EXTRACT_32BITS(bp->message_digest + 8),
+		               EXTRACT_32BITS(bp->message_digest + 12),
+		               EXTRACT_32BITS(bp->message_digest + 16)));
         }
 	return;
 


### PR DESCRIPTION
Here are some improvements for the NTP printer to support sub-second polling intervals, MACs using 160-bit digests and reference IDs generated from IPv6 addresses. There is also a fix for printing key IDs.

I'd like to add a test for the NTP printer, but there is a problem that NTP timestamps are printed in local time and won't match the expected output unless the timezone is the same. Would it be ok to set TZ=UTC in tests/TESTonce?