### PR TITLE
Update print-lldp.c

### DIFF
--- a/print-lldp.c
+++ b/print-lldp.c
@@ -588,7 +588,7 @@ static const struct tok lldp_intf_numb_subtype_values[] = {
 static const struct tok lldp_evb_mode_values[]={
     { LLDP_EVB_MODE_NOT_SUPPORTED, "Not Supported"},
     { LLDP_EVB_MODE_EVB_BRIDGE, "EVB Bridge"},
-    { LLDP_EVB_MODE_EVB_STATION, "EVB Staion"},
+    { LLDP_EVB_MODE_EVB_STATION, "EVB Station"},
     { LLDP_EVB_MODE_RESERVED, "Reserved for future Standardization"},
     { 0, NULL},
 };


### PR DESCRIPTION
Small typo fix for `EVB Station` in Link Layer Discovery Protocol (LLDP) printer - `print-lldp.c`