### PR TITLE
child_cleanup: reap as many child processes as possible

### DIFF
--- a/tcpdump.c
+++ b/tcpdump.c
@@ -2836,7 +2836,7 @@ cleanup(int signo _U_)
 static void
 child_cleanup(int signo _U_)
 {
-  wait(NULL);
+  while (waitpid(-1, NULL, WNOHANG) >= 0);
 }
 #endif /* HAVE_FORK && HAVE_VFORK */
 


### PR DESCRIPTION
Hello,
one of our customer reported zombie processes when running tcpdump under load with -C/-z and I've been able to reproduce. Here's a patch suggestion, but feel free to use something else -- waitpid is also mandated by posix so there should be no portability issue (same requirement as wait) but I've only tested this on linux.

Commit message below:
Under load it's possible multiple children have been killed before we start processing the SIGCHILD signal, leaving zombie processes behind everytime we miss a process.
Reap as many processes as possible instead of assuming one handler call = one process like we currently did.

Can be reproduced by running the following commands in parallel:
 - tcpdump -i lo -w /tmp/test -C 1 -z /usr/bin/true
 - iperf3 -s
 - iperf3 -c localhost

Test summary:
- problem reproduces and fixed with this on linux, FreeBSD
- no-op on windows (code ifdef'd out)