### PR TITLE
Clean exit from tcpdump with asan.

### DIFF
--- a/tcpdump.c
+++ b/tcpdump.c
@@ -2239,8 +2239,12 @@ main(int argc, char **argv)
 		error("%s", pcap_geterr(pd));
 	if (dflag) {
 		bpf_dump(&fcode, dflag);
-		pcap_close(pd);
+		/* Clear pd so our signal handler won't use-after-free it. */
+		pcap_t *to_free = pd;
+		pd = NULL;
+		pcap_close(to_free);
 		free(cmdbuf);
+		free(device);
 		pcap_freecode(&fcode);
 		exit_tcpdump(S_SUCCESS);
 	}
@@ -2559,7 +2563,10 @@ DIAG_ON_CLANG(assign-enum)
 			 */
 			info(1);
 		}
-		pcap_close(pd);
+		/* Clear pd so our signal handler won't use-after-free it. */
+		pcap_t *to_free = pd;
+		pd = NULL;
+		pcap_close(to_free);
 		if (VFileName != NULL) {
 			ret = get_next_file(VFile, VFileLine);
 			if (ret) {
@@ -2640,6 +2647,7 @@ DIAG_ON_CLANG(assign-enum)
 			PLURAL_SUFFIX(packets_captured));
 
 	free(cmdbuf);
+	free(device);
 	pcap_freecode(&fcode);
 	exit_tcpdump(status == -1 ? 1 : 0);
 }
@@ -2692,7 +2700,8 @@ cleanup(int signo _U_)
 	 * to do anything with standard I/O streams in a signal handler -
 	 * the ANSI C standard doesn't say it is).
 	 */
-	pcap_breakloop(pd);
+	if (pd != NULL)
+		pcap_breakloop(pd);
 #else
 	/*
 	 * We don't have "pcap_breakloop()"; this isn't safe, but


### PR DESCRIPTION
Fixes the use-after-free of `pd` caused by leaving the signal handlers
that call pcap_breakloop() active after freeing the `struct pcap_t`.

This also fixes the leak of `device`.

Caught by gwp-asan in the wild. Android internal bug 170778539.