### PR TITLE
move packets_captured out of arguments, and into netdissect_options

### DIFF
--- a/netdissect.h
+++ b/netdissect.h
@@ -221,7 +221,8 @@ struct netdissect_options {
   const char *ndo_protocol;	/* protocol */
   jmp_buf ndo_truncated;	/* jmp_buf for setjmp()/longjmp() */
   void *ndo_last_mem_p;		/* pointer to the last allocated memory chunk */
-  int ndo_packet_number;	/* print a packet number in the beginning of line */
+  int ndo_packet_number;	/* flag: print a packet number in the beginning of line */
+  int ndo_packets_captured;     /* current count of captured packets */
   int ndo_suppress_default_print; /* don't use default_print() for unknown packet types */
   int ndo_tstamp_precision;	/* requested time stamp precision */
   const char *program_name;	/* Name of the program using the library */

--- a/print.c
+++ b/print.c
@@ -397,14 +397,15 @@ get_if_printer(netdissect_options *ndo, int type)
 }
 
 void
-pretty_print_packet(netdissect_options *ndo, const struct pcap_pkthdr *h,
-		    const u_char *sp, u_int packets_captured)
+pretty_print_packet(netdissect_options *ndo,
+                    const struct pcap_pkthdr *h,
+                    const u_char       *sp)
 {
 	u_int hdrlen;
 	int invalid_header = 0;
 
 	if (ndo->ndo_packet_number)
-		ND_PRINT("%5u  ", packets_captured);
+		ND_PRINT("%5u  ", ndo->ndo_packets_captured);
 
 	/* Sanity checks on packet length / capture length */
 	if (h->caplen == 0) {

--- a/print.h
+++ b/print.h
@@ -34,9 +34,9 @@ int	has_printer(int type);
 
 if_printer_t get_if_printer(netdissect_options *ndo, int type);
 
-void	pretty_print_packet(netdissect_options *ndo,
-	    const struct pcap_pkthdr *h, const u_char *sp,
-	    u_int packets_captured);
+void    pretty_print_packet(netdissect_options *ndo,
+                            const struct pcap_pkthdr *h,
+                            const u_char       *sp);
 
 void	ndo_set_function_pointers(netdissect_options *ndo);
 

--- a/tests/TESTrun
+++ b/tests/TESTrun
@@ -49,10 +49,15 @@ close(FAILUREOUTPUT);
 $confighhash = undef;
 
 sub runtest {
-    local($name, $input, $output, $options) = @_;
+    my %opt = @_;
     my $r;
 
-    $outputbase = basename($output);
+    my $name = %opt{'name'};
+    my $input= %opt{'input'};
+    my $output=%opt{'output'};
+    my $args = %opt{'args'};
+
+    my $outputbase = basename($output);
     my $coredump = false;
     my $status = 0;
     my $linecount = 0;
@@ -62,13 +67,13 @@ sub runtest {
     my $errdiffstat = 0;
 
     if ($^O eq 'MSWin32') {
-        $r = system "..\\windump -# -n -r $input $options 2>NUL | sed 's/\\r//' | tee tests/NEW/$outputbase | diff $output - >tests/DIFF/$outputbase.diff";
+        $r = system "..\\windump -# -n -r $input $args 2>NUL | sed 's/\\r//' | tee tests/NEW/$outputbase | diff $output - >tests/DIFF/$outputbase.diff";
         # need to do same as below for Cygwin.
     }
     else {
         # we used to do this as a nice pipeline, but the problem is that $r fails to
         # to be set properly if the tcpdump core dumps.
-        $r = system "$TCPDUMP 2>${rawstderrlog} -# -n -r $input $options >tests/NEW/${outputbase}";
+        $r = system "$TCPDUMP 2>${rawstderrlog} -# -n -r $input $args >tests/NEW/${outputbase}";
         if($r == -1) {
             # failed to start due to error.
             $status = $!;
@@ -228,7 +233,7 @@ sub runOneComplexTest {
     my $output = $testconfig->{output};
     my $input  = $testconfig->{input};
     my $name   = $testconfig->{name};
-    my $options= $testconfig->{args};
+    my $args   = $testconfig->{args};
     my $foundit = 1;
     my $unfoundit=1;
 
@@ -258,12 +263,12 @@ sub runOneComplexTest {
     #print Dumper($testconfig);
 
     # EXPAND any occurances of @TESTDIR@ to $testsdir
-    $options =~ s/\@TESTDIR\@/$testsdir/;
+    $args =~ s/\@TESTDIR\@/$testsdir/;
 
-    my $result = runtest($name,
-                         $testsdir . "/" . $input,
-                         $testsdir . "/" . $output,
-                         $options);
+    my $result = runtest(name => $name,
+                         input=> $testsdir . "/" . $input,
+                         output=>$testsdir . "/" . $output,
+                         args => $args);
 
     if($result == 0) {
         $passedcount++;


### PR DESCRIPTION
This minor bit of cleanup moves the packets_captured variable into the ndo structure.
Unfortunately, this requires that the ndo structure be available globally for the signal handler to be able to call info().  It's not clear that we should really be doing that much work in a signal handler, but we do that already, so I did not change that.
Fundamentally, I made this change so make it easier to call pretty_print_packet() from other contexts (in patches still coming).
