### PR TITLE
Fix the misleading comment regarding "From DS", "To DS" Frame Control Flags

### DIFF
--- a/print-802_11.c
+++ b/print-802_11.c
@@ -1908,7 +1908,7 @@ get_data_src_dst_mac(uint16_t fc, const u_char *p, const uint8_t **srcp,
 		}
 	} else {
 		if (!FC_FROM_DS(fc)) {
-			/* From DS and not To DS */
+			/* To DS and not From DS */
 			*srcp = ADDR2;
 			*dstp = ADDR3;
 		} else {


### PR DESCRIPTION
In the case where the "From DS" bit is not set and the "To DS" bit is set in the Frame Control Bitmask, the comment line in the corresponding if else block was misleading that the "From DS" bit is set and the "To DS" bit is not set.