### PR TITLE
Add check for pcap warning PCAP_WARNING_TSTAMP_TYPE_NOTSUP

### DIFF
--- a/tcpdump.c
+++ b/tcpdump.c
@@ -1306,7 +1306,7 @@ open_interface(const char *device, netdissect_options *ndo, char *ebuf)
 			error("%s: Can't set time stamp type: %s",
 		              device, pcap_statustostr(status));
 		else if (status > 0)
-		  warning("Could not set timestamp type '%s' on %s: %s",
+		  warning("When trying to set timestamp type '%s' on %s: %s",
 			  pcap_tstamp_type_val_to_name(jflag), device,
 			  pcap_statustostr(status));
 	}

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -1306,9 +1306,9 @@ open_interface(const char *device, netdissect_options *ndo, char *ebuf)
 			error("%s: Can't set time stamp type: %s",
 		              device, pcap_statustostr(status));
 		else if (status > 0)
-		  warning("When trying to set timestamp type '%s' on %s: %s",
-			  pcap_tstamp_type_val_to_name(jflag), device,
-			  pcap_statustostr(status));
+			warning("When trying to set timestamp type '%s' on %s: %s",
+				pcap_tstamp_type_val_to_name(jflag), device,
+				pcap_statustostr(status));
 	}
 #endif
 	status = pcap_activate(pc);

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -1305,6 +1305,10 @@ open_interface(const char *device, netdissect_options *ndo, char *ebuf)
 		if (status < 0)
 			error("%s: Can't set time stamp type: %s",
 		              device, pcap_statustostr(status));
+    else if (status == PCAP_WARNING_TSTAMP_TYPE_NOTSUP)
+      warning("Could not set timestamp type '%s' on %s: %s",
+        pcap_tstamp_type_val_to_name(jflag), device,
+        pcap_statustostr(status));
 	}
 #endif
 	status = pcap_activate(pc);

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -1305,10 +1305,10 @@ open_interface(const char *device, netdissect_options *ndo, char *ebuf)
 		if (status < 0)
 			error("%s: Can't set time stamp type: %s",
 		              device, pcap_statustostr(status));
-    else if (status == PCAP_WARNING_TSTAMP_TYPE_NOTSUP)
-      warning("Could not set timestamp type '%s' on %s: %s",
-        pcap_tstamp_type_val_to_name(jflag), device,
-        pcap_statustostr(status));
+		else if (status > 0)
+		  warning("Could not set timestamp type '%s' on %s: %s",
+			  pcap_tstamp_type_val_to_name(jflag), device,
+			  pcap_statustostr(status));
 	}
 #endif
 	status = pcap_activate(pc);


### PR DESCRIPTION
Previously would silently accept any of "host", "adapter", or
"adapter_unsynced" regardless of whether the interface supported
the option.