### PR TITLE
Lowered the minimum length of second field in mkdep's awk command

### DIFF
--- a/mkdep
+++ b/mkdep
@@ -112,7 +112,7 @@ awk '{
 		prev = $1;
 	}
 	else {
-		if (length(rec $2) > 78) {
+		if (length(rec $2) > 58) {
 			print rec;
 			rec = $0;
 		}


### PR DESCRIPTION
The awk command that is run last as part of `mkdep` to remove duplicate lines doesn't work on my machine. It removes duplicate lines but leaves their backslashes \

This is an estimation of how I think this can be fixes/improved.
I think that the length of this field can vary so much from OS to OS, that the value set now is as arbitrary as the old one. Though a lower value may be a better choice.

Another way is to add a newline if the minimum length isn't met like so `else rec = rec " \n" $2` 