### PR TITLE
Set default linktype LINUX_SLL2 when capturing on the "any" device

### DIFF
--- a/tcpdump.c
+++ b/tcpdump.c
@@ -1932,6 +1932,14 @@ main(int argc, char **argv)
 		show_remote_devices_and_exit();
 #endif
 
+#if defined(DLT_LINUX_SLL2) && defined(HAVE_PCAP_SET_DATALINK)
+/* Set default linktype DLT_LINUX_SLL2 when capturing on the "any" device */
+		if (device != NULL &&
+		    strncmp (device, "any", strlen("any")) == 0
+		    && yflag_dlt == -1)
+			yflag_dlt = DLT_LINUX_SLL2;
+#endif
+
 	switch (ndo->ndo_tflag) {
 
 	case 0: /* Default */
@@ -2180,7 +2188,8 @@ main(int argc, char **argv)
 			}
 #endif
 			(void)fprintf(stderr, "%s: data link type %s\n",
-				      program_name, yflag_dlt_name);
+				      program_name,
+				      pcap_datalink_val_to_name(yflag_dlt));
 			(void)fflush(stderr);
 		}
 		i = pcap_snapshot(pd);


### PR DESCRIPTION
[Request for comments]

I propose to set the default linktype to LINUX_SLL2 when capturing on the "any" device.
(if available in libpcap)

It gives useful informations: interface name, in/out with '-e' option.

libpcap support since 1.9.1 version.
The printing is currently not supported in release 4.9.3.

Already asked on the mailing list.
No one said "no".