### PR TITLE
Made tests suite work with tcpdump.exe and msys build of Perl

### DIFF
--- a/tests/TESTonce
+++ b/tests/TESTonce
@@ -18,6 +18,10 @@ if ($^O eq 'MSWin32') {
     $r = system "..\\windump -n -t -r $input $options 2>NUL | sed 's/\\r//' | tee NEW/$output | diff $output - >DIFF/$output.diff";
     # need to do same as below for Cygwin.
 }
+elsif ($^O eq 'msys') {
+    $r = system "../tcpdump 2>/dev/null -n -t -r $input $options >NEW/$output";
+    #print sprintf("END: %08x\n", $r);
+}
 else {
     # we used to do this as a nice pipeline, but the problem is that $r fails to
     # to be set properly if the tcpdump core dumps.


### PR DESCRIPTION
these 15 tests fail:
kday1-8
cve2015-0261_01
pcap-invalid-version-1
pcap-invalid-version-2
pcap-ng-invalid-vers-1
pcap-ng-invalid-vers-2
l2tp-avp-overflow
pktap-heap-overflow

How to interpret their exit code?
A log is attached.
[test_results.txt](https://github.com/the-tcpdump-group/tcpdump/files/1485189/test_results.txt)
