### PR TITLE
Remove historic ECN definitions from IPv6

### DIFF
--- a/ip6.h
+++ b/ip6.h
@@ -98,11 +98,6 @@ struct ip6_hdr {
 /* in network endian */
 #define IPV6_FLOWINFO_MASK	((uint32_t)htonl(0x0fffffff))	/* flow info (28 bits) */
 #define IPV6_FLOWLABEL_MASK	((uint32_t)htonl(0x000fffff))	/* flow label (20 bits) */
-#if 1
-/* ECN bits proposed by Sally Floyd */
-#define IP6TOS_CE		0x01	/* congestion experienced */
-#define IP6TOS_ECT		0x02	/* ECN-capable transport */
-#endif
 
 /*
  * Extension Headers


### PR DESCRIPTION
ipv6.h still carries some unused, historic ECN references.

These are incompatible with the ECN signaling adopted by
IETF for both IPv4 and IPv6.

Fortunately, these references are nowhere used. Removing
these definitions should keep it this way in the future.

See also  https://reviews.freebsd.org/D23903