### PR TITLE
cross-compiling: do not check dlpi.

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -550,7 +550,9 @@ don't.])
 fi
 
 # libdlpi is needed for Solaris 11 and later.
-AC_CHECK_LIB(dlpi, dlpi_walk, LIBS="$LIBS -ldlpi" LDFLAGS="-L/lib $LDFLAGS", ,-L/lib)
+if test "$cross_compiling" != yes; then
+	AC_CHECK_LIB(dlpi, dlpi_walk, LIBS="$LIBS -ldlpi" LDFLAGS="-L/lib $LDFLAGS", ,-L/lib)
+fi
 
 dnl
 dnl Check for "pcap_list_datalinks()", "pcap_set_datalink()",


### PR DESCRIPTION
For cross-compiling on Linux platforms, we do not need to check libdlpi
since it is only placed on Solaris.

Signed-off-by: Xin Ouyang <Xin.Ouyang@windriver.com>