### PR TITLE
Fix fail to capture on RDMA device on FreeBSD

### DIFF
--- a/tcpdump.c
+++ b/tcpdump.c
@@ -2089,7 +2089,7 @@ DIAG_ON_CLANG(assign-enum)
 	if (pcap_setfilter(pd, &fcode) < 0)
 		error("%s", pcap_geterr(pd));
 #ifdef HAVE_CAPSICUM
-	if (RFileName == NULL && VFileName == NULL) {
+	if (RFileName == NULL && VFileName == NULL && pcap_fileno(pd) != -1) {
 		static const unsigned long cmds[] = { BIOCGSTATS, BIOCROTZBUF };
 
 		/*


### PR DESCRIPTION
In pcap for RDMA devices, on FreeBSD where we have support for capsicum
but we don't have file descriptor for a live capture we will fail with:
"tcpdump: unable to limit pcap descriptor"
We just fail to set the proper access rights - don't fail the capture.

Signed-off-by: Slava Shwartsman <slavash@mellanox.com>