### PR TITLE
Fix printing of wildcard retractions and IHU in Babel printer.

### DIFF
--- a/tests/babel_auth.out
+++ b/tests/babel_auth.out
@@ -1,6 +1,6 @@
 IP6 (class 0xc0, hlim 1, next-header UDP (17) payload length: 436) fe80::b299:28ff:fec8:d646.6696 > ff02::1:6.6696: [udp sum ok] babel 2 (424)
 	Hello seqno 58134 interval 4.00s
-	Update/id ::/0 metric 65535 seqno 41391 interval infinity
+	Update/id any metric 65535 seqno 41391 interval infinity
 	Request for any
 	TS/PC timestamp 1339081200 packetcounter 2
 	HMAC key-id 30 digest-20 AD0FA7CD8D5A1898EC5409C8EDDA68B3ACA21B80


### PR DESCRIPTION
When the AE field is 0, the message applies to any routes or
neighbours.  Tcpdump used to print it as ::/0, which is confusing.