### PR TITLE
Avoid calling setuid() with -Zroot

### DIFF
--- a/tcpdump.c
+++ b/tcpdump.c
@@ -2065,7 +2065,9 @@ main(int argc, char **argv)
 	/* if run as root, prepare for dropping root privileges */
 	if (getuid() == 0 || geteuid() == 0) {
 		/* Run with '-Z root' to restore old behaviour */
-		if (!username)
+		if (username && strcmp(username, "root") == 0)
+			username = NULL;
+		else if (!username)
 			username = WITH_USER;
 	}
 #endif


### PR DESCRIPTION
Fixes an issue under Linux user namespaces, where having a uid of 0 is not enough for setuid(0) to succeed making tcpdump exit. There was no way to avoid this when compiled `-DWITH_USER='"tcpdump"'`

This patch achieves the behaviour documented in source by avoiding the setuid() when `-Zroot` is supplied.

FIxes this scenario on Linux:

     $ unshare -Urn
     # ip link add br0 type bridge
     # ip link set br0 up
     # tcpdump -ibr0 -lvn
     tcpdump: Couldn't change to 'tcpdump' uid=137 gid=146: Operation not permitted
     # tcpdump -Zroot -ibr0 -lvn
     tcpdump: Couldn't change to 'root' uid=0 gid=0: Operation not permitted

closes #1000 