### PR TITLE
Display interface on live captures on DLT_LINUX_SLL2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,6 +191,7 @@ include(CheckTypeSize)
 #
 check_include_file(fcntl.h HAVE_FCNTL_H)
 check_include_file(rpc/rpc.h HAVE_RPC_RPC_H)
+check_include_file(net/if.h HAVE_NET_IF_H)
 if(HAVE_RPC_RPC_H)
     check_include_files("rpc/rpc.h;rpc/rpcent.h" HAVE_RPC_RPCENT_H)
 endif(HAVE_RPC_RPC_H)

--- a/cmakeconfig.h.in
+++ b/cmakeconfig.h.in
@@ -78,6 +78,9 @@
 /* Define to 1 if you have the <netdnet/dn.h> header file. */
 #cmakedefine HAVE_NETDNET_DN_H 1
 
+/* Define to 1 if you have the <net/if.h> header file. */
+#cmakedefine HAVE_NET_IF_H 1
+
 /* Define to 1 if you have the <net/if_pflog.h> header file. */
 #cmakedefine HAVE_NET_IF_PFLOG_H 1
 

--- a/config.h.in
+++ b/config.h.in
@@ -78,6 +78,9 @@
 /* Define to 1 if you have the <netdnet/dn.h> header file. */
 #undef HAVE_NETDNET_DN_H
 
+/* Define to 1 if you have the <net/if.h> header file. */
+#undef HAVE_NET_IF_H
+
 /* Define to 1 if you have the <net/if_pflog.h> header file. */
 #undef HAVE_NET_IF_PFLOG_H
 

--- a/configure
+++ b/configure
@@ -4037,7 +4037,7 @@ fi
 done
 
 
-for ac_header in fcntl.h rpc/rpc.h rpc/rpcent.h
+for ac_header in fcntl.h rpc/rpc.h rpc/rpcent.h net/if.h
 do :
   as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
 ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"

--- a/configure.ac
+++ b/configure.ac
@@ -24,7 +24,7 @@ AC_PROG_CC_C99
 AC_LBL_C_INIT(V_CCOPT, V_INCLS)
 AC_LBL_C_INLINE
 
-AC_CHECK_HEADERS(fcntl.h rpc/rpc.h rpc/rpcent.h)
+AC_CHECK_HEADERS(fcntl.h rpc/rpc.h rpc/rpcent.h net/if.h)
 AC_CHECK_HEADERS(net/pfvar.h, , , [#include <sys/types.h>
 #include <sys/socket.h>
 #include <net/if.h>])

--- a/print-sll.c
+++ b/print-sll.c
@@ -25,6 +25,10 @@
 #include <config.h>
 #endif
 
+#ifdef HAVE_NET_IF_H
+#include <net/if.h>
+#endif
+
 #include "netdissect-stdinc.h"
 
 #include "netdissect.h"
@@ -395,6 +399,9 @@ sll2_if_print(netdissect_options *ndo, const struct pcap_pkthdr *h, const u_char
 	u_short ether_type;
 	int llc_hdrlen;
 	u_int hdrlen;
+#ifdef HAVE_NET_IF_H
+	char ifname[IF_NAMESIZE];
+#endif
 
 	ndo->ndo_protocol = "sll2_if";
 	if (caplen < SLL2_HDR_LEN) {
@@ -408,6 +415,13 @@ sll2_if_print(netdissect_options *ndo, const struct pcap_pkthdr *h, const u_char
 	}
 
 	sllp = (const struct sll2_header *)p;
+#ifdef HAVE_NET_IF_H
+	uint32_t index = EXTRACT_BE_U_4(sllp->sll2_if_index);
+	if (if_indextoname(index, ifname))
+		ND_PRINT("ifindex %u (%s) ", index, ifname);
+	else
+		ND_PRINT("ifindex %u ", index);
+#endif
 
 	if (ndo->ndo_eflag)
 		sll2_print(ndo, sllp, length);

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -1978,6 +1978,10 @@ main(int argc, char **argv)
 			    RFileName, dlt_name,
 			    pcap_datalink_val_to_description(dlt));
 		}
+#ifdef DLT_LINUX_SLL2
+		if (dlt == DLT_LINUX_SLL2)
+			fprintf(stderr, "Warning: interface names might be incorrect\n");
+#endif
 	} else {
 		/*
 		 * We're doing a live capture.


### PR DESCRIPTION
The reason why displaying interface only for live captures is different
index when display pcap file on another machine than the one which was
doing the capture on [1].

See: GH the-tcpdump-group/libpcap#127

[1] https://lists.sandelman.ca/pipermail/tcpdump-workers/2018-July/001019.html

Signed-off-by: Petr Vorel <pvorel@suse.cz>
Suggested-by: Guy Harris <guy@alum.mit.edu>