### PR TITLE
CVE-2018-19519 buffer overread.

### DIFF
--- a/print-hncp.c
+++ b/print-hncp.c
@@ -208,6 +208,8 @@ print_prefix(netdissect_options *ndo, const u_char *prefix, u_int max_length)
     int plenbytes;
     char buf[sizeof("xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx::/128")];
 
+    buf[0] = '\0';
+    
     if (EXTRACT_U_1(prefix) >= 96 && max_length >= IPV4_MAPPED_HEADING_LEN + 1 &&
         is_ipv4_mapped_address(prefix + 1)) {
         struct in_addr addr;


### PR DESCRIPTION
Here is the patch with the suggested solution for CVE-2018-19519 as mentioned in [0] which initializes buf in print-hncp.c:print_prefix.

[0] https://github.com/zyingp/temp/blob/master/tcpdump.md

