### PR TITLE
If decode_prefix6() returns a negative number, don't print buf.

### DIFF
--- a/print-hncp.c
+++ b/print-hncp.c
@@ -229,6 +229,8 @@ print_prefix(netdissect_options *ndo, const u_char *prefix, u_int max_length)
         plenbytes += 1 + IPV4_MAPPED_HEADING_LEN;
     } else {
         plenbytes = decode_prefix6(ndo, prefix, max_length, buf, sizeof(buf));
+        if (plenbytes < 0)
+            return plenbytes;
     }
 
     ND_PRINT((ndo, "%s", buf));


### PR DESCRIPTION
If it returns a negative number, it hasn't necessarily filled in buf, so
just return immediately; this is similar to the IPv4 code path, wherein
we just return a negative number, and print nothing, on an error.

This should fix GitHub issue #763.

(backported from commit 511915bef7e4de2f31b8d9f581b4a44b0cfbcf53)