### PR TITLE
Add -nn option to manpage

### DIFF
--- a/tcpdump.1.in
+++ b/tcpdump.1.in
@@ -579,7 +579,10 @@ Use \fIsecret\fP as a shared secret for validating the digests found in
 TCP segments with the TCP-MD5 option (RFC 2385), if present.
 .TP
 .B \-n
-Don't convert addresses (i.e., host addresses, port numbers, etc.) to names.
+Don't convert addresses (i.e., host addresses, etc.) to names.
+.TP
+.B \-nn
+Don't convert addresses (i.e., host addresses, etc.) and port numbers to names.
 .TP
 .B \-N
 Don't print domain name qualification of host names.


### PR DESCRIPTION
Running tcpdump with `-n` option specified yields the following results
```
sudo tcpdump -n -i eth0 -c 3
tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
listening on eth0, link-type EN10MB (Ethernet), capture size 262144 bytes
11:38:16.007550 IP 172.16.0.4.ssh > 172.168.0.3.27821: Flags [P.], seq 3060418479:3060418595, ack 534867288, win 323, options [nop,nop,TS val 2032458301 ecr 1041040746], length 116
11:38:16.007638 IP 172.16.0.4.ssh > 172.168.0.3.27821: Flags [P.], seq 116:232, ack 1, win 323, options [nop,nop,TS val 2032458301 ecr 1041040746], length 116
11:38:16.007695 IP 172.16.0.4.ssh > 172.168.0.3.27821: Flags [P.], seq 232:452, ack 1, win 323, options [nop,nop,TS val 2032458301 ecr 1041040746], length 220
```

and running with `-nn`
```
sudo tcpdump -nn -i eth0 -c 3
tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
listening on eth0, link-type EN10MB (Ethernet), capture size 262144 bytes
11:38:06.430249 IP 172.16.0.4.22 > 172.168.0.3.27821: Flags [P.], seq 3060415183:3060415299, ack 534866556, win 323, options [nop,nop,TS val 2032448723 ecr 1041031419], length 116
11:38:06.430366 IP 172.16.0.4.22 > 172.168.0.3.27821: Flags [P.], seq 116:232, ack 1, win 323, options [nop,nop,TS val 2032448724 ecr 1041031419], length 116
11:38:06.430409 IP 172.16.0.4.22 > 172.168.0.3.27821: Flags [P.], seq 232:452, ack 1, win 323, options [nop,nop,TS val 2032448724 ecr 1041031419], length 220
```