### PR TITLE
Add option to show packet direction

### DIFF
--- a/netdissect.h
+++ b/netdissect.h
@@ -198,6 +198,9 @@ struct netdissect_options {
   int   ndo_packettype;	/* as specified by -T */
 
   int   ndo_snaplen;
+#ifdef HAVE_PCAP_SETDIRECTION
+  int   ndo_showdir;		/* show packet direction */
+#endif
 
   /*global pointers to beginning and end of current packet (during printing) */
   const u_char *ndo_packetp;

--- a/print.c
+++ b/print.c
@@ -373,6 +373,22 @@ pretty_print_packet(netdissect_options *ndo, const struct pcap_pkthdr *h,
 	 * bigger lengths.
 	 */
 
+#ifdef HAVE_PCAP_SETDIRECTION
+	if (ndo->ndo_showdir) {
+		switch (h->dir) {
+		case PCAP_D_IN:
+			ND_PRINT("<  ");
+			break;
+		case PCAP_D_OUT:
+			ND_PRINT(" > ");
+			break;
+		default:
+			ND_PRINT("   ");
+			break;
+		}
+	}
+#endif
+
 	ts_print(ndo, &h->ts);
 
 	/*

--- a/tcpdump.1.in
+++ b/tcpdump.1.in
@@ -85,7 +85,7 @@ tcpdump \- dump traffic on a network
 ]
 [
 .B \-Q
-.I in|out|inout
+.I in|out|inout|show
 ]
 .ti +8
 [
@@ -593,8 +593,10 @@ flag.
 .BI \-\-direction= direction
 .PD
 Choose send/receive direction \fIdirection\fR for which packets should be
-captured. Possible values are `in', `out' and `inout'. Not available
-on all platforms.
+captured. Possible values are `in', `out', `inout' and `show'. `show' is the
+same as `inout' except that it prints the direction of the packet, if known.
+A < sign indicates a received packet, while a > sign a transmitted one.
+Not available on all platforms.
 .TP
 .B \-q
 Quick (quiet?) output.

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -1697,7 +1697,10 @@ main(int argc, char **argv)
 				Qflag = PCAP_D_OUT;
 			else if (ascii_strcasecmp(optarg, "inout") == 0)
 				Qflag = PCAP_D_INOUT;
-			else
+			else if (ascii_strcasecmp(optarg, "show") == 0) {
+				Qflag = PCAP_D_INOUT;
+				ndo->ndo_showdir = 1;
+			} else
 				error("unknown capture direction `%s'", optarg);
 			break;
 #endif /* HAVE_PCAP_SETDIRECTION */


### PR DESCRIPTION
Add a `-Q show` option to show the packet direction. Example:

```
$ tcpdump -ni enp9s0 -Q show
tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
listening on enp9s0, link-type EN10MB (Ethernet), capture size 262144 bytes
<  18:57:39.586150 IP 192.30.253.125.443 > 192.168.85.6.42512: Flags [P.], seq 3024695923:3024695954, ack 1359064726, win 31, options [nop,nop,TS val 919701565 ecr 2600782278], length 31
 > 18:57:39.586397 IP 192.168.85.6.42512 > 192.30.253.125.443: Flags [P.], seq 1:36, ack 31, win 329, options [nop,nop,TS val 2600842337 ecr 919701565], length 35
<  18:57:39.683849 IP 192.30.253.125.443 > 192.168.85.6.42512: Flags [.], ack 36, win 31, options [nop,nop,TS val 919701590 ecr 2600842337], length 0
<  18:57:39.926715 STP 802.1d, Config, Flags [none], bridge-id 8000.00:90:a9:f0:73:d1.8001, length 43
 > 18:57:40.139927 IP 192.168.85.6.44592 > 192.168.85.34.443: Flags [P.], seq 1812804671:1812804898, ack 1090051569, win 1394, options [nop,nop,TS val 2115702367 ecr 3472791082], length 22
```

Depends on the-tcpdump-group/libpcap#719