### PR TITLE
[RFC] Print packets for unsupported link protocols in hexadecimal and ASCII

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1077,6 +1077,7 @@ set(NETDISSECT_SOURCE_LIST_C
     print-token.c
     print-udld.c
     print-udp.c
+    print-unsupported.c
     print-usb.c
     print-vjc.c
     print-vqp.c

--- a/Makefile.in
+++ b/Makefile.in
@@ -233,6 +233,7 @@ LIBNETDISSECT_SRC=\
 	print-token.c \
 	print-udld.c \
 	print-udp.c \
+	print-unsupported.c \
 	print-usb.c \
 	print-vjc.c \
 	print-vqp.c \

--- a/netdissect.h
+++ b/netdissect.h
@@ -524,6 +524,7 @@ extern u_int sll2_if_print IF_PRINTER_ARGS;
 extern void sunatm_if_print IF_PRINTER_ARGS;
 extern void symantec_if_print IF_PRINTER_ARGS;
 extern u_int token_if_print IF_PRINTER_ARGS;
+extern void unsupported_if_print IF_PRINTER_ARGS;
 extern void usb_linux_48_byte_if_print IF_PRINTER_ARGS;
 extern void usb_linux_64_byte_if_print IF_PRINTER_ARGS;
 extern u_int vsock_if_print IF_PRINTER_ARGS;

--- a/print-unsupported.c
+++ b/print-unsupported.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2020 The TCPDUMP project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that: (1) source code
+ * distributions retain the above copyright notice and this paragraph
+ * in its entirety, and (2) distributions including binary code include
+ * the above copyright notice and this paragraph in its entirety in
+ * the documentation or other materials provided with the distribution.
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND
+ * WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, WITHOUT
+ * LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE.
+ */
+
+/* \summary: unsupported link-layer protocols printer */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include "netdissect-stdinc.h"
+
+#include "netdissect.h"
+
+void
+unsupported_if_print(netdissect_options *ndo, const struct pcap_pkthdr *h,
+		     const u_char *p)
+{
+	ndo->ndo_protocol = "unsupported";
+	nd_print_protocol_caps(ndo);
+	hex_and_ascii_print(ndo, "\n\t", p, h->caplen);
+}

--- a/print.c
+++ b/print.c
@@ -379,20 +379,11 @@ has_printer(int type)
 if_printer_t
 get_if_printer(netdissect_options *ndo, int type)
 {
-	const char *dltname;
 	if_printer_t printer;
 
 	printer = lookup_printer(ndo, type);
-	if (printer.printer == NULL) {
-		dltname = pcap_datalink_val_to_name(type);
-		if (dltname != NULL)
-			(*ndo->ndo_error)(ndo, S_ERR_ND_NO_PRINTER,
-					  "packet printing is not supported for link type %s: use -w",
-					  dltname);
-		else
-			(*ndo->ndo_error)(ndo, S_ERR_ND_NO_PRINTER,
-					  "packet printing is not supported for link type %d: use -w", type);
-	}
+	if (printer.printer == NULL)
+		printer.void_printer = unsupported_if_print;
 	return printer;
 }
 


### PR DESCRIPTION
    This avoids to get only:
    tcpdump: packet printing is not supported for link type XYZ: use -w
    
    Set ndo->ndo_packet_number.
    
    The default printing is like:
        1  15:00:02.232595 UNSUPPORTED
            0x0000:  0000 0338 0000 0000 0000 0000 0000 0000
            0x0010:  1400 0000 1600 0503 0000 0000 0000 0000
            0x0020:  0200 0000
        2  15:00:02.232622 UNSUPPORTED
            0x0000:  0000 0338 0000 0000 0000 0000 0000 0000
            0x0010:  3000 0000 1400 0200 0000 0000 0000 0000
            0x0020:  0208 0000 0000 0000 0800 0200 7f00 0001
            [...]
