### PR TITLE
Fix ssize_t for _WIN64

### DIFF
--- a/netdissect-stdinc.h
+++ b/netdissect-stdinc.h
@@ -184,7 +184,11 @@
   /*
    * Windows doesn't have ssize_t; routines such as _read() return int.
    */
-  typedef int ssize_t;
+  #ifdef _WIN64
+    typedef __int64 ssize_t;
+  #else
+    typedef int ssize_t;
+  #endif  
 #endif  /* _MSC_VER */
 
 /*


### PR DESCRIPTION
Compiling Windump for `x64` using clang-cl, gives this warning:
```c
tcpdump.c(1085,45): warning: format specifies type 'ssize_t' (aka 'long long') but the argument has type 'ssize_t'
      (aka 'int') [-Wformat]
                error("short read %s (%zd != %d)", fname, cc, (int)buf.st_size);
                                      ~~~                 ^~
                                      %zd

```
So do as MinGW does and define `ssize_t` as `__int64` for `_WIN64`.