### PR TITLE
git: Ignore instrument_functions.nm in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ tcpdump.sln
 .vs/
 .passed
 .failed
+tcpdump_instrument_functions.nm


### PR DESCRIPTION
Related commit 6d854639ea6702adc7fcb077361ae00d2229f875.