### PR TITLE
Support DLT_IEEE802_15_4_TAP.

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -93,6 +93,7 @@ Additional people who have contributed patches (in alphabetical order):
     Jacek Tobiasz                 <Jacek dot Tobiasz at atm dot com dot pl>
     Jakob Schlyter                <jakob at openbsd dot org>
     Jamal Hadi Salim              <hadi at cyberus dot ca>
+    James Ko                      <jck at exegin dot com>
     Jan Oravec                    <wsx at wsx6 dot net>
     Jason R. Thorpe               <thorpej at netbsd dot org>
     Jefferson Ogata               <jogata at nodc dot noaa dot gov>

--- a/netdissect.h
+++ b/netdissect.h
@@ -447,6 +447,7 @@ extern u_int ieee802_11_if_print IF_PRINTER_ARGS;
 extern u_int ieee802_11_radio_avs_if_print IF_PRINTER_ARGS;
 extern u_int ieee802_11_radio_if_print IF_PRINTER_ARGS;
 extern u_int ieee802_15_4_if_print IF_PRINTER_ARGS;
+extern u_int ieee802_15_4_tap_if_print IF_PRINTER_ARGS;
 extern u_int ipfc_if_print IF_PRINTER_ARGS;
 extern u_int ipnet_if_print IF_PRINTER_ARGS;
 extern u_int juniper_atm1_if_print IF_PRINTER_ARGS;

--- a/print-802_15_4.c
+++ b/print-802_15_4.c
@@ -230,3 +230,33 @@ ieee802_15_4_if_print(netdissect_options *ndo,
 	ndo->ndo_protocol = "802.15.4_if";
 	return ieee802_15_4_print(ndo, p, h->caplen);
 }
+
+/* For DLT_IEEE802_15_4_TAP */
+/* https://github.com/jkcko/ieee802.15.4-tap */
+u_int
+ieee802_15_4_tap_if_print(netdissect_options *ndo,
+                          const struct pcap_pkthdr *h, const u_char *p)
+{
+	uint8_t version;
+	uint16_t length;
+
+	ndo->ndo_protocol = "802.15.4_tap";
+	if (h->caplen < 4) {
+		nd_print_trunc(ndo);
+		return h->caplen;
+	}
+
+	version = EXTRACT_U_1(p);
+	length = EXTRACT_LE_U_2(p+2);
+	if (version != 0 || length < 4) {
+		nd_print_invalid(ndo);
+		return 0;
+	}
+
+	if (h->caplen < length) {
+		nd_print_trunc(ndo);
+		return h->caplen;
+	}
+
+	return ieee802_15_4_print(ndo, p+length, h->caplen-length) + length;
+}

--- a/print.c
+++ b/print.c
@@ -57,6 +57,9 @@ static const struct printer printers[] = {
 #ifdef DLT_IEEE802_15_4_NOFCS
 	{ ieee802_15_4_if_print, DLT_IEEE802_15_4_NOFCS },
 #endif
+#ifdef DLT_IEEE802_15_4_TAP
+	{ ieee802_15_4_tap_if_print, DLT_IEEE802_15_4_TAP },
+#endif
 #ifdef DLT_PPI
 	{ ppi_if_print,		DLT_PPI },
 #endif


### PR DESCRIPTION
New link type for IEEE 802.15.4 with additional meta-data.

See https://bugs.wireshark.org/bugzilla/show_bug.cgi?id=15429 for full specification.

No actual parsing of meta-data TLVs are performed.  The header and TLVs are skipped and the PHY payload is passed to the common IEEE 802.15.4 print function.
