### PR TITLE
Don't try to print any information about gQUIC packets.

### DIFF
--- a/print-quic.c
+++ b/print-quic.c
@@ -168,7 +168,10 @@ quic_print_packet(netdissect_options *ndo, const u_char *bp, const u_char *end)
 		version = GET_BE_U_4(bp);
 		bp += 4;
 
-		if (version == 0)
+		if (version >> 24 == 0x51) {
+			ND_PRINT(", unsupported gquic");
+			return end;
+		} else if (version == 0)
 			ND_PRINT(", version negotiation");
 		else if (packet_type == QUIC_LH_TYPE_INITIAL)
 			ND_PRINT(", initial");

--- a/tests/gquic.out
+++ b/tests/gquic.out
@@ -1,2 +1,2 @@
     1  06:42:38.000000 IP (tos 0x0, ttl 64, id 38137, offset 0, flags [DF], proto UDP (17), length 1378)
-    10.7.0.3.38824 > 216.58.195.67.443: quic, initial, v51303436, length 0, protected
+    10.7.0.3.38824 > 216.58.195.67.443: quic, unsupported gquic


### PR DESCRIPTION
Fixes #959.