### PR TITLE
return-checks: Added a return check for malloc and for strsep

### DIFF
--- a/print-esp.c
+++ b/print-esp.c
@@ -424,7 +424,7 @@ espprint_decode_encalgo(netdissect_options *ndo,
 USES_APPLE_RST
 
 /*
- * for the moment, ignore the auth algorith, just hard code the authenticator
+ * for the moment, ignore the auth algorithm, just hard code the authenticator
  * length. Need to research how openssl looks up HMAC stuff.
  */
 static int
@@ -577,6 +577,10 @@ static void esp_print_decode_onesecret(netdissect_options *ndo, char *line,
 		uint32_t spino;
 
 		spistr = strsep(&spikey, "@");
+		if (spistr == NULL) {
+			(*ndo->ndo_warning)(ndo, "print_esp: failed to find the @ token");
+			return;
+		}
 
 		spino = strtoul(spistr, &foo, 0);
 		if (spistr == foo || !spikey) {

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -1156,6 +1156,9 @@ _U_
 		 */
 		endp++;	/* Include the trailing / in the URL; pcap_findalldevs_ex() requires it */
 		host_url = malloc(endp - url + 1);
+		if (host_url == NULL && (endp - url + 1) > 0)
+			error("Invalid allocation for host");
+
 		memcpy(host_url, url, endp - url);
 		host_url[endp - url] = '\0';
 		status = pcap_findalldevs_ex(host_url, NULL, &devlist, ebuf);


### PR DESCRIPTION
Added a return check for `malloc` in tcpdump.c.
Added a return check for `strsep` in print-esp.c.
Fixed a small typo.
All tests passed.