### PR TITLE
Ensure isatty is defined on Win32.

### DIFF
--- a/netdissect-stdinc.h
+++ b/netdissect-stdinc.h
@@ -215,6 +215,7 @@
    * #defines to let us use them.
    */
   #define isascii __isascii
+  #define isatty _isatty
   #define stat _stat
   #define strdup _strdup
   #define open _open


### PR DESCRIPTION
`isatty` has been deprecated in Visual Studio since [at least VS 2012](https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2012/ms235388(v=vs.110)). It doesn't cause a compile error, but does generate a warning that it's not defined and is assumed to be an `extern` returning an `int`. This change includes the appropriate header, `io.h`, for [the replacement `_isatty` function](https://docs.microsoft.com/en-gb/cpp/c-runtime-library/reference/isatty?view=vs-2017) and defines `isatty` to be `_isatty` if it's not already defined.