### PR TITLE
 We should use a separate input buffer as well 

### DIFF
--- a/print-esp.c
+++ b/print-esp.c
@@ -255,7 +255,7 @@ int esp_print_decrypt_buffer_by_ikev2(netdissect_options *ndo,
 	memset(input_buffer, 0, output_buffer_size);
 	memcpy(input_buffer, buf, len);
 
-	EVP_Cipher(ctx, output_buffer, buf, output_buffer_size);
+	EVP_Cipher(ctx, output_buffer, input_buffer, output_buffer_size);
 	EVP_CIPHER_CTX_free(ctx);
 
 	/*


### PR DESCRIPTION
The issue #586 still created some problems on ppc64(le) architectures. I think we should use separate input buffer as well and it should be the same size as the output buffer. Also I think we should use memset for both buffers or allocate them with calloc.