### PR TITLE
Use WDversion only when building windump

### DIFF
--- a/tcpdump.c
+++ b/tcpdump.c
@@ -2794,7 +2794,7 @@ print_packet(u_char *user, const struct pcap_pkthdr *h, const u_char *sp)
 		info(0);
 }
 
-#ifdef _WIN32
+#if defined(_WIN32) && defined(WPCAP)
 	/*
 	 * XXX - there should really be libpcap calls to get the version
 	 * number as a string (the string would be generated from #defines


### PR DESCRIPTION
...with the project files in tcpdump\win32\prj\.
This is achieved by checking whether WPCAP is true, which is only defined in tcpdump\win32\prj\WinDump.vcproj.