### PR TITLE
Fix order when printing PGM_OPT_REDIRECT_FIXED_LEN and opt_len

### DIFF
--- a/print-pgm.c
+++ b/print-pgm.c
@@ -594,7 +594,7 @@ pgm_print(netdissect_options *ndo,
 		    case AFNUM_INET6:
 			if (opt_len != PGM_OPT_REDIRECT_FIXED_LEN + sizeof(nd_ipv6)) {
 			    ND_PRINT("[Bad OPT_REDIRECT option, length %u != %u + address size]",
-			        PGM_OPT_REDIRECT_FIXED_LEN, opt_len);
+			        opt_len, PGM_OPT_REDIRECT_FIXED_LEN);
 			    return;
 			}
 			ND_TCHECK_LEN(bp, sizeof(nd_ipv6));


### PR DESCRIPTION
Fix order of PGM_OPT_REDIRECT_FIXED_LEN and opt_len to match the expression when printing in function print-pgm(), case PGM_OPT_REDIRECT.