### PR TITLE
Fix printing VLAN ID values larger than 256 for Marvell DSA switches

### DIFF
--- a/print-dsa.c
+++ b/print-dsa.c
@@ -83,7 +83,7 @@
 #define DSA_RX_SNIFF(tag) TOK(tag, 1, 0x04, 2)
 #define DSA_CFI(tag) TOK(tag, 1, 0x01, 0)
 #define DSA_PRI(tag) TOK(tag, 2, 0xe0, 5)
-#define DSA_VID(tag) ((u_short)((TOK(tag, 2, 0xe0, 5) << 8) | (TOK(tag, 3, 0xff, 0))))
+#define DSA_VID(tag) ((u_short)((TOK(tag, 2, 0x0f, 0) << 8) | (TOK(tag, 3, 0xff, 0))))
 #define DSA_CODE(tag) ((TOK(tag, 1, 0x06, 1) << 1) | TOK(tag, 2, 0x10, 4))
 
 #define EDSA_LEN 8


### PR DESCRIPTION
The VLAN ID in Marvell DSA tags is split into two bytes of the switch
header. The extraction logic for the upper byte is broken, it is copy
pasted from the DSA_PRI above. So any VLAN ID higher than 256 gets
truncated to only the bottom-most 8 bits.