### PR TITLE
some parameters for enabling probot on the repository

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,21 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  activity in the past 60 days.
+  Code contributions should include test pcap files, and may need to be rebased regularly.
+  Discussion of non-trivial contributes on the tcpdump-workers@lists.tcpdump.org mailing list
+  is encouraged.
+  This issue will be closed if no further activity occurs.
+  Thank you for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: true


### PR DESCRIPTION
https://github.com/organizations/the-tcpdump-group/settings/installations/19853667 explains how to enable probot.
This bot can close issues which have not had any activity.
Part of the goal of using this is to make active issues more active, and to figure out which issues have not had any focus.
The text of the message and the daysUntilX are open for discussion.
A similiar setting for libpcap would be enacted.
Maybe it's all a bad idea.  Opinions?

