### PR TITLE
Subject: Introduce -nn option

### DIFF
--- a/addrtoname.c
+++ b/addrtoname.c
@@ -802,7 +802,7 @@ init_servarray(netdissect_options *ndo)
 
 		while (table->name)
 			table = table->nxt;
-		if (ndo->ndo_nflag) {
+		if (ndo->ndo_nflag > 1) {
 			(void)nd_snprintf(buf, sizeof(buf), "%d", port);
 			table->name = strdup(buf);
 		} else
@@ -1226,7 +1226,7 @@ init_addrtoname(netdissect_options *ndo, uint32_t localnet, uint32_t mask)
 		f_localnet = localnet;
 		f_netmask = mask;
 	}
-	if (ndo->ndo_nflag)
+	if (ndo->ndo_nflag > 1)
 		/*
 		 * Simplest way to suppress names.
 		 */

--- a/tcpdump.1.in
+++ b/tcpdump.1.in
@@ -546,7 +546,11 @@ Use \fIsecret\fP as a shared secret for validating the digests found in
 TCP segments with the TCP-MD5 option (RFC 2385), if present.
 .TP
 .B \-n
-Don't convert addresses (i.e., host addresses, port numbers, etc.) to names.
+Don't convert host addresses to names.  This can be used to avoid
+DNS lookups.
+.TP
+.B \-nn
+Don't convert protocol and port numbers etc. to names either.
 .TP
 .B \-N
 Don't print domain name qualification of host names.

--- a/tests/TESTonce
+++ b/tests/TESTonce
@@ -21,7 +21,7 @@ if ($^O eq 'MSWin32') {
 else {
     # we used to do this as a nice pipeline, but the problem is that $r fails to
     # to be set properly if the tcpdump core dumps.
-    $r = system "../tcpdump 2>/dev/null -# -n -r $input $options >NEW/$output";
+    $r = system "../tcpdump 2>/dev/null -# -nn -r $input $options >NEW/$output";
     if($r != 0) {
         # this means tcpdump failed.
         open(OUTPUT, ">>"."NEW/$output") || die "fail to open $output\n";


### PR DESCRIPTION
This changes the semantics on -n option so only namelookups are skipped. Port
numbers *are* translated to their string representations. Option -nn then has
the same semantics as -n had originally.

This is a partial upstreaming of tcpdump-4.9.2-3 used in CentOs 7.5.

Signed-off-by: Timothee Boucher-Lambert <timothee.boucher-lambert@tessares.net>