### PR TITLE
Add suggested fix for CVE-2018-19519

### DIFF
--- a/print-hncp.c
+++ b/print-hncp.c
@@ -206,6 +206,7 @@ print_prefix(netdissect_options *ndo, const u_char *prefix, u_int max_length)
 {
     int plenbytes;
     char buf[sizeof("xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx::/128")];
+    buf[0] = '\0';
 
     if (GET_U_1(prefix) >= 96 && max_length >= IPV4_MAPPED_HEADING_LEN + 1 &&
         is_ipv4_mapped_address(prefix + 1)) {


### PR DESCRIPTION
There is a buffer read in print-hncp.c error due to a lack of initialisation of the buffer.
Fix my initialising the buffer with a null byte as suggested in the write up of the 
discoverer of the problem:

"Initialize buf[0] to '\0' in 'print_prefix'.
buf[0] = '\0';
(Just as print-cnfp.c and print-bgp.c do.)"

https://github.com/zyingp/temp/blob/master/tcpdump.md