### PR TITLE
Check mstp_len before dereferencing

### DIFF
--- a/print-stp.c
+++ b/print-stp.c
@@ -475,6 +475,7 @@ stp_print(netdissect_options *ndo, const u_char *p, u_int length)
             if (stp_bpdu->protocol_version == STP_PROTO_SPB)
             {
               /* Validate v4 length */
+              ND_TCHECK_16BITS(p + MST_BPDU_VER3_LEN_OFFSET + mstp_len);
               spb_len = EXTRACT_16BITS (p + MST_BPDU_VER3_LEN_OFFSET + mstp_len);
               spb_len += 2;
               if (length < (sizeof(struct stp_bpdu_) + mstp_len + spb_len) ||


### PR DESCRIPTION
During STP processing, we have a special handler for `SPB` (Shortest
Path Bridging) which parses a part of the packet for that specific
protocol. To find the length of that part of the packet (`spb_len`),
it uses the `mstp_len` variable to find where that value is
stored. Since `mstp_len` is unpacked from the packet earlier, it is a
user-controlled value and so, the pointer to `sbp_len` can also be
user-controlled.

We therefore need to check that we can extract it safely, using the
`ND_TCHECK_16BITS` macro, as per *Code style and generic remarks* in
the `CONTRIBUTING` document. The pointer taken to extract `mstp_len`
itself *is* checked, but, oddly, even though the comments say
`sbp_len` is validated as well, the macro call is missing.

This fixes the symptoms described by CVE-2017-11108 in my tests, but
someone with e deeper knowledge of the code should review this to
confirm it is the correct solution.

Closes: #616