### PR TITLE
Add shortcuts for setting time stamp precision

### DIFF
--- a/tcpdump.1.in
+++ b/tcpdump.1.in
@@ -478,6 +478,19 @@ The supported values for \fItimestamp_precision\fP are \fBmicro\fP for
 microsecond resolution and \fBnano\fP for nanosecond resolution.  The
 default is microsecond resolution.
 .TP
+.B \-\-micro
+.PD 0
+.TP
+.B \-\-nano
+.PD
+Shorthands for \fB\-\-time\-stamp\-precision=micro\fP or
+\fB\-\-time\-stamp\-precision=nano\fP, adjusting the time stamp
+precision accordingly.  When reading packets from a savefile, using
+\fB\-\-micro\fP truncates time stamps if the savefile was created with
+nanosecond precision.  In contrast, a savefile created with microsecond
+precision will have trailing zeroes added to the time stamp when
+\fB\-\-nano\fP is used.
+.TP
 .B \-K
 .PD 0
 .TP

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -670,6 +670,8 @@ show_remote_devices_and_exit(void)
 #define OPTION_IMMEDIATE_MODE		130
 #define OPTION_PRINT			131
 #define OPTION_LIST_REMOTE_INTERFACES	132
+#define OPTION_TSTAMP_MICRO		133
+#define OPTION_TSTAMP_NANO		134
 
 static const struct option longopts[] = {
 #if defined(HAVE_PCAP_CREATE) || defined(_WIN32)
@@ -689,6 +691,8 @@ static const struct option longopts[] = {
 	{ "list-time-stamp-types", no_argument, NULL, 'J' },
 #endif
 #ifdef HAVE_PCAP_SET_TSTAMP_PRECISION
+	{ "micro", no_argument, NULL, OPTION_TSTAMP_MICRO},
+	{ "nano", no_argument, NULL, OPTION_TSTAMP_NANO},
 	{ "time-stamp-precision", required_argument, NULL, OPTION_TSTAMP_PRECISION},
 #endif
 	{ "dont-verify-checksums", no_argument, NULL, 'K' },
@@ -727,12 +731,6 @@ static const struct option longopts[] = {
 #define IMMEDIATE_MODE_USAGE " [ --immediate-mode ]"
 #else
 #define IMMEDIATE_MODE_USAGE ""
-#endif
-
-#ifdef HAVE_PCAP_SET_TSTAMP_PRECISION
-#define TIME_STAMP_PRECISION_USAGE " [ --time-stamp-precision precision ]"
-#else
-#define TIME_STAMP_PRECISION_USAGE
 #endif
 
 #ifndef _WIN32
@@ -1859,6 +1857,16 @@ main(int argc, char **argv)
 		case OPTION_PRINT:
 			print = 1;
 			break;
+
+#ifdef HAVE_PCAP_SET_TSTAMP_PRECISION
+		case OPTION_TSTAMP_MICRO:
+			ndo->ndo_tstamp_precision = PCAP_TSTAMP_PRECISION_MICRO;
+			break;
+
+		case OPTION_TSTAMP_NANO:
+			ndo->ndo_tstamp_precision = PCAP_TSTAMP_PRECISION_NANO;
+			break;
+#endif
 
 		default:
 			print_usage();
@@ -3074,11 +3082,13 @@ print_usage(void)
 	(void)fprintf(stderr,
 "\t\t[ -M secret ] [ --number ] [ --print ]" Q_FLAG_USAGE "\n");
 	(void)fprintf(stderr,
-"\t\t[ -r file ] [ -s snaplen ]" TIME_STAMP_PRECISION_USAGE "\n");
+"\t\t[ -r file ] [ -s snaplen ] [ -T type ] [ --version ]\n");
 	(void)fprintf(stderr,
-"\t\t[ -T type ] [ --version ] [ -V file ] [ -w file ]\n");
+"\t\t[ -V file ] [ -w file ] [ -W filecount ] [ -y datalinktype ]\n");
+#ifdef HAVE_PCAP_SET_TSTAMP_PRECISION
 	(void)fprintf(stderr,
-"\t\t[ -W filecount ] [ -y datalinktype ]\n");
+"\t\t[ --time-stamp-precision precision ] [ --micro ] [ --nano ]\n");
+#endif
 	(void)fprintf(stderr,
 "\t\t[ -z postrotate-command ] [ -Z user ] [ expression ]\n");
 }


### PR DESCRIPTION
Rationale: when you need to quickly start collecting packets into a savefile and you happen to need a different time stamp precision as the default, it is easy to confuse whether the proper option it is `--time-stamp-precision`, `--timestamp-precision`, or what.  These shortcuts do not change `tcpdump`'s behavior, they are equivalent to using the `--time-stamp-precision` option.

In order to present the shortcuts in `print_usage()`, it felt adequate to reshuffle the strings and group the ones related to time stamping (i.e., `--time-stamp-precision` and the included shortcuts).