### PR TITLE
Generate "CMakeLists.txt" to open tcpdump project with many IDEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.orig
 *.rej
 Makefile
+CMakeLists.txt
+CMakeLists.txt.user
 *~
 *.o
 libnetdissect.a

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -1,0 +1,297 @@
+#  Copyright (c) 2017 The TCPdump team
+#
+#  2-clause BSD license
+
+#
+# The file "CMakeLists.txt" is generated from "CMakeLists.txt.in" by the script ./configure
+# Remember to edit "CMakeLists.txt.in", not "CMakeLists.txt"
+#
+# Please keep correspondance between "Makefile.in" and "CMakeLists.txt.in" to ease maintenance.
+# Please verify your CMake-related changes using these command line options:
+# mkdir -p build ; cd build ; cmake .. -Wdeprecated -Wdev --warn-uninitialized
+#
+
+cmake_minimum_required(VERSION 2.8.12)
+# The most recent feature used in this file is "add_compile_options()"
+# that requires at least CMake-2.8.12 (Oct 2013)
+
+project(tcpdump LANGUAGES C)
+
+add_compile_options(@V_CCOPT@)
+string(REPLACE "-I" " " V_INCLS "@V_INCLS@")
+include_directories(. ${V_INCLS})
+add_definitions(@DEFS@ @CPPFLAGS@ @V_DEFS@)
+add_compile_options(@CFLAGS@)
+
+
+# Standard LIBS
+string(REPLACE " "  ""  LIBS "@LIBS@")
+string(REPLACE "-l" ";" LIBS ${LIBS})
+
+set(CSRC setsignal.c tcpdump.c)
+
+set(LIBNETDISSECT_SRC
+	addrtoname.c
+	addrtostr.c
+	af.c
+	ascii_strcasecmp.c
+	checksum.c
+	cpack.c
+	gmpls.c
+	gmt2local.c
+	in_cksum.c
+	ipproto.c
+	l2vpn.c
+	machdep.c
+	nlpid.c
+	oui.c
+	parsenfsfh.c
+	print.c
+	print-802_11.c
+	print-802_15_4.c
+	print-ah.c
+	print-ahcp.c
+	print-aodv.c
+	print-aoe.c
+	print-ap1394.c
+	print-arcnet.c
+	print-arp.c
+	print-ascii.c
+	print-atalk.c
+	print-atm.c
+	print-babel.c
+	print-beep.c
+	print-bfd.c
+	print-bgp.c
+	print-bootp.c
+	print-bt.c
+	print-calm-fast.c
+	print-carp.c
+	print-cdp.c
+	print-cfm.c
+	print-chdlc.c
+	print-cip.c
+	print-cnfp.c
+	print-dccp.c
+	print-decnet.c
+	print-dhcp6.c
+	print-domain.c
+	print-dtp.c
+	print-dvmrp.c
+	print-eap.c
+	print-egp.c
+	print-eigrp.c
+	print-enc.c
+	print-esp.c
+	print-ether.c
+	print-fddi.c
+	print-forces.c
+	print-fr.c
+	print-frag6.c
+	print-ftp.c
+	print-geneve.c
+	print-geonet.c
+	print-gre.c
+	print-hncp.c
+	print-hsrp.c
+	print-http.c
+	print-icmp.c
+	print-icmp6.c
+	print-igmp.c
+	print-igrp.c
+	print-ip.c
+	print-ip6.c
+	print-ip6opts.c
+	print-ipcomp.c
+	print-ipfc.c
+	print-ipnet.c
+	print-ipx.c
+	print-isakmp.c
+	print-isoclns.c
+	print-juniper.c
+	print-krb.c
+	print-l2tp.c
+	print-lane.c
+	print-ldp.c
+	print-lisp.c
+	print-llc.c
+	print-lldp.c
+	print-lmp.c
+	print-loopback.c
+	print-lspping.c
+	print-lwapp.c
+	print-lwres.c
+	print-m3ua.c
+	print-medsa.c
+	print-mobile.c
+	print-mobility.c
+	print-mpcp.c
+	print-mpls.c
+	print-mptcp.c
+	print-msdp.c
+	print-msnlb.c
+	print-nflog.c
+	print-nfs.c
+	print-nsh.c
+	print-ntp.c
+	print-null.c
+	print-olsr.c
+	print-openflow-1.0.c
+	print-openflow.c
+	print-ospf.c
+	print-ospf6.c
+	print-otv.c
+	print-pgm.c
+	print-pim.c
+	print-pktap.c
+	print-ppi.c
+	print-ppp.c
+	print-pppoe.c
+	print-pptp.c
+	print-radius.c
+	print-raw.c
+	print-resp.c
+	print-rip.c
+	print-ripng.c
+	print-rpki-rtr.c
+	print-rrcp.c
+	print-rsvp.c
+	print-rt6.c
+	print-rtsp.c
+	print-rx.c
+	print-sctp.c
+	print-sflow.c
+	print-sip.c
+	print-sl.c
+	print-sll.c
+	print-slow.c
+	print-smtp.c
+	print-snmp.c
+	print-stp.c
+	print-sunatm.c
+	print-sunrpc.c
+	print-symantec.c
+	print-syslog.c
+	print-tcp.c
+	print-telnet.c
+	print-tftp.c
+	print-timed.c
+	print-tipc.c
+	print-token.c
+	print-udld.c
+	print-udp.c
+	print-usb.c
+	print-vjc.c
+	print-vqp.c
+	print-vrrp.c
+	print-vtp.c
+	print-vxlan.c
+	print-vxlan-gpe.c
+	print-wb.c
+	print-zephyr.c
+	print-zeromq.c
+	netdissect.c
+	signature.c
+	strtoaddr.c
+	util-print.c
+)
+
+set(LOCALSRC @LOCALSRC@)
+set(GENSRC ${CMAKE_BINARY_DIR}/version.c)
+set(LIBOBJDIR "")
+string(REPLACE " "     ""  LIBOBJS "@LIBOBJS@")
+string(REPLACE "$U.o"  ";" LIBOBJS ${LIBOBJS})
+
+add_library(netdissect ${LIBNETDISSECT_SRC} ${LOCALSRC})
+# The dependecy between netdissect and LIBOBJS
+# is defined further below (at about line 268)
+
+set(HDR
+	addrtoname.h
+	addrtostr.h
+	af.h
+	ah.h
+	appletalk.h
+	ascii_strcasecmp.h
+	atm.h
+	chdlc.h
+	cpack.h
+	ether.h
+	ethertype.h
+	extract.h
+	getopt_long.h
+	gmpls.h
+	gmt2local.h
+	interface.h
+	ip.h
+	ip6.h
+	ipproto.h
+	l2vpn.h
+	llc.h
+	machdep.h
+	mib.h
+	mpls.h
+	nameser.h
+	netdissect.h
+	nfs.h
+	nfsfh.h
+	nlpid.h
+	openflow.h
+	ospf.h
+	oui.h
+	pcap-missing.h
+	ppp.h
+	print.h
+	rpc_auth.h
+	rpc_msg.h
+	rpl.h
+	setsignal.h
+	signature.h
+	slcompress.h
+	smb.h
+	strtoaddr.h
+	tcp.h
+	netdissect-stdinc.h
+	timeval-operations.h
+	udp.h
+)
+
+set(TAGHDR
+	/usr/include/arpa/tftp.h
+	/usr/include/net/if_arp.h
+	/usr/include/netinet/if_ether.h
+	/usr/include/netinet/in.h
+	/usr/include/netinet/ip_icmp.h
+	/usr/include/netinet/tcp.h
+	/usr/include/netinet/udp.h
+	/usr/include/protocols/routed.h
+)
+
+add_library(datalinks   EXCLUDE_FROM_ALL missing/datalinks.c)
+add_library(dlnames     EXCLUDE_FROM_ALL missing/dlnames.c)
+add_library(getopt_long EXCLUDE_FROM_ALL missing/getopt_long.c)
+add_library(snprintf    EXCLUDE_FROM_ALL missing/snprintf.c)
+add_library(strdup      EXCLUDE_FROM_ALL missing/strdup.c)
+add_library(strlcat     EXCLUDE_FROM_ALL missing/strlcat.c)
+add_library(strlcpy     EXCLUDE_FROM_ALL missing/strlcpy.c)
+add_library(strsep      EXCLUDE_FROM_ALL missing/strsep.c)
+target_link_libraries(netdissect ${LIBOBJS})
+
+# Generate the file build/version.c
+# When there is GIT in the file VERSION, the below CMake statements corresponds to this sed expression:
+# sed 's/.*/const char version[] = "&_$(date +_%Y_%m_%d)";/'<VERSION >${GENSRC}
+file(STRINGS VERSION version LIMIT_COUNT 1)
+if(${version} MATCHES GIT)
+    string(TIMESTAMP _YYYY_MM_DD _%Y_%m_%d)
+else()
+    set(_YYYY_MM_DD)  # Empty string
+endif()
+file(GENERATE OUTPUT ${GENSRC} CONTENT "const char version[] = \"${version}${_YYYY_MM_DD}\";")
+
+add_library(tcpdump_headers ${HDR})
+add_library(usr_inc_headers ${TAGHDR})
+set_target_properties(tcpdump_headers PROPERTIES LINKER_LANGUAGE C)
+set_target_properties(usr_inc_headers PROPERTIES LINKER_LANGUAGE C)
+
+add_executable(tcpdump ${CSRC} ${GENSRC})
+target_link_libraries(tcpdump netdissect ${LIBS} tcpdump_headers usr_inc_headers)

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -15,6 +15,33 @@ directory), run ./configure (a shell script).  "configure" will
 determine your system attributes and generate an appropriate Makefile
 from Makefile.in.  Now build tcpdump by running "make".
 
+    ./configure
+    make
+
+For convenience ./configure also generates a file "CMakeLists.txt" from
+the file "CMakeLists.txt.in". Then you can open the project tcpdump
+using a CMake-friendly IDE as Qt Creator, KDevelop, GNOME Builder, 
+NetBeans, CLion, Visual Studio, Code::Blocks, Eclipse... and many more.
+
+You can also use "CMakeLists.txt" to build from command line:
+
+    ./configure
+    mkdir your-build-directory
+    cd    your-build-directory
+    cmake ..         # Generate Makefiles on Unix-like OS
+    cmake --build .  # Same as just "make"
+
+You can also replace "make" by "ninja" (see ninja-build.org)
+
+    ./configure
+    mkdir build
+    cd    build
+    cmake .. -G Ninja  # Generate Ninja build files
+    cmake --build .    # Same as just "ninja"
+
+However the current "CMakeLists.txt" is still for developers only,
+and cannot (yet?) be used to install tcpdump or to replace "./configure".
+
 If everything builds ok, su and type "make install".  This will install
 tcpdump and the manual entry.  Any user will be able to use tcpdump to
 read saved captures.  Whether a user will be able to capture traffic

--- a/Makefile.in
+++ b/Makefile.in
@@ -320,6 +320,7 @@ EXTRA_DIST = \
 	INSTALL.txt \
 	LICENSE \
 	Makefile.in \
+	CMakeLists.txt.in \
 	Makefile-devel-adds \
 	PLATFORMS \
 	README \

--- a/configure
+++ b/configure
@@ -3662,9 +3662,9 @@ fi
 
 CFLAGS="$save_CFLAGS"
 if test "$ac_cv___attribute___unused" = "yes"; then
-  V_DEFS="$V_DEFS -D_U_=\"__attribute__((unused))\""
+  V_DEFS="$V_DEFS \"-D_U_=__attribute__((unused))\""
 else
-  V_DEFS="$V_DEFS -D_U_=\"\""
+  V_DEFS="$V_DEFS -D_U_="
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv___attribute___unused" >&5
 $as_echo "$ac_cv___attribute___unused" >&6; }
@@ -8436,7 +8436,7 @@ ac_config_headers="$ac_config_headers config.h"
 
 ac_config_commands="$ac_config_commands default-1"
 
-ac_config_files="$ac_config_files Makefile tcpdump.1"
+ac_config_files="$ac_config_files Makefile CMakeLists.txt tcpdump.1"
 
 cat >confcache <<\_ACEOF
 # This file is a shell script that caches the results of configure
@@ -9140,6 +9140,7 @@ do
     "config.h") CONFIG_HEADERS="$CONFIG_HEADERS config.h" ;;
     "default-1") CONFIG_COMMANDS="$CONFIG_COMMANDS default-1" ;;
     "Makefile") CONFIG_FILES="$CONFIG_FILES Makefile" ;;
+    "CMakeLists.txt") CONFIG_FILES="$CONFIG_FILES CMakeLists.txt" ;;
     "tcpdump.1") CONFIG_FILES="$CONFIG_FILES tcpdump.1" ;;
 
   *) as_fn_error $? "invalid argument: \`$ac_config_target'" "$LINENO" 5;;

--- a/configure.in
+++ b/configure.in
@@ -1008,5 +1008,5 @@ AC_OUTPUT_COMMANDS([if test -f .devel; then
 	cat Makefile-devel-adds >> Makefile
 	make depend
 fi])
-AC_OUTPUT(Makefile tcpdump.1)
+AC_OUTPUT(Makefile CMakeLists.txt tcpdump.1)
 exit 0


### PR DESCRIPTION
This implementation of "CMakeLists.txt" is NOT a replacement
of automake/autotools/autoconf but a generated file by
"./configure" like the generation of file "Makefile".

The main objective is just to ease the opening of the tcpdump project
using many CMake-friendly IDE as Qt Creator, KDevelop, 
GNOME Builder, NetBeans, CLion, Visual Studio... and many more...

The file "./configure" has been modified because I do not know
how to handle some double quotes `\"\"` within `-DMACRO=""`  :-/
I hope "./configure" is not often generated from "configure.in"...

The "configure.in" has also been modified to add generation
of the "CMakeLists.txt" from "CMakeLists.txt.in".

The new added file "CMakeLists.txt.in" is the mirror of
the reference file "Makefile.in" in order to ease maintenance.
Any modification within "Makefile.in" should be easily ported
to "CMakeLists.txt.in".

However, I have not implemented all features from
files "Makefile.in" and "Makefile-devel-adds".
But I may do it if some people request it...

For the moment, the generated "CMakeLists.txt" is basic
and does not contains all the nice features we can expect
from advanced CMake-based project. 
However, if requested, I may add the nice features 
I have already provided to project tcpflow: 
https://github.com/simsong/tcpflow/pull/145/files

I do not plan to fully replace "./configure"
by a standalone CMake because the "./configure"
is very large and handle so many platforms
and different configurations.
(nearly impossible to test all the combinations)