### PR TITLE
[bugfix]configure: fix error when cross-compile:

### DIFF
--- a/configure
+++ b/configure
@@ -5189,10 +5189,11 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether printf(3) supports the z length modifier" >&5
 $as_echo_n "checking whether printf(3) supports the z length modifier... " >&6; }
 if test "$cross_compiling" = yes; then :
-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "cannot run test program while cross compiling
-See \`config.log' for more details" "$LINENO" 5; }
+
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: not while cross-compiling" >&5
+$as_echo "not while cross-compiling" >&6; }
+
+
 else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -5221,7 +5222,6 @@ else
 $as_echo "no" >&6; }
 
 $as_echo "#define HAVE_NO_PRINTF_Z 1" >>confdefs.h
-
 
 
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -423,6 +423,9 @@ int main()
         AC_MSG_RESULT(no)
         AC_DEFINE(HAVE_NO_PRINTF_Z, 1,
             [Define to 1 if printf(3) does not support the z length modifier.])
+    ],
+    [
+        AC_MSG_RESULT(not while cross-compiling)
     ]
 )
 


### PR DESCRIPTION
While cross-compile, `./configure --host=xxx` will output:
"checking whether printf(3) supports the z length modifier...
 configure: error: in `/${path_to_tcpdump}/tcpdump':"

That is casued by AC_RUN_IFELSE, as describe in
"https://www.gnu.org/software/autoconf/manual/autoconf-2.63/html_node/Runtime.html"
, if AC_RUN_IFELSE do not have cross-compile option, configure prints an error message and exits.

Signed-off-by: Mingrui Ren <jiladahe1997@gmail.com>