### PR TITLE
DNS: Sync types with IANA

### DIFF
--- a/nameser.h
+++ b/nameser.h
@@ -169,13 +169,35 @@
 #define T_RRSIG		46		/* new security signature */
 #define T_NSEC		47		/* provable insecure information */
 #define T_DNSKEY	48		/* new security key */
+#define T_DHCID		49		/* DHCP IDentifier */
+#define T_NSEC3		50		/* Next SECure record v3 */
+#define T_NSEC3PARAM	51		/* NSEC3 PARAMeter */
+#define T_TLSA		52		/* TLS Authentication */
+#define T_SMIMEA	53		/* S/MIME Authentication */
+/* Unassigned */
+#define T_HIP		55		/* Host Identity Protocol */
+#define T_NINFO		56		/* zone status information */
+#define T_RKEY		57		/* Record encryption KEY */
+#define T_TALINK	58		/* Trust Anchor LINK */
+#define T_CDS		59		/* Child Delegation Signer */
+#define T_CDNSKEY	60		/* Child DNSKEY */
+#define T_OPENPGPKEY	61		/* OpenPGP KEY */
+#define T_CSYNC		62		/* Child to parent SYNCronization */
+#define T_ZONEMD	63		/* ZONE data Message Digest */
+#define T_SVCB		64		/* SerViCe Binding */
+#define T_HTTPS		65		/* HTTPS binding */
 	/* non standard */
 #define T_SPF		99		/* sender policy framework */
 #define T_UINFO		100		/* user (finger) information */
 #define T_UID		101		/* user ID */
 #define T_GID		102		/* group ID */
 #define T_UNSPEC	103		/* Unspecified format (binary data) */
-#define T_UNSPECA	104		/* "unspecified ASCII". Ugly MIT hack */
+#define T_NID		104		/* Node IDentifier */
+#define T_L32		105		/* Locator 32-bit */
+#define T_L64		106		/* Locator 64-bit */
+#define T_LP		107		/* Locator Pointer */
+#define T_EUI48		108		/* an EUI-48 address */
+#define T_EUI64		109		/* an EUI-64 address */
 	/* Query type values which do not appear in resource records */
 #define T_TKEY		249		/* Transaction Key [RFC2930] */
 #define T_TSIG		250		/* Transaction Signature [RFC2845] */
@@ -185,6 +207,12 @@
 #define T_MAILA		254		/* transfer mail agent records */
 #define T_ANY		255		/* wildcard match */
 #define T_URI		256		/* uri records [RFC7553] */
+#define T_CAA		257		/* Certification Authority Authorization */
+#define T_AVC		258		/* Application Visibility and Control */
+#define T_DOA		259		/* Digital Object Architecture */
+#define T_AMTRELAY	260		/* Automatic Multicast Tunneling RELAY */
+#define T_TA		32768		/* DNSSEC Trust Authorities */
+#define T_DLV		32769		/* DNSSEC Lookaside Validation */
 
 /*
  * Values for class field

--- a/print-domain.c
+++ b/print-domain.c
@@ -495,30 +495,30 @@ const struct tok ns_type2str[] = {
 	{ T_MX,		"MX" },			/* RFC 1035 */
 	{ T_TXT,	"TXT" },		/* RFC 1035 */
 	{ T_RP,		"RP" },			/* RFC 1183 */
-	{ T_AFSDB,	"AFSDB" },		/* RFC 1183 */
+	{ T_AFSDB,	"AFSDB" },		/* RFC 5864 */
 	{ T_X25,	"X25" },		/* RFC 1183 */
 	{ T_ISDN,	"ISDN" },		/* RFC 1183 */
 	{ T_RT,		"RT" },			/* RFC 1183 */
 	{ T_NSAP,	"NSAP" },		/* RFC 1706 */
-	{ T_NSAP_PTR,	"NSAP_PTR" },
-	{ T_SIG,	"SIG" },		/* RFC 2535 */
-	{ T_KEY,	"KEY" },		/* RFC 2535 */
+	{ T_NSAP_PTR,	"NSAP_PTR" },		/* RFC 1706 */
+	{ T_SIG,	"SIG" },		/* RFC 3008 */
+	{ T_KEY,	"KEY" },		/* RFC 3110 */
 	{ T_PX,		"PX" },			/* RFC 2163 */
 	{ T_GPOS,	"GPOS" },		/* RFC 1712 */
-	{ T_AAAA,	"AAAA" },		/* RFC 1886 */
+	{ T_AAAA,	"AAAA" },		/* RFC 3596 */
 	{ T_LOC,	"LOC" },		/* RFC 1876 */
-	{ T_NXT,	"NXT" },		/* RFC 2535 */
+	{ T_NXT,	"NXT" },		/* RFC 3755 */
 	{ T_EID,	"EID" },		/* Nimrod */
 	{ T_NIMLOC,	"NIMLOC" },		/* Nimrod */
 	{ T_SRV,	"SRV" },		/* RFC 2782 */
 	{ T_ATMA,	"ATMA" },		/* ATM Forum */
-	{ T_NAPTR,	"NAPTR" },		/* RFC 2168, RFC 2915 */
+	{ T_NAPTR,	"NAPTR" },		/* RFC 3403 */
 	{ T_KX,		"KX" },			/* RFC 2230 */
-	{ T_CERT,	"CERT" },		/* RFC 2538 */
-	{ T_A6,		"A6" },			/* RFC 2874 */
-	{ T_DNAME,	"DNAME" },		/* RFC 2672 */
+	{ T_CERT,	"CERT" },		/* RFC 4398 */
+	{ T_A6,		"A6" },			/* RFC 6563 */
+	{ T_DNAME,	"DNAME" },		/* RFC 6672 */
 	{ T_SINK, 	"SINK" },
-	{ T_OPT,	"OPT" },		/* RFC 2671 */
+	{ T_OPT,	"OPT" },		/* RFC 6891 */
 	{ T_APL, 	"APL" },		/* RFC 3123 */
 	{ T_DS,		"DS" },			/* RFC 4034 */
 	{ T_SSHFP,	"SSHFP" },		/* RFC 4255 */
@@ -526,20 +526,47 @@ const struct tok ns_type2str[] = {
 	{ T_RRSIG, 	"RRSIG" },		/* RFC 4034 */
 	{ T_NSEC,	"NSEC" },		/* RFC 4034 */
 	{ T_DNSKEY,	"DNSKEY" },		/* RFC 4034 */
-	{ T_SPF,	"SPF" },		/* RFC-schlitt-spf-classic-02.txt */
+	{ T_DHCID,	"DHCID" },		/* RFC 4071 */
+	{ T_NSEC3,	"NSEC3" },		/* RFC 5155 */
+	{ T_NSEC3PARAM,	"NSEC3PARAM" },		/* RFC 5155 */
+	{ T_TLSA,	"TLSA" },		/* RFC 6698 */
+	{ T_SMIMEA,	"SMIMEA" },		/* RFC 8162 */
+	{ T_HIP,	"HIP" },		/* RFC 8005 */
+	{ T_NINFO,	"NINFO" },
+	{ T_RKEY,	"RKEY" },
+	{ T_TALINK,	"TALINK" },
+	{ T_CDS,	"CDS" },		/* RFC 7344 */
+	{ T_CDNSKEY,	"CDNSKEY" },		/* RFC 7344 */
+	{ T_OPENPGPKEY,	"OPENPGPKEY" },		/* RFC 7929 */
+	{ T_CSYNC,	"CSYNC" },		/* RFC 7477 */
+	{ T_ZONEMD,	"ZONEMD" },		/* RFC 8976 */
+	{ T_SVCB,	"SVCB" },
+	{ T_HTTPS,	"HTTPS" },
+	{ T_SPF,	"SPF" },		/* RFC 7208 */
 	{ T_UINFO,	"UINFO" },
 	{ T_UID,	"UID" },
 	{ T_GID,	"GID" },
 	{ T_UNSPEC,	"UNSPEC" },
-	{ T_UNSPECA,	"UNSPECA" },
+	{ T_NID,	"NID" },		/* RFC 6742 */
+	{ T_L32,	"L32" },		/* RFC 6742 */
+	{ T_L64,	"L64" },		/* RFC 6742 */
+	{ T_LP,		"LP" },			/* RFC 6742 */
+	{ T_EUI48,	"EUI48" },		/* RFC 7043 */
+	{ T_EUI64,	"EUI64" },		/* RFC 7043 */
 	{ T_TKEY,	"TKEY" },		/* RFC 2930 */
-	{ T_TSIG,	"TSIG" },		/* RFC 2845 */
+	{ T_TSIG,	"TSIG" },		/* RFC 8945 */
 	{ T_IXFR,	"IXFR" },		/* RFC 1995 */
-	{ T_AXFR,	"AXFR" },		/* RFC 1035 */
+	{ T_AXFR,	"AXFR" },		/* RFC 5936 */
 	{ T_MAILB,	"MAILB" },		/* RFC 1035 */
 	{ T_MAILA,	"MAILA" },		/* RFC 1035 */
-	{ T_ANY,	"ANY" },
+	{ T_ANY,	"ANY" },		/* RFC 8482 */
 	{ T_URI,	"URI" },		/* RFC 7553 */
+	{ T_CAA,	"CAA" },		/* RFC 8659 */
+	{ T_AVC,	"AVC" },
+	{ T_DOA,	"DOA" },
+	{ T_AMTRELAY,	"AMTRELAY" },		/* RFC 8777 */
+	{ T_TA,		"TA" },
+	{ T_DLV,	"DLV" },		/* RFC 8749 */
 	{ 0,		NULL }
 };
 
@@ -832,13 +859,6 @@ ns_rprint(netdissect_options *ndo,
             }
             ND_PRINT("]");
         }
-		break;
-
-	case T_UNSPECA:		/* One long string */
-		if (!ND_TTEST_LEN(cp, len))
-			return(NULL);
-		if (nd_printn(ndo, cp, len, ndo->ndo_snapend))
-			return(NULL);
 		break;
 
 	case T_TSIG:


### PR DESCRIPTION
IANA reference: https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml

I updated the comments to reference the latest RFC where they didn't already. Let me know if you'd prefer that I leave that out.

Removed the `UNSPECA` type parsing as IANA has that query type number assigned to `NID` now.