### PR TITLE
allow unit tests to specify an alternate tcpdump binary

### DIFF
--- a/tests/TESTonce
+++ b/tests/TESTonce
@@ -1,5 +1,7 @@
 #!/usr/bin/env perl
 
+$TCPDUMP = "../tcpdump" if (!($TCPDUMP = $ENV{TCPDUMP_BIN}));
+
 system("mkdir -p NEW DIFF");
 
 if(@ARGV != 4) {
@@ -21,7 +23,7 @@ if ($^O eq 'MSWin32') {
 else {
     # we used to do this as a nice pipeline, but the problem is that $r fails to
     # to be set properly if the tcpdump core dumps.
-    $r = system "../tcpdump 2>/dev/null -# -n -r $input $options >NEW/$output";
+    $r = system "$TCPDUMP 2>/dev/null -# -n -r $input $options >NEW/$output";
     if($r != 0) {
         # this means tcpdump failed.
         open(OUTPUT, ">>"."NEW/$output") || die "fail to open $output\n";


### PR DESCRIPTION
solaris userland gate requires this change. will make our
life bit easier if upstream will kindly accept this change.