### PR TITLE
Made up for missing getservent() and endservent()

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -381,6 +381,8 @@ datalinks.o: $(srcdir)/missing/datalinks.c
 	$(CC) $(FULL_CFLAGS) -o $@ -c $(srcdir)/missing/datalinks.c
 dlnames.o: $(srcdir)/missing/dlnames.c
 	$(CC) $(FULL_CFLAGS) -o $@ -c $(srcdir)/missing/dlnames.c
+getservent.o: $(srcdir)/missing/getservent.c
+	$(CC) $(FULL_CFLAGS) -o $@ -c $(srcdir)/missing/getservent.c
 getopt_long.o: $(srcdir)/missing/getopt_long.c
 	$(CC) $(FULL_CFLAGS) -o $@ -c $(srcdir)/missing/getopt_long.c
 snprintf.o: $(srcdir)/missing/snprintf.c

--- a/Makefile.in
+++ b/Makefile.in
@@ -264,6 +264,7 @@ HDR = \
 	extract.h \
 	funcattrs.h \
 	getopt_long.h \
+	getservent.h \
 	gmpls.h \
 	gmt2local.h \
 	interface.h \
@@ -342,6 +343,7 @@ EXTRA_DIST = \
 	missing/dlnames.c \
 	missing/datalinks.c \
 	missing/getopt_long.c \
+	missing/getservent.c \
 	missing/snprintf.c \
 	missing/strdup.c \
 	missing/strlcat.c \

--- a/addrtoname.c
+++ b/addrtoname.c
@@ -57,6 +57,9 @@ extern int ether_ntohost(char *, const struct ether_addr *);
 
 #include <pcap.h>
 #include <pcap-namedb.h>
+#ifndef HAVE_GETSERVENT
+#include <getservent.h>
+#endif
 #include <signal.h>
 #include <stdio.h>
 #include <string.h>

--- a/config.h.in
+++ b/config.h.in
@@ -55,6 +55,9 @@
 /* define if you have getrpcbynumber() */
 #undef HAVE_GETRPCBYNUMBER
 
+/* Define to 1 if you have the `getservent' function. */
+#undef HAVE_GETSERVENT
+
 /* Define to 1 if you have the <inttypes.h> header file. */
 #undef HAVE_INTTYPES_H
 

--- a/configure
+++ b/configure
@@ -5006,6 +5006,19 @@ esac
 
 fi
 
+ac_fn_c_check_func "$LINENO" "getservent" "ac_cv_func_getservent"
+if test "x$ac_cv_func_getservent" = xyes; then :
+  $as_echo "#define HAVE_GETSERVENT 1" >>confdefs.h
+
+else
+  case " $LIBOBJS " in
+  *" getservent.$ac_objext "* ) ;;
+  *) LIBOBJS="$LIBOBJS getservent.$ac_objext"
+ ;;
+esac
+
+fi
+
 ac_fn_c_check_func "$LINENO" "getopt_long" "ac_cv_func_getopt_long"
 if test "x$ac_cv_func_getopt_long" = xyes; then :
   $as_echo "#define HAVE_GETOPT_LONG 1" >>confdefs.h

--- a/configure.in
+++ b/configure.in
@@ -400,7 +400,7 @@ if test "$td_cv_decl_netdnet_dnetdb_h_dnet_htoa" = yes; then
 	    [define if you have a dnet_htoa declaration in <netdnet/dnetdb.h>])
 fi
 
-AC_REPLACE_FUNCS(vfprintf strlcat strlcpy strdup strsep getopt_long)
+AC_REPLACE_FUNCS(vfprintf strlcat strlcpy strdup strsep getservent getopt_long)
 AC_CHECK_FUNCS(fork vfork strftime)
 AC_CHECK_FUNCS(setlinebuf alarm)
 

--- a/getservent.h
+++ b/getservent.h
@@ -1,0 +1,67 @@
+/*
+* Copyright (c) 1983, 1993	The Regents of the University of California.
+* Copyright (c) 1993 Digital Equipment Corporation.
+* Copyright (c) 2012 G. Vanem <gvanem@yahoo.no>.
+* Copyright (c) 2017 Ali Abdulkadir <autostart.ini@gmail.com>.
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+* 3. All advertising materials mentioning features or use of this software
+*    must display the following acknowledgement:
+*	This product includes software developed by the University of
+*	California, Berkeley and its contributors.
+* 4. Neither the name of the University nor the names of its contributors
+*    may be used to endorse or promote products derived from this software
+*    without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+* LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+* OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+* SUCH DAMAGE.
+*/
+
+#ifndef _GETSERVENT_H
+#define _GETSERVENT_H
+
+#ifdef _NETDB_H_
+/* Just in case... */
+#error netdb.h and getservent.h are incompatible
+#else
+#define _NETDB_H_
+#endif
+
+#ifdef _WIN32
+#define __PATH_SYSROOT "SYSTEMROOT"
+#define __PATH_ETC_INET "\\System32\\drivers\\etc\\"
+#define __PATH_SERVICES "services"
+#else
+/*
+* The idea here is to be able to replace "PREFIX" in __PATH_SYSROOT with a variable
+* that could, for example, point to an alternative install location.
+*/
+#define __PATH_SYSROOT "PREFIX"
+#define __PATH_ETC_INET "/etc/"
+#define __PATH_SERVICES __PATH_SYSROOT__PATH_ETC_INET"services"
+#endif
+
+#define MAXALIASES 35
+
+void endservent (void);
+struct servent *getservent(void);
+void setservent (int f);
+
+#endif /* !_GETSERVENT_H */

--- a/getservent.h
+++ b/getservent.h
@@ -55,7 +55,7 @@
 */
 #define __PATH_SYSROOT "PREFIX"
 #define __PATH_ETC_INET "/etc/"
-#define __PATH_SERVICES __PATH_SYSROOT__PATH_ETC_INET"services"
+#define __PATH_SERVICES __PATH_ETC_INET"services"
 #endif
 
 #define MAXALIASES 35

--- a/missing/getservent.c
+++ b/missing/getservent.c
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 1983, 1993	The Regents of the University of California.
+ * Copyright (c) 1993 Digital Equipment Corporation.
+ * Copyright (c) 2012 G. Vanem <gvanem@yahoo.no>.
+ * Copyright (c) 2017 Ali Abdulkadir <autostart.ini@gmail.com>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <netdissect-stdinc.h>
+#include <getservent.h>
+
+static FILE *servf = NULL;
+static char line[BUFSIZ+1];
+static struct servent serv;
+static char *serv_aliases[MAXALIASES];
+int _serv_stayopen;
+const char *etc_path(const char *file);
+
+/*
+* Return either "%SYSTEMROOT%\System32\drivers\etc\<file>",
+* $PREFIX/etc/<file> or simply "<file>" if those failed.
+* "<file>" is aka __PATH_SERVICES (aka "services" on Windows and
+* "/etc/services" on other platforms that would need this)
+*/
+const char *etc_path(const char *file)
+{
+    const char *env = getenv(__PATH_SYSROOT);
+    static char path[_MAX_PATH];
+
+    if (!env)
+/*
+* #ifdef _DEBUG
+*   printf("Warning: Environment Variable \"%s\" invalid\nResorting to [CurrentDirectory]/%s\n",
+*       __PATH_SYSROOT, file);
+* #endif
+*/
+        return (file);
+
+    snprintf(path, sizeof(path), "%s%s%s", env, __PATH_ETC_INET, file);
+    return (path);
+}
+
+void
+setservent(int f)
+{
+    if (servf == NULL)
+        servf = fopen(etc_path(__PATH_SERVICES), "r");
+    else
+        rewind(servf);
+    _serv_stayopen |= f;
+}
+
+void
+endservent(void)
+{
+    if (servf) {
+        fclose(servf);
+        servf = NULL;
+    }
+    _serv_stayopen = 0;
+}
+
+struct servent *
+getservent(void)
+{
+    char *p;
+    register char *cp, **q;
+
+    if (servf == NULL && (servf = fopen(etc_path(__PATH_SERVICES), "r")) == NULL)
+        return (NULL);
+
+again:
+    if ((p = fgets(line, BUFSIZ, servf)) == NULL)
+        return (NULL);
+    if (*p == '#')
+        goto again;
+    cp = strpbrk(p, "#\n");
+    if (cp == NULL)
+        goto again;
+    *cp = '\0';
+    serv.s_name = p;
+    p = strpbrk(p, " \t");
+    if (p == NULL)
+        goto again;
+    *p++ = '\0';
+    while (*p == ' ' || *p == '\t')
+        p++;
+    cp = strpbrk(p, ",/");
+    if (cp == NULL)
+        goto again;
+    *cp++ = '\0';
+    serv.s_port = htons((u_short)atoi(p));
+    serv.s_proto = cp;
+    q = serv.s_aliases = serv_aliases;
+    cp = strpbrk(cp, " \t");
+    if (cp != NULL)
+        *cp++ = '\0';
+    while (cp && *cp) {
+        if (*cp == ' ' || *cp == '\t') {
+            cp++;
+            continue;
+        }
+        if (q < &serv_aliases[MAXALIASES - 1])
+            *q++ = cp;
+        cp = strpbrk(cp, " \t");
+        if (cp != NULL)
+            *cp++ = '\0';
+    }
+    *q = NULL;
+    return (&serv);
+}


### PR DESCRIPTION
As discussed earlier in issue #640. I eventually went with a mix of C and D to remove some useless files/functions and because simply replacing a few defines/parameter didn't really work. 

I tried to keep it as universal as possible so that platforms other than windows (who don't have this) can use it as too **and** so that it won't take too much effort to make it (possibly someday) read other files as well.

It currently reads %SYSTEMROOT%\System32\drivers\etc\services ($PREFIX/etc/services if not win32) and falls back to read just [same directory as tcpdump]\services (/etc/services).
Maybe it should be the other way around, allowing user to supply their own services database, since the default one on windows is quite limited (280 entries).