### PR TITLE
Added a flag (-R) to terminate capture after specified time

### DIFF
--- a/tcpdump.1.in
+++ b/tcpdump.1.in
@@ -27,7 +27,7 @@ tcpdump \- dump traffic on a network
 .na
 .B tcpdump
 [
-.B \-AbdDefhHIJKlLnNOpqStuUvxX#
+.B \-AbdDefhHIJKlLnNOpqRStuUvxX#
 ] [
 .B \-B
 .I buffer_size
@@ -606,6 +606,18 @@ Read packets from \fIfile\fR (which was created with the
 .B \-w
 option or by other tools that write pcap or pcapng files).
 Standard input is used if \fIfile\fR is ``-''.
+.TP
+.BI \-R " time"
+.PD 0
+.TP
+.BI \-\-max\-runtime= time
+.PD
+Capture packets until \fItime\fP has elapsed since the first packet arrived.
+Valid units are `us', `ms', `s', `m' and `h'.
+Respectively, these correspond to microseconds, milliseconds, seconds, minutes,
+and hours.
+There should be no space between the number and the units; `5ms' is good,
+`5 ms' is not.
 .TP
 .B \-S
 .PD 0


### PR DESCRIPTION
Context/Background: I needed this feature to be able to capture short bursts 
(single ms to tens of ms) on high-rate interfaces. Googling produced some 
results of people trying to do timed captures using watch(1) or other 
coarser-grained checks. These OS-level checks also relied on the runtime 
of the program, not the time interval of packets captured. Adding this 
check seems more reliable, easier to use, and provides finer-grained control.

The check works by adding a check to the callback function passed to pcap;
it saves the time of the first packet seen and then compares later packets
to that time. Time interval is specified with units of microseconds,
milliseconds, seconds, minutes, or hours. Internally, this gets converted
to an integer number of microseconds.

Updated the generated manpage and the printed usage. Haven't added any
tests; I didn't see any for other command line flags like -c, but can
add a couple if desired.