### PR TITLE
OpenSSL_add_all_algorithms() is deprecated since OpenSSL 1.1.0, use it accordingly

### DIFF
--- a/print-esp.c
+++ b/print-esp.c
@@ -674,12 +674,7 @@ static void esp_print_decode_onesecret(netdissect_options *ndo, char *line,
 DIAG_OFF_DEPRECATION
 static void esp_init(netdissect_options *ndo _U_)
 {
-	/*
-	 * 0.9.6 doesn't appear to define OPENSSL_API_COMPAT, so
-	 * we check whether it's undefined or it's less than the
-	 * value for 1.1.0.
-	 */
-#if !defined(OPENSSL_API_COMPAT) || OPENSSL_API_COMPAT < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 	OpenSSL_add_all_algorithms();
 #endif
 	EVP_add_cipher_alias(SN_des_ede3_cbc, "3des");


### PR DESCRIPTION
OPENSSL_API_COMPAT is to be set by the module including OpenSSL header to request a certain API level compatibility, and starting with OpenSSL 3, it's no more defined by OpenSSL header to the default API level.

OPENSSL_VERSION_NUMBER must be used instead.

Fixes #977
