### PR TITLE
An alternative check for alarm()

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -3,9 +3,6 @@
 /* define if you want to build the possibly-buggy SMB printer */
 #undef ENABLE_SMB
 
-/* Define to 1 if you have the `alarm' function. */
-#undef HAVE_ALARM
-
 /* Define to 1 if you have the `bpf_dump' function. */
 #undef HAVE_BPF_DUMP
 
@@ -26,6 +23,10 @@
 
 /* Casper support available */
 #undef HAVE_CASPER
+
+/* Define to 1 if you have the declaration of `alarm', and to 0 if you don't.
+   */
+#undef HAVE_DECL_ALARM
 
 /* Define to 1 if you have the declaration of `ether_ntohost', and to 0 if you
    don't. */

--- a/configure
+++ b/configure
@@ -5037,7 +5037,7 @@ esac
 fi
 
 
-for ac_func in fork vfork strftime
+for ac_func in fork vfork strftime setlinebuf
 do :
   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
 ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
@@ -5049,17 +5049,18 @@ _ACEOF
 fi
 done
 
-for ac_func in setlinebuf alarm
-do :
-  as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
-ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
-if eval test \"x\$"$as_ac_var"\" = x"yes"; then :
-  cat >>confdefs.h <<_ACEOF
-#define `$as_echo "HAVE_$ac_func" | $as_tr_cpp` 1
+
+ac_fn_c_check_decl "$LINENO" "alarm" "ac_cv_have_decl_alarm" "$ac_includes_default"
+if test "x$ac_cv_have_decl_alarm" = xyes; then :
+  ac_have_decl=1
+else
+  ac_have_decl=0
+fi
+
+cat >>confdefs.h <<_ACEOF
+#define HAVE_DECL_ALARM $ac_have_decl
 _ACEOF
 
-fi
-done
 
 
 needsnprintf=no

--- a/configure.in
+++ b/configure.in
@@ -405,8 +405,9 @@ if test "$td_cv_decl_netdnet_dnetdb_h_dnet_htoa" = yes; then
 fi
 
 AC_REPLACE_FUNCS(vfprintf strlcat strlcpy strdup strsep getservent getopt_long)
-AC_CHECK_FUNCS(fork vfork strftime)
-AC_CHECK_FUNCS(setlinebuf alarm)
+AC_CHECK_FUNCS(fork vfork strftime setlinebuf)
+
+AC_CHECK_DECLS_ONCE(alarm)
 
 needsnprintf=no
 AC_CHECK_FUNCS(vsnprintf snprintf,,

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -227,7 +227,7 @@ void requestinfo(int);
   #include <MMsystem.h>
   static UINT timer_id;
   static void CALLBACK verbose_stats_dump(UINT, UINT, DWORD_PTR, DWORD_PTR, DWORD_PTR);
-#elif defined(HAVE_ALARM)
+#elif defined(HAVE_DECL_ALARM)
   static void verbose_stats_dump(int sig);
 #endif
 
@@ -2206,7 +2206,7 @@ DIAG_ON_CLANG(assign-enum)
 		/* call verbose_stats_dump() each 1000 +/-100msec */
 		timer_id = timeSetEvent(1000, 100, verbose_stats_dump, 0, TIME_PERIODIC);
 		setvbuf(stderr, NULL, _IONBF, 0);
-#elif defined(HAVE_ALARM)
+#elif defined(HAVE_DECL_ALARM)
 		(void)setsignal(SIGALRM, verbose_stats_dump);
 		alarm(1);
 #endif
@@ -2397,7 +2397,7 @@ cleanup(int signo _U_)
 	if (timer_id)
 		timeKillEvent(timer_id);
 	timer_id = 0;
-#elif defined(HAVE_ALARM)
+#elif defined(HAVE_DECL_ALARM)
 	alarm(0);
 #endif
 
@@ -2852,7 +2852,7 @@ void CALLBACK verbose_stats_dump (UINT timer_id _U_, UINT msg _U_, DWORD_PTR arg
 {
 	print_packets_captured();
 }
-#elif defined(HAVE_ALARM)
+#elif defined(HAVE_DECL_ALARM)
 static void verbose_stats_dump(int sig _U_)
 {
 	print_packets_captured();


### PR DESCRIPTION
MinGW's alarm() implementation is a [stub](https://github.com/Alexpux/mingw-w64/blob/master/mingw-w64-crt/misc/alarm.c) and its [declaration is guarded](https://github.com/Alexpux/mingw-w64/blob/master/mingw-w64-headers/crt/io.h#L358).

The current check does not verify whether alarm() is usable.
This one doesn't either, but at least it checks whether it is declared in the default include files, which I think is, at least in this case, a more reliable test.

https://www.gnu.org/software/autoconf/manual/autoconf-2.65/html_node/Generic-Declarations.html