### PR TITLE
Packet sanitization and IP masking

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -70,7 +70,7 @@ DEPENDENCY_CFLAG = @DEPENDENCY_CFLAG@
 	@rm -f $@
 	$(CC) $(FULL_CFLAGS) -c $(srcdir)/$*.c
 
-CSRC =	setsignal.c tcpdump.c
+CSRC =	setsignal.c tcpdump.c 
 
 LIBNETDISSECT_SRC=\
 	addrtoname.c \
@@ -235,7 +235,8 @@ LIBNETDISSECT_SRC=\
 	netdissect.c \
 	signature.c \
 	strtoaddr.c \
-	util-print.c
+	util-print.c \
+	clean_cap_dump.c
 
 LOCALSRC = @LOCALSRC@
 GENSRC = version.c
@@ -258,6 +259,7 @@ HDR = \
 	appletalk.h \
 	ascii_strcasecmp.h \
 	atm.h \
+	clean_cap_dump.h \
 	chdlc.h \
 	cpack.h \
 	ether.h \
@@ -297,7 +299,7 @@ HDR = \
 	tcp.h \
 	netdissect-stdinc.h \
 	timeval-operations.h \
-	udp.h
+	udp.h \
 
 TAGHDR = \
 	/usr/include/arpa/tftp.h \

--- a/Makefile.in
+++ b/Makefile.in
@@ -70,7 +70,7 @@ DEPENDENCY_CFLAG = @DEPENDENCY_CFLAG@
 	@rm -f $@
 	$(CC) $(FULL_CFLAGS) -c $(srcdir)/$*.c
 
-CSRC =	setsignal.c tcpdump.c 
+CSRC =	setsignal.c tcpdump.c
 
 LIBNETDISSECT_SRC=\
 	addrtoname.c \

--- a/Makefile.in
+++ b/Makefile.in
@@ -70,7 +70,7 @@ DEPENDENCY_CFLAG = @DEPENDENCY_CFLAG@
 	@rm -f $@
 	$(CC) $(FULL_CFLAGS) -c $(srcdir)/$*.c
 
-CSRC =	setsignal.c tcpdump.c
+CSRC =	setsignal.c tcpdump.c 
 
 LIBNETDISSECT_SRC=\
 	addrtoname.c \

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # tcpdump
 
-[![Build
-Status](https://travis-ci.org/the-tcpdump-group/tcpdump.png)](https://travis-ci.org/the-tcpdump-group/tcpdump)
+[![Build Status](https://travis-ci.org/lilchurro/tcpdump.svg?branch=master)](https://travis-ci.org/lilchurro/tcpdump)
 
 To report a security issue please send an e-mail to security@tcpdump.org.
 

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-4.11.0_CyberReboot_mod_r4
+4.11.0_CyberReboot_mod_r5

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-4.10.0-PRE-GIT
+4.11.0_CyberReboot_mod_r4

--- a/clean_cap_dump.c
+++ b/clean_cap_dump.c
@@ -187,7 +187,7 @@ pcap_mod_and_dump(u_char *user, const struct pcap_pkthdr *h, const u_char *sp,
 	switch(dlt) {
 	case DLT_EN10MB:
 		if ((ip = get_iph_ptr(h, modp)) == NULL)
-		break;
+		    break;
 		p_len -= ETHER_HDRLEN;
 
 		if (mask_ip_flag && maskIP != NULL) {

--- a/clean_cap_dump.c
+++ b/clean_cap_dump.c
@@ -1,0 +1,245 @@
+/* CyberReboot edition:
+ *
+ * In new creating sanitization methods for tcpdump, it became necessary
+ * to make modifications to pcap_dump() supplied by pcap/sf-pcap -- and in
+ * so doing, required an awareness of internal structs located in the
+ * pcap-int.h (a component of libpcap). To simplify things, required data
+ * structs have been extrapolated and given new names to avoid conflict,
+ * and while these are completely extricated from libpcap's internal
+ * structure, data types and sizes should be identical (as they've been
+ * shamelessly cut-and-pasted from pcap-int.h).
+ *
+ *
+ */
+
+ #ifdef HAVE_CONFIG_H
+ #include "config.h"
+ #endif
+
+ #include <stdlib.h>
+ #include <string.h>
+
+ #include <netdissect-stdinc.h>
+
+ #include <inttypes.h>
+ #include "netdissect.h"
+ #include <pcap/pcap.h>
+ #include <ether.h>
+ #include "clean_cap_dump.h"
+ #include <extract.h>
+ #include "ethertype.h"
+ #include "ip.h"
+ #include "tcp.h"
+ #include "udp.h"
+
+
+#define MAXPACKET   65549
+
+
+/* Returns the pointer of the IP header or NULL if that couldn't be found. */
+u_char *
+get_iph_ptr(const struct pcap_pkthdr *h, u_char *bp) {
+    u_short length_type;
+    u_char *s;
+    const struct ip *ip;
+    const struct ether_header *ep = (const struct ether_header *)bp;
+    if (h->caplen < ETHER_HDRLEN || h->len < ETHER_HDRLEN) {
+        return NULL;
+    }
+    length_type = EXTRACT_16BITS(&ep->ether_length_type);
+    if (length_type == ETHERTYPE_IP) {
+        s = bp + ETHER_HDRLEN;
+        ip = (const struct ip *)s;
+        if (IP_V(ip) == 4)
+            return s;
+    }
+    return NULL;
+}
+
+uint32_t
+nd_ipv4_to_network_uint(nd_ipv4 a) {
+    char ip[INET_ADDRSTRLEN];
+    uint32_t ip_uint = 0;
+
+    snprintf(ip, INET_ADDRSTRLEN, "%d.%d.%d.%d",
+             a.bytes[0], a.bytes[1], a.bytes[2], a.bytes[3]);
+    inet_pton(AF_INET, ip, &ip_uint);
+
+    return ip_uint;
+}
+
+nd_ipv4
+network_uint_to_nd_ipv4(uint32_t a) {
+    nd_ipv4 addr;
+
+    addr.bytes[3] = (a>>24) & 0xff;
+    addr.bytes[2] = (a>>16) & 0xff;
+    addr.bytes[1] = (a>>8) & 0xff;
+    addr.bytes[0] = a & 0xff;
+
+    return addr;
+}
+
+/* Returns 1 if IP address presented in nd_ipv4 falls within reserved IP range;
+ * else returns 0. */
+int
+is_reserved(nd_ipv4 a) {
+    /* List of all the reserved IPv4 address spaces, per RFC5735,
+    * ...PROVIDED IN NETWORK BYTE ORDER!! */
+    struct netblock specialblock[] = {
+        { .netip = 0x00000000, .netmask = 0x000000ff  }, /* 0.0.0.0/8 */
+        { .netip = 0x0000000a, .netmask = 0x000000ff  }, /* 10.0.0.0/8 */
+        { .netip = 0x0000007f, .netmask = 0x000000ff  }, /* 127.0.0.0/8 */
+        { .netip = 0x0000fea9, .netmask = 0x0000ffff  }, /* 169.254.0.0/16 */
+        { .netip = 0x000010ac, .netmask = 0x00000fff  }, /* 172.16.0.0/12 */
+        { .netip = 0x000000c0, .netmask = 0x00ffffff  }, /* 192.0.0.0/24 */
+        { .netip = 0x000200c0, .netmask = 0x00ffffff  }, /* 192.0.2.0/24 */
+        { .netip = 0x006433c0, .netmask = 0x00ffffff  }, /* 192.88.99.0/24 */
+        { .netip = 0x0000a8c0, .netmask = 0x0000ffff  }, /* 192.168.0.0/16 */
+        { .netip = 0x000012c0, .netmask = 0x0000fffe  }, /* 192.18.0.0/15 */
+        { .netip = 0x006433c0, .netmask = 0x00ffffff  }, /* 198.51.100.0/24 */
+        { .netip = 0x007100cb, .netmask = 0x00ffffff  }, /* 203.0.113.0/24 */
+        { .netip = 0x000000e0, .netmask = 0x000000f0  }, /* 224.0.0.0/4 */
+        { .netip = 0x000000f0, .netmask = 0x000000f0  }, /* 240.0.0.0/4 */
+        { .netip = 0xffffffff, .netmask = 0xffffffff  }  /* 255.255.255.255 */
+    };
+    int sb_sz = sizeof(specialblock)/sizeof(specialblock[0]);
+    int reserved = 0;
+
+    uint32_t addr = nd_ipv4_to_network_uint(a);
+    for (int i = 0; i < sb_sz; i++) {
+        if ((addr & specialblock[i].netmask) == (specialblock[i].netip & specialblock[i].netmask)) {
+            reserved = 1;
+            break;
+        }
+    }
+
+    return reserved;
+}
+
+/* Takes as input the IP header struct pointer and length of packet, and
+ * returns -1 if the IP header is parseable; else returns 0. */
+int
+validate_iph_len(u_char *iph, int len) {
+    struct ip *ip = (struct ip *)iph;
+    if (IP_V(ip) != 4) {
+        printf("DEBUG: Not IP4 packet -- version %u\n", IP_V(ip));
+        return -1;
+    }
+
+    if (len < sizeof(struct ip)) {
+        printf("DEBUG: truncated IP or bad datagram length\n");
+        return -1;
+    }
+
+    if ((IP_HL(ip)*4) < sizeof(struct ip)) {
+        printf("DEBUG: bad header length\n");
+        return -1;
+    }
+    return 0;
+}
+
+/* Compare the addresses to reserved address ranges and mask if it's not within
+ * range. Returns 0 if successful, -1 on malformed datagram, 1 if not reserveds.
+ */
+int
+mask_ip(u_char *iph, int len, const char * maskIP) {
+    struct ip *ip = (struct ip *)iph;
+    uint32_t m = 0;
+    inet_pton(AF_INET, maskIP, &m);
+
+    if (validate_iph_len(iph, len) < 0)
+        return -1;
+
+    if (is_reserved(ip->ip_src) == 0) {
+        nd_ipv4 mask = network_uint_to_nd_ipv4(m);
+        memcpy(&(ip->ip_src), &mask, sizeof(mask));
+    }
+    if (is_reserved(ip->ip_dst) == 0) {
+        nd_ipv4 mask = network_uint_to_nd_ipv4(m);
+        memcpy(&(ip->ip_dst), &mask, sizeof(mask));
+    }
+
+    return 0;
+}
+
+void
+pcap_mod_and_dump(u_char *user, const struct pcap_pkthdr *h, const u_char *sp,
+                  int dlt, int no_payload_flag, int mask_ip_flag, const char *maskIP) {
+    register FILE *f;
+    struct clean_cap_sf_pkthdr sf_hdr;
+    u_char *ip, *nh, *p_end;
+    u_char *modp;
+    int p_len, modp_len;
+    p_len = modp_len = h->caplen;
+
+    if ((modp = (u_char *)malloc(MAXPACKET)) == NULL) {
+        fprintf(stderr,
+                "Unable to malloc %d bytes for packet modification", MAXPACKET);
+        exit(1);
+    } else
+        memset(modp, '\0', MAXPACKET);
+
+    memcpy(modp, sp, h->caplen);
+
+    f = (FILE *)user;
+    sf_hdr.ts.tv_sec    = h->ts.tv_sec;
+    sf_hdr.ts.tv_usec   = h->ts.tv_usec;
+    sf_hdr.caplen       = h->caplen;
+    sf_hdr.len          = h->len;
+
+    switch(dlt) {
+    case DLT_EN10MB:
+        if ((ip = get_iph_ptr(h, modp)) == NULL)
+            break;
+        p_len -= ETHER_HDRLEN;
+
+        if (mask_ip_flag && maskIP != NULL) {
+            mask_ip(ip, p_len, maskIP);
+        }
+
+        if (no_payload_flag > 0 && validate_iph_len(ip, p_len) > -1) {
+            struct ip *p = (struct ip *)ip;
+            int ph_len = IP_HL(p) * 4;
+
+            if (p-> ip_p != IPPROTO_TCP && p-> ip_p != IPPROTO_UDP) {
+                break;
+            }
+            if (p->ip_p == IPPROTO_TCP) {
+                struct tcphdr *t = (struct tcphdr *)(ip+ph_len);
+                p_len = TH_OFF(t) * 4;
+                if (p_len < sizeof(*t)) {
+                    break;
+                }
+                p_end = ip + ph_len + p_len;
+            }
+            else if (p->ip_p == IPPROTO_UDP) {
+                struct udphdr *u = (struct udphdr *)(ip+ph_len);
+                if (p_len < sizeof(struct udphdr) ||
+                        EXTRACT_16BITS(&u->uh_ulen) < sizeof(struct udphdr)) {
+                    break;
+                } else {
+                    p_end = (u_char *)(ip + ph_len + sizeof(struct udphdr));
+                }
+            }
+            if (no_payload_flag > 1) {
+                sf_hdr.caplen = modp_len = p_end - modp;
+            } else {
+                size_t diff = p_end - modp;
+                memset(p_end, 0, h->len - diff);
+            }
+        }
+
+        break;
+    /* For any other DLT support, put here. Otherwise:
+     *
+     * default:
+     *    printf("DEBUG: not Ethernet LL.\n");
+    */
+    }
+
+    (void)fwrite(&sf_hdr, sizeof(sf_hdr), 1, f);
+    (void)fwrite(modp, modp_len, 1, f);
+
+    free(modp);
+}

--- a/clean_cap_dump.c
+++ b/clean_cap_dump.c
@@ -4,25 +4,25 @@
  *
  */
 
- #ifdef HAVE_CONFIG_H
- #include "config.h"
- #endif
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
 
- #include <stdlib.h>
- #include <string.h>
+#include <stdlib.h>
+#include <string.h>
 
- #include <netdissect-stdinc.h>
+#include <netdissect-stdinc.h>
 
- #include <inttypes.h>
- #include "netdissect.h"
- #include <pcap/pcap.h>
- #include <ether.h>
- #include "clean_cap_dump.h"
- #include <extract.h>
- #include "ethertype.h"
- #include "ip.h"
- #include "tcp.h"
- #include "udp.h"
+#include <inttypes.h>
+#include "netdissect.h"
+#include <pcap/pcap.h>
+#include <ether.h>
+#include "clean_cap_dump.h"
+#include <extract.h>
+#include "ethertype.h"
+#include "ip.h"
+#include "tcp.h"
+#include "udp.h"
 
 
 #define MAXPACKET   65549
@@ -31,209 +31,211 @@
 /* Returns the pointer of the IP header or NULL if that couldn't be found. */
 u_char *
 get_iph_ptr(const struct pcap_pkthdr *h, u_char *bp) {
-    u_short length_type;
-    u_char *s;
-    const struct ip *ip;
-    const struct ether_header *ep = (const struct ether_header *)bp;
+	u_short length_type;
+	u_char *s;
+	const struct ip *ip;
+	const struct ether_header *ep = (const struct ether_header *)bp;
 
-    if (h->caplen < ETHER_HDRLEN || h->len < ETHER_HDRLEN) {
-        return NULL;
-    }
-    length_type = EXTRACT_16BITS(&ep->ether_length_type);
-    if (length_type == ETHERTYPE_IP) {
-        s = bp + ETHER_HDRLEN;
-        ip = (const struct ip *)s;
-        if (IP_V(ip) == 4)
-            return s;
-    }
-    return NULL;
+	if (h->caplen < ETHER_HDRLEN || h->len < ETHER_HDRLEN) {
+	    return NULL;
+	}
+	length_type = EXTRACT_16BITS(&ep->ether_length_type);
+	if (length_type == ETHERTYPE_IP) {
+		s = bp + ETHER_HDRLEN;
+		ip = (const struct ip *)s;
+		if (IP_V(ip) == 4)
+		return s;
+	}
+	return NULL;
 }
 
 uint32_t
 nd_ipv4_to_network_uint(nd_ipv4 a) {
-    char ip[INET_ADDRSTRLEN];
-    uint32_t ip_uint = 0;
+	char ip[INET_ADDRSTRLEN];
+	uint32_t ip_uint = 0;
 
-    snprintf(ip, INET_ADDRSTRLEN, "%d.%d.%d.%d",
-             a.bytes[0], a.bytes[1], a.bytes[2], a.bytes[3]);
-    inet_pton(AF_INET, ip, &ip_uint);
+	snprintf(ip, INET_ADDRSTRLEN, "%d.%d.%d.%d",
+		 a.bytes[0], a.bytes[1], a.bytes[2], a.bytes[3]);
+	inet_pton(AF_INET, ip, &ip_uint);
 
-    return ip_uint;
+	return ip_uint;
 }
 
 nd_ipv4
 network_uint_to_nd_ipv4(uint32_t a) {
-    nd_ipv4 addr;
+	nd_ipv4 addr;
 
-    addr.bytes[3] = (a>>24) & 0xff;
-    addr.bytes[2] = (a>>16) & 0xff;
-    addr.bytes[1] = (a>>8) & 0xff;
-    addr.bytes[0] = a & 0xff;
+	addr.bytes[3] = (a>>24) & 0xff;
+	addr.bytes[2] = (a>>16) & 0xff;
+	addr.bytes[1] = (a>>8) & 0xff;
+	addr.bytes[0] = a & 0xff;
 
-    return addr;
+	return addr;
 }
 
 /* Returns 1 if IP address presented in nd_ipv4 falls within reserved IP range;
- * else returns 0. */
+* else returns 0. */
 int
 is_reserved(nd_ipv4 a) {
-    /* List of all the reserved IPv4 address spaces, per RFC5735,
-    * ...PROVIDED IN NETWORK BYTE ORDER!! */
-    struct netblock specialblock[] = {
-        { .netip = 0x00000000, .netmask = 0x000000ff  }, /* 0.0.0.0/8 */
-        { .netip = 0x0000000a, .netmask = 0x000000ff  }, /* 10.0.0.0/8 */
-        { .netip = 0x0000007f, .netmask = 0x000000ff  }, /* 127.0.0.0/8 */
-        { .netip = 0x0000fea9, .netmask = 0x0000ffff  }, /* 169.254.0.0/16 */
-        { .netip = 0x000010ac, .netmask = 0x00000fff  }, /* 172.16.0.0/12 */
-        { .netip = 0x000000c0, .netmask = 0x00ffffff  }, /* 192.0.0.0/24 */
-        { .netip = 0x000200c0, .netmask = 0x00ffffff  }, /* 192.0.2.0/24 */
-        { .netip = 0x006433c0, .netmask = 0x00ffffff  }, /* 192.88.99.0/24 */
-        { .netip = 0x0000a8c0, .netmask = 0x0000ffff  }, /* 192.168.0.0/16 */
-        { .netip = 0x000012c0, .netmask = 0x0000fffe  }, /* 192.18.0.0/15 */
-        { .netip = 0x006433c0, .netmask = 0x00ffffff  }, /* 198.51.100.0/24 */
-        { .netip = 0x007100cb, .netmask = 0x00ffffff  }, /* 203.0.113.0/24 */
-        { .netip = 0x000000e0, .netmask = 0x000000f0  }, /* 224.0.0.0/4 */
-        { .netip = 0x000000f0, .netmask = 0x000000f0  }, /* 240.0.0.0/4 */
-        { .netip = 0xffffffff, .netmask = 0xffffffff  }  /* 255.255.255.255 */
-    };
-    int sb_sz = sizeof(specialblock)/sizeof(specialblock[0]);
-    int reserved = 0;
+	/* List of all the reserved IPv4 address spaces, per RFC5735,
+	* ...PROVIDED IN NETWORK BYTE ORDER!! */
+	struct netblock specialblock[] = {
+		{ .netip = 0x00000000, .netmask = 0x000000ff  }, /* 0.0.0.0/8 */
+		{ .netip = 0x0000000a, .netmask = 0x000000ff  }, /* 10.0.0.0/8 */
+		{ .netip = 0x0000007f, .netmask = 0x000000ff  }, /* 127.0.0.0/8 */
+		{ .netip = 0x0000fea9, .netmask = 0x0000ffff  }, /* 169.254.0.0/16 */
+		{ .netip = 0x000010ac, .netmask = 0x00000fff  }, /* 172.16.0.0/12 */
+		{ .netip = 0x000000c0, .netmask = 0x00ffffff  }, /* 192.0.0.0/24 */
+		{ .netip = 0x000200c0, .netmask = 0x00ffffff  }, /* 192.0.2.0/24 */
+		{ .netip = 0x006433c0, .netmask = 0x00ffffff  }, /* 192.88.99.0/24 */
+		{ .netip = 0x0000a8c0, .netmask = 0x0000ffff  }, /* 192.168.0.0/16 */
+		{ .netip = 0x000012c0, .netmask = 0x0000fffe  }, /* 192.18.0.0/15 */
+		{ .netip = 0x006433c0, .netmask = 0x00ffffff  }, /* 198.51.100.0/24 */
+		{ .netip = 0x007100cb, .netmask = 0x00ffffff  }, /* 203.0.113.0/24 */
+		{ .netip = 0x000000e0, .netmask = 0x000000f0  }, /* 224.0.0.0/4 */
+		{ .netip = 0x000000f0, .netmask = 0x000000f0  }, /* 240.0.0.0/4 */
+		{ .netip = 0xffffffff, .netmask = 0xffffffff  }  /* 255.255.255.255 */
+	};
 
-    uint32_t addr = nd_ipv4_to_network_uint(a);
-    for (int i = 0; i < sb_sz; i++) {
-        if ((addr & specialblock[i].netmask) == (specialblock[i].netip & specialblock[i].netmask)) {
-            reserved = 1;
-            break;
-        }
-    }
+	int sb_sz = sizeof(specialblock)/sizeof(specialblock[0]);
+	int reserved = 0;
 
-    return reserved;
+	uint32_t addr = nd_ipv4_to_network_uint(a);
+	for (int i = 0; i < sb_sz; i++) {
+		if ((addr & specialblock[i].netmask) == 
+		    (specialblock[i].netip & specialblock[i].netmask)) {
+			reserved = 1;
+			break;
+		}
+	}
+
+	return reserved;
 }
 
 /* Takes as input the IP header struct pointer and length of packet, and
- * returns -1 if the IP header is parseable; else returns 0. */
+* returns -1 if the IP header is parseable; else returns 0. */
 int
 validate_iph_len(u_char *iph, int len) {
-    struct ip *ip = (struct ip *)iph;
-    if (IP_V(ip) != 4) {
-        printf("DEBUG: Not IP4 packet -- version %u\n", IP_V(ip));
-        return -1;
-    }
+	struct ip *ip = (struct ip *)iph;
+	if (IP_V(ip) != 4) {
+		printf("DEBUG: Not IP4 packet -- version %u\n", IP_V(ip));
+		return -1;
+	}
 
-    if (len < sizeof(struct ip)) {
-        printf("DEBUG: truncated IP or bad datagram length\n");
-        return -1;
-    }
+	if (len < sizeof(struct ip)) {
+		printf("DEBUG: truncated IP or bad datagram length\n");
+		return -1;
+	}
 
-    if ((IP_HL(ip)*4) < sizeof(struct ip)) {
-        printf("DEBUG: bad header length\n");
-        return -1;
-    }
-    return 0;
+	if ((IP_HL(ip)*4) < sizeof(struct ip)) {
+		printf("DEBUG: bad header length\n");
+		return -1;
+	}
+	return 0;
 }
 
 /* Compare the addresses to reserved address ranges and mask if it's not within
- * range. Returns 0 if successful, -1 on malformed datagram, 1 if not reserveds.
- */
+* range. Returns 0 if successful, -1 on malformed datagram, 1 if not reserveds.
+*/
 int
 mask_ip(u_char *iph, int len, const char * maskIP) {
-    struct ip *ip = (struct ip *)iph;
-    uint32_t m = 0;
-    
-    inet_pton(AF_INET, maskIP, &m);
+	struct ip *ip = (struct ip *)iph;
+	uint32_t m = 0;
 
-    if (validate_iph_len(iph, len) < 0)
-        return -1;
+	inet_pton(AF_INET, maskIP, &m);
 
-    if (is_reserved(ip->ip_src) == 0) {
-        nd_ipv4 mask = network_uint_to_nd_ipv4(m);
-        memcpy(&(ip->ip_src), &mask, sizeof(mask));
-    }
-    if (is_reserved(ip->ip_dst) == 0) {
-        nd_ipv4 mask = network_uint_to_nd_ipv4(m);
-        memcpy(&(ip->ip_dst), &mask, sizeof(mask));
-    }
+	if (validate_iph_len(iph, len) < 0)
+		return -1;
 
-    return 0;
+	if (is_reserved(ip->ip_src) == 0) {
+		nd_ipv4 mask = network_uint_to_nd_ipv4(m);
+		memcpy(&(ip->ip_src), &mask, sizeof(mask));
+	}
+	if (is_reserved(ip->ip_dst) == 0) {
+		nd_ipv4 mask = network_uint_to_nd_ipv4(m);
+		memcpy(&(ip->ip_dst), &mask, sizeof(mask));
+	}
+
+	return 0;
 }
 
 void
 pcap_mod_and_dump(u_char *user, const struct pcap_pkthdr *h, const u_char *sp,
-                  int dlt, int no_payload_flag, int mask_ip_flag, const char *maskIP) {
-    register FILE *f;
-    struct clean_cap_sf_pkthdr sf_hdr;
-    u_char *ip, *nh, *p_end;
-    u_char *modp;
-    int p_len, modp_len;
-    p_len = modp_len = h->caplen;
+      int dlt, int no_payload_flag, int mask_ip_flag, const char *maskIP) {
+	register FILE *f;
+	struct clean_cap_sf_pkthdr sf_hdr;
+	u_char *ip, *nh, *p_end;
+	u_char *modp;
+	int p_len, modp_len;
+	p_len = modp_len = h->caplen;
 
-    if ((modp = (u_char *)malloc(MAXPACKET)) == NULL) {
-        fprintf(stderr,
-                "Unable to malloc %d bytes for packet modification", MAXPACKET);
-        exit(1);
-    } else
-        memset(modp, '\0', MAXPACKET);
+	if ((modp = (u_char *)malloc(MAXPACKET)) == NULL) {
+		fprintf(stderr,
+		    "Unable to malloc %d bytes for packet modification", MAXPACKET);
+		exit(1);
+	} else
+		memset(modp, '\0', MAXPACKET);
 
-    memcpy(modp, sp, h->caplen);
+	memcpy(modp, sp, h->caplen);
 
-    f = (FILE *)user;
-    sf_hdr.ts.tv_sec    = h->ts.tv_sec;
-    sf_hdr.ts.tv_usec   = h->ts.tv_usec;
-    sf_hdr.caplen       = h->caplen;
-    sf_hdr.len          = h->len;
+	f = (FILE *)user;
+	sf_hdr.ts.tv_sec    = h->ts.tv_sec;
+	sf_hdr.ts.tv_usec   = h->ts.tv_usec;
+	sf_hdr.caplen       = h->caplen;
+	sf_hdr.len          = h->len;
 
-    switch(dlt) {
-    case DLT_EN10MB:
-        if ((ip = get_iph_ptr(h, modp)) == NULL)
-            break;
-        p_len -= ETHER_HDRLEN;
+	switch(dlt) {
+	case DLT_EN10MB:
+		if ((ip = get_iph_ptr(h, modp)) == NULL)
+		break;
+		p_len -= ETHER_HDRLEN;
 
-        if (mask_ip_flag && maskIP != NULL) {
-            mask_ip(ip, p_len, maskIP);
-        }
+		if (mask_ip_flag && maskIP != NULL) {
+			mask_ip(ip, p_len, maskIP);
+		}
 
-        if (no_payload_flag > 0 && validate_iph_len(ip, p_len) > -1) {
-            struct ip *p = (struct ip *)ip;
-            int ph_len = IP_HL(p) * 4;
+		if (no_payload_flag > 0 && validate_iph_len(ip, p_len) > -1) { 
+			struct ip *p = (struct ip *)ip;
+			int ph_len = IP_HL(p) * 4;
 
-            if (p-> ip_p != IPPROTO_TCP && p-> ip_p != IPPROTO_UDP) {
-                break;
-            }
-            if (p->ip_p == IPPROTO_TCP) {
-                struct tcphdr *t = (struct tcphdr *)(ip+ph_len);
-                p_len = TH_OFF(t) * 4;
-                if (p_len < sizeof(*t)) {
-                    break;
-                }
-                p_end = ip + ph_len + p_len;
-            }
-            else if (p->ip_p == IPPROTO_UDP) {
-                struct udphdr *u = (struct udphdr *)(ip+ph_len);
-                if (p_len < sizeof(struct udphdr) ||
-                        EXTRACT_16BITS(&u->uh_ulen) < sizeof(struct udphdr)) {
-                    break;
-                } else {
-                    p_end = (u_char *)(ip + ph_len + sizeof(struct udphdr));
-                }
-            }
-            if (no_payload_flag > 1) {
-                sf_hdr.caplen = modp_len = p_end - modp;
-            } else {
-                size_t diff = p_end - modp;
-                memset(p_end, 0, h->len - diff);
-            }
-        }
+			if (p-> ip_p != IPPROTO_TCP && p-> ip_p != IPPROTO_UDP) {
+				break;
+			}
+			if (p->ip_p == IPPROTO_TCP) {
+				struct tcphdr *t = (struct tcphdr *)(ip+ph_len);
+				p_len = TH_OFF(t) * 4;
+				if (p_len < sizeof(*t)) {
+					break;
+				}
+				p_end = ip + ph_len + p_len;
+			}
+			else if (p->ip_p == IPPROTO_UDP) {
+				struct udphdr *u = (struct udphdr *)(ip+ph_len);
+				if (p_len < sizeof(struct udphdr) ||
+				    EXTRACT_16BITS(&u->uh_ulen) < sizeof(struct udphdr)) {
+					break;
+				} else {
+					p_end = (u_char *)(ip + ph_len + sizeof(struct udphdr));
+				}
+			}
+			if (no_payload_flag > 1) {
+				sf_hdr.caplen = modp_len = p_end - modp;
+			} else {
+				size_t diff = p_end - modp;
+				memset(p_end, 0, h->len - diff);
+			}
+		}
+		break;
 
-        break;
-    /* For any other DLT support, put here. Otherwise:
-     *
-     * default:
-     *    printf("DEBUG: not Ethernet LL.\n");
-    */
-    }
+	/* For any other DLT support, put here. Otherwise:
+	*
+	* default:
+	*    printf("DEBUG: not Ethernet LL.\n");
+	*/
+	}
 
-    (void)fwrite(&sf_hdr, sizeof(sf_hdr), 1, f);
-    (void)fwrite(modp, modp_len, 1, f);
+	(void)fwrite(&sf_hdr, sizeof(sf_hdr), 1, f);
+	(void)fwrite(modp, modp_len, 1, f);
 
-    free(modp);
+	free(modp);
 }

--- a/clean_cap_dump.c
+++ b/clean_cap_dump.c
@@ -56,7 +56,7 @@ get_iph_ptr(const struct pcap_pkthdr *h, u_char *bp) {
 	return NULL;
 }
 
-uint32_t
+static uint32_t
 nd_ipv4_to_network_uint(nd_ipv4 a) {
 	char ip[INET_ADDRSTRLEN];
 	uint32_t ip_uint = 0;
@@ -68,7 +68,7 @@ nd_ipv4_to_network_uint(nd_ipv4 a) {
 	return ip_uint;
 }
 
-nd_ipv4
+static nd_ipv4
 network_uint_to_nd_ipv4(uint32_t a) {
 	nd_ipv4 addr;
 
@@ -82,7 +82,7 @@ network_uint_to_nd_ipv4(uint32_t a) {
 
 /* Returns 1 if IP address presented in nd_ipv4 falls within reserved IP range;
  * else returns 0. */
-int
+static int
 is_reserved(nd_ipv4 a) {
 	/* List of all the reserved IPv4 address spaces, per RFC5735,
 	 * ...PROVIDED IN NETWORK BYTE ORDER!! */
@@ -105,9 +105,10 @@ is_reserved(nd_ipv4 a) {
 	};
 	int sb_sz = sizeof(specialblock)/sizeof(specialblock[0]);
 	int reserved = 0;
-
+	int i = 0;
 	uint32_t addr = nd_ipv4_to_network_uint(a);
-	for (int i = 0; i < sb_sz; i++) {
+
+	for (i = 0; i < sb_sz; i++) {
 		if ((addr & specialblock[i].netmask) == 
 		    (specialblock[i].netip & specialblock[i].netmask)) {
 			reserved = 1;
@@ -120,8 +121,8 @@ is_reserved(nd_ipv4 a) {
 
 /* Takes as input the IP header struct pointer and length of packet, and
  * returns -1 if the IP header is parseable; else returns 0. */
-int
-validate_iph_len(u_char *iph, int len) {
+static int
+validate_iph_len(u_char *iph, unsigned int len) {
 	struct ip *ip = (struct ip *)iph;
 	if (IP_V(ip) != 4) {
 		printf("DEBUG: Not IP4 packet -- version %u\n", IP_V(ip));
@@ -144,7 +145,7 @@ validate_iph_len(u_char *iph, int len) {
  * range. Returns 0 if successful, -1 on malformed datagram, 1 if not reserveds.
  */
 int
-mask_ip(u_char *iph, int len, const char * maskIP) {
+mask_ip(u_char *iph, unsigned int len, const char * maskIP) {
 	struct ip *ip = (struct ip *)iph;
 	uint32_t m = 0;
 	inet_pton(AF_INET, maskIP, &m);
@@ -169,9 +170,9 @@ pcap_mod_and_dump(u_char *user, const struct pcap_pkthdr *h, const u_char *sp,
 	      int dlt, int no_payload_flag, int mask_ip_flag, const char *maskIP) {
 	register FILE *f;
 	struct clean_cap_sf_pkthdr sf_hdr;
-	u_char *ip, *nh, *p_end;
+	u_char *ip, *p_end;
 	u_char *modp;
-	int p_len, modp_len;
+	unsigned int p_len, modp_len;
 	p_len = modp_len = h->caplen;
 
 	if ((modp = (u_char *)malloc(MAXPACKET)) == NULL) {

--- a/clean_cap_dump.c
+++ b/clean_cap_dump.c
@@ -37,7 +37,7 @@ get_iph_ptr(const struct pcap_pkthdr *h, u_char *bp) {
 	const struct ether_header *ep = (const struct ether_header *)bp;
 
 	if (h->caplen < ETHER_HDRLEN || h->len < ETHER_HDRLEN) {
-	    return NULL;
+		return NULL;
 	}
 	length_type = EXTRACT_16BITS(&ep->ether_length_type);
 	if (length_type == ETHERTYPE_IP) {

--- a/clean_cap_dump.c
+++ b/clean_cap_dump.c
@@ -1,14 +1,6 @@
 /* CyberReboot edition:
  *
- * In new creating sanitization methods for tcpdump, it became necessary
- * to make modifications to pcap_dump() supplied by pcap/sf-pcap -- and in
- * so doing, required an awareness of internal structs located in the
- * pcap-int.h (a component of libpcap). To simplify things, required data
- * structs have been extrapolated and given new names to avoid conflict,
- * and while these are completely extricated from libpcap's internal
- * structure, data types and sizes should be identical (as they've been
- * shamelessly cut-and-pasted from pcap-int.h).
- *
+ * Author: achang@cyberreboot.org
  *
  */
 

--- a/clean_cap_dump.c
+++ b/clean_cap_dump.c
@@ -43,6 +43,7 @@ get_iph_ptr(const struct pcap_pkthdr *h, u_char *bp) {
     u_char *s;
     const struct ip *ip;
     const struct ether_header *ep = (const struct ether_header *)bp;
+
     if (h->caplen < ETHER_HDRLEN || h->len < ETHER_HDRLEN) {
         return NULL;
     }
@@ -146,6 +147,7 @@ int
 mask_ip(u_char *iph, int len, const char * maskIP) {
     struct ip *ip = (struct ip *)iph;
     uint32_t m = 0;
+    
     inet_pton(AF_INET, maskIP, &m);
 
     if (validate_iph_len(iph, len) < 0)

--- a/clean_cap_dump.c
+++ b/clean_cap_dump.c
@@ -232,8 +232,10 @@ pcap_mod_and_dump(u_char *user, const struct pcap_pkthdr *h, const u_char *sp,
 			}
 		}
 		break;
-	default:
-		printf("DEBUG: not Ethernet LL.\n");
+
+	/* default:
+	 *	printf("DEBUG: not Ethernet LL.\n");
+	 */
 	}
 
 	(void)fwrite(&sf_hdr, sizeof(sf_hdr), 1, f);

--- a/clean_cap_dump.h
+++ b/clean_cap_dump.h
@@ -33,25 +33,25 @@
  * the file was written.
  */
 struct clean_cap_timeval {
-    int tv_sec;		/* seconds */
-    int tv_usec;	/* microseconds */
+	int tv_sec;	/* seconds */
+	int tv_usec;	/* microseconds */
 } clean_cap_timeval;
 
 struct clean_cap_sf_pkthdr {
-    struct clean_cap_timeval ts;  /* time stamp */
-    bpf_u_int32 caplen;		      /* length of portion present */
-    bpf_u_int32 len;		      /* length this packet (off wire) */
+	struct clean_cap_timeval ts;  	/* time stamp */
+	bpf_u_int32 caplen;		/* length of portion present */
+	bpf_u_int32 len;		/* length this packet (off wire) */
 } clean_cap_sf_pkthdr;
 
 struct netblock {
-    uint32_t netip;
-    uint32_t netmask;
+	uint32_t netip;
+	uint32_t netmask;
 } netblock;
 
 
 /* Takes over the packet mods and pcap_dump when the new flags are called */
 void pcap_mod_and_dump(u_char *, const struct pcap_pkthdr *, const u_char *,
-                  int, int, int, const char *);
+		int, int, int, const char *);
 
 u_char * get_iph_ptr(const struct pcap_pkthdr *, u_char *);
 int mask_ip(u_char *, int, const char *);

--- a/clean_cap_dump.h
+++ b/clean_cap_dump.h
@@ -49,7 +49,7 @@ void pcap_mod_and_dump(u_char *, const struct pcap_pkthdr *, const u_char *,
                   int, int, int, const char *);
 
 u_char * get_iph_ptr(const struct pcap_pkthdr *, u_char *);
-int mask_ip(u_char *, int, const char *);
+int mask_ip(u_char *, unsigned int, const char *);
 
 
 #endif

--- a/clean_cap_dump.h
+++ b/clean_cap_dump.h
@@ -1,13 +1,9 @@
-/* CyberReboot edition:
- *
- * Author: achang@cyberreboot.org
- */
-
-
 #ifndef clean_cap_dump_h
 #define clean_cap_dump_h
 
 #include <pcap/pcap.h>
+
+
 
 
 /* CyberReboot edition:
@@ -38,8 +34,8 @@ struct clean_cap_timeval {
 } clean_cap_timeval;
 
 struct clean_cap_sf_pkthdr {
-	struct clean_cap_timeval ts;  	/* time stamp */
-	bpf_u_int32 caplen;		/* length of portion present */
+	struct clean_cap_timeval ts;	/* time stamp */
+	bpf_u_int32 caplen;	   	/* length of portion present */
 	bpf_u_int32 len;		/* length this packet (off wire) */
 } clean_cap_sf_pkthdr;
 
@@ -48,12 +44,12 @@ struct netblock {
 	uint32_t netmask;
 } netblock;
 
-
 /* Takes over the packet mods and pcap_dump when the new flags are called */
 void pcap_mod_and_dump(u_char *, const struct pcap_pkthdr *, const u_char *,
-		int, int, int, const char *);
+                  int, int, int, const char *);
 
 u_char * get_iph_ptr(const struct pcap_pkthdr *, u_char *);
 int mask_ip(u_char *, int, const char *);
+
 
 #endif

--- a/clean_cap_dump.h
+++ b/clean_cap_dump.h
@@ -1,0 +1,55 @@
+#ifndef clean_cap_dump_h
+#define clean_cap_dump_h
+
+#include <pcap/pcap.h>
+
+
+
+
+/* CyberReboot edition:
+ *
+ * In new creating sanitization methods for tcpdump, it became necessary
+ * to make modifications to pcap_dump() supplied by pcap/sf-pcap -- and in
+ * so doing, required an awareness of internal structs located in the
+ * pcap-int.h (a component of libpcap). To simplify things, required data
+ * structs have been extrapolated and given new names to avoid conflict,
+ * and while these are completely extricated from libpcap's internal
+ * structure, data types and sizes should be identical (as they've been
+ * shamelessly cut-and-pasted from pcap-int.h).
+ *
+ */
+
+/*
+ * This is a timeval as stored in a savefile.
+ * It has to use the same types everywhere, independent of the actual
+ * `struct timeval'; `struct timeval' has 32-bit tv_sec values on some
+ * platforms and 64-bit tv_sec values on other platforms, and writing
+ * out native `struct timeval' values would mean files could only be
+ * read on systems with the same tv_sec size as the system on which
+ * the file was written.
+ */
+struct clean_cap_timeval {
+    int tv_sec;		/* seconds */
+    int tv_usec;	/* microseconds */
+} clean_cap_timeval;
+
+struct clean_cap_sf_pkthdr {
+    struct clean_cap_timeval ts;  /* time stamp */
+    bpf_u_int32 caplen;		      /* length of portion present */
+    bpf_u_int32 len;		      /* length this packet (off wire) */
+} clean_cap_sf_pkthdr;
+
+struct netblock {
+    uint32_t netip;
+    uint32_t netmask;
+} netblock;
+
+
+/* Takes over the packet mods and pcap_dump when the new flags are called */
+void pcap_mod_and_dump(u_char *, const struct pcap_pkthdr *, const u_char *,
+                  int, int, int, const char *);
+
+u_char * get_iph_ptr(const struct pcap_pkthdr *, u_char *);
+int mask_ip(u_char *, int, const char *);
+
+#endif

--- a/clean_cap_dump.h
+++ b/clean_cap_dump.h
@@ -1,13 +1,16 @@
+/* CyberReboot edition:
+ *
+ * Author: achang@cyberreboot.org
+ */
+
+
 #ifndef clean_cap_dump_h
 #define clean_cap_dump_h
 
 #include <pcap/pcap.h>
 
 
-
-
-/* CyberReboot edition:
- *
+/*
  * In new creating sanitization methods for tcpdump, it became necessary
  * to make modifications to pcap_dump() supplied by pcap/sf-pcap -- and in
  * so doing, required an awareness of internal structs located in the

--- a/clean_cap_dump.h
+++ b/clean_cap_dump.h
@@ -10,7 +10,8 @@
 #include <pcap/pcap.h>
 
 
-/*
+/* CyberReboot edition:
+ *
  * In new creating sanitization methods for tcpdump, it became necessary
  * to make modifications to pcap_dump() supplied by pcap/sf-pcap -- and in
  * so doing, required an awareness of internal structs located in the

--- a/tcpdump.1.in
+++ b/tcpdump.1.in
@@ -27,7 +27,7 @@ tcpdump \- dump traffic on a network
 .na
 .B tcpdump
 [
-.B \-AbdDefhHIJKlLnNOpqStuUvxX#
+.B \-0AbdDefhHIJKlLnNOpqStuUvxX#
 ] [
 .B \-B
 .I buffer_size
@@ -130,6 +130,11 @@ tcpdump \- dump traffic on a network
 ]
 .ti +8
 [
+.BI \-\-external\-mask
+.I mask_ip
+]
+.ti +8
+[
 .B \-\-immediate\-mode
 ]
 [
@@ -220,6 +225,12 @@ special privileges; see the
 man page for details.  Reading a saved packet file doesn't require
 special privileges.
 .SH OPTIONS
+.TP
+.B \-0
+Zero out payload bytes beyond TCP or UDP headers.
+.TP
+.B \-00
+Remove payload bytes beyond TCP or UDP headers.
 .TP
 .B \-A
 Print each packet (minus its link level header) in ASCII.  Handy for
@@ -627,6 +638,14 @@ Setting
 \fIsnaplen\fP to 0 sets it to the default of 262144,
 for backwards compatibility with recent older versions of
 .IR tcpdump .
+.TP
+.BI \-* " mask_ip"
+.PD 0
+.TP
+.BI \-\-external\-mask " mask_ip"
+.PD
+Mask external IPv4 addresses (non-RFC 1918, plus other reserved spaces)
+to the designated IP.
 .TP
 .BI \-T " type"
 Force packets selected by "\fIexpression\fP" to be interpreted the

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -127,7 +127,7 @@ The Regents of the University of California.  All rights reserved.\n";
 #include "gmt2local.h"
 #include "pcap-missing.h"
 #include "ascii_strcasecmp.h"
-#include "clean_cap_dump.h" // CyberReboot addition
+#include "clean_cap_dump.h" /* CyberReboot addition */
 
 #include "print.h"
 
@@ -257,7 +257,7 @@ struct dump_info {
 	char	*CurrentFileName;
 	pcap_t	*pd;
 	pcap_dumper_t *p;
-    char    *maskIP;
+	char    *maskIP;
 #ifdef HAVE_CAPSICUM
 	int	dirfd;
 #endif
@@ -605,7 +605,7 @@ static const struct option longopts[] = {
 	{ "debug-filter-parser", no_argument, NULL, 'Y' },
 #endif
 	{ "relinquish-privileges", required_argument, NULL, 'Z' },
-    { "external-mask", required_argument, NULL, '*' },
+	{ "external-mask", required_argument, NULL, '*' },
 	{ "number", no_argument, NULL, '#' },
 	{ "version", no_argument, NULL, OPTION_VERSION },
 	{ NULL, 0, NULL, 0 }
@@ -697,7 +697,7 @@ MakeFilename(char *buffer, char *orig_name, int cnt, int max_chars)
 {
         char *filename = malloc(PATH_MAX + 1);
         if (filename == NULL)
-            error("Makefilename: malloc");
+        error("Makefilename: malloc");
 
         /* Process with strftime if Gflag is set. */
         if (Gflag != 0) {
@@ -1189,10 +1189,10 @@ open_interface(const char *device, netdissect_options *ndo, char *ebuf)
 /* Returns 0 if the given string is a valid IP address; else, returns -1. */
 int
 verify_IP(char *ip) {
-    struct sockaddr_in sa;
-    if (inet_pton(AF_INET, ip, &(sa.sin_addr)) == 1)
-        return 0;
-    return -1;
+	struct sockaddr_in sa;
+	if (inet_pton(AF_INET, ip, &(sa.sin_addr)) == 1)
+		return 0;
+	return -1;
 }
 
 int
@@ -1240,7 +1240,6 @@ main(int argc, char **argv)
 	if (nd_init(ebuf, sizeof ebuf) == -1)
 		error("%s", ebuf);
 
-    // cool way to set all flags to zero. - @lilchurro
 	memset(ndo, 0, sizeof(*ndo));
 	ndo_set_function_pointers(ndo);
 
@@ -1273,7 +1272,7 @@ main(int argc, char **argv)
 		error("%s", ebuf);
 
 	while (
-	    (op = getopt_long(argc, argv, SHORTOPTS, longopts, NULL)) != -1)
+		(op = getopt_long(argc, argv, SHORTOPTS, longopts, NULL)) != -1)
 		switch (op) {
 
 		case 'a':
@@ -1588,16 +1587,16 @@ main(int argc, char **argv)
 			ndo->ndo_packet_number = 1;
 			break;
 
-        case '0':       // CyberReboot: new flag
-            ++no_payload;
-            break;
+		case '0':       /* CyberReboot: new flag */
+			++no_payload;
+			break;
 
-        case '*':       // CyberReboot: new flag
-            if (verify_IP(optarg) < 0)
-                error("IP address mask is not a legal IP address");
-            ++mask_external_ip;
-            dumpinfo.maskIP = optarg;
-            break;
+		case '*':       /* CyberReboot: new flag */
+			if (verify_IP(optarg) < 0)
+			error("IP address mask is not a legal IP address");
+			++mask_external_ip;
+			dumpinfo.maskIP = optarg;
+			break;
 
 		case OPTION_VERSION:
 			print_version();
@@ -1722,7 +1721,7 @@ main(int argc, char **argv)
 
 #ifdef HAVE_PCAP_SET_TSTAMP_PRECISION
 		pd = pcap_open_offline_with_tstamp_precision(RFileName,
-		    ndo->ndo_tstamp_precision, ebuf);
+			ndo->ndo_tstamp_precision, ebuf);
 #else
 		pd = pcap_open_offline(RFileName, ebuf);
 #endif
@@ -1880,7 +1879,7 @@ main(int argc, char **argv)
 #endif
 	if (pcap_compile(pd, &fcode, cmdbuf, Oflag, netmask) < 0)
 		error("%s", pcap_geterr(pd));
-	if (dflag) { // print filter code
+	if (dflag) { 
 		bpf_dump(&fcode, dflag);
 		pcap_close(pd);
 		free(cmdbuf);
@@ -2586,14 +2585,13 @@ dump_packet_and_trunc(u_char *user, const struct pcap_pkthdr *h, const u_char *s
 		}
 	}
 
-    // CyberReboot dump insert:
-    if (no_payload > 0 || mask_external_ip > 0) {
-        //printf("DEBUG: packet #%d\n", packets_captured);
-        pcap_mod_and_dump((u_char *)dump_info->p, h, sp, pcap_datalink(dump_info->pd),
-                          no_payload, mask_external_ip, dump_info->maskIP);
-    } else {
-        pcap_dump((u_char *)dump_info->p, h, sp);
-    }
+	/* CyberReboot dump insert: */
+	if (no_payload > 0 || mask_external_ip > 0) {
+		pcap_mod_and_dump((u_char *)dump_info->p, h, sp, pcap_datalink(dump_info->pd),
+				no_payload, mask_external_ip, dump_info->maskIP);
+	} else {
+		pcap_dump((u_char *)dump_info->p, h, sp);
+	}
 
 #ifdef HAVE_PCAP_DUMP_FLUSH
 	if (Uflag)
@@ -2611,16 +2609,15 @@ dump_packet(u_char *user, const struct pcap_pkthdr *h, const u_char *sp)
 	++packets_captured;
 	++infodelay;
 
-    struct dump_info *dump_info = (struct dump_info *)user;
+	struct dump_info *dump_info = (struct dump_info *)user;
 
-    // CyberReboot dump insert:
-    if (no_payload > 0 || mask_external_ip > 0) {
-        //printf("DEBUG: packet #%d\n", packets_captured);
-        pcap_mod_and_dump((u_char *)dump_info->p, h, sp, pcap_datalink(dump_info->pd),
-                          no_payload, mask_external_ip, dump_info->maskIP);
-    } else {
-        pcap_dump((u_char *)dump_info->p, h, sp);
-    }
+	/* CyberReboot dump insert: */
+	if (no_payload > 0 || mask_external_ip > 0) {
+		pcap_mod_and_dump((u_char *)dump_info->p, h, sp, pcap_datalink(dump_info->pd),
+				  no_payload, mask_external_ip, dump_info->maskIP);
+	} else {
+		pcap_dump((u_char *)dump_info->p, h, sp);
+	}
 
 #ifdef HAVE_PCAP_DUMP_FLUSH
 	if (Uflag)

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -1191,7 +1191,7 @@ int
 verify_IP(char *ip) {
 	struct sockaddr_in sa;
 	if (inet_pton(AF_INET, ip, &(sa.sin_addr)) == 1)
-       		 return 0;
+		return 0;
 	return -1;
 }
 
@@ -2015,8 +2015,8 @@ main(int argc, char **argv)
 #ifdef HAVE_CAPSICUM
 		set_dumper_capsicum_rights(p);
 #endif
-        dumpinfo.pd = pd;
-        dumpinfo.p = p;
+		dumpinfo.pd = pd;
+		dumpinfo.p = p;
 		if (Cflag != 0 || Gflag != 0) {
 #ifdef HAVE_CAPSICUM
 			dumpinfo.WFileName = strdup(basename(WFileName));
@@ -2140,7 +2140,7 @@ main(int argc, char **argv)
 			}
 			(void)fflush(stdout);
 		}
-        if (status == -2) {
+		if (status == -2) {
 			/*
 			 * We got interrupted. If we are reading multiple
 			 * files (via -V) set these so that we stop.
@@ -2335,10 +2335,10 @@ info(register int verbose)
 			putc('\n', stderr);
 		(void)fprintf(stderr, "%u packet%s dropped by interface\n",
 		    stats.ps_ifdrop, PLURAL_SUFFIX(stats.ps_ifdrop));
-    } else
-        putc('\n', stderr);
+	} else
+		putc('\n', stderr);
 
-    infoprint = 0;
+	infoprint = 0;
 }
 
 #if defined(HAVE_FORK) || defined(HAVE_VFORK)
@@ -2398,13 +2398,17 @@ static void
 dump_packet_and_trunc(u_char *user, const struct pcap_pkthdr *h, const u_char *sp)
 {
 	struct dump_info *dump_info;
-    int dlt;
 
 	++packets_captured;
 
 	++infodelay;
 
 	dump_info = (struct dump_info *)user;
+
+	if ((no_payload > 0 || mask_external_ip > 0) && pcap_datalink(user->pd) != DLT_EN10MB) {
+		error("-0 and -* flags are only available for Ethernet data link type; exiting");
+		exit_tcpdump(0);
+	}
 
 	/*
 	 * XXX - this won't force the file to rotate on the specified time
@@ -2586,13 +2590,13 @@ dump_packet_and_trunc(u_char *user, const struct pcap_pkthdr *h, const u_char *s
 		}
 	}
 
-    /* CyberReboot dump insert: */
-    if (no_payload > 0 || mask_external_ip > 0) {
-        pcap_mod_and_dump((u_char *)dump_info->p, h, sp, pcap_datalink(dump_info->pd),
-                          no_payload, mask_external_ip, dump_info->maskIP);
-    } else {
-        pcap_dump((u_char *)dump_info->p, h, sp);
-    }
+	/* CyberReboot dump insert: */
+	if (no_payload > 0 || mask_external_ip > 0) {
+		pcap_mod_and_dump((u_char *)dump_info->p, h, sp, pcap_datalink(dump_info->pd),
+				  no_payload, mask_external_ip, dump_info->maskIP);
+	} else {
+		pcap_dump((u_char *)dump_info->p, h, sp);
+	}
 
 #ifdef HAVE_PCAP_DUMP_FLUSH
 	if (Uflag)
@@ -2610,15 +2614,20 @@ dump_packet(u_char *user, const struct pcap_pkthdr *h, const u_char *sp)
 	++packets_captured;
 	++infodelay;
 
-    struct dump_info *dump_info = (struct dump_info *)user;
+	struct dump_info *dump_info = (struct dump_info *)user;
 
-    /* CyberReboot dump insert: */
-    if (no_payload > 0 || mask_external_ip > 0) {
-        pcap_mod_and_dump((u_char *)dump_info->p, h, sp, pcap_datalink(dump_info->pd),
-                          no_payload, mask_external_ip, dump_info->maskIP);
-    } else {
-        pcap_dump((u_char *)dump_info->p, h, sp);
-    }
+	/* CyberReboot dump insert: */
+	if (no_payload > 0 || mask_external_ip > 0) {
+		if (pcap_datalink(user->pd) != DLT_EN10MB) {
+			error("-0 and -* flags are only available for Ethernet data link type; exiting");
+			exit_tcpdump(0);
+		}
+
+		pcap_mod_and_dump((u_char *)dump_info->p, h, sp, pcap_datalink(dump_info->pd),
+				  no_payload, mask_external_ip, dump_info->maskIP);
+	} else {
+		pcap_dump((u_char *)dump_info->p, h, sp);
+	}
 
 #ifdef HAVE_PCAP_DUMP_FLUSH
 	if (Uflag)

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -1187,7 +1187,7 @@ open_interface(const char *device, netdissect_options *ndo, char *ebuf)
 }
 
 /* Returns 0 if the given string is a valid IP address; else, returns -1. */
-int
+static int
 verify_IP(char *ip) {
 	struct sockaddr_in sa;
 	if (inet_pton(AF_INET, ip, &(sa.sin_addr)) == 1)
@@ -2405,7 +2405,7 @@ dump_packet_and_trunc(u_char *user, const struct pcap_pkthdr *h, const u_char *s
 
 	dump_info = (struct dump_info *)user;
 
-	if ((no_payload > 0 || mask_external_ip > 0) && pcap_datalink(user->pd) != DLT_EN10MB) {
+	if ((no_payload > 0 || mask_external_ip > 0) && pcap_datalink(dump_info->pd) != DLT_EN10MB) {
 		error("-0 and -* flags are only available for Ethernet data link type; exiting");
 		exit_tcpdump(0);
 	}
@@ -2611,14 +2611,15 @@ dump_packet_and_trunc(u_char *user, const struct pcap_pkthdr *h, const u_char *s
 static void
 dump_packet(u_char *user, const struct pcap_pkthdr *h, const u_char *sp)
 {
+	struct dump_info *dump_info;
 	++packets_captured;
 	++infodelay;
 
-	struct dump_info *dump_info = (struct dump_info *)user;
+	dump_info = (struct dump_info *)user;
 
 	/* CyberReboot dump insert: */
 	if (no_payload > 0 || mask_external_ip > 0) {
-		if (pcap_datalink(user->pd) != DLT_EN10MB) {
+		if (pcap_datalink(dump_info->pd) != DLT_EN10MB) {
 			error("-0 and -* flags are only available for Ethernet data link type; exiting");
 			exit_tcpdump(0);
 		}

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -695,25 +695,25 @@ getWflagChars(int x)
 static void
 MakeFilename(char *buffer, char *orig_name, int cnt, int max_chars)
 {
-        char *filename = malloc(PATH_MAX + 1);
-        if (filename == NULL)
-        error("Makefilename: malloc");
+	char *filename = malloc(PATH_MAX + 1);
+	if (filename == NULL)
+	error("Makefilename: malloc");
 
         /* Process with strftime if Gflag is set. */
         if (Gflag != 0) {
-          struct tm *local_tm;
+		struct tm *local_tm;
 
-          /* Convert Gflag_time to a usable format */
-          if ((local_tm = localtime(&Gflag_time)) == NULL) {
-                  error("MakeTimedFilename: localtime");
-          }
+		/* Convert Gflag_time to a usable format */
+		if ((local_tm = localtime(&Gflag_time)) == NULL) {
+			error("MakeTimedFilename: localtime");
+		}
 
-          /* There's no good way to detect an error in strftime since a return
-           * value of 0 isn't necessarily failure.
-           */
-          strftime(filename, PATH_MAX, orig_name, local_tm);
-        } else {
-          strncpy(filename, orig_name, PATH_MAX);
+		/* There's no good way to detect an error in strftime since a return
+		 * value of 0 isn't necessarily failure.
+		 */
+		strftime(filename, PATH_MAX, orig_name, local_tm);
+	} else {
+		strncpy(filename, orig_name, PATH_MAX);
         }
 
 	if (cnt == 0 && max_chars == 0)
@@ -721,7 +721,7 @@ MakeFilename(char *buffer, char *orig_name, int cnt, int max_chars)
 	else
 		if (snprintf(buffer, PATH_MAX + 1, "%s%0*d", filename, max_chars, cnt) > PATH_MAX)
                   /* Report an error if the filename is too large */
-                  error("too many output files or filename is too long (> %d)", PATH_MAX);
+			error("too many output files or filename is too long (> %d)", PATH_MAX);
         free(filename);
 }
 
@@ -1587,6 +1587,7 @@ main(int argc, char **argv)
 			ndo->ndo_packet_number = 1;
 			break;
 
+<<<<<<< 6386443723ea6dc24bb821c9aa928a2ab20da774
 		case '0':       /* CyberReboot: new flag */
 			++no_payload;
 			break;
@@ -1597,7 +1598,18 @@ main(int argc, char **argv)
 			++mask_external_ip;
 			dumpinfo.maskIP = optarg;
 			break;
+=======
+		case '0':      /* CyberReboot: new flag */ 
+			++no_payload;
+			break;
+>>>>>>> Changed indentation to tabs (8-char width); also added a warning that the flags are ignored
 
+		case '*':       /* CyberReboot: new flag */
+			if (verify_IP(optarg) < 0)
+				error("IP address mask is not a legal IP address");
+ 			++mask_external_ip;
+			dumpinfo.maskIP = optarg;
+			break;
 		case OPTION_VERSION:
 			print_version();
 			exit_tcpdump(0);
@@ -2397,7 +2409,7 @@ static void
 dump_packet_and_trunc(u_char *user, const struct pcap_pkthdr *h, const u_char *sp)
 {
 	struct dump_info *dump_info;
-    int dlt;
+	int dlt;
 
 	++packets_captured;
 
@@ -2588,7 +2600,11 @@ dump_packet_and_trunc(u_char *user, const struct pcap_pkthdr *h, const u_char *s
 	/* CyberReboot dump insert: */
 	if (no_payload > 0 || mask_external_ip > 0) {
 		pcap_mod_and_dump((u_char *)dump_info->p, h, sp, pcap_datalink(dump_info->pd),
+<<<<<<< 6386443723ea6dc24bb821c9aa928a2ab20da774
 				no_payload, mask_external_ip, dump_info->maskIP);
+=======
+				  no_payload, mask_external_ip, dump_info->maskIP);
+>>>>>>> Changed indentation to tabs (8-char width); also added a warning that the flags are ignored
 	} else {
 		pcap_dump((u_char *)dump_info->p, h, sp);
 	}
@@ -2614,7 +2630,11 @@ dump_packet(u_char *user, const struct pcap_pkthdr *h, const u_char *sp)
 	/* CyberReboot dump insert: */
 	if (no_payload > 0 || mask_external_ip > 0) {
 		pcap_mod_and_dump((u_char *)dump_info->p, h, sp, pcap_datalink(dump_info->pd),
+<<<<<<< 6386443723ea6dc24bb821c9aa928a2ab20da774
 				  no_payload, mask_external_ip, dump_info->maskIP);
+=======
+				no_payload, mask_external_ip, dump_info->maskIP);
+>>>>>>> Changed indentation to tabs (8-char width); also added a warning that the flags are ignored
 	} else {
 		pcap_dump((u_char *)dump_info->p, h, sp);
 	}
@@ -2635,6 +2655,9 @@ print_packet(u_char *user, const struct pcap_pkthdr *h, const u_char *sp)
 	++packets_captured;
 
 	++infodelay;
+	if (no_payload > 0 || mask_external_ip > 0) {
+		warning("Not saving to pcap file; ignoring -0 and -* flags");
+	}
 	pretty_print_packet((netdissect_options *)user, h, sp, packets_captured);
 
 	--infodelay;

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -176,11 +176,11 @@ static int Wflag;			/* recycle output files after this number of files */
 static int WflagChars;
 static char *zflag = NULL;		/* compress each savefile using a specified command (like gzip or bzip2) */
 static int immediate_mode;
-static int no_payload = 0;       	/* CyberReboot: clear away payload */
-static int mask_external_ip = 0; 	/* CyberReboot: mask external IPs */
+static int no_payload = 0;       /* CyberReboot: ndo_0flag copy; clear away payload */
+static int mask_external_ip = 0; /* CyberReboot: ndo_starflag copy; mask external IPs */
 
-static int infodelay;     
-static int infoprint;    
+static int infodelay;
+static int infoprint;
 
 char *program_name;
 
@@ -695,25 +695,25 @@ getWflagChars(int x)
 static void
 MakeFilename(char *buffer, char *orig_name, int cnt, int max_chars)
 {
-	char *filename = malloc(PATH_MAX + 1);
-	if (filename == NULL)
-	error("Makefilename: malloc");
+        char *filename = malloc(PATH_MAX + 1);
+        if (filename == NULL)
+            error("Makefilename: malloc");
 
         /* Process with strftime if Gflag is set. */
         if (Gflag != 0) {
-		struct tm *local_tm;
+          struct tm *local_tm;
 
-		/* Convert Gflag_time to a usable format */
-		if ((local_tm = localtime(&Gflag_time)) == NULL) {
-			error("MakeTimedFilename: localtime");
-		}
+          /* Convert Gflag_time to a usable format */
+          if ((local_tm = localtime(&Gflag_time)) == NULL) {
+                  error("MakeTimedFilename: localtime");
+          }
 
-		/* There's no good way to detect an error in strftime since a return
-		 * value of 0 isn't necessarily failure.
-		 */
-		strftime(filename, PATH_MAX, orig_name, local_tm);
-	} else {
-		strncpy(filename, orig_name, PATH_MAX);
+          /* There's no good way to detect an error in strftime since a return
+           * value of 0 isn't necessarily failure.
+           */
+          strftime(filename, PATH_MAX, orig_name, local_tm);
+        } else {
+          strncpy(filename, orig_name, PATH_MAX);
         }
 
 	if (cnt == 0 && max_chars == 0)
@@ -721,7 +721,7 @@ MakeFilename(char *buffer, char *orig_name, int cnt, int max_chars)
 	else
 		if (snprintf(buffer, PATH_MAX + 1, "%s%0*d", filename, max_chars, cnt) > PATH_MAX)
                   /* Report an error if the filename is too large */
-			error("too many output files or filename is too long (> %d)", PATH_MAX);
+                  error("too many output files or filename is too long (> %d)", PATH_MAX);
         free(filename);
 }
 
@@ -1191,7 +1191,7 @@ int
 verify_IP(char *ip) {
 	struct sockaddr_in sa;
 	if (inet_pton(AF_INET, ip, &(sa.sin_addr)) == 1)
-		return 0;
+       		 return 0;
 	return -1;
 }
 
@@ -1271,8 +1271,7 @@ main(int argc, char **argv)
 	if (abort_on_misalignment(ebuf, sizeof(ebuf)) < 0)
 		error("%s", ebuf);
 
-	while (
-		(op = getopt_long(argc, argv, SHORTOPTS, longopts, NULL)) != -1)
+	while ((op = getopt_long(argc, argv, SHORTOPTS, longopts, NULL)) != -1)
 		switch (op) {
 
 		case 'a':
@@ -1598,12 +1597,6 @@ main(int argc, char **argv)
 			dumpinfo.maskIP = optarg;
 			break;
 
-		case '*':       /* CyberReboot: new flag */
-			if (verify_IP(optarg) < 0)
-				error("IP address mask is not a legal IP address");
- 			++mask_external_ip;
-			dumpinfo.maskIP = optarg;
-			break;
 		case OPTION_VERSION:
 			print_version();
 			exit_tcpdump(0);
@@ -1727,7 +1720,7 @@ main(int argc, char **argv)
 
 #ifdef HAVE_PCAP_SET_TSTAMP_PRECISION
 		pd = pcap_open_offline_with_tstamp_precision(RFileName,
-			ndo->ndo_tstamp_precision, ebuf);
+		    ndo->ndo_tstamp_precision, ebuf);
 #else
 		pd = pcap_open_offline(RFileName, ebuf);
 #endif
@@ -2061,6 +2054,8 @@ main(int argc, char **argv)
     			pcap_dump_flush(p);
 #endif
 	} else {
+		if (no_payload > 0 || mask_external_ip > 0)
+			warning("Flags -0 or -* set without savefile will be ignored.");
 		dlt = pcap_datalink(pd);
 		ndo->ndo_if_printer = get_if_printer(ndo, dlt);
 		callback = print_packet;
@@ -2403,7 +2398,7 @@ static void
 dump_packet_and_trunc(u_char *user, const struct pcap_pkthdr *h, const u_char *sp)
 {
 	struct dump_info *dump_info;
-	int dlt;
+    int dlt;
 
 	++packets_captured;
 
@@ -2591,13 +2586,13 @@ dump_packet_and_trunc(u_char *user, const struct pcap_pkthdr *h, const u_char *s
 		}
 	}
 
-	/* CyberReboot dump insert: */
-	if (no_payload > 0 || mask_external_ip > 0) {
-		pcap_mod_and_dump((u_char *)dump_info->p, h, sp, pcap_datalink(dump_info->pd),
-				no_payload, mask_external_ip, dump_info->maskIP);
-	} else {
-		pcap_dump((u_char *)dump_info->p, h, sp);
-	}
+    /* CyberReboot dump insert: */
+    if (no_payload > 0 || mask_external_ip > 0) {
+        pcap_mod_and_dump((u_char *)dump_info->p, h, sp, pcap_datalink(dump_info->pd),
+                          no_payload, mask_external_ip, dump_info->maskIP);
+    } else {
+        pcap_dump((u_char *)dump_info->p, h, sp);
+    }
 
 #ifdef HAVE_PCAP_DUMP_FLUSH
 	if (Uflag)
@@ -2615,15 +2610,15 @@ dump_packet(u_char *user, const struct pcap_pkthdr *h, const u_char *sp)
 	++packets_captured;
 	++infodelay;
 
-	struct dump_info *dump_info = (struct dump_info *)user;
+    struct dump_info *dump_info = (struct dump_info *)user;
 
-	/* CyberReboot dump insert: */
-	if (no_payload > 0 || mask_external_ip > 0) {
-		pcap_mod_and_dump((u_char *)dump_info->p, h, sp, pcap_datalink(dump_info->pd),
-				  no_payload, mask_external_ip, dump_info->maskIP);
-	} else {
-		pcap_dump((u_char *)dump_info->p, h, sp);
-	}
+    /* CyberReboot dump insert: */
+    if (no_payload > 0 || mask_external_ip > 0) {
+        pcap_mod_and_dump((u_char *)dump_info->p, h, sp, pcap_datalink(dump_info->pd),
+                          no_payload, mask_external_ip, dump_info->maskIP);
+    } else {
+        pcap_dump((u_char *)dump_info->p, h, sp);
+    }
 
 #ifdef HAVE_PCAP_DUMP_FLUSH
 	if (Uflag)
@@ -2639,11 +2634,8 @@ static void
 print_packet(u_char *user, const struct pcap_pkthdr *h, const u_char *sp)
 {
 	++packets_captured;
-
 	++infodelay;
-	if (no_payload > 0 || mask_external_ip > 0) {
-		warning("Not saving to pcap file; ignoring -0 and -* flags");
-	}
+
 	pretty_print_packet((netdissect_options *)user, h, sp, packets_captured);
 
 	--infodelay;


### PR DESCRIPTION
Built two new flags to sanitize packets as they are written to savefiles:
- 0 zeroes out the packet payload bytes after (the first encountered) TCP/UDP header
- 00 truncates the packet right after the (first encountered) TCP/UDP header
- * [mask_ip] strips the external IP addresses (i.e., addresses outside of the reserved netblocks specified in RFC5735) and replaces it with [mask_ip].