### PR TITLE
Don't use nd_ipv4 for non-packet data

### DIFF
--- a/print-rx.c
+++ b/print-rx.c
@@ -480,8 +480,8 @@ static const struct tok rx_ack_reasons[] = {
 
 struct rx_cache_entry {
 	uint32_t	callnum;	/* Call number (net order) */
-	nd_ipv4	client;			/* client IP address (net order) */
-	nd_ipv4	server;			/* server IP address (net order) */
+	uint32_t	client;		/* client IP address (net order) */
+	uint32_t	server;		/* server IP address (net order) */
 	u_int		dport;		/* server port (host order) */
 	uint16_t	serviceId;	/* Service identifier (net order) */
 	uint32_t	opcode;		/* RX opcode (host order) */
@@ -698,8 +698,8 @@ rx_cache_insert(netdissect_options *ndo,
 		rx_cache_next = 0;
 
 	rxent->callnum = GET_BE_U_4(rxh->callNumber);
-	UNALIGNED_MEMCPY(&rxent->client, ip->ip_src, sizeof(uint32_t));
-	UNALIGNED_MEMCPY(&rxent->server, ip->ip_dst, sizeof(uint32_t));
+	rxent->client = GET_IPV4_TO_NETWORK_ORDER(ip->ip_src);
+	rxent->server = GET_IPV4_TO_NETWORK_ORDER(ip->ip_dst);
 	rxent->dport = dport;
 	rxent->serviceId = GET_BE_U_2(rxh->serviceId);
 	rxent->opcode = GET_BE_U_4(bp + sizeof(struct rx_header));
@@ -721,8 +721,8 @@ rx_cache_find(netdissect_options *ndo, const struct rx_header *rxh,
 	uint32_t clip;
 	uint32_t sip;
 
-	UNALIGNED_MEMCPY(&clip, ip->ip_dst, sizeof(uint32_t));
-	UNALIGNED_MEMCPY(&sip, ip->ip_src, sizeof(uint32_t));
+	clip = GET_IPV4_TO_NETWORK_ORDER(ip->ip_dst);
+	sip = GET_IPV4_TO_NETWORK_ORDER(ip->ip_src);
 
 	/* Start the search where we last left off */
 
@@ -730,8 +730,8 @@ rx_cache_find(netdissect_options *ndo, const struct rx_header *rxh,
 	do {
 		rxent = &rx_cache[i];
 		if (rxent->callnum == GET_BE_U_4(rxh->callNumber) &&
-		    GET_IPV4_TO_NETWORK_ORDER(rxent->client) == clip &&
-		    GET_IPV4_TO_NETWORK_ORDER(rxent->server) == sip &&
+		    rxent->client == clip &&
+		    rxent->server == sip &&
 		    rxent->serviceId == GET_BE_U_2(rxh->serviceId) &&
 		    rxent->dport == sport) {
 


### PR DESCRIPTION
nd_ipv4 was created for an unaligned field access inside of packet data,
so it should not be used for the rx_cache_entry.  Use uint32_t, and use
GET_IPV4_TO_NETWORK_ORDER instead of UNALIGNED_MEMCPY() to get the data
into them.

This caused test failures when your memory layout is such that the cache data
is stored above the packet data, since the GET_IPV4_TO_NETWORK_ORDER
accessing the cache would report that the packet is truncated.