### PR TITLE
Include correct capsicum header

### DIFF
--- a/tcpdump.c
+++ b/tcpdump.c
@@ -81,7 +81,7 @@ The Regents of the University of California.  All rights reserved.\n";
  * in the opposite order works fine.
  */
 #ifdef HAVE_CAPSICUM
-#include <sys/capability.h>
+#include <sys/capsicum.h>
 #include <sys/ioccom.h>
 #include <net/bpf.h>
 #include <libgen.h>


### PR DESCRIPTION
Current included header `sys/capability.h` is deprecated. All
supported FreeBSD versions have now the proper header `sys/capsicum.h`