### PR TITLE
optional unit suffix on -C file size

### DIFF
--- a/tcpdump.1.in
+++ b/tcpdump.1.in
@@ -265,8 +265,12 @@ savefile and open a new one.  Savefiles after the first savefile will
 have the name specified with the
 .B \-w
 flag, with a number after it, starting at 1 and continuing upward.
-The units of \fIfile_size\fP are millions of bytes (1,000,000 bytes,
+The default unit of \fIfile_size\fP is millions of bytes (1,000,000 bytes,
 not 1,048,576 bytes).
+.IP
+By adding a suffix of k, m or g to the value, the unit
+can be changed to 1,024 (KiB), 1,048,576 (MiB), or 1,073,741,824 (GiB)
+respectively.
 .TP
 .B \-d
 Dump the compiled packet-matching code in a human readable form to

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -1482,6 +1482,7 @@ main(int argc, char **argv)
 	int yflag_dlt = -1;
 	const char *yflag_dlt_name = NULL;
 	int print = 0;
+	long Cflagmult = 1000000;
 
 	netdissect_options Ndo;
 	netdissect_options *ndo = &Ndo;
@@ -1558,6 +1559,18 @@ main(int argc, char **argv)
 
 		case 'C':
 			errno = 0;
+			if (optarg[strlen(optarg)-1] == 'k') {
+				Cflagmult = 1024;
+				optarg[strlen(optarg)-1] = '\0';
+			}
+			if (optarg[strlen(optarg)-1] == 'm') {
+				Cflagmult = 1024*1024;
+				optarg[strlen(optarg)-1] = '\0';
+			}
+			if (optarg[strlen(optarg)-1] == 'g') {
+				Cflagmult = 1024*1024*1024;
+				optarg[strlen(optarg)-1] = '\0';
+			}
 #ifdef HAVE_PCAP_DUMP_FTELL64
 			Cflag = strtoint64_t(optarg, &endp, 10);
 #else
@@ -1567,15 +1580,15 @@ main(int argc, char **argv)
 			    || Cflag <= 0)
 				error("invalid file size %s", optarg);
 			/*
-			 * Will multiplying it by 1000000 overflow?
+			 * Will multiplying it by multiplier overflow?
 			 */
 #ifdef HAVE_PCAP_DUMP_FTELL64
-			if (Cflag > INT64_T_CONSTANT(0x7fffffffffffffff) / 1000000)
+			if (Cflag > INT64_T_CONSTANT(0x7fffffffffffffff) / Cflagmult)
 #else
-			if (Cflag > LONG_MAX / 1000000)
+			if (Cflag > LONG_MAX / Cflagmult)
 #endif
 				error("file size %s is too large", optarg);
-			Cflag *= 1000000;
+			Cflag *= Cflagmult;
 			break;
 
 		case 'd':


### PR DESCRIPTION
In response to https://github.com/the-tcpdump-group/tcpdump/issues/884 *Add GNU-like block size suffix support to savefile's file_size*

````
[steve@localhost tcpdump]$ sudo /home/steve/out/bin/tcpdump -C 5m -w /tmp/foo
tcpdump: listening on enp0s3, link-type EN10MB (Ethernet), snapshot length 262144 bytes
^C4951 packets captured
4959 packets received by filter
0 packets dropped by kernel
[steve@localhost tcpdump]$ ls -l /tmp/foo*
-rw-r--r--. 1 root root 5244047 May  8 14:31 /tmp/foo
-rw-r--r--. 1 root root 2644025 May  8 14:31 /tmp/foo1
[steve@localhost tcpdump]$ 
````

Default behaviour remains unchanged.
````
[steve@localhost tcpdump]$ sudo rm -f /tmp/foo*
[steve@localhost tcpdump]$ sudo /home/steve/out/bin/tcpdump -C 1 -w /tmp/foo
tcpdump: listening on enp0s3, link-type EN10MB (Ethernet), snapshot length 262144 bytes
^C4786 packets captured
4788 packets received by filter
0 packets dropped by kernel
[steve@localhost tcpdump]$ ls -l /tmp/foo*
-rw-r--r--. 1 root root 1003892 May  8 14:37 /tmp/foo
-rw-r--r--. 1 root root 1005480 May  8 14:37 /tmp/foo1
-rw-r--r--. 1 root root 1000046 May  8 14:37 /tmp/foo2
-rw-r--r--. 1 root root 1003442 May  8 14:37 /tmp/foo3
-rw-r--r--. 1 root root 1001766 May  8 14:37 /tmp/foo4
-rw-r--r--. 1 root root 1000152 May  8 14:37 /tmp/foo5
-rw-r--r--. 1 root root 1004212 May  8 14:37 /tmp/foo6
-rw-r--r--. 1 root root  849885 May  8 14:37 /tmp/foo7
[steve@localhost tcpdump]$