### PR TITLE
Add support for EAP Dump in RADIUS Messages

### DIFF
--- a/netdissect.h
+++ b/netdissect.h
@@ -577,6 +577,7 @@ extern int dstopt_process(netdissect_options *, const u_char *);
 extern void dtp_print(netdissect_options *, const u_char *, u_int);
 extern void dvmrp_print(netdissect_options *, const u_char *, u_int);
 extern void eap_print(netdissect_options *, const u_char *, u_int);
+extern void eapol_print(netdissect_options *, const u_char *);
 extern void egp_print(netdissect_options *, const u_char *, u_int);
 extern void eigrp_print(netdissect_options *, const u_char *, u_int);
 extern void esp_print(netdissect_options *, const u_char *, u_int, const u_char *, u_int, int, u_int);

--- a/print-ether.c
+++ b/print-ether.c
@@ -599,7 +599,7 @@ ethertype_print(netdissect_options *ndo,
 		return (1);
 
 	case ETHERTYPE_EAPOL:
-		eap_print(ndo, p, length);
+		eapol_print(ndo, p);
 		return (1);
 
 	case ETHERTYPE_RRCP:

--- a/print-radius.c
+++ b/print-radius.c
@@ -173,6 +173,8 @@ static const struct tok radius_command_values[] = {
 #define ARAP_PASS          70
 #define ARAP_FEATURES      71
 
+#define EAP_MESSAGE        79
+
 #define TUNNEL_PRIV_GROUP  81
 #define TUNNEL_ASSIGN_ID   82
 #define TUNNEL_PREFERENCE  83
@@ -673,6 +675,11 @@ print_attr_string(netdissect_options *ndo,
            data++;
            length--;
         break;
+      case EAP_MESSAGE:
+           if (length < 1)
+              goto trunc;
+           eap_print(ndo, data, length);
+           return;
    }
 
    for (i=0; i < length && GET_U_1(data); i++, data++)

--- a/tests/radius-v.out
+++ b/tests/radius-v.out
@@ -9,7 +9,8 @@
 	  Calling-Station-Id Attribute (31), length: 19, Value: 00-14-22-E9-54-5E
 	  Service-Type Attribute (6), length: 6, Value: Framed
 	  Framed-MTU Attribute (12), length: 6, Value: 1500
-	  EAP-Message Attribute (79), length: 19, Value: .
+	  EAP-Message Attribute (79), length: 19, Value: Response (2), id 0, len 17
+		 Type Identity (1), Identity: John.McGuirk
 	  Message-Authenticator Attribute (80), length: 18, Value: (....$..p.Q1o.x.
     2  22:52:17.875771 IP (tos 0x0, ttl 64, id 0, offset 0, flags [DF], proto UDP (17), length 137)
     10.0.0.100.1812 > 10.0.0.1.1645: RADIUS, length: 109
@@ -18,7 +19,8 @@
 	  Framed-MTU Attribute (12), length: 6, Value: 576
 	  Service-Type Attribute (6), length: 6, Value: Framed
 	  Reply-Message Attribute (18), length: 11, Value: Hello, %u
-	  EAP-Message Attribute (79), length: 24, Value: ..
+	  EAP-Message Attribute (79), length: 24, Value: Request (1), id 1, len 22
+		 Type MD5-challenge (4)
 	  Message-Authenticator Attribute (80), length: 18, Value: ...<.(.X.13..t4.
 	  State Attribute (24), length: 18, Value: ..../.0$.s..1..w
     3  22:52:17.916736 IP (tos 0x0, ttl 255, id 71, offset 0, flags [none], proto UDP (17), length 202)
@@ -33,7 +35,8 @@
 	  Service-Type Attribute (6), length: 6, Value: Framed
 	  Framed-MTU Attribute (12), length: 6, Value: 1500
 	  State Attribute (24), length: 18, Value: ..../.0$.s..1..w
-	  EAP-Message Attribute (79), length: 36, Value: ..
+	  EAP-Message Attribute (79), length: 36, Value: Response (2), id 1, len 34
+		 Type MD5-challenge (4)
 	  Message-Authenticator Attribute (80), length: 18, Value: '&.q1.....Ojb..8
     4  22:52:17.916850 IP (tos 0x0, ttl 64, id 0, offset 0, flags [DF], proto UDP (17), length 125)
     10.0.0.100.1812 > 10.0.0.1.1645: RADIUS, length: 97
@@ -42,6 +45,6 @@
 	  Framed-MTU Attribute (12), length: 6, Value: 576
 	  Service-Type Attribute (6), length: 6, Value: Framed
 	  Reply-Message Attribute (18), length: 21, Value: Hello, John.McGuirk
-	  EAP-Message Attribute (79), length: 6, Value: ..
+	  EAP-Message Attribute (79), length: 6, Value: Success (3), id 1, len 4
 	  Message-Authenticator Attribute (80), length: 18, Value: ...b...2.^..NLc`
 	  User-Name Attribute (1), length: 14, Value: John.McGuirk


### PR DESCRIPTION
Usually, for EAP related authentications, RADIUS messages contain EAP payload. Currently, RADIUS dump messages donot display the EAP frame information. Hence, added changes for displaying EAP info within RADIUS dump messages. 

Sample O/P:

1) EAP Request Identity Frame:

Before this change:
```
         EAP-Message Attribute (79), length: 19, Value: .
```
       
After this change:
```
           EAP-Message Attribute (79), length: 10, Value: Response (2), id 1, len 8
                 Type Identity (1), Identity: avi
            0x0000:  0201 0008 0161 7669
```

2) EAP Request Challenge Frame:
Before this change:
```
          EAP-Message Attribute (79), length: 24, Value: ..
            0x0000:  0102 0016 0410 cd32 576a 04bd ea97 14c6
            0x0010:  9e84 ae7c 6de2
```

After this change:
```
          EAP-Message Attribute (79), length: 24, Value: Request (1), id 2, len 22
                 Type MD5-challenge (4)
            0x0000:  0102 0016 0410 cd32 576a 04bd ea97 14c6
            0x0010:  9e84 ae7c 6de2
```

3) EAP Response Challenge frame:

Before this change:
```
          EAP-Message Attribute (79), length: 27, Value: ..
            0x0000:  0202 0019 0410 035f 1f16 c4e2 d71e 1553
            0x0010:  6b55 effc 0a0f 6176 69
```

After this change:
```
          EAP-Message Attribute (79), length: 27, Value: Response (2), id 2, len 25
                 Type MD5-challenge (4)
            0x0000:  0202 0019 0410 035f 1f16 c4e2 d71e 1553
            0x0010:  6b55 effc 0a0f 6176 69
```

4) EAP Success Frame:

Before this change:
```
          EAP-Message Attribute (79), length: 6, Value: ..
            0x0000:  0302 0004
```

After this change:
```
          EAP-Message Attribute (79), length: 6, Value: Success (3), id 2, len 4
            0x0000:  0302 0004
```