### PR TITLE
Extract NTP printing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -945,6 +945,7 @@ set(NETDISSECT_SOURCE_LIST_C
     netdissect-alloc.c
     nlpid.c
     oui.c
+    ntp.c
     parsenfsfh.c
     print.c
     print-802_11.c

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -85,6 +85,8 @@ machdep.h	- machine dependent definitions
 makemib		- mib to header script
 mib.h		- mib definitions
 missing/*	- replacements for missing library functions
+ntp.c		- functions to handle ntp structs
+ntp.h		- declarations of functions to handle ntp structs
 mkdep		- construct Makefile dependency list
 mpls.h		- MPLS definitions
 nameser.h	- DNS definitions

--- a/Makefile.in
+++ b/Makefile.in
@@ -87,6 +87,7 @@ LIBNETDISSECT_SRC=\
 	netdissect.c \
 	netdissect-alloc.c \
 	nlpid.c \
+	ntp.c \
 	oui.c \
 	parsenfsfh.c \
 	print.c \
@@ -286,6 +287,7 @@ HDR = \
 	nfs.h \
 	nfsfh.h \
 	nlpid.h \
+	ntp.h \
 	openflow.h \
 	ospf.h \
 	oui.h \

--- a/ntp.c
+++ b/ntp.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 1990, 1991, 1992, 1993, 1994, 1995, 1996, 1997
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that: (1) source code distributions
+ * retain the above copyright notice and this paragraph in its entirety, (2)
+ * distributions including binary code include the above copyright notice and
+ * this paragraph in its entirety in the documentation or other materials
+ * provided with the distribution, and (3) all advertising materials mentioning
+ * features or use of this software display the following acknowledgement:
+ * ``This product includes software developed by the University of California,
+ * Lawrence Berkeley Laboratory and its contributors.'' Neither the name of
+ * the University nor the names of its contributors may be used to endorse
+ * or promote products derived from this software without specific prior
+ * written permission.
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ */
+
+#include "ntp.h"
+
+#define	JAN_1970	INT64_T_CONSTANT(2208988800)	/* 1970 - 1900 in seconds */
+
+void
+p_ntp_time(netdissect_options *ndo,
+	   const struct l_fixedpt *lfp)
+{
+	uint32_t i;
+	uint32_t uf;
+	uint32_t f;
+	double ff;
+
+	i = GET_BE_U_4(lfp->int_part);
+	uf = GET_BE_U_4(lfp->fraction);
+	ff = uf;
+	if (ff < 0.0)		/* some compilers are buggy */
+		ff += FMAXINT;
+	ff = ff / FMAXINT;			/* shift radix point by 32 bits */
+	f = (uint32_t)(ff * 1000000000.0);	/* treat fraction as parts per billion */
+	ND_PRINT("%u.%09u", i, f);
+
+#ifdef HAVE_STRFTIME
+	/*
+	 * print the UTC time in human-readable format.
+	 */
+	if (i) {
+	    int64_t seconds_64bit = (int64_t)i - JAN_1970;
+	    time_t seconds;
+	    struct tm *tm;
+	    char time_buf[128];
+
+	    seconds = (time_t)seconds_64bit;
+	    if (seconds != seconds_64bit) {
+		/*
+		 * It doesn't fit into a time_t, so we can't hand it
+		 * to gmtime.
+		 */
+		ND_PRINT(" (unrepresentable)");
+	    } else {
+		tm = gmtime(&seconds);
+		if (tm == NULL) {
+		    /*
+		     * gmtime() can't handle it.
+		     * (Yes, that might happen with some version of
+		     * Microsoft's C library.)
+		     */
+		    ND_PRINT(" (unrepresentable)");
+		} else {
+		    /* use ISO 8601 (RFC3339) format */
+		    strftime(time_buf, sizeof (time_buf), "%Y-%m-%dT%H:%M:%SZ", tm);
+		    ND_PRINT(" (%s)", time_buf);
+		}
+	    }
+	}
+#endif
+}

--- a/ntp.h
+++ b/ntp.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 1990, 1991, 1992, 1993, 1994, 1995, 1996, 1997
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that: (1) source code distributions
+ * retain the above copyright notice and this paragraph in its entirety, (2)
+ * distributions including binary code include the above copyright notice and
+ * this paragraph in its entirety in the documentation or other materials
+ * provided with the distribution, and (3) all advertising materials mentioning
+ * features or use of this software display the following acknowledgement:
+ * ``This product includes software developed by the University of California,
+ * Lawrence Berkeley Laboratory and its contributors.'' Neither the name of
+ * the University nor the names of its contributors may be used to endorse
+ * or promote products derived from this software without specific prior
+ * written permission.
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include "netdissect-stdinc.h"
+
+#include "netdissect.h"
+#include "extract.h"
+
+#ifdef HAVE_STRFTIME
+#include <time.h>
+#endif
+
+/*
+ * Structure definitions for NTP fixed point values
+ *
+ *    0			  1		      2			  3
+ *    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ *   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *   |			       Integer Part			     |
+ *   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *   |			       Fraction Part			     |
+ *   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *
+ *    0			  1		      2			  3
+ *    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ *   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *   |		  Integer Part	     |	   Fraction Part	     |
+ *   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+*/
+struct l_fixedpt {
+	nd_uint32_t int_part;
+	nd_uint32_t fraction;
+};
+
+struct s_fixedpt {
+	nd_uint16_t int_part;
+	nd_uint16_t fraction;
+};
+
+#define	FMAXINT	(4294967296.0)	/* floating point rep. of MAXINT */
+
+void p_ntp_time(netdissect_options *, const struct l_fixedpt *);

--- a/win32/prj/GNUmakefile
+++ b/win32/prj/GNUmakefile
@@ -42,6 +42,7 @@ OBJS = \
 	../../machdep.o \
 	../../oui.o \
 	../../parsenfsfh.o \
+	../../ntp.o \
 	../../print-802_11.o \
 	../../print-ah.o \
 	../../print-aodv.o \

--- a/win32/prj/WinDump.dsp
+++ b/win32/prj/WinDump.dsp
@@ -125,6 +125,10 @@ SOURCE=..\..\missing\getopt_long.c
 # End Source File
 # Begin Source File
 
+SOURCE=..\..\ntp.c
+# End Source File
+# Begin Source File
+
 SOURCE=..\..\gmpls.c
 # End Source File
 # Begin Source File

--- a/win32/prj/WinDump.vcproj
+++ b/win32/prj/WinDump.vcproj
@@ -425,6 +425,28 @@
 			</FileConfiguration>
 		</File>
 		<File
+			RelativePath="..\..\ntp.c"
+			>
+			<FileConfiguration
+				Name="Debug|Win32"
+				>
+				<Tool
+					Name="VCCLCompilerTool"
+					AdditionalIncludeDirectories=""
+					PreprocessorDefinitions=""
+				/>
+			</FileConfiguration>
+			<FileConfiguration
+				Name="Release|Win32"
+				>
+				<Tool
+					Name="VCCLCompilerTool"
+					AdditionalIncludeDirectories=""
+					PreprocessorDefinitions=""
+				/>
+			</FileConfiguration>
+		</File>
+		<File
 			RelativePath="..\..\gmpls.c"
 			>
 			<FileConfiguration


### PR DESCRIPTION
This method is required to disect some RADIUS attributes (see #706)

The changes in the win32 folder are based on what grep could find for other shared modules, and have not been tested in any way.