### PR TITLE
CVE-2017-16808/AoE: Add a missing bounds check.

### DIFF
--- a/print-aoe.c
+++ b/print-aoe.c
@@ -325,6 +325,7 @@ aoev1_reserve_print(netdissect_options *ndo,
 		goto invalid;
 	/* addresses */
 	for (i = 0; i < nmacs; i++) {
+		ND_TCHECK_LEN(cp, ETHER_ADDR_LEN);
 		ND_PRINT((ndo, "\n\tEthernet Address %u: %s", i, etheraddr_string(ndo, cp)));
 		cp += ETHER_ADDR_LEN;
 	}


### PR DESCRIPTION
In aoev1_reserve_print() check bounds before trying to print an Ethernet
address.

Updated from a Denis Ovsienko's fix.

This fixes a buffer over-read discovered by Bhargava Shastry,
SecT/TU Berlin.

(backported from commit 46aead6c5265e8ae376d2cf274fb2b5195cd6b57)
Signed-off-by: Rebecca Chang Swee Fun<rebecca.swee.fun.chang@intel.com>