### PR TITLE
Remove last remaining trailing whitespace

### DIFF
--- a/print-icmp.c
+++ b/print-icmp.c
@@ -809,7 +809,7 @@ icmp_print(netdissect_options *ndo, const u_char *bp, u_int plen, const u_char *
 					/*
 
 					Ctype in a INTERFACE_INFORMATION_OBJECT_CLASS object:
-					
+
 					Bit     0       1       2       3       4       5       6       7
 					+-------+-------+-------+-------+-------+-------+-------+-------+
 					| Interface Role| Rsvd1 | Rsvd2 |ifIndex| IPAddr|  name |  MTU  |

--- a/print-mptcp.c
+++ b/print-mptcp.c
@@ -250,7 +250,7 @@ mp_capable_print(netdissect_options *ndo,
                         ND_PRINT(" Unknown Version (%u)", version);
                         return 1;
         }
- 
+
         ND_PRINT(" flags [%s]", bittok2str_nosep(mp_capable_flags, "none",
                  GET_U_1(mpc->flags)));
 


### PR DESCRIPTION
The CONTRIBUTING file advises us to "Avoid trailing tabs/spaces". This PR removes last remaining trailing whitespace from the source code, making it easier to setup a warning in case any new trailing whitespace were to be introduced.