### PR TITLE
Add colorful output support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ tcpdump.sln
 .failed
 instrument_functions_global.devel
 instrument_functions_off.devel
+.cache
+compile_commands.json

--- a/Makefile.in
+++ b/Makefile.in
@@ -321,7 +321,8 @@ HDR = \
 	tcp.h \
 	timeval-operations.h \
 	udp.h \
-	varattrs.h
+	varattrs.h \
+	colors.h
 
 TAGHDR = \
 	/usr/include/netinet/if_ether.h \

--- a/colors.h
+++ b/colors.h
@@ -1,0 +1,12 @@
+#ifndef COLORS_H
+#define COLORS_H
+
+#define C_RESET   "\033[0m"
+#define C_RED     "\033[31m"
+#define C_GREEN   "\033[32m"
+#define C_YELLOW  "\033[33m"
+#define C_BLUE    "\033[34m"
+#define C_MAGENTA "\033[35m"
+#define C_CYAN    "\033[36m"
+
+#endif

--- a/netdissect.h
+++ b/netdissect.h
@@ -33,6 +33,7 @@
 #include "status-exit-codes.h"
 #include "funcattrs.h" /* for PRINTFLIKE_FUNCPTR() */
 #include "diag-control.h" /* for ND_UNREACHABLE */
+#include "colors.h"
 
 /*
  * Data types corresponding to multi-byte integral values within data
@@ -233,6 +234,7 @@ struct netdissect_options {
 
   int   ndo_snaplen;
   int   ndo_ll_hdr_len;	/* link-layer header length */
+  int   ndo_color;	/* print using colors */
 
   /*global pointers to beginning and end of current packet (during printing) */
   const u_char *ndo_packetp;
@@ -402,7 +404,7 @@ nd_trunc_longjmp(netdissect_options *ndo)
  */
 #define ND_ICHECKMSG_U(message, expression_1, operator, expression_2) \
 if ((expression_1) operator (expression_2)) { \
-ND_PRINT(" [%s %u %s %u]", (message), (expression_1), (#operator), (expression_2)); \
+ND_PRINT(C_RESET, " [%s %u %s %u]", (message), (expression_1), (#operator), (expression_2)); \
 goto invalid; \
 }
 
@@ -419,7 +421,7 @@ ND_ICHECKMSG_U((#expression_1), (expression_1), operator, (expression_2))
  */
 #define ND_ICHECKMSG_ZU(message, expression_1, operator, expression_2) \
 if ((expression_1) operator (expression_2)) { \
-ND_PRINT(" [%s %u %s %zu]", (message), (expression_1), (#operator), (expression_2)); \
+ND_PRINT(C_RESET, " [%s %u %s %zu]", (message), (expression_1), (#operator), (expression_2)); \
 goto invalid; \
 }
 
@@ -430,7 +432,9 @@ goto invalid; \
 #define ND_ICHECK_ZU(expression_1, operator, expression_2) \
 ND_ICHECKMSG_ZU((#expression_1), (expression_1), operator, (expression_2))
 
-#define ND_PRINT(...) (ndo->ndo_printf)(ndo, __VA_ARGS__)
+#define ND_PRINT(COLOR, FMT, ...) if(ndo->ndo_color) (ndo->ndo_printf)(ndo, COLOR FMT C_RESET __VA_OPT__(,) __VA_ARGS__); \
+	else (ndo->ndo_printf)(ndo, FMT __VA_OPT__(,) __VA_ARGS__)
+
 #define ND_DEFAULTPRINT(ap, length) (*ndo->ndo_default_print)(ndo, ap, length)
 
 extern void ts_print(netdissect_options *, const struct timeval *);

--- a/ntp.c
+++ b/ntp.c
@@ -46,7 +46,7 @@ p_ntp_time(netdissect_options *ndo,
 		ff += FMAXINT;
 	ff = ff / FMAXINT;			/* shift radix point by 32 bits */
 	f = (uint32_t)(ff * 1000000000.0);	/* treat fraction as parts per billion */
-	ND_PRINT("%u.%09u", i, f);
+	ND_PRINT(C_RESET, "%u.%09u", i, f);
 
 #ifdef HAVE_STRFTIME
 	/*
@@ -64,7 +64,7 @@ p_ntp_time(netdissect_options *ndo,
 		 * It doesn't fit into a time_t, so we can't hand it
 		 * to gmtime.
 		 */
-		ND_PRINT(" (unrepresentable)");
+		ND_PRINT(C_RESET, " (unrepresentable)");
 	    } else {
 		tm = gmtime(&seconds);
 		if (tm == NULL) {
@@ -73,11 +73,11 @@ p_ntp_time(netdissect_options *ndo,
 		     * (Yes, that might happen with some version of
 		     * Microsoft's C library.)
 		     */
-		    ND_PRINT(" (unrepresentable)");
+		    ND_PRINT(C_RESET, " (unrepresentable)");
 		} else {
 		    /* use ISO 8601 (RFC3339) format */
 		    strftime(time_buf, sizeof (time_buf), "%Y-%m-%dT%H:%M:%SZ", tm);
-		    ND_PRINT(" (%s)", time_buf);
+		    ND_PRINT(C_RESET, " (%s)", time_buf);
 		}
 	    }
 	}

--- a/print-802_11.c
+++ b/print-802_11.c
@@ -404,13 +404,13 @@ struct meshcntl_t {
 
 #define PRINT_SSID(p) \
 	if (p.ssid_present) { \
-		ND_PRINT(" ("); \
+		ND_PRINT(C_RESET, " ("); \
 		fn_print_str(ndo, p.ssid.ssid); \
-		ND_PRINT(")"); \
+		ND_PRINT(C_RESET, ")"); \
 	}
 
 #define PRINT_RATE(_sep, _r, _suf) \
-	ND_PRINT("%s%2.1f%s", _sep, (.5 * ((_r) & 0x7f)), _suf)
+	ND_PRINT(C_RESET, "%s%2.1f%s", _sep, (.5 * ((_r) & 0x7f)), _suf)
 #define PRINT_RATES(p) \
 	if (p.rates_present) { \
 		const char *sep = " ["; \
@@ -420,21 +420,21 @@ struct meshcntl_t {
 					(p.rates.rate[z] & 0x80 ? "*" : "")); \
 				sep = " "; \
 			} \
-			ND_PRINT(" Mbit]"); \
+			ND_PRINT(C_RESET, " Mbit]"); \
 		} \
 	}
 
 #define PRINT_DS_CHANNEL(p) \
 	if (p.ds_present) \
-		ND_PRINT(" CH: %u", p.ds.channel); \
-	ND_PRINT("%s", \
+		ND_PRINT(C_RESET, " CH: %u", p.ds.channel); \
+	ND_PRINT(C_RESET, "%s", \
 	    CAPABILITY_PRIVACY(p.capability_info) ? ", PRIVACY" : "");
 
 #define PRINT_MESHID(p) \
 	if (p.meshid_present) { \
-		ND_PRINT(" (MESHID: "); \
+		ND_PRINT(C_RESET, " (MESHID: "); \
 		fn_print_str(ndo, p.meshid.meshid); \
-		ND_PRINT(")"); \
+		ND_PRINT(C_RESET, ")"); \
 	}
 
 #define MAX_MCS_INDEX	76
@@ -1135,7 +1135,7 @@ wep_print(netdissect_options *ndo,
 	ND_TCHECK_LEN(p, IEEE802_11_IV_LEN + IEEE802_11_KID_LEN);
 	iv = GET_LE_U_4(p);
 
-	ND_PRINT(" IV:%3x Pad %x KeyID %x", IV_IV(iv), IV_PAD(iv),
+	ND_PRINT(C_RESET, " IV:%3x Pad %x KeyID %x", IV_IV(iv), IV_PAD(iv),
 	    IV_KEYID(iv));
 
 	return 1;
@@ -1381,7 +1381,7 @@ parse_elements(netdissect_options *ndo,
 			break;
 		default:
 #if 0
-			ND_PRINT("(1) unhandled element_id (%u)  ",
+			ND_PRINT(C_RESET, "(1) unhandled element_id (%u)  ",
 			    GET_U_1(p + offset));
 #endif
 			offset += 2 + elementlen;
@@ -1429,7 +1429,7 @@ handle_beacon(netdissect_options *ndo,
 
 	PRINT_SSID(pbody);
 	PRINT_RATES(pbody);
-	ND_PRINT(" %s",
+	ND_PRINT(C_RESET, " %s",
 	    CAPABILITY_ESS(pbody.capability_info) ? "ESS" : "IBSS");
 	PRINT_DS_CHANNEL(pbody);
 	PRINT_MESHID(pbody);
@@ -1495,7 +1495,7 @@ handle_assoc_response(netdissect_options *ndo,
 
 	ret = parse_elements(ndo, &pbody, p, offset, length);
 
-	ND_PRINT(" AID(%x) :%s: %s", ((uint16_t)(pbody.aid << 2 )) >> 2 ,
+	ND_PRINT(C_RESET, " AID(%x) :%s: %s", ((uint16_t)(pbody.aid << 2 )) >> 2 ,
 	    CAPABILITY_PRIVACY(pbody.capability_info) ? " PRIVACY " : "",
 	    (pbody.status_code < NUM_STATUSES
 		? status_text[pbody.status_code]
@@ -1534,7 +1534,7 @@ handle_reassoc_request(netdissect_options *ndo,
 	ret = parse_elements(ndo, &pbody, p, offset, length);
 
 	PRINT_SSID(pbody);
-	ND_PRINT(" AP : %s", etheraddr_string(ndo,  pbody.ap ));
+	ND_PRINT(C_RESET, " AP : %s", etheraddr_string(ndo,  pbody.ap ));
 
 	return ret;
 trunc:
@@ -1624,7 +1624,7 @@ handle_disassoc(netdissect_options *ndo,
 		goto trunc;
 	pbody.reason_code = GET_LE_U_2(p);
 
-	ND_PRINT(": %s",
+	ND_PRINT(C_RESET, ": %s",
 	    (pbody.reason_code < NUM_REASONS)
 		? reason_text[pbody.reason_code]
 		: "Reserved");
@@ -1662,7 +1662,7 @@ handle_auth(netdissect_options *ndo,
 	if ((pbody.auth_alg == 1) &&
 	    ((pbody.auth_trans_seq_num == 2) ||
 	     (pbody.auth_trans_seq_num == 3))) {
-		ND_PRINT(" (%s)-%x [Challenge Text] %s",
+		ND_PRINT(C_RESET, " (%s)-%x [Challenge Text] %s",
 		    (pbody.auth_alg < NUM_AUTH_ALGS)
 			? auth_alg_text[pbody.auth_alg]
 			: "Reserved",
@@ -1673,7 +1673,7 @@ handle_auth(netdissect_options *ndo,
 			       : "n/a") : ""));
 		return ret;
 	}
-	ND_PRINT(" (%s)-%x: %s",
+	ND_PRINT(C_RESET, " (%s)-%x: %s",
 	    (pbody.auth_alg < NUM_AUTH_ALGS)
 		? auth_alg_text[pbody.auth_alg]
 		: "Reserved",
@@ -1708,9 +1708,9 @@ handle_deauth(netdissect_options *ndo,
 			: "Reserved";
 
 	if (ndo->ndo_eflag) {
-		ND_PRINT(": %s", reason);
+		ND_PRINT(C_RESET, ": %s", reason);
 	} else {
-		ND_PRINT(" (%s): %s", GET_ETHERADDR_STRING(src), reason);
+		ND_PRINT(C_RESET, " (%s): %s", GET_ETHERADDR_STRING(src), reason);
 	}
 	return 1;
 trunc:
@@ -1793,18 +1793,18 @@ handle_action(netdissect_options *ndo,
 	if (length < 2)
 		goto trunc;
 	if (ndo->ndo_eflag) {
-		ND_PRINT(": ");
+		ND_PRINT(C_RESET, ": ");
 	} else {
-		ND_PRINT(" (%s): ", GET_ETHERADDR_STRING(src));
+		ND_PRINT(C_RESET, " (%s): ", GET_ETHERADDR_STRING(src));
 	}
 	category = GET_U_1(p);
-	ND_PRINT("%s ", tok2str(category_str, "Reserved(%u)", category));
+	ND_PRINT(C_RESET, "%s ", tok2str(category_str, "Reserved(%u)", category));
 	action = GET_U_1(p + 1);
 	action_str = uint2tokary(category2tokary, category);
 	if (!action_str)
-		ND_PRINT("Act#%u", action);
+		ND_PRINT(C_RESET, "Act#%u", action);
 	else
-		ND_PRINT("%s", tok2str(action_str, "Act#%u", action));
+		ND_PRINT(C_RESET, "%s", tok2str(action_str, "Act#%u", action));
 
 	return 1;
 trunc:
@@ -1821,7 +1821,7 @@ static int
 mgmt_body_print(netdissect_options *ndo,
 		uint16_t fc, const uint8_t *src, const u_char *p, u_int length)
 {
-	ND_PRINT("%s", tok2str(st_str, "Unhandled Management subtype(%x)", FC_SUBTYPE(fc)));
+	ND_PRINT(C_RESET, "%s", tok2str(st_str, "Unhandled Management subtype(%x)", FC_SUBTYPE(fc)));
 
 	/* There may be a problem w/ AP not having this bit set */
 	if (FC_PROTECTED(fc))
@@ -1865,7 +1865,7 @@ static int
 ctrl_body_print(netdissect_options *ndo,
 		uint16_t fc, const u_char *p)
 {
-	ND_PRINT("%s", tok2str(ctrl_str, "Unknown Ctrl Subtype", FC_SUBTYPE(fc)));
+	ND_PRINT(C_RESET, "%s", tok2str(ctrl_str, "Unknown Ctrl Subtype", FC_SUBTYPE(fc)));
 	switch (FC_SUBTYPE(fc)) {
 	case CTRL_CONTROL_WRAPPER:
 		/* XXX - requires special handling */
@@ -1873,7 +1873,7 @@ ctrl_body_print(netdissect_options *ndo,
 	case CTRL_BAR:
 		ND_TCHECK_LEN(p, CTRL_BAR_HDRLEN);
 		if (!ndo->ndo_eflag)
-			ND_PRINT(" RA:%s TA:%s CTL(%x) SEQ(%u) ",
+			ND_PRINT(C_RESET, " RA:%s TA:%s CTL(%x) SEQ(%u) ",
 			    GET_ETHERADDR_STRING(((const struct ctrl_bar_hdr_t *)p)->ra),
 			    GET_ETHERADDR_STRING(((const struct ctrl_bar_hdr_t *)p)->ta),
 			    GET_LE_U_2(((const struct ctrl_bar_hdr_t *)p)->ctl),
@@ -1882,42 +1882,42 @@ ctrl_body_print(netdissect_options *ndo,
 	case CTRL_BA:
 		ND_TCHECK_LEN(p, CTRL_BA_HDRLEN);
 		if (!ndo->ndo_eflag)
-			ND_PRINT(" RA:%s ",
+			ND_PRINT(C_RESET, " RA:%s ",
 			    GET_ETHERADDR_STRING(((const struct ctrl_ba_hdr_t *)p)->ra));
 		break;
 	case CTRL_PS_POLL:
 		ND_TCHECK_LEN(p, CTRL_PS_POLL_HDRLEN);
-		ND_PRINT(" AID(%x)",
+		ND_PRINT(C_RESET, " AID(%x)",
 		    GET_LE_U_2(((const struct ctrl_ps_poll_hdr_t *)p)->aid));
 		break;
 	case CTRL_RTS:
 		ND_TCHECK_LEN(p, CTRL_RTS_HDRLEN);
 		if (!ndo->ndo_eflag)
-			ND_PRINT(" TA:%s ",
+			ND_PRINT(C_RESET, " TA:%s ",
 			    GET_ETHERADDR_STRING(((const struct ctrl_rts_hdr_t *)p)->ta));
 		break;
 	case CTRL_CTS:
 		ND_TCHECK_LEN(p, CTRL_CTS_HDRLEN);
 		if (!ndo->ndo_eflag)
-			ND_PRINT(" RA:%s ",
+			ND_PRINT(C_RESET, " RA:%s ",
 			    GET_ETHERADDR_STRING(((const struct ctrl_cts_hdr_t *)p)->ra));
 		break;
 	case CTRL_ACK:
 		ND_TCHECK_LEN(p, CTRL_ACK_HDRLEN);
 		if (!ndo->ndo_eflag)
-			ND_PRINT(" RA:%s ",
+			ND_PRINT(C_RESET, " RA:%s ",
 			    GET_ETHERADDR_STRING(((const struct ctrl_ack_hdr_t *)p)->ra));
 		break;
 	case CTRL_CF_END:
 		ND_TCHECK_LEN(p, CTRL_END_HDRLEN);
 		if (!ndo->ndo_eflag)
-			ND_PRINT(" RA:%s ",
+			ND_PRINT(C_RESET, " RA:%s ",
 			    GET_ETHERADDR_STRING(((const struct ctrl_end_hdr_t *)p)->ra));
 		break;
 	case CTRL_END_ACK:
 		ND_TCHECK_LEN(p, CTRL_END_ACK_HDRLEN);
 		if (!ndo->ndo_eflag)
-			ND_PRINT(" RA:%s ",
+			ND_PRINT(C_RESET, " RA:%s ",
 			    GET_ETHERADDR_STRING(((const struct ctrl_end_ack_hdr_t *)p)->ra));
 		break;
 	}
@@ -1998,19 +1998,19 @@ data_header_print(netdissect_options *ndo, uint16_t fc, const u_char *p)
 
 	if (DATA_FRAME_IS_CF_ACK(subtype) || DATA_FRAME_IS_CF_POLL(subtype) ||
 	    DATA_FRAME_IS_QOS(subtype)) {
-		ND_PRINT("CF ");
+		ND_PRINT(C_RESET, "CF ");
 		if (DATA_FRAME_IS_CF_ACK(subtype)) {
 			if (DATA_FRAME_IS_CF_POLL(subtype))
-				ND_PRINT("Ack/Poll");
+				ND_PRINT(C_RESET, "Ack/Poll");
 			else
-				ND_PRINT("Ack");
+				ND_PRINT(C_RESET, "Ack");
 		} else {
 			if (DATA_FRAME_IS_CF_POLL(subtype))
-				ND_PRINT("Poll");
+				ND_PRINT(C_RESET, "Poll");
 		}
 		if (DATA_FRAME_IS_QOS(subtype))
-			ND_PRINT("+QoS");
-		ND_PRINT(" ");
+			ND_PRINT(C_RESET, "+QoS");
+		ND_PRINT(C_RESET, " ");
 	}
 
 #define ADDR1  (p + 4)
@@ -2019,19 +2019,19 @@ data_header_print(netdissect_options *ndo, uint16_t fc, const u_char *p)
 #define ADDR4  (p + 24)
 
 	if (!FC_TO_DS(fc) && !FC_FROM_DS(fc)) {
-		ND_PRINT("DA:%s SA:%s BSSID:%s ",
+		ND_PRINT(C_RESET, "DA:%s SA:%s BSSID:%s ",
 		    GET_ETHERADDR_STRING(ADDR1), GET_ETHERADDR_STRING(ADDR2),
 		    GET_ETHERADDR_STRING(ADDR3));
 	} else if (!FC_TO_DS(fc) && FC_FROM_DS(fc)) {
-		ND_PRINT("DA:%s BSSID:%s SA:%s ",
+		ND_PRINT(C_RESET, "DA:%s BSSID:%s SA:%s ",
 		    GET_ETHERADDR_STRING(ADDR1), GET_ETHERADDR_STRING(ADDR2),
 		    GET_ETHERADDR_STRING(ADDR3));
 	} else if (FC_TO_DS(fc) && !FC_FROM_DS(fc)) {
-		ND_PRINT("BSSID:%s SA:%s DA:%s ",
+		ND_PRINT(C_RESET, "BSSID:%s SA:%s DA:%s ",
 		    GET_ETHERADDR_STRING(ADDR1), GET_ETHERADDR_STRING(ADDR2),
 		    GET_ETHERADDR_STRING(ADDR3));
 	} else if (FC_TO_DS(fc) && FC_FROM_DS(fc)) {
-		ND_PRINT("RA:%s TA:%s DA:%s SA:%s ",
+		ND_PRINT(C_RESET, "RA:%s TA:%s DA:%s SA:%s ",
 		    GET_ETHERADDR_STRING(ADDR1), GET_ETHERADDR_STRING(ADDR2),
 		    GET_ETHERADDR_STRING(ADDR3), GET_ETHERADDR_STRING(ADDR4));
 	}
@@ -2047,7 +2047,7 @@ mgmt_header_print(netdissect_options *ndo, const u_char *p)
 {
 	const struct mgmt_header_t *hp = (const struct mgmt_header_t *) p;
 
-	ND_PRINT("BSSID:%s DA:%s SA:%s ",
+	ND_PRINT(C_RESET, "BSSID:%s DA:%s SA:%s ",
 	    GET_ETHERADDR_STRING((hp)->bssid), GET_ETHERADDR_STRING((hp)->da),
 	    GET_ETHERADDR_STRING((hp)->sa));
 }
@@ -2057,42 +2057,42 @@ ctrl_header_print(netdissect_options *ndo, uint16_t fc, const u_char *p)
 {
 	switch (FC_SUBTYPE(fc)) {
 	case CTRL_BAR:
-		ND_PRINT(" RA:%s TA:%s CTL(%x) SEQ(%u) ",
+		ND_PRINT(C_RESET, " RA:%s TA:%s CTL(%x) SEQ(%u) ",
 		    GET_ETHERADDR_STRING(((const struct ctrl_bar_hdr_t *)p)->ra),
 		    GET_ETHERADDR_STRING(((const struct ctrl_bar_hdr_t *)p)->ta),
 		    GET_LE_U_2(((const struct ctrl_bar_hdr_t *)p)->ctl),
 		    GET_LE_U_2(((const struct ctrl_bar_hdr_t *)p)->seq));
 		break;
 	case CTRL_BA:
-		ND_PRINT("RA:%s TA:%s ",
+		ND_PRINT(C_RESET, "RA:%s TA:%s ",
 		    GET_ETHERADDR_STRING(((const struct ctrl_ba_hdr_t *)p)->ra),
 		    GET_ETHERADDR_STRING(((const struct ctrl_ba_hdr_t *)p)->ta));
 		break;
 	case CTRL_PS_POLL:
-		ND_PRINT("BSSID:%s TA:%s ",
+		ND_PRINT(C_RESET, "BSSID:%s TA:%s ",
 		    GET_ETHERADDR_STRING(((const struct ctrl_ps_poll_hdr_t *)p)->bssid),
 		    GET_ETHERADDR_STRING(((const struct ctrl_ps_poll_hdr_t *)p)->ta));
 		break;
 	case CTRL_RTS:
-		ND_PRINT("RA:%s TA:%s ",
+		ND_PRINT(C_RESET, "RA:%s TA:%s ",
 		    GET_ETHERADDR_STRING(((const struct ctrl_rts_hdr_t *)p)->ra),
 		    GET_ETHERADDR_STRING(((const struct ctrl_rts_hdr_t *)p)->ta));
 		break;
 	case CTRL_CTS:
-		ND_PRINT("RA:%s ",
+		ND_PRINT(C_RESET, "RA:%s ",
 		    GET_ETHERADDR_STRING(((const struct ctrl_cts_hdr_t *)p)->ra));
 		break;
 	case CTRL_ACK:
-		ND_PRINT("RA:%s ",
+		ND_PRINT(C_RESET, "RA:%s ",
 		    GET_ETHERADDR_STRING(((const struct ctrl_ack_hdr_t *)p)->ra));
 		break;
 	case CTRL_CF_END:
-		ND_PRINT("RA:%s BSSID:%s ",
+		ND_PRINT(C_RESET, "RA:%s BSSID:%s ",
 		    GET_ETHERADDR_STRING(((const struct ctrl_end_hdr_t *)p)->ra),
 		    GET_ETHERADDR_STRING(((const struct ctrl_end_hdr_t *)p)->bssid));
 		break;
 	case CTRL_END_ACK:
-		ND_PRINT("RA:%s BSSID:%s ",
+		ND_PRINT(C_RESET, "RA:%s BSSID:%s ",
 		    GET_ETHERADDR_STRING(((const struct ctrl_end_ack_hdr_t *)p)->ra),
 		    GET_ETHERADDR_STRING(((const struct ctrl_end_ack_hdr_t *)p)->bssid));
 		break;
@@ -2132,7 +2132,7 @@ extract_header_length(netdissect_options *ndo,
 		case CTRL_END_ACK:
 			return CTRL_END_ACK_HDRLEN;
 		default:
-			ND_PRINT("unknown 802.11 ctrl frame subtype (%u)", FC_SUBTYPE(fc));
+			ND_PRINT(C_RESET, "unknown 802.11 ctrl frame subtype (%u)", FC_SUBTYPE(fc));
 			return 0;
 		}
 	case T_DATA:
@@ -2141,7 +2141,7 @@ extract_header_length(netdissect_options *ndo,
 			len += 2;
 		return len;
 	default:
-		ND_PRINT("unknown 802.11 frame type (%u)", FC_TYPE(fc));
+		ND_PRINT(C_RESET, "unknown 802.11 frame type (%u)", FC_TYPE(fc));
 		return 0;
 	}
 }
@@ -2162,19 +2162,19 @@ ieee_802_11_hdr_print(netdissect_options *ndo,
 {
 	if (ndo->ndo_vflag) {
 		if (FC_MORE_DATA(fc))
-			ND_PRINT("More Data ");
+			ND_PRINT(C_RESET, "More Data ");
 		if (FC_MORE_FLAG(fc))
-			ND_PRINT("More Fragments ");
+			ND_PRINT(C_RESET, "More Fragments ");
 		if (FC_POWER_MGMT(fc))
-			ND_PRINT("Pwr Mgmt ");
+			ND_PRINT(C_RESET, "Pwr Mgmt ");
 		if (FC_RETRY(fc))
-			ND_PRINT("Retry ");
+			ND_PRINT(C_RESET, "Retry ");
 		if (FC_ORDER(fc))
-			ND_PRINT("Strictly Ordered ");
+			ND_PRINT(C_RESET, "Strictly Ordered ");
 		if (FC_PROTECTED(fc))
-			ND_PRINT("Protected ");
+			ND_PRINT(C_RESET, "Protected ");
 		if (FC_TYPE(fc) != T_CTRL || FC_SUBTYPE(fc) != CTRL_PS_POLL)
-			ND_PRINT("%uus ",
+			ND_PRINT(C_RESET, "%uus ",
 			    GET_LE_U_2(((const struct mgmt_header_t *)p)->duration));
 	}
 	if (meshdrlen != 0) {
@@ -2182,15 +2182,15 @@ ieee_802_11_hdr_print(netdissect_options *ndo,
 		    (const struct meshcntl_t *)(p + hdrlen - meshdrlen);
 		u_int ae = GET_U_1(mc->flags) & 3;
 
-		ND_PRINT("MeshData (AE %u TTL %u seq %u", ae,
+		ND_PRINT(C_RESET, "MeshData (AE %u TTL %u seq %u", ae,
 		    GET_U_1(mc->ttl), GET_LE_U_4(mc->seq));
 		if (ae > 0)
-			ND_PRINT(" A4:%s", GET_ETHERADDR_STRING(mc->addr4));
+			ND_PRINT(C_RESET, " A4:%s", GET_ETHERADDR_STRING(mc->addr4));
 		if (ae > 1)
-			ND_PRINT(" A5:%s", GET_ETHERADDR_STRING(mc->addr5));
+			ND_PRINT(C_RESET, " A5:%s", GET_ETHERADDR_STRING(mc->addr5));
 		if (ae > 2)
-			ND_PRINT(" A6:%s", GET_ETHERADDR_STRING(mc->addr6));
-		ND_PRINT(") ");
+			ND_PRINT(C_RESET, " A6:%s", GET_ETHERADDR_STRING(mc->addr6));
+		ND_PRINT(C_RESET, ") ");
 	}
 
 	switch (FC_TYPE(fc)) {
@@ -2293,7 +2293,7 @@ ieee802_11_print(netdissect_options *ndo,
 			return hdrlen;	/* no-data frame */
 		/* There may be a problem w/ AP not having this bit set */
 		if (FC_PROTECTED(fc)) {
-			ND_PRINT("Data");
+			ND_PRINT(C_RESET, "Data");
 			if (!wep_print(ndo, p)) {
 				nd_print_trunc(ndo);
 				return hdrlen;
@@ -2706,46 +2706,46 @@ static void
 print_chaninfo(netdissect_options *ndo,
 	       uint16_t freq, uint32_t flags, uint32_t presentflags)
 {
-	ND_PRINT("%u MHz", freq);
+	ND_PRINT(C_RESET, "%u MHz", freq);
 	if (presentflags & (1 << IEEE80211_RADIOTAP_MCS)) {
 		/*
 		 * We have the MCS field, so this is 11n, regardless
 		 * of what the channel flags say.
 		 */
-		ND_PRINT(" 11n");
+		ND_PRINT(C_RESET, " 11n");
 	} else {
 		if (IS_CHAN_FHSS(flags))
-			ND_PRINT(" FHSS");
+			ND_PRINT(C_RESET, " FHSS");
 		if (IS_CHAN_A(flags)) {
 			if (flags & IEEE80211_CHAN_HALF)
-				ND_PRINT(" 11a/10Mhz");
+				ND_PRINT(C_RESET, " 11a/10Mhz");
 			else if (flags & IEEE80211_CHAN_QUARTER)
-				ND_PRINT(" 11a/5Mhz");
+				ND_PRINT(C_RESET, " 11a/5Mhz");
 			else
-				ND_PRINT(" 11a");
+				ND_PRINT(C_RESET, " 11a");
 		}
 		if (IS_CHAN_ANYG(flags)) {
 			if (flags & IEEE80211_CHAN_HALF)
-				ND_PRINT(" 11g/10Mhz");
+				ND_PRINT(C_RESET, " 11g/10Mhz");
 			else if (flags & IEEE80211_CHAN_QUARTER)
-				ND_PRINT(" 11g/5Mhz");
+				ND_PRINT(C_RESET, " 11g/5Mhz");
 			else
-				ND_PRINT(" 11g");
+				ND_PRINT(C_RESET, " 11g");
 		} else if (IS_CHAN_B(flags))
-			ND_PRINT(" 11b");
+			ND_PRINT(C_RESET, " 11b");
 		if (flags & IEEE80211_CHAN_TURBO)
-			ND_PRINT(" Turbo");
+			ND_PRINT(C_RESET, " Turbo");
 	}
 	/*
 	 * These apply to 11n.
 	 */
 	if (flags & IEEE80211_CHAN_HT20)
-		ND_PRINT(" ht/20");
+		ND_PRINT(C_RESET, " ht/20");
 	else if (flags & IEEE80211_CHAN_HT40D)
-		ND_PRINT(" ht/40-");
+		ND_PRINT(C_RESET, " ht/40-");
 	else if (flags & IEEE80211_CHAN_HT40U)
-		ND_PRINT(" ht/40+");
-	ND_PRINT(" ");
+		ND_PRINT(C_RESET, " ht/40+");
+	ND_PRINT(C_RESET, " ");
 }
 
 static int
@@ -2764,7 +2764,7 @@ print_radiotap_field(netdissect_options *ndo,
 		rc = nd_cpack_uint64(ndo, s, &tsft);
 		if (rc != 0)
 			goto trunc;
-		ND_PRINT("%" PRIu64 "us tsft ", tsft);
+		ND_PRINT(C_RESET, "%" PRIu64 "us tsft ", tsft);
 		break;
 		}
 
@@ -2776,15 +2776,15 @@ print_radiotap_field(netdissect_options *ndo,
 			goto trunc;
 		*flagsp = flagsval;
 		if (flagsval & IEEE80211_RADIOTAP_F_CFP)
-			ND_PRINT("cfp ");
+			ND_PRINT(C_RESET, "cfp ");
 		if (flagsval & IEEE80211_RADIOTAP_F_SHORTPRE)
-			ND_PRINT("short preamble ");
+			ND_PRINT(C_RESET, "short preamble ");
 		if (flagsval & IEEE80211_RADIOTAP_F_WEP)
-			ND_PRINT("wep ");
+			ND_PRINT(C_RESET, "wep ");
 		if (flagsval & IEEE80211_RADIOTAP_F_FRAG)
-			ND_PRINT("fragmented ");
+			ND_PRINT(C_RESET, "fragmented ");
 		if (flagsval & IEEE80211_RADIOTAP_F_BADFCS)
-			ND_PRINT("bad-fcs ");
+			ND_PRINT(C_RESET, "bad-fcs ");
 		break;
 		}
 
@@ -2832,9 +2832,9 @@ print_radiotap_field(netdissect_options *ndo,
 			 * information from Flags, at least on
 			 * FreeBSD?
 			 */
-			ND_PRINT("MCS %u ", rate & 0x7f);
+			ND_PRINT(C_RESET, "MCS %u ", rate & 0x7f);
 		} else
-			ND_PRINT("%2.1f Mb/s ", .5 * rate);
+			ND_PRINT(C_RESET, "%2.1f Mb/s ", .5 * rate);
 		break;
 		}
 
@@ -2868,7 +2868,7 @@ print_radiotap_field(netdissect_options *ndo,
 		rc = nd_cpack_uint8(ndo, s, &hoppat);
 		if (rc != 0)
 			goto trunc;
-		ND_PRINT("fhset %u fhpat %u ", hopset, hoppat);
+		ND_PRINT(C_RESET, "fhset %u fhpat %u ", hopset, hoppat);
 		break;
 		}
 
@@ -2878,7 +2878,7 @@ print_radiotap_field(netdissect_options *ndo,
 		rc = nd_cpack_int8(ndo, s, &dbm_antsignal);
 		if (rc != 0)
 			goto trunc;
-		ND_PRINT("%ddBm signal ", dbm_antsignal);
+		ND_PRINT(C_RESET, "%ddBm signal ", dbm_antsignal);
 		break;
 		}
 
@@ -2888,7 +2888,7 @@ print_radiotap_field(netdissect_options *ndo,
 		rc = nd_cpack_int8(ndo, s, &dbm_antnoise);
 		if (rc != 0)
 			goto trunc;
-		ND_PRINT("%ddBm noise ", dbm_antnoise);
+		ND_PRINT(C_RESET, "%ddBm noise ", dbm_antnoise);
 		break;
 		}
 
@@ -2898,7 +2898,7 @@ print_radiotap_field(netdissect_options *ndo,
 		rc = nd_cpack_uint16(ndo, s, &lock_quality);
 		if (rc != 0)
 			goto trunc;
-		ND_PRINT("%u sq ", lock_quality);
+		ND_PRINT(C_RESET, "%u sq ", lock_quality);
 		break;
 		}
 
@@ -2908,7 +2908,7 @@ print_radiotap_field(netdissect_options *ndo,
 		rc = nd_cpack_int16(ndo, s, &tx_attenuation);
 		if (rc != 0)
 			goto trunc;
-		ND_PRINT("%d tx power ", -tx_attenuation);
+		ND_PRINT(C_RESET, "%d tx power ", -tx_attenuation);
 		break;
 		}
 
@@ -2918,7 +2918,7 @@ print_radiotap_field(netdissect_options *ndo,
 		rc = nd_cpack_int8(ndo, s, &db_tx_attenuation);
 		if (rc != 0)
 			goto trunc;
-		ND_PRINT("%ddB tx attenuation ", -db_tx_attenuation);
+		ND_PRINT(C_RESET, "%ddB tx attenuation ", -db_tx_attenuation);
 		break;
 		}
 
@@ -2928,7 +2928,7 @@ print_radiotap_field(netdissect_options *ndo,
 		rc = nd_cpack_int8(ndo, s, &dbm_tx_power);
 		if (rc != 0)
 			goto trunc;
-		ND_PRINT("%ddBm tx power ", dbm_tx_power);
+		ND_PRINT(C_RESET, "%ddBm tx power ", dbm_tx_power);
 		break;
 		}
 
@@ -2938,7 +2938,7 @@ print_radiotap_field(netdissect_options *ndo,
 		rc = nd_cpack_uint8(ndo, s, &antenna);
 		if (rc != 0)
 			goto trunc;
-		ND_PRINT("antenna %u ", antenna);
+		ND_PRINT(C_RESET, "antenna %u ", antenna);
 		break;
 		}
 
@@ -2948,7 +2948,7 @@ print_radiotap_field(netdissect_options *ndo,
 		rc = nd_cpack_uint8(ndo, s, &db_antsignal);
 		if (rc != 0)
 			goto trunc;
-		ND_PRINT("%udB signal ", db_antsignal);
+		ND_PRINT(C_RESET, "%udB signal ", db_antsignal);
 		break;
 		}
 
@@ -2958,7 +2958,7 @@ print_radiotap_field(netdissect_options *ndo,
 		rc = nd_cpack_uint8(ndo, s, &db_antnoise);
 		if (rc != 0)
 			goto trunc;
-		ND_PRINT("%udB noise ", db_antnoise);
+		ND_PRINT(C_RESET, "%udB noise ", db_antnoise);
 		break;
 		}
 
@@ -3053,36 +3053,36 @@ print_radiotap_field(netdissect_options *ndo,
 				 * We have the rate.
 				 * Print it.
 				 */
-				ND_PRINT("%.1f Mb/s MCS %u ", htrate, mcs_index);
+				ND_PRINT(C_RESET, "%.1f Mb/s MCS %u ", htrate, mcs_index);
 			} else {
 				/*
 				 * We at least have the MCS index.
 				 * Print it.
 				 */
-				ND_PRINT("MCS %u ", mcs_index);
+				ND_PRINT(C_RESET, "MCS %u ", mcs_index);
 			}
 		}
 		if (known & IEEE80211_RADIOTAP_MCS_BANDWIDTH_KNOWN) {
-			ND_PRINT("%s ",
+			ND_PRINT(C_RESET, "%s ",
 				ht_bandwidth[flags & IEEE80211_RADIOTAP_MCS_BANDWIDTH_MASK]);
 		}
 		if (known & IEEE80211_RADIOTAP_MCS_GUARD_INTERVAL_KNOWN) {
-			ND_PRINT("%s GI ",
+			ND_PRINT(C_RESET, "%s GI ",
 				(flags & IEEE80211_RADIOTAP_MCS_SHORT_GI) ?
 				"short" : "long");
 		}
 		if (known & IEEE80211_RADIOTAP_MCS_HT_FORMAT_KNOWN) {
-			ND_PRINT("%s ",
+			ND_PRINT(C_RESET, "%s ",
 				(flags & IEEE80211_RADIOTAP_MCS_HT_GREENFIELD) ?
 				"greenfield" : "mixed");
 		}
 		if (known & IEEE80211_RADIOTAP_MCS_FEC_TYPE_KNOWN) {
-			ND_PRINT("%s FEC ",
+			ND_PRINT(C_RESET, "%s FEC ",
 				(flags & IEEE80211_RADIOTAP_MCS_FEC_LDPC) ?
 				"LDPC" : "BCC");
 		}
 		if (known & IEEE80211_RADIOTAP_MCS_STBC_KNOWN) {
-			ND_PRINT("RX-STBC%u ",
+			ND_PRINT(C_RESET, "RX-STBC%u ",
 				(flags & IEEE80211_RADIOTAP_MCS_STBC_MASK) >> IEEE80211_RADIOTAP_MCS_STBC_SHIFT);
 		}
 		break;
@@ -3184,17 +3184,17 @@ print_radiotap_field(netdissect_options *ndo,
 			if (nss == 0)
 				continue;
 
-			ND_PRINT("User %u MCS %u ", i, mcs);
-			ND_PRINT("%s FEC ",
+			ND_PRINT(C_RESET, "User %u MCS %u ", i, mcs);
+			ND_PRINT(C_RESET, "%s FEC ",
 				(coding & (IEEE80211_RADIOTAP_CODING_LDPC_USERn << i)) ?
 				"LDPC" : "BCC");
 		}
 		if (known & IEEE80211_RADIOTAP_VHT_BANDWIDTH_KNOWN) {
-			ND_PRINT("%s ",
+			ND_PRINT(C_RESET, "%s ",
 				vht_bandwidth[bandwidth & IEEE80211_RADIOTAP_VHT_BANDWIDTH_MASK]);
 		}
 		if (known & IEEE80211_RADIOTAP_VHT_GUARD_INTERVAL_KNOWN) {
-			ND_PRINT("%s GI ",
+			ND_PRINT(C_RESET, "%s GI ",
 				(flags & IEEE80211_RADIOTAP_VHT_SHORT_GI) ?
 				"short" : "long");
 		}
@@ -3206,7 +3206,7 @@ print_radiotap_field(netdissect_options *ndo,
 		 * size we do not know, so we cannot
 		 * proceed.  Just print the bit number.
 		 */
-		ND_PRINT("[bit %u] ", bit);
+		ND_PRINT(C_RESET, "[bit %u] ", bit);
 		return -1;
 	}
 

--- a/print-802_15_4.c
+++ b/print-802_15_4.c
@@ -540,13 +540,13 @@ ieee802_15_4_print_addr(netdissect_options *ndo, const u_char *p,
 {
 	switch (dst_addr_len) {
 	case 0:
-		ND_PRINT("none");
+		ND_PRINT(C_RESET, "none");
 		break;
 	case 2:
-		ND_PRINT("%04x", GET_LE_U_2(p));
+		ND_PRINT(C_RESET, "%04x", GET_LE_U_2(p));
 		break;
 	case 8:
-		ND_PRINT("%s", GET_LE64ADDR_STRING(p));
+		ND_PRINT(C_RESET, "%s", GET_LE64ADDR_STRING(p));
 		break;
 	}
 }
@@ -563,13 +563,13 @@ ieee802_15_4_print_superframe_specification(netdissect_options *ndo,
 	if (ndo->ndo_vflag < 1) {
 		return;
 	}
-	ND_PRINT("\n\tBeacon order = %d, Superframe order = %d, ",
+	ND_PRINT(C_RESET, "\n\tBeacon order = %d, Superframe order = %d, ",
 		 (ss & 0xf), ((ss >> 4) & 0xf));
-	ND_PRINT("Final CAP Slot = %d",
+	ND_PRINT(C_RESET, "Final CAP Slot = %d",
 		 ((ss >> 8) & 0xf));
-	if (CHECK_BIT(ss, 12)) { ND_PRINT(", BLE enabled"); }
-	if (CHECK_BIT(ss, 14)) { ND_PRINT(", PAN Coordinator"); }
-	if (CHECK_BIT(ss, 15)) { ND_PRINT(", Association Permit"); }
+	if (CHECK_BIT(ss, 12)) { ND_PRINT(C_RESET, ", BLE enabled"); }
+	if (CHECK_BIT(ss, 14)) { ND_PRINT(C_RESET, ", PAN Coordinator"); }
+	if (CHECK_BIT(ss, 15)) { ND_PRINT(C_RESET, ", Association Permit"); }
 }
 
 /*
@@ -592,31 +592,31 @@ ieee802_15_4_print_gts_info(netdissect_options *ndo,
 
 	if (gts_cnt == 0) {
 		if (ndo->ndo_vflag > 0) {
-			ND_PRINT("\n\tGTS Descriptor Count = %d, ", gts_cnt);
+			ND_PRINT(C_RESET, "\n\tGTS Descriptor Count = %d, ", gts_cnt);
 		}
 		return 1;
 	}
 	len = 1 + 1 + gts_cnt * 3;
 
 	if (data_len < len) {
-		ND_PRINT(" [ERROR: Truncated GTS Info List]");
+		ND_PRINT(C_RESET, " [ERROR: Truncated GTS Info List]");
 		return -1;
 	}
 	if (ndo->ndo_vflag < 2) {
 		return len;
 	}
-	ND_PRINT("GTS Descriptor Count = %d, ", gts_cnt);
-	ND_PRINT("GTS Directions Mask = %02x, [ ",
+	ND_PRINT(C_RESET, "GTS Descriptor Count = %d, ", gts_cnt);
+	ND_PRINT(C_RESET, "GTS Directions Mask = %02x, [ ",
 		 GET_U_1(p + 1) & 0x7f);
 
 	for(i = 0; i < gts_cnt; i++) {
-		ND_PRINT("[ ");
+		ND_PRINT(C_RESET, "[ ");
 		ieee802_15_4_print_addr(ndo, p + 2 + i * 3, 2);
-		ND_PRINT(", Start slot = %d, Length = %d ] ",
+		ND_PRINT(C_RESET, ", Start slot = %d, Length = %d ] ",
 			 GET_U_1(p + 2 + i * 3 + 1) & 0x0f,
 			 (GET_U_1(p + 2 + i * 3 + 1) >> 4) & 0x0f);
 	}
-	ND_PRINT("]");
+	ND_PRINT(C_RESET, "]");
 	return len;
 }
 
@@ -638,33 +638,33 @@ ieee802_15_4_print_pending_addresses(netdissect_options *ndo,
 	e_cnt = (pas >> 4) & 0x7;
 	len = 1 + s_cnt * 2 + e_cnt * 8;
 	if (ndo->ndo_vflag > 0) {
-		ND_PRINT("\n\tPending address list, "
+		ND_PRINT(C_RESET, "\n\tPending address list, "
 			 "# short addresses = %d, # extended addresses = %d",
 			 s_cnt, e_cnt);
 	}
 	if (data_len < len) {
-		ND_PRINT(" [ERROR: Pending address list truncated]");
+		ND_PRINT(C_RESET, " [ERROR: Pending address list truncated]");
 		return -1;
 	}
 	if (ndo->ndo_vflag < 2) {
 		return len;
 	}
 	if (s_cnt != 0) {
-		ND_PRINT(", Short address list = [ ");
+		ND_PRINT(C_RESET, ", Short address list = [ ");
 		for(i = 0; i < s_cnt; i++) {
 			ieee802_15_4_print_addr(ndo, p + 1 + i * 2, 2);
-			ND_PRINT(" ");
+			ND_PRINT(C_RESET, " ");
 		}
-		ND_PRINT("]");
+		ND_PRINT(C_RESET, "]");
 	}
 	if (e_cnt != 0) {
-		ND_PRINT(", Extended address list = [ ");
+		ND_PRINT(C_RESET, ", Extended address list = [ ");
 		for(i = 0; i < e_cnt; i++) {
 			ieee802_15_4_print_addr(ndo, p + 1 + s_cnt * 2 +
 						i * 8, 8);
-			ND_PRINT(" ");
+			ND_PRINT(C_RESET, " ");
 		}
-		ND_PRINT("]");
+		ND_PRINT(C_RESET, "]");
 	}
 	return len;
 }
@@ -683,36 +683,36 @@ ieee802_15_4_print_header_ie(netdissect_options *ndo,
 	switch (element_id) {
 	case 0x00: /* Vendor Specific Header IE */
 		if (ie_len < 3) {
-			ND_PRINT("[ERROR: Vendor OUI missing]");
+			ND_PRINT(C_RESET, "[ERROR: Vendor OUI missing]");
 		} else {
-			ND_PRINT("OUI = 0x%02x%02x%02x, ", GET_U_1(p),
+			ND_PRINT(C_RESET, "OUI = 0x%02x%02x%02x, ", GET_U_1(p),
 				 GET_U_1(p + 1), GET_U_1(p + 2));
-			ND_PRINT("Data = ");
+			ND_PRINT(C_RESET, "Data = ");
 			for(i = 3; i < ie_len; i++) {
-				ND_PRINT("%02x ", GET_U_1(p + i));
+				ND_PRINT(C_RESET, "%02x ", GET_U_1(p + i));
 			}
 		}
 		break;
 	case 0x1a: /* LE CSL IE */
 		if (ie_len < 4) {
-			ND_PRINT("[ERROR: Truncated CSL IE]");
+			ND_PRINT(C_RESET, "[ERROR: Truncated CSL IE]");
 		} else {
-			ND_PRINT("CSL Phase = %d, CSL Period = %d",
+			ND_PRINT(C_RESET, "CSL Phase = %d, CSL Period = %d",
 				 GET_LE_U_2(p), GET_LE_U_2(p + 2));
 			if (ie_len >= 6) {
-				ND_PRINT(", Rendezvous time = %d",
+				ND_PRINT(C_RESET, ", Rendezvous time = %d",
 					 GET_LE_U_2(p + 4));
 			}
 			if (ie_len != 4 && ie_len != 6) {
-				ND_PRINT(" [ERROR: CSL IE length wrong]");
+				ND_PRINT(C_RESET, " [ERROR: CSL IE length wrong]");
 			}
 		}
 		break;
 	case 0x1b: /* LE RIT IE */
 		if (ie_len < 4) {
-			ND_PRINT("[ERROR: Truncated RIT IE]");
+			ND_PRINT(C_RESET, "[ERROR: Truncated RIT IE]");
 		} else {
-			ND_PRINT("Time to First Listen = %d, # of Repeat Listen = %d, Repeat Listen Interval = %d",
+			ND_PRINT(C_RESET, "Time to First Listen = %d, # of Repeat Listen = %d, Repeat Listen Interval = %d",
 				 GET_U_1(p),
 				 GET_U_1(p + 1),
 				 GET_LE_U_2(p + 2));
@@ -722,7 +722,7 @@ ieee802_15_4_print_header_ie(netdissect_options *ndo,
 		/*FALLTHROUGH*/
 	case 0x21: /* Extended DSME PAN descriptor IE */
 		if (ie_len < 2) {
-			ND_PRINT("[ERROR: Truncated DSME PAN IE]");
+			ND_PRINT(C_RESET, "[ERROR: Truncated DSME PAN IE]");
 		} else {
 			uint16_t ss, ptr, ulen;
 			int16_t len;
@@ -733,7 +733,7 @@ ieee802_15_4_print_header_ie(netdissect_options *ndo,
 			ss = GET_LE_U_2(p);
 			ieee802_15_4_print_superframe_specification(ndo, ss);
 			if (ie_len < 3) {
-				ND_PRINT("[ERROR: Truncated before pending addresses field]");
+				ND_PRINT(C_RESET, "[ERROR: Truncated before pending addresses field]");
 				break;
 			}
 			ptr = 2;
@@ -749,78 +749,78 @@ ieee802_15_4_print_header_ie(netdissect_options *ndo,
 			if (element_id == 0x21) {
 				/* Extended version. */
 				if (ie_len < ptr + 2) {
-					ND_PRINT("[ERROR: Truncated before DSME Superframe Specification]");
+					ND_PRINT(C_RESET, "[ERROR: Truncated before DSME Superframe Specification]");
 					break;
 				}
 				ss = GET_LE_U_2(p + ptr);
 				ptr += 2;
-				ND_PRINT("Multi-superframe Order = %d", ss & 0xff);
-				ND_PRINT(", %s", ((ss & 0x100) ?
+				ND_PRINT(C_RESET, "Multi-superframe Order = %d", ss & 0xff);
+				ND_PRINT(C_RESET, ", %s", ((ss & 0x100) ?
 						  "Channel hopping mode" :
 						  "Channel adaptation mode"));
 				if (ss & 0x400) {
-					ND_PRINT(", CAP reduction enabled");
+					ND_PRINT(C_RESET, ", CAP reduction enabled");
 				}
 				if (ss & 0x800) {
-					ND_PRINT(", Deferred beacon enabled");
+					ND_PRINT(C_RESET, ", Deferred beacon enabled");
 				}
 				if (ss & 0x1000) {
-					ND_PRINT(", Hopping Sequence Present");
+					ND_PRINT(C_RESET, ", Hopping Sequence Present");
 					hopping_present = 1;
 				}
 			} else {
 				if (ie_len < ptr + 1) {
-					ND_PRINT("[ERROR: Truncated before DSME Superframe Specification]");
+					ND_PRINT(C_RESET, "[ERROR: Truncated before DSME Superframe Specification]");
 					break;
 				}
 				ss = GET_U_1(p + ptr);
 				ptr++;
-				ND_PRINT("Multi-superframe Order = %d",
+				ND_PRINT(C_RESET, "Multi-superframe Order = %d",
 					 ss & 0x0f);
-				ND_PRINT(", %s", ((ss & 0x10) ?
+				ND_PRINT(C_RESET, ", %s", ((ss & 0x10) ?
 						  "Channel hopping mode" :
 						  "Channel adaptation mode"));
 				if (ss & 0x40) {
-					ND_PRINT(", CAP reduction enabled");
+					ND_PRINT(C_RESET, ", CAP reduction enabled");
 				}
 				if (ss & 0x80) {
-					ND_PRINT(", Deferred beacon enabled");
+					ND_PRINT(C_RESET, ", Deferred beacon enabled");
 				}
 			}
 			if (ie_len < ptr + 8) {
-				ND_PRINT(" [ERROR: Truncated before Time synchronization specification]");
+				ND_PRINT(C_RESET, " [ERROR: Truncated before Time synchronization specification]");
 				break;
 			}
-			ND_PRINT("Beacon timestamp = %" PRIu64 ", offset = %d",
+			ND_PRINT(C_RESET, "Beacon timestamp = %" PRIu64 ", offset = %d",
 				 GET_LE_U_6(p + ptr),
 				 GET_LE_U_2(p + ptr + 6));
 			ptr += 8;
 			if (ie_len < ptr + 4) {
-				ND_PRINT(" [ERROR: Truncated before Beacon Bitmap]");
+				ND_PRINT(C_RESET, " [ERROR: Truncated before Beacon Bitmap]");
 				break;
 			}
 
 			ulen = GET_LE_U_2(p + ptr + 2);
-			ND_PRINT("SD Index = %d, Bitmap len = %d, ",
+			ND_PRINT(C_RESET, "SD Index = %d, Bitmap len = %d, ",
 				 GET_LE_U_2(p + ptr), ulen);
 			ptr += 4;
 			if (ie_len < ptr + ulen) {
-				ND_PRINT(" [ERROR: Truncated in SD bitmap]");
+				ND_PRINT(C_RESET, " [ERROR: Truncated in SD bitmap]");
 				break;
 			}
-			ND_PRINT(" SD Bitmap = ");
+			ND_PRINT(C_RESET, " SD Bitmap = ");
 			for(i = 0; i < ulen; i++) {
-				ND_PRINT("%02x ", GET_U_1(p + ptr + i));
+				ND_PRINT(C_RESET, "%02x ", GET_U_1(p + ptr + i));
 			}
 			ptr += ulen;
 
 			if (ie_len < ptr + 5) {
-				ND_PRINT(" [ERROR: Truncated before Channel hopping specification]");
+				ND_PRINT(C_RESET, " [ERROR: Truncated before Channel hopping specification]");
 				break;
 			}
 
 			ulen = GET_LE_U_2(p + ptr + 4);
-			ND_PRINT("Hopping Seq ID = %d, PAN Coordinator BSN = %d, "
+			ND_PRINT(C_RESET, "Hopping Seq ID = %d, PAN Coordinator BSN = %d, "
 				 "Channel offset = %d, Bitmap length = %d, ",
 				 GET_U_1(p + ptr),
 				 GET_U_1(p + ptr + 1),
@@ -828,67 +828,67 @@ ieee802_15_4_print_header_ie(netdissect_options *ndo,
 				 ulen);
 			ptr += 5;
 			if (ie_len < ptr + ulen) {
-				ND_PRINT(" [ERROR: Truncated in Channel offset bitmap]");
+				ND_PRINT(C_RESET, " [ERROR: Truncated in Channel offset bitmap]");
 				break;
 			}
-			ND_PRINT(" Channel offset bitmap = ");
+			ND_PRINT(C_RESET, " Channel offset bitmap = ");
 			for(i = 0; i < ulen; i++) {
-				ND_PRINT("%02x ", GET_U_1(p + ptr + i));
+				ND_PRINT(C_RESET, "%02x ", GET_U_1(p + ptr + i));
 			}
 			ptr += ulen;
 			if (hopping_present) {
 				if (ie_len < ptr + 1) {
-					ND_PRINT(" [ERROR: Truncated in Hopping Sequence length]");
+					ND_PRINT(C_RESET, " [ERROR: Truncated in Hopping Sequence length]");
 					break;
 				}
 				ulen = GET_U_1(p + ptr);
 				ptr++;
-				ND_PRINT("Hopping Seq length = %d [ ", ulen);
+				ND_PRINT(C_RESET, "Hopping Seq length = %d [ ", ulen);
 
 				/* The specification is not clear how the
 				   hopping sequence is encoded, I assume two
 				   octet unsigned integers for each channel. */
 
 				if (ie_len < ptr + ulen * 2) {
-					ND_PRINT(" [ERROR: Truncated in Channel offset bitmap]");
+					ND_PRINT(C_RESET, " [ERROR: Truncated in Channel offset bitmap]");
 					break;
 				}
 				for(i = 0; i < ulen; i++) {
-					ND_PRINT("%02x ",
+					ND_PRINT(C_RESET, "%02x ",
 						 GET_LE_U_2(p + ptr + i * 2));
 				}
-				ND_PRINT("]");
+				ND_PRINT(C_RESET, "]");
 				ptr += ulen * 2;
 			}
 		}
 		break;
 	case 0x1d: /* Rendezvous Tome IE */
 		if (ie_len != 4) {
-			ND_PRINT("[ERROR: Length != 2]");
+			ND_PRINT(C_RESET, "[ERROR: Length != 2]");
 		} else {
 			uint16_t r_time, w_u_interval;
 			r_time = GET_LE_U_2(p);
 			w_u_interval = GET_LE_U_2(p + 2);
 
-			ND_PRINT("Rendezvous time = %d, Wake-up Interval = %d",
+			ND_PRINT(C_RESET, "Rendezvous time = %d, Wake-up Interval = %d",
 				 r_time, w_u_interval);
 		}
 		break;
 	case 0x1e: /* Time correction IE */
 		if (ie_len != 2) {
-			ND_PRINT("[ERROR: Length != 2]");
+			ND_PRINT(C_RESET, "[ERROR: Length != 2]");
 		} else {
 			uint16_t val;
 			int16_t timecorr;
 
 			val = GET_LE_U_2(p);
-			if (val & 0x8000) { ND_PRINT("Negative "); }
+			if (val & 0x8000) { ND_PRINT(C_RESET, "Negative "); }
 			val &= 0xfff;
 			val <<= 4;
 			timecorr = val;
 			timecorr >>= 4;
 
-			ND_PRINT("Ack time correction = %d, ", timecorr);
+			ND_PRINT(C_RESET, "Ack time correction = %d, ", timecorr);
 		}
 		break;
 	case 0x22: /* Fragment Sequence Content Description IE */
@@ -910,9 +910,9 @@ ieee802_15_4_print_header_ie(netdissect_options *ndo,
 	case 0x2b: /* DA IE */
 		/* XXX Not implemented */
 	default:
-		ND_PRINT("IE Data = ");
+		ND_PRINT(C_RESET, "IE Data = ");
 		for(i = 0; i < ie_len; i++) {
-			ND_PRINT("%02x ", GET_U_1(p + i));
+			ND_PRINT(C_RESET, "%02x ", GET_U_1(p + i));
 		}
 		break;
 	}
@@ -937,30 +937,30 @@ ieee802_15_4_print_header_ie_list(netdissect_options *ndo,
 	len = 0;
 	do {
 		if (caplen < 2) {
-			ND_PRINT("[ERROR: Truncated header IE]");
+			ND_PRINT(C_RESET, "[ERROR: Truncated header IE]");
 			return -1;
 		}
 		/* Extract IE Header */
 		ie = GET_LE_U_2(p);
 		if (CHECK_BIT(ie, 15)) {
-			ND_PRINT("[ERROR: Header IE with type 1] ");
+			ND_PRINT(C_RESET, "[ERROR: Header IE with type 1] ");
 		}
 		/* Get length and Element ID */
 		ie_len = ie & 0x7f;
 		element_id = (ie >> 7) & 0xff;
 		if (element_id > 127) {
-			ND_PRINT("Reserved Element ID %02x, length = %d ",
+			ND_PRINT(C_RESET, "Reserved Element ID %02x, length = %d ",
 				 element_id, ie_len);
 		} else {
 			if (ie_len == 0) {
-				ND_PRINT("\n\t%s [", h_ie_names[element_id]);
+				ND_PRINT(C_RESET, "\n\t%s [", h_ie_names[element_id]);
 			} else {
-				ND_PRINT("\n\t%s [ length = %d, ",
+				ND_PRINT(C_RESET, "\n\t%s [ length = %d, ",
 					 h_ie_names[element_id], ie_len);
 			}
 		}
 		if (caplen < 2U + ie_len) {
-			ND_PRINT("[ERROR: Truncated IE data]");
+			ND_PRINT(C_RESET, "[ERROR: Truncated IE data]");
 			return -1;
 		}
 		/* Skip header */
@@ -972,13 +972,13 @@ ieee802_15_4_print_header_ie_list(netdissect_options *ndo,
 						     ie_len, element_id);
 		} else {
 			if (ie_len != 0) {
-				ND_PRINT("IE Data = ");
+				ND_PRINT(C_RESET, "IE Data = ");
 				for(i = 0; i < ie_len; i++) {
-					ND_PRINT("%02x ", GET_U_1(p + i));
+					ND_PRINT(C_RESET, "%02x ", GET_U_1(p + i));
 				}
 			}
 		}
-		ND_PRINT("] ");
+		ND_PRINT(C_RESET, "] ");
 		len += 2 + ie_len;
 		p += ie_len;
 		caplen -= 2 + ie_len;
@@ -1010,89 +1010,89 @@ ieee802_15_4_print_mlme_ie(netdissect_options *ndo,
 	switch (sub_id) {
 	case 0x08: /* Vendor Specific Nested IE */
 		if (sub_ie_len < 3) {
-			ND_PRINT("[ERROR: Vendor OUI missing]");
+			ND_PRINT(C_RESET, "[ERROR: Vendor OUI missing]");
 		} else {
-			ND_PRINT("OUI = 0x%02x%02x%02x, ",
+			ND_PRINT(C_RESET, "OUI = 0x%02x%02x%02x, ",
 				 GET_U_1(p),
 				 GET_U_1(p + 1),
 				 GET_U_1(p + 2));
-			ND_PRINT("Data = ");
+			ND_PRINT(C_RESET, "Data = ");
 			for(i = 3; i < sub_ie_len; i++) {
-				ND_PRINT("%02x ", GET_U_1(p + i));
+				ND_PRINT(C_RESET, "%02x ", GET_U_1(p + i));
 			}
 		}
 		break;
 	case 0x09: /* Channel Hopping IE */
 		if (sub_ie_len < 1) {
-			ND_PRINT("[ERROR: Hopping sequence ID missing]");
+			ND_PRINT(C_RESET, "[ERROR: Hopping sequence ID missing]");
 		} else if (sub_ie_len == 1) {
-			ND_PRINT("Hopping Sequence ID = %d", GET_U_1(p));
+			ND_PRINT(C_RESET, "Hopping Sequence ID = %d", GET_U_1(p));
 			p++;
 			sub_ie_len--;
 		} else {
 			uint16_t channel_page, number_of_channels;
 
-			ND_PRINT("Hopping Sequence ID = %d", GET_U_1(p));
+			ND_PRINT(C_RESET, "Hopping Sequence ID = %d", GET_U_1(p));
 			p++;
 			sub_ie_len--;
 			if (sub_ie_len < 7) {
-				ND_PRINT("[ERROR: IE truncated]");
+				ND_PRINT(C_RESET, "[ERROR: IE truncated]");
 				break;
 			}
 			channel_page = GET_U_1(p);
 			number_of_channels = GET_LE_U_2(p + 1);
-			ND_PRINT("Channel Page = %d, Number of Channels = %d, ",
+			ND_PRINT(C_RESET, "Channel Page = %d, Number of Channels = %d, ",
 				 channel_page, number_of_channels);
-			ND_PRINT("Phy Configuration = 0x%08x, ",
+			ND_PRINT(C_RESET, "Phy Configuration = 0x%08x, ",
 				 GET_LE_U_4(p + 3));
 			p += 7;
 			sub_ie_len -= 7;
 			if (channel_page == 9 || channel_page == 10) {
 				len = (number_of_channels + 7) / 8;
 				if (sub_ie_len < len) {
-					ND_PRINT("[ERROR: IE truncated]");
+					ND_PRINT(C_RESET, "[ERROR: IE truncated]");
 					break;
 				}
-				ND_PRINT("Extended bitmap = 0x");
+				ND_PRINT(C_RESET, "Extended bitmap = 0x");
 				for(i = 0; i < len; i++) {
-					ND_PRINT("%02x", GET_U_1(p + i));
+					ND_PRINT(C_RESET, "%02x", GET_U_1(p + i));
 				}
-				ND_PRINT(", ");
+				ND_PRINT(C_RESET, ", ");
 				p += len;
 				sub_ie_len -= len;
 			}
 			if (sub_ie_len < 2) {
-				ND_PRINT("[ERROR: IE truncated]");
+				ND_PRINT(C_RESET, "[ERROR: IE truncated]");
 				break;
 			}
 			len = GET_LE_U_2(p);
 			p += 2;
 			sub_ie_len -= 2;
-			ND_PRINT("Hopping Seq length = %d [ ", len);
+			ND_PRINT(C_RESET, "Hopping Seq length = %d [ ", len);
 
 			if (sub_ie_len < len * 2) {
-				ND_PRINT(" [ERROR: IE truncated]");
+				ND_PRINT(C_RESET, " [ERROR: IE truncated]");
 				break;
 			}
 			for(i = 0; i < len; i++) {
-				ND_PRINT("%02x ", GET_LE_U_2(p + i * 2));
+				ND_PRINT(C_RESET, "%02x ", GET_LE_U_2(p + i * 2));
 			}
-			ND_PRINT("]");
+			ND_PRINT(C_RESET, "]");
 			p += len * 2;
 			sub_ie_len -= len * 2;
 			if (sub_ie_len < 2) {
-				ND_PRINT("[ERROR: IE truncated]");
+				ND_PRINT(C_RESET, "[ERROR: IE truncated]");
 				break;
 			}
-			ND_PRINT("Current hop = %d", GET_LE_U_2(p));
+			ND_PRINT(C_RESET, "Current hop = %d", GET_LE_U_2(p));
 		}
 
 		break;
 	case 0x1a: /* TSCH Synchronization IE. */
 		if (sub_ie_len < 6) {
-			ND_PRINT("[ERROR: Length != 6]");
+			ND_PRINT(C_RESET, "[ERROR: Length != 6]");
 		}
-		ND_PRINT("ASN = %010" PRIx64 ", Join Metric = %d ",
+		ND_PRINT(C_RESET, "ASN = %010" PRIx64 ", Join Metric = %d ",
 			 GET_LE_U_5(p), GET_U_1(p + 5));
 		break;
 	case 0x1b: /* TSCH Slotframe and Link IE. */
@@ -1100,53 +1100,53 @@ ieee802_15_4_print_mlme_ie(netdissect_options *ndo,
 			int sf_num, off, links, opts;
 
 			if (sub_ie_len < 1) {
-				ND_PRINT("[ERROR: Truncated IE]");
+				ND_PRINT(C_RESET, "[ERROR: Truncated IE]");
 				break;
 			}
 			sf_num = GET_U_1(p);
-			ND_PRINT("Slotframes = %d ", sf_num);
+			ND_PRINT(C_RESET, "Slotframes = %d ", sf_num);
 			off = 1;
 			for(i = 0; i < sf_num; i++) {
 				if (sub_ie_len < off + 4) {
-					ND_PRINT("[ERROR: Truncated IE before slotframes]");
+					ND_PRINT(C_RESET, "[ERROR: Truncated IE before slotframes]");
 					break;
 				}
 				links = GET_U_1(p + off + 3);
-				ND_PRINT("\n\t\t\t[ Handle %d, size = %d, links = %d ",
+				ND_PRINT(C_RESET, "\n\t\t\t[ Handle %d, size = %d, links = %d ",
 					 GET_U_1(p + off),
 					 GET_LE_U_2(p + off + 1),
 					 links);
 				off += 4;
 				for(j = 0; j < links; j++) {
 					if (sub_ie_len < off + 5) {
-						ND_PRINT("[ERROR: Truncated IE links]");
+						ND_PRINT(C_RESET, "[ERROR: Truncated IE links]");
 						break;
 					}
 					opts = GET_U_1(p + off + 4);
-					ND_PRINT("\n\t\t\t\t[ Timeslot =  %d, Offset = %d, Options = ",
+					ND_PRINT(C_RESET, "\n\t\t\t\t[ Timeslot =  %d, Offset = %d, Options = ",
 						 GET_LE_U_2(p + off),
 						 GET_LE_U_2(p + off + 2));
-					if (opts & 0x1) { ND_PRINT("TX "); }
-					if (opts & 0x2) { ND_PRINT("RX "); }
-					if (opts & 0x4) { ND_PRINT("Shared "); }
+					if (opts & 0x1) { ND_PRINT(C_RESET, "TX "); }
+					if (opts & 0x2) { ND_PRINT(C_RESET, "RX "); }
+					if (opts & 0x4) { ND_PRINT(C_RESET, "Shared "); }
 					if (opts & 0x8) {
-						ND_PRINT("Timekeeping ");
+						ND_PRINT(C_RESET, "Timekeeping ");
 					}
 					if (opts & 0x10) {
-						ND_PRINT("Priority ");
+						ND_PRINT(C_RESET, "Priority ");
 					}
 					off += 5;
-					ND_PRINT("] ");
+					ND_PRINT(C_RESET, "] ");
 				}
-				ND_PRINT("] ");
+				ND_PRINT(C_RESET, "] ");
 			}
 		}
 		break;
 	case 0x1c: /* TSCH Timeslot IE. */
 		if (sub_ie_len == 1) {
-			ND_PRINT("Time slot ID = %d ", GET_U_1(p));
+			ND_PRINT(C_RESET, "Time slot ID = %d ", GET_U_1(p));
 		} else if (sub_ie_len == 25) {
-			ND_PRINT("Time slot ID = %d, CCA Offset = %d, CCA = %d, TX Offset = %d, RX Offset = %d, RX Ack Delay = %d, TX Ack Delay = %d, RX Wait = %d, Ack Wait = %d, RX TX = %d, Max Ack = %d, Max TX = %d, Time slot Length = %d ",
+			ND_PRINT(C_RESET, "Time slot ID = %d, CCA Offset = %d, CCA = %d, TX Offset = %d, RX Offset = %d, RX Ack Delay = %d, TX Ack Delay = %d, RX Wait = %d, Ack Wait = %d, RX TX = %d, Max Ack = %d, Max TX = %d, Time slot Length = %d ",
 				 GET_U_1(p),
 				 GET_LE_U_2(p + 1),
 				 GET_LE_U_2(p + 3),
@@ -1161,7 +1161,7 @@ ieee802_15_4_print_mlme_ie(netdissect_options *ndo,
 				 GET_LE_U_2(p + 21),
 				 GET_LE_U_2(p + 23));
 		} else if (sub_ie_len == 27) {
-			ND_PRINT("Time slot ID = %d, CCA Offset = %d, CCA = %d, TX Offset = %d, RX Offset = %d, RX Ack Delay = %d, TX Ack Delay = %d, RX Wait = %d, Ack Wait = %d, RX TX = %d, Max Ack = %d, Max TX = %d, Time slot Length = %d ",
+			ND_PRINT(C_RESET, "Time slot ID = %d, CCA Offset = %d, CCA = %d, TX Offset = %d, RX Offset = %d, RX Ack Delay = %d, TX Ack Delay = %d, RX Wait = %d, Ack Wait = %d, RX TX = %d, Max Ack = %d, Max TX = %d, Time slot Length = %d ",
 				 GET_U_1(p),
 				 GET_LE_U_2(p + 1),
 				 GET_LE_U_2(p + 3),
@@ -1176,10 +1176,10 @@ ieee802_15_4_print_mlme_ie(netdissect_options *ndo,
 				 GET_LE_U_3(p + 21),
 				 GET_LE_U_3(p + 24));
 		} else {
-			ND_PRINT("[ERROR: Length not 1, 25, or 27]");
-			ND_PRINT("\n\t\t\tIE Data = ");
+			ND_PRINT(C_RESET, "[ERROR: Length not 1, 25, or 27]");
+			ND_PRINT(C_RESET, "\n\t\t\tIE Data = ");
 			for(i = 0; i < sub_ie_len; i++) {
-				ND_PRINT("%02x ", GET_U_1(p + i));
+				ND_PRINT(C_RESET, "%02x ", GET_U_1(p + i));
 			}
 		}
 		break;
@@ -1234,9 +1234,9 @@ ieee802_15_4_print_mlme_ie(netdissect_options *ndo,
 	case 0x36: /* TCC PHY Operating Mode IE */
 		/* XXX Not implemented */
 	default:
-		ND_PRINT("IE Data = ");
+		ND_PRINT(C_RESET, "IE Data = ");
 		for(i = 0; i < sub_ie_len; i++) {
-			ND_PRINT("%02x ", GET_U_1(p + i));
+			ND_PRINT(C_RESET, "%02x ", GET_U_1(p + i));
 		}
 		break;
 	}
@@ -1256,7 +1256,7 @@ ieee802_15_4_print_mlme_ie_list(netdissect_options *ndo,
 
 	do {
 		if (ie_len < 2) {
-			ND_PRINT("[ERROR: Truncated MLME IE]");
+			ND_PRINT(C_RESET, "[ERROR: Truncated MLME IE]");
 			return;
 		}
 		/* Extract IE header */
@@ -1275,28 +1275,28 @@ ieee802_15_4_print_mlme_ie_list(netdissect_options *ndo,
 		p += 2;
 
 		if (type == 0) {
-			ND_PRINT("\n\t\t%s [ length = %d, ",
+			ND_PRINT(C_RESET, "\n\t\t%s [ length = %d, ",
 				 p_mlme_short_names[sub_id], sub_ie_len);
 		} else {
-			ND_PRINT("\n\t\t%s [ length = %d, ",
+			ND_PRINT(C_RESET, "\n\t\t%s [ length = %d, ",
 				 p_mlme_long_names[sub_id], sub_ie_len);
 		}
 
 		if (ie_len < 2 + sub_ie_len) {
-			ND_PRINT("[ERROR: Truncated IE data]");
+			ND_PRINT(C_RESET, "[ERROR: Truncated IE data]");
 			return;
 		}
 		if (sub_ie_len != 0) {
 			if (ndo->ndo_vflag > 3) {
 				ieee802_15_4_print_mlme_ie(ndo, p, sub_ie_len, sub_id);
 			} else if (ndo->ndo_vflag > 2) {
-				ND_PRINT("IE Data = ");
+				ND_PRINT(C_RESET, "IE Data = ");
 				for(i = 0; i < sub_ie_len; i++) {
-					ND_PRINT("%02x ", GET_U_1(p + i));
+					ND_PRINT(C_RESET, "%02x ", GET_U_1(p + i));
 				}
 			}
 		}
-		ND_PRINT("] ");
+		ND_PRINT(C_RESET, "] ");
 		p += sub_ie_len;
 		ie_len -= 2 + sub_ie_len;
 	} while (ie_len > 0);
@@ -1318,7 +1318,7 @@ ieee802_15_4_print_mpx_ie(netdissect_options *ndo,
 
 	data_start = 0;
 	if (ie_len < 1) {
-		ND_PRINT("[ERROR: Transaction control byte missing]");
+		ND_PRINT(C_RESET, "[ERROR: Transaction control byte missing]");
 		return;
 	}
 
@@ -1327,31 +1327,31 @@ ieee802_15_4_print_mpx_ie(netdissect_options *ndo,
 	switch (transfer_type) {
 	case 0x00: /* Full upper layer frame. */
 	case 0x01: /* Full upper layer frame with small Multiplex ID. */
-		ND_PRINT("Type = Full upper layer fragment%s, ",
+		ND_PRINT(C_RESET, "Type = Full upper layer fragment%s, ",
 			 (transfer_type == 0x01 ?
 			  " with small Multiplex ID" : ""));
 		if (transfer_type == 0x00) {
 			if (ie_len < 3) {
-				ND_PRINT("[ERROR: Multiplex ID missing]");
+				ND_PRINT(C_RESET, "[ERROR: Multiplex ID missing]");
 				return;
 			}
 			data_start = 3;
-			ND_PRINT("tid = 0x%02x, Multiplex ID = 0x%04x, ",
+			ND_PRINT(C_RESET, "tid = 0x%02x, Multiplex ID = 0x%04x, ",
 				 tid, GET_LE_U_2(p + 1));
 		} else {
 			data_start = 1;
-			ND_PRINT("Multiplex ID = 0x%04x, ", tid);
+			ND_PRINT(C_RESET, "Multiplex ID = 0x%04x, ", tid);
 		}
 		break;
 	case 0x02: /* First, or middle, Fragments */
 	case 0x04: /* Last fragment */
 		if (ie_len < 2) {
-			ND_PRINT("[ERROR: fragment number missing]");
+			ND_PRINT(C_RESET, "[ERROR: fragment number missing]");
 			return;
 		}
 
 		fragment_number = GET_U_1(p + 1);
-		ND_PRINT("Type = %s, tid = 0x%02x, fragment = 0x%02x, ",
+		ND_PRINT(C_RESET, "Type = %s, tid = 0x%02x, fragment = 0x%02x, ",
 			 (transfer_type == 0x02 ?
 			  (fragment_number == 0 ?
 			   "First fragment" : "Middle fragment") :
@@ -1362,29 +1362,29 @@ ieee802_15_4_print_mpx_ie(netdissect_options *ndo,
 			int total_size, multiplex_id;
 
 			if (ie_len < 6) {
-				ND_PRINT("[ERROR: Total upper layer size or multiplex ID missing]");
+				ND_PRINT(C_RESET, "[ERROR: Total upper layer size or multiplex ID missing]");
 				return;
 			}
 			total_size = GET_LE_U_2(p + 2);
 			multiplex_id = GET_LE_U_2(p + 4);
-			ND_PRINT("Total upper layer size = 0x%04x, Multiplex ID = 0x%04x, ",
+			ND_PRINT(C_RESET, "Total upper layer size = 0x%04x, Multiplex ID = 0x%04x, ",
 				 total_size, multiplex_id);
 			data_start = 6;
 		}
 		break;
 	case 0x06: /* Abort code */
 		if (ie_len == 1) {
-			ND_PRINT("Type = Abort, tid = 0x%02x, no max size given",
+			ND_PRINT(C_RESET, "Type = Abort, tid = 0x%02x, no max size given",
 				 tid);
 		} else if (ie_len == 3) {
-			ND_PRINT("Type = Abort, tid = 0x%02x, max size = 0x%04x",
+			ND_PRINT(C_RESET, "Type = Abort, tid = 0x%02x, max size = 0x%04x",
 				 tid, GET_LE_U_2(p + 1));
 		} else {
-			ND_PRINT("Type = Abort, tid = 0x%02x, invalid length = %d (not 1 or 3)",
+			ND_PRINT(C_RESET, "Type = Abort, tid = 0x%02x, invalid length = %d (not 1 or 3)",
 				 tid, ie_len);
-			ND_PRINT("Abort data = ");
+			ND_PRINT(C_RESET, "Abort data = ");
 			for(i = 1; i < ie_len; i++) {
-				ND_PRINT("%02x ", GET_U_1(p + i));
+				ND_PRINT(C_RESET, "%02x ", GET_U_1(p + i));
 			}
 		}
 		return;
@@ -1393,15 +1393,15 @@ ieee802_15_4_print_mpx_ie(netdissect_options *ndo,
 	case 0x03: /* Reserved */
 	case 0x05: /* Reserved */
 	case 0x07: /* Reserved */
-		ND_PRINT("Type = %d (Reserved), tid = 0x%02x, ",
+		ND_PRINT(C_RESET, "Type = %d (Reserved), tid = 0x%02x, ",
 			 transfer_type, tid);
 		data_start = 1;
 		break;
 	}
 
-	ND_PRINT("Upper layer data = ");
+	ND_PRINT(C_RESET, "Upper layer data = ");
 	for(i = data_start; i < ie_len; i++) {
-		ND_PRINT("%02x ", GET_U_1(p + i));
+		ND_PRINT(C_RESET, "%02x ", GET_U_1(p + i));
 	}
 }
 
@@ -1422,13 +1422,13 @@ ieee802_15_4_print_payload_ie_list(netdissect_options *ndo,
 	len = 0;
 	do {
 		if (caplen < 2) {
-			ND_PRINT("[ERROR: Truncated header IE]");
+			ND_PRINT(C_RESET, "[ERROR: Truncated header IE]");
 			return -1;
 		}
 		/* Extract IE header */
 		ie = GET_LE_U_2(p);
 		if ((CHECK_BIT(ie, 15)) == 0) {
-			ND_PRINT("[ERROR: Payload IE with type 0] ");
+			ND_PRINT(C_RESET, "[ERROR: Payload IE with type 0] ");
 		}
 		ie_len = ie & 0x3ff;
 		group_id = (ie >> 11) & 0x0f;
@@ -1436,13 +1436,13 @@ ieee802_15_4_print_payload_ie_list(netdissect_options *ndo,
 		/* Skip the IE header */
 		p += 2;
 		if (ie_len == 0) {
-			ND_PRINT("\n\t%s [", p_ie_names[group_id]);
+			ND_PRINT(C_RESET, "\n\t%s [", p_ie_names[group_id]);
 		} else {
-			ND_PRINT("\n\t%s [ length = %d, ",
+			ND_PRINT(C_RESET, "\n\t%s [ length = %d, ",
 				 p_ie_names[group_id], ie_len);
 		}
 		if (caplen < 2U + ie_len) {
-			ND_PRINT("[ERROR: Truncated IE data]");
+			ND_PRINT(C_RESET, "[ERROR: Truncated IE data]");
 			return -1;
 		}
 		if (ndo->ndo_vflag > 3 && ie_len != 0) {
@@ -1452,15 +1452,15 @@ ieee802_15_4_print_payload_ie_list(netdissect_options *ndo,
 				break;
 			case 0x2: /* Vendor Specific Nested IE */
 				if (ie_len < 3) {
-					ND_PRINT("[ERROR: Vendor OUI missing]");
+					ND_PRINT(C_RESET, "[ERROR: Vendor OUI missing]");
 				} else {
-					ND_PRINT("OUI = 0x%02x%02x%02x, ",
+					ND_PRINT(C_RESET, "OUI = 0x%02x%02x%02x, ",
 						 GET_U_1(p),
 						 GET_U_1(p + 1),
 						 GET_U_1(p + 2));
-					ND_PRINT("Data = ");
+					ND_PRINT(C_RESET, "Data = ");
 					for(i = 3; i < ie_len; i++) {
-						ND_PRINT("%02x ",
+						ND_PRINT(C_RESET, "%02x ",
 							 GET_U_1(p + i));
 					}
 				}
@@ -1470,32 +1470,32 @@ ieee802_15_4_print_payload_ie_list(netdissect_options *ndo,
 				break;
 			case 0x5: /* IETF IE */
 				if (ie_len < 1) {
-					ND_PRINT("[ERROR: Subtype ID missing]");
+					ND_PRINT(C_RESET, "[ERROR: Subtype ID missing]");
 				} else {
-					ND_PRINT("Subtype ID = 0x%02x, Subtype content = ",
+					ND_PRINT(C_RESET, "Subtype ID = 0x%02x, Subtype content = ",
 						 GET_U_1(p));
 					for(i = 1; i < ie_len; i++) {
-						ND_PRINT("%02x ",
+						ND_PRINT(C_RESET, "%02x ",
 							 GET_U_1(p + i));
 					}
 				}
 				break;
 			default:
-				ND_PRINT("IE Data = ");
+				ND_PRINT(C_RESET, "IE Data = ");
 				for(i = 0; i < ie_len; i++) {
-					ND_PRINT("%02x ", GET_U_1(p + i));
+					ND_PRINT(C_RESET, "%02x ", GET_U_1(p + i));
 				}
 				break;
 			}
 		} else {
 			if (ie_len != 0) {
-				ND_PRINT("IE Data = ");
+				ND_PRINT(C_RESET, "IE Data = ");
 				for(i = 0; i < ie_len; i++) {
-					ND_PRINT("%02x ", GET_U_1(p + i));
+					ND_PRINT(C_RESET, "%02x ", GET_U_1(p + i));
 				}
 			}
 		}
-		ND_PRINT("]\n\t");
+		ND_PRINT(C_RESET, "]\n\t");
 		len += 2 + ie_len;
 		p += ie_len;
 		caplen -= 2 + ie_len;
@@ -1520,7 +1520,7 @@ ieee802_15_4_print_aux_sec_header(netdissect_options *ndo,
 	int sc, key_id_mode, len;
 
 	if (caplen < 1) {
-		ND_PRINT("[ERROR: Truncated before Aux Security Header]");
+		ND_PRINT(C_RESET, "[ERROR: Truncated before Aux Security Header]");
 		return -1;
 	}
 	sc = GET_U_1(p);
@@ -1532,16 +1532,16 @@ ieee802_15_4_print_aux_sec_header(netdissect_options *ndo,
 	p += 1;
 
 	if (ndo->ndo_vflag > 0) {
-		ND_PRINT("\n\tSecurity Level %d, Key Id Mode %d, ",
+		ND_PRINT(C_RESET, "\n\tSecurity Level %d, Key Id Mode %d, ",
 			 *security_level, key_id_mode);
 	}
 	if ((CHECK_BIT(sc, 5)) == 0) {
 		if (caplen < 4) {
-			ND_PRINT("[ERROR: Truncated before Frame Counter]");
+			ND_PRINT(C_RESET, "[ERROR: Truncated before Frame Counter]");
 			return -1;
 		}
 		if (ndo->ndo_vflag > 1) {
-			ND_PRINT("Frame Counter 0x%08x ",
+			ND_PRINT(C_RESET, "Frame Counter 0x%08x ",
 				 GET_LE_U_4(p));
 		}
 		p += 4;
@@ -1551,7 +1551,7 @@ ieee802_15_4_print_aux_sec_header(netdissect_options *ndo,
 	switch (key_id_mode) {
 	case 0x00: /* Implicit. */
 		if (ndo->ndo_vflag > 1) {
-			ND_PRINT("Implicit");
+			ND_PRINT(C_RESET, "Implicit");
 		}
 		return len;
 		break;
@@ -1559,11 +1559,11 @@ ieee802_15_4_print_aux_sec_header(netdissect_options *ndo,
 		break;
 	case 0x02: /* PAN and Short address Key Source, and Key Index. */
 		if (caplen < 4) {
-			ND_PRINT("[ERROR: Truncated before Key Source]");
+			ND_PRINT(C_RESET, "[ERROR: Truncated before Key Source]");
 			return -1;
 		}
 		if (ndo->ndo_vflag > 1) {
-			ND_PRINT("KeySource 0x%04x:%0x4x, ",
+			ND_PRINT(C_RESET, "KeySource 0x%04x:%0x4x, ",
 				 GET_LE_U_2(p), GET_LE_U_2(p + 2));
 		}
 		p += 4;
@@ -1572,11 +1572,11 @@ ieee802_15_4_print_aux_sec_header(netdissect_options *ndo,
 		break;
 	case 0x03: /* Extended address and Key Index. */
 		if (caplen < 8) {
-			ND_PRINT("[ERROR: Truncated before Key Source]");
+			ND_PRINT(C_RESET, "[ERROR: Truncated before Key Source]");
 			return -1;
 		}
 		if (ndo->ndo_vflag > 1) {
-			ND_PRINT("KeySource %s, ", GET_LE64ADDR_STRING(p));
+			ND_PRINT(C_RESET, "KeySource %s, ", GET_LE64ADDR_STRING(p));
 		}
 		p += 4;
 		caplen -= 4;
@@ -1584,11 +1584,11 @@ ieee802_15_4_print_aux_sec_header(netdissect_options *ndo,
 		break;
 	}
 	if (caplen < 1) {
-		ND_PRINT("[ERROR: Truncated before Key Index]");
+		ND_PRINT(C_RESET, "[ERROR: Truncated before Key Index]");
 		return -1;
 	}
 	if (ndo->ndo_vflag > 1) {
-		ND_PRINT("KeyIndex 0x%02x, ", GET_U_1(p));
+		ND_PRINT(C_RESET, "KeyIndex 0x%02x, ", GET_U_1(p));
 	}
 	caplen -= 1;
 	p += 1;
@@ -1612,12 +1612,12 @@ ieee802_15_4_print_command_data(netdissect_options *ndo,
 	switch (command_id) {
 	case 0x01: /* Association Request */
 		if (caplen != 1) {
-			ND_PRINT("Invalid Association request command length");
+			ND_PRINT(C_RESET, "Invalid Association request command length");
 			return -1;
 		} else {
 			uint8_t cap_info;
 			cap_info = GET_U_1(p);
-			ND_PRINT("%s%s%s%s%s%s",
+			ND_PRINT(C_RESET, "%s%s%s%s%s%s",
 				 ((cap_info & 0x02) ?
 				  "FFD, " : "RFD, "),
 				 ((cap_info & 0x04) ?
@@ -1635,29 +1635,29 @@ ieee802_15_4_print_command_data(netdissect_options *ndo,
 		break;
 	case 0x02: /* Association Response */
 		if (caplen != 3) {
-			ND_PRINT("Invalid Association response command length");
+			ND_PRINT(C_RESET, "Invalid Association response command length");
 			return -1;
 		} else {
-			ND_PRINT("Short address = ");
+			ND_PRINT(C_RESET, "Short address = ");
 			ieee802_15_4_print_addr(ndo, p, 2);
 			switch (GET_U_1(p + 2)) {
 			case 0x00:
-				ND_PRINT(", Association successful");
+				ND_PRINT(C_RESET, ", Association successful");
 				break;
 			case 0x01:
-				ND_PRINT(", PAN at capacity");
+				ND_PRINT(C_RESET, ", PAN at capacity");
 				break;
 			case 0x02:
-				ND_PRINT(", PAN access denied");
+				ND_PRINT(C_RESET, ", PAN access denied");
 				break;
 			case 0x03:
-				ND_PRINT(", Hooping sequence offset duplication");
+				ND_PRINT(C_RESET, ", Hooping sequence offset duplication");
 				break;
 			case 0x80:
-				ND_PRINT(", Fast association successful");
+				ND_PRINT(C_RESET, ", Fast association successful");
 				break;
 			default:
-				ND_PRINT(", Status = 0x%02x",
+				ND_PRINT(C_RESET, ", Status = 0x%02x",
 					 GET_U_1(p + 2));
 				break;
 			}
@@ -1666,21 +1666,21 @@ ieee802_15_4_print_command_data(netdissect_options *ndo,
 		break;
 	case 0x03: /* Diassociation Notification command */
 		if (caplen != 1) {
-			ND_PRINT("Invalid Disassociation Notification command length");
+			ND_PRINT(C_RESET, "Invalid Disassociation Notification command length");
 			return -1;
 		} else {
 			switch (GET_U_1(p)) {
 			case 0x00:
-				ND_PRINT("Reserved");
+				ND_PRINT(C_RESET, "Reserved");
 				break;
 			case 0x01:
-				ND_PRINT("Reason = The coordinator wishes the device to leave PAN");
+				ND_PRINT(C_RESET, "Reason = The coordinator wishes the device to leave PAN");
 				break;
 			case 0x02:
-				ND_PRINT("Reason = The device wishes to leave the PAN");
+				ND_PRINT(C_RESET, "Reason = The device wishes to leave the PAN");
 				break;
 			default:
-				ND_PRINT("Reason = 0x%02x", GET_U_1(p + 2));
+				ND_PRINT(C_RESET, "Reason = 0x%02x", GET_U_1(p + 2));
 				break;
 			}
 			return caplen;
@@ -1695,12 +1695,12 @@ ieee802_15_4_print_command_data(netdissect_options *ndo,
 		return 0;
 	case 0x08: /* Coordinator Realignment command */
 		if (caplen < 7 || caplen > 8) {
-			ND_PRINT("Invalid Coordinator Realignment command length");
+			ND_PRINT(C_RESET, "Invalid Coordinator Realignment command length");
 			return -1;
 		} else {
 			uint16_t channel, page;
 
-			ND_PRINT("Pan ID = 0x%04x, Coordinator short address = ",
+			ND_PRINT(C_RESET, "Pan ID = 0x%04x, Coordinator short address = ",
 				 GET_LE_U_2(p));
 			ieee802_15_4_print_addr(ndo, p + 2, 2);
 			channel = GET_U_1(p + 4);
@@ -1714,25 +1714,25 @@ ieee802_15_4_print_command_data(netdissect_options *ndo,
 				/* No page present, instead we have msb of
 				   channel in the page. */
 				channel |= (page & 0x7f) << 8;
-				ND_PRINT(", Channel Number = %d", channel);
+				ND_PRINT(C_RESET, ", Channel Number = %d", channel);
 			} else {
-				ND_PRINT(", Channel Number = %d, page = %d",
+				ND_PRINT(C_RESET, ", Channel Number = %d, page = %d",
 					 channel, page);
 			}
-			ND_PRINT(", Short address = ");
+			ND_PRINT(C_RESET, ", Short address = ");
 			ieee802_15_4_print_addr(ndo, p + 5, 2);
 			return caplen;
 		}
 		break;
 	case 0x09: /* GTS Request command */
 		if (caplen != 1) {
-			ND_PRINT("Invalid GTS Request command length");
+			ND_PRINT(C_RESET, "Invalid GTS Request command length");
 			return -1;
 		} else {
 			uint8_t gts;
 
 			gts = GET_U_1(p);
-			ND_PRINT("GTS Length = %d, %s, %s",
+			ND_PRINT(C_RESET, "GTS Length = %d, %s, %s",
 				 gts & 0xf,
 				 (CHECK_BIT(gts, 4) ?
 				  "Receive-only GTS" : "Transmit-only GTS"),
@@ -1776,9 +1776,9 @@ ieee802_15_4_print_command_data(netdissect_options *ndo,
 	case 0x0b: /* TRLE Management Response command */
 		/* XXX Not implemented */
 	default:
-		ND_PRINT("Command Data = ");
+		ND_PRINT(C_RESET, "Command Data = ");
 		for(i = 0; i < caplen; i++) {
-			ND_PRINT("%02x ", GET_U_1(p + i));
+			ND_PRINT(C_RESET, "%02x ", GET_U_1(p + i));
 		}
 		break;
 	}
@@ -1837,15 +1837,15 @@ ieee802_15_4_std_frames(netdissect_options *ndo,
 	/* Frame version. */
 	frame_version = FC_FRAME_VERSION(fc);
 	frame_type = FC_FRAME_TYPE(fc);
-	ND_PRINT("v%d ", frame_version);
+	ND_PRINT(C_RESET, "v%d ", frame_version);
 
 	if (ndo->ndo_vflag > 2) {
-		if (CHECK_BIT(fc, 3)) { ND_PRINT("Security Enabled, "); }
-		if (CHECK_BIT(fc, 4)) { ND_PRINT("Frame Pending, "); }
-		if (CHECK_BIT(fc, 5)) { ND_PRINT("AR, "); }
-		if (CHECK_BIT(fc, 6)) { ND_PRINT("PAN ID Compression, "); }
-		if (CHECK_BIT(fc, 8)) { ND_PRINT("Sequence Number Suppression, "); }
-		if (CHECK_BIT(fc, 9)) { ND_PRINT("IE present, "); }
+		if (CHECK_BIT(fc, 3)) { ND_PRINT(C_RESET, "Security Enabled, "); }
+		if (CHECK_BIT(fc, 4)) { ND_PRINT(C_RESET, "Frame Pending, "); }
+		if (CHECK_BIT(fc, 5)) { ND_PRINT(C_RESET, "AR, "); }
+		if (CHECK_BIT(fc, 6)) { ND_PRINT(C_RESET, "PAN ID Compression, "); }
+		if (CHECK_BIT(fc, 8)) { ND_PRINT(C_RESET, "Sequence Number Suppression, "); }
+		if (CHECK_BIT(fc, 9)) { ND_PRINT(C_RESET, "IE present, "); }
 	}
 
 	/* Check for the sequence number suppression. */
@@ -1854,10 +1854,10 @@ ieee802_15_4_std_frames(netdissect_options *ndo,
 		if (frame_version < 2) {
 			/* Sequence number can only be suppressed for frame
 			   version 2 or higher, this is invalid frame. */
-			ND_PRINT("[ERROR: Sequence number suppressed on frames where version < 2]");
+			ND_PRINT(C_RESET, "[ERROR: Sequence number suppressed on frames where version < 2]");
 		}
 		if (ndo->ndo_vflag)
-			ND_PRINT("seq suppressed ");
+			ND_PRINT(C_RESET, "seq suppressed ");
 		if (caplen < 2) {
 			nd_print_trunc(ndo);
 			return 0;
@@ -1867,7 +1867,7 @@ ieee802_15_4_std_frames(netdissect_options *ndo,
 	} else {
 		seq = GET_U_1(p + 2);
 		if (ndo->ndo_vflag)
-			ND_PRINT("seq %02x ", seq);
+			ND_PRINT(C_RESET, "seq %02x ", seq);
 		if (caplen < 3) {
 			nd_print_trunc(ndo);
 			return 0;
@@ -1880,11 +1880,11 @@ ieee802_15_4_std_frames(netdissect_options *ndo,
 	dst_addr_len = ieee802_15_4_addr_len((fc >> 10) & 0x3);
 	src_addr_len = ieee802_15_4_addr_len((fc >> 14) & 0x3);
 	if (src_addr_len < 0) {
-		ND_PRINT("[ERROR: Invalid src address mode]");
+		ND_PRINT(C_RESET, "[ERROR: Invalid src address mode]");
 		return 0;
 	}
 	if (dst_addr_len < 0) {
-		ND_PRINT("[ERROR: Invalid dst address mode]");
+		ND_PRINT(C_RESET, "[ERROR: Invalid dst address mode]");
 		return 0;
 	}
 	src_pan = 0;
@@ -1901,7 +1901,7 @@ ieee802_15_4_std_frames(netdissect_options *ndo,
 			if (dst_addr_len <= 0 || src_addr_len <= 0) {
 				/* Invalid frame, PAN ID Compression must be 0
 				   if only one address in the frame. */
-				ND_PRINT("[ERROR: PAN ID Compression != 0, and only one address with frame version < 2]");
+				ND_PRINT(C_RESET, "[ERROR: PAN ID Compression != 0, and only one address with frame version < 2]");
 			}
 		} else {
 			src_pan = 1;
@@ -1978,43 +1978,43 @@ ieee802_15_4_std_frames(netdissect_options *ndo,
 	/* Print dst PAN and address. */
 	if (dst_pan) {
 		if (caplen < 2) {
-			ND_PRINT("[ERROR: Truncated before dst_pan]");
+			ND_PRINT(C_RESET, "[ERROR: Truncated before dst_pan]");
 			return 0;
 		}
-		ND_PRINT("%04x:", GET_LE_U_2(p));
+		ND_PRINT(C_RESET, "%04x:", GET_LE_U_2(p));
 		p += 2;
 		caplen -= 2;
 	} else {
-		ND_PRINT("-:");
+		ND_PRINT(C_RESET, "-:");
 	}
 	if (caplen < (u_int) dst_addr_len) {
-		ND_PRINT("[ERROR: Truncated before dst_addr]");
+		ND_PRINT(C_RESET, "[ERROR: Truncated before dst_addr]");
 		return 0;
 	}
 	ieee802_15_4_print_addr(ndo, p, dst_addr_len);
 	p += dst_addr_len;
 	caplen -= dst_addr_len;
 
-	ND_PRINT(" < ");
+	ND_PRINT(C_RESET, " < ");
 
 	/* Print src PAN and address. */
 	if (src_pan) {
 		if (caplen < 2) {
-			ND_PRINT("[ERROR: Truncated before dst_pan]");
+			ND_PRINT(C_RESET, "[ERROR: Truncated before dst_pan]");
 			return 0;
 		}
-		ND_PRINT("%04x:", GET_LE_U_2(p));
+		ND_PRINT(C_RESET, "%04x:", GET_LE_U_2(p));
 		p += 2;
 		caplen -= 2;
 	} else {
-		ND_PRINT("-:");
+		ND_PRINT(C_RESET, "-:");
 	}
 	if (caplen < (u_int) src_addr_len) {
-		ND_PRINT("[ERROR: Truncated before dst_addr]");
+		ND_PRINT(C_RESET, "[ERROR: Truncated before dst_addr]");
 		return 0;
 	}
 	ieee802_15_4_print_addr(ndo, p, src_addr_len);
-	ND_PRINT(" ");
+	ND_PRINT(C_RESET, " ");
 	p += src_addr_len;
 	caplen -= src_addr_len;
 	if (CHECK_BIT(fc, 3)) {
@@ -2059,7 +2059,7 @@ ieee802_15_4_std_frames(netdissect_options *ndo,
 	/* Remove MIC */
 	if (miclen != 0) {
 		if (caplen < miclen) {
-			ND_PRINT("[ERROR: Truncated before MIC]");
+			ND_PRINT(C_RESET, "[ERROR: Truncated before MIC]");
 			return 0;
 		}
 		caplen -= miclen;
@@ -2080,7 +2080,7 @@ ieee802_15_4_std_frames(netdissect_options *ndo,
 
 	if (payload_ie_present) {
 		if (security_level >= 4) {
-			ND_PRINT("Payload IEs present, but encrypted, cannot print ");
+			ND_PRINT(C_RESET, "Payload IEs present, but encrypted, cannot print ");
 		} else {
 			len = ieee802_15_4_print_payload_ie_list(ndo, p, caplen);
 			if (len < 0) {
@@ -2093,20 +2093,20 @@ ieee802_15_4_std_frames(netdissect_options *ndo,
 
 	/* Print MIC */
 	if (ndo->ndo_vflag > 2 && miclen != 0) {
-		ND_PRINT("\n\tMIC ");
+		ND_PRINT(C_RESET, "\n\tMIC ");
 
 		for (u_int micoffset = 0; micoffset < miclen; micoffset++) {
-			ND_PRINT("%02x", GET_U_1(mic_start + micoffset));
+			ND_PRINT(C_RESET, "%02x", GET_U_1(mic_start + micoffset));
 		}
-		ND_PRINT(" ");
+		ND_PRINT(C_RESET, " ");
 	}
 
 	/* Print FCS */
 	if (ndo->ndo_vflag > 2) {
 		if (crc_check == fcs) {
-			ND_PRINT("FCS %x ", fcs);
+			ND_PRINT(C_RESET, "FCS %x ", fcs);
 		} else {
-			ND_PRINT("wrong FCS %x vs %x (assume no FCS stored) ",
+			ND_PRINT(C_RESET, "wrong FCS %x vs %x (assume no FCS stored) ",
 				 fcs, crc_check);
 		}
 	}
@@ -2116,7 +2116,7 @@ ieee802_15_4_std_frames(netdissect_options *ndo,
 	case 0x00: /* Beacon */
 		if (frame_version < 2) {
 			if (caplen < 2) {
-				ND_PRINT("[ERROR: Truncated before beacon information]");
+				ND_PRINT(C_RESET, "[ERROR: Truncated before beacon information]");
 				break;
 			} else {
 				uint16_t ss;
@@ -2128,7 +2128,7 @@ ieee802_15_4_std_frames(netdissect_options *ndo,
 
 				/* GTS */
 				if (caplen < 1) {
-					ND_PRINT("[ERROR: Truncated before GTS info]");
+					ND_PRINT(C_RESET, "[ERROR: Truncated before GTS info]");
 					break;
 				}
 
@@ -2142,7 +2142,7 @@ ieee802_15_4_std_frames(netdissect_options *ndo,
 
 				/* Pending Addresses */
 				if (caplen < 1) {
-					ND_PRINT("[ERROR: Truncated before pending addresses]");
+					ND_PRINT(C_RESET, "[ERROR: Truncated before pending addresses]");
 					break;
 				}
 				len = ieee802_15_4_print_pending_addresses(ndo, p, caplen);
@@ -2165,16 +2165,16 @@ ieee802_15_4_std_frames(netdissect_options *ndo,
 		break;
 	case 0x03: /* MAC Command */
 		if (caplen < 1) {
-			ND_PRINT("[ERROR: Truncated before Command ID]");
+			ND_PRINT(C_RESET, "[ERROR: Truncated before Command ID]");
 		} else {
 			uint8_t command_id;
 
 			command_id = GET_U_1(p);
 			if (command_id >= 0x30) {
-				ND_PRINT("Command ID = Reserved 0x%02x ",
+				ND_PRINT(C_RESET, "Command ID = Reserved 0x%02x ",
 					 command_id);
 			} else {
-				ND_PRINT("Command ID = %s ",
+				ND_PRINT(C_RESET, "Command ID = %s ",
 					 mac_c_names[command_id]);
 			}
 			p++;
@@ -2255,21 +2255,21 @@ ieee802_15_4_mp_frame(netdissect_options *ndo,
 
 		/* Frame version. */
 		frame_version = FC_FRAME_VERSION(fc);
-		ND_PRINT("v%d ", frame_version);
+		ND_PRINT(C_RESET, "v%d ", frame_version);
 
 		pan_id_present = CHECK_BIT(fc, 8);
 		ie_present = CHECK_BIT(fc, 15);
 		security_enabled = CHECK_BIT(fc, 9);
 
 		if (ndo->ndo_vflag > 2) {
-			if (security_enabled) { ND_PRINT("Security Enabled, "); }
-			if (CHECK_BIT(fc, 11)) { ND_PRINT("Frame Pending, "); }
-			if (CHECK_BIT(fc, 14)) { ND_PRINT("AR, "); }
-			if (pan_id_present) { ND_PRINT("PAN ID Present, "); }
+			if (security_enabled) { ND_PRINT(C_RESET, "Security Enabled, "); }
+			if (CHECK_BIT(fc, 11)) { ND_PRINT(C_RESET, "Frame Pending, "); }
+			if (CHECK_BIT(fc, 14)) { ND_PRINT(C_RESET, "AR, "); }
+			if (pan_id_present) { ND_PRINT(C_RESET, "PAN ID Present, "); }
 			if (CHECK_BIT(fc, 10)) {
-				ND_PRINT("Sequence Number Suppression, ");
+				ND_PRINT(C_RESET, "Sequence Number Suppression, ");
 			}
-			if (ie_present) { ND_PRINT("IE present, "); }
+			if (ie_present) { ND_PRINT(C_RESET, "IE present, "); }
 		}
 
 		/* Check for the sequence number suppression. */
@@ -2284,7 +2284,7 @@ ieee802_15_4_mp_frame(netdissect_options *ndo,
 		} else {
 			seq = GET_U_1(p + 2);
 			if (ndo->ndo_vflag)
-				ND_PRINT("seq %02x ", seq);
+				ND_PRINT(C_RESET, "seq %02x ", seq);
 			if (caplen < 3) {
 				nd_print_trunc(ndo);
 				return 0;
@@ -2298,51 +2298,51 @@ ieee802_15_4_mp_frame(netdissect_options *ndo,
 		p += 2;
 		caplen -= 2;
 		if (ndo->ndo_vflag)
-			ND_PRINT("seq %02x ", seq);
+			ND_PRINT(C_RESET, "seq %02x ", seq);
 	}
 
 	/* See which parts of addresses we have. */
 	dst_addr_len = ieee802_15_4_addr_len((fc >> 4) & 0x3);
 	src_addr_len = ieee802_15_4_addr_len((fc >> 6) & 0x3);
 	if (src_addr_len < 0) {
-		ND_PRINT("[ERROR: Invalid src address mode]");
+		ND_PRINT(C_RESET, "[ERROR: Invalid src address mode]");
 		return 0;
 	}
 	if (dst_addr_len < 0) {
-		ND_PRINT("[ERROR: Invalid dst address mode]");
+		ND_PRINT(C_RESET, "[ERROR: Invalid dst address mode]");
 		return 0;
 	}
 
 	/* Print dst PAN and address. */
 	if (pan_id_present) {
 		if (caplen < 2) {
-			ND_PRINT("[ERROR: Truncated before dst_pan]");
+			ND_PRINT(C_RESET, "[ERROR: Truncated before dst_pan]");
 			return 0;
 		}
-		ND_PRINT("%04x:", GET_LE_U_2(p));
+		ND_PRINT(C_RESET, "%04x:", GET_LE_U_2(p));
 		p += 2;
 		caplen -= 2;
 	} else {
-		ND_PRINT("-:");
+		ND_PRINT(C_RESET, "-:");
 	}
 	if (caplen < (u_int) dst_addr_len) {
-		ND_PRINT("[ERROR: Truncated before dst_addr]");
+		ND_PRINT(C_RESET, "[ERROR: Truncated before dst_addr]");
 		return 0;
 	}
 	ieee802_15_4_print_addr(ndo, p, dst_addr_len);
 	p += dst_addr_len;
 	caplen -= dst_addr_len;
 
-	ND_PRINT(" < ");
+	ND_PRINT(C_RESET, " < ");
 
 	/* Print src PAN and address. */
-	ND_PRINT(" -:");
+	ND_PRINT(C_RESET, " -:");
 	if (caplen < (u_int) src_addr_len) {
-		ND_PRINT("[ERROR: Truncated before dst_addr]");
+		ND_PRINT(C_RESET, "[ERROR: Truncated before dst_addr]");
 		return 0;
 	}
 	ieee802_15_4_print_addr(ndo, p, src_addr_len);
-	ND_PRINT(" ");
+	ND_PRINT(C_RESET, " ");
 	p += src_addr_len;
 	caplen -= src_addr_len;
 
@@ -2381,7 +2381,7 @@ ieee802_15_4_mp_frame(netdissect_options *ndo,
 	/* Remove MIC */
 	if (miclen != 0) {
 		if (caplen < miclen) {
-			ND_PRINT("[ERROR: Truncated before MIC]");
+			ND_PRINT(C_RESET, "[ERROR: Truncated before MIC]");
 			return 0;
 		}
 		caplen -= miclen;
@@ -2402,7 +2402,7 @@ ieee802_15_4_mp_frame(netdissect_options *ndo,
 
 	if (payload_ie_present) {
 		if (security_level >= 4) {
-			ND_PRINT("Payload IEs present, but encrypted, cannot print ");
+			ND_PRINT(C_RESET, "Payload IEs present, but encrypted, cannot print ");
 		} else {
 			len = ieee802_15_4_print_payload_ie_list(ndo, p,
 								 caplen);
@@ -2416,21 +2416,21 @@ ieee802_15_4_mp_frame(netdissect_options *ndo,
 
 	/* Print MIC */
 	if (ndo->ndo_vflag > 2 && miclen != 0) {
-		ND_PRINT("\n\tMIC ");
+		ND_PRINT(C_RESET, "\n\tMIC ");
 
 		for (u_int micoffset = 0; micoffset < miclen; micoffset++) {
-			ND_PRINT("%02x", GET_U_1(mic_start + micoffset));
+			ND_PRINT(C_RESET, "%02x", GET_U_1(mic_start + micoffset));
 		}
-		ND_PRINT(" ");
+		ND_PRINT(C_RESET, " ");
 	}
 
 
 	/* Print FCS */
 	if (ndo->ndo_vflag > 2) {
 		if (crc_check == fcs) {
-			ND_PRINT("FCS %x ", fcs);
+			ND_PRINT(C_RESET, "FCS %x ", fcs);
 		} else {
-			ND_PRINT("wrong FCS %x vs %x (assume no FCS stored) ",
+			ND_PRINT(C_RESET, "wrong FCS %x vs %x (assume no FCS stored) ",
 				 fcs, crc_check);
 		}
 	}
@@ -2485,7 +2485,7 @@ ieee802_15_4_print(netdissect_options *ndo,
 	*/
 
 	frame_type = FC_FRAME_TYPE(fc);
-	ND_PRINT("IEEE 802.15.4 %s packet ", ftypes[frame_type]);
+	ND_PRINT(C_RESET, "IEEE 802.15.4 %s packet ", ftypes[frame_type]);
 
 	switch (frame_type) {
 	case 0x00: /* Beacon */

--- a/print-ah.c
+++ b/print-ah.c
@@ -58,18 +58,18 @@ ah_print(netdissect_options *ndo, const u_char *bp)
 	ah_len = GET_U_1(ah->ah_len);
 	ah_hdr_len = (ah_len + 2) * 4;
 
-	ND_PRINT("(");
+	ND_PRINT(C_RESET, "(");
 	if (ndo->ndo_vflag)
-		ND_PRINT("length=%u(%u-bytes),", ah_len, ah_hdr_len);
+		ND_PRINT(C_RESET, "length=%u(%u-bytes),", ah_len, ah_hdr_len);
 	reserved = GET_BE_U_2(ah->ah_reserved);
 	if (reserved)
-		ND_PRINT("reserved=0x%x[MustBeZero],", reserved);
-	ND_PRINT("spi=0x%08x,", GET_BE_U_4(ah->ah_spi));
-	ND_PRINT("seq=0x%x,", GET_BE_U_4(ah->ah_seq));
-	ND_PRINT("icv=0x");
+		ND_PRINT(C_RESET, "reserved=0x%x[MustBeZero],", reserved);
+	ND_PRINT(C_RESET, "spi=0x%08x,", GET_BE_U_4(ah->ah_spi));
+	ND_PRINT(C_RESET, "seq=0x%x,", GET_BE_U_4(ah->ah_seq));
+	ND_PRINT(C_RESET, "icv=0x");
 	for (p = (const u_char *)(ah + 1); p < bp + ah_hdr_len; p++)
-		ND_PRINT("%02x", GET_U_1(p));
-	ND_PRINT("): ");
+		ND_PRINT(C_RESET, "%02x", GET_U_1(p));
+	ND_PRINT(C_RESET, "): ");
 
 	return ah_hdr_len;
 }

--- a/print-ahcp.c
+++ b/print-ahcp.c
@@ -109,11 +109,11 @@ ahcp_time_print(netdissect_options *ndo,
 		goto invalid;
 	t = GET_BE_U_4(cp);
 	if (NULL == (tm = gmtime(&t)))
-		ND_PRINT(": gmtime() error");
+		ND_PRINT(C_RESET, ": gmtime() error");
 	else if (0 == strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", tm))
-		ND_PRINT(": strftime() error");
+		ND_PRINT(C_RESET, ": strftime() error");
 	else
-		ND_PRINT(": %s UTC", buf);
+		ND_PRINT(C_RESET, ": %s UTC", buf);
 	return;
 
 invalid:
@@ -127,7 +127,7 @@ ahcp_seconds_print(netdissect_options *ndo,
 {
 	if (len != 4)
 		goto invalid;
-	ND_PRINT(": %us", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, ": %us", GET_BE_U_4(cp));
 	return;
 
 invalid:
@@ -144,7 +144,7 @@ ahcp_ipv6_addresses_print(netdissect_options *ndo,
 	while (len) {
 		if (len < 16)
 			goto invalid;
-		ND_PRINT("%s%s", sep, GET_IP6ADDR_STRING(cp));
+		ND_PRINT(C_RESET, "%s%s", sep, GET_IP6ADDR_STRING(cp));
 		cp += 16;
 		len -= 16;
 		sep = ", ";
@@ -165,7 +165,7 @@ ahcp_ipv4_addresses_print(netdissect_options *ndo,
 	while (len) {
 		if (len < 4)
 			goto invalid;
-		ND_PRINT("%s%s", sep, GET_IPADDR_STRING(cp));
+		ND_PRINT(C_RESET, "%s%s", sep, GET_IPADDR_STRING(cp));
 		cp += 4;
 		len -= 4;
 		sep = ", ";
@@ -186,7 +186,7 @@ ahcp_ipv6_prefixes_print(netdissect_options *ndo,
 	while (len) {
 		if (len < 17)
 			goto invalid;
-		ND_PRINT("%s%s/%u", sep, GET_IP6ADDR_STRING(cp), GET_U_1(cp + 16));
+		ND_PRINT(C_RESET, "%s%s/%u", sep, GET_IP6ADDR_STRING(cp), GET_U_1(cp + 16));
 		cp += 17;
 		len -= 17;
 		sep = ", ";
@@ -207,7 +207,7 @@ ahcp_ipv4_prefixes_print(netdissect_options *ndo,
 	while (len) {
 		if (len < 5)
 			goto invalid;
-		ND_PRINT("%s%s/%u", sep, GET_IPADDR_STRING(cp), GET_U_1(cp + 4));
+		ND_PRINT(C_RESET, "%s%s/%u", sep, GET_IPADDR_STRING(cp), GET_U_1(cp + 4));
 		cp += 5;
 		len -= 5;
 		sep = ", ";
@@ -248,7 +248,7 @@ ahcp1_options_print(netdissect_options *ndo,
 		option_no = GET_U_1(cp);
 		cp += 1;
 		len -= 1;
-		ND_PRINT("\n\t %s", tok2str(ahcp1_opt_str, "Unknown-%u", option_no));
+		ND_PRINT(C_RESET, "\n\t %s", tok2str(ahcp1_opt_str, "Unknown-%u", option_no));
 		if (option_no == AHCP1_OPT_PAD || option_no == AHCP1_OPT_MANDATORY)
 			continue;
 		/* Length */
@@ -263,7 +263,7 @@ ahcp1_options_print(netdissect_options *ndo,
 		if (option_no <= AHCP1_OPT_MAX && data_decoders[option_no] != NULL) {
 			data_decoders[option_no](ndo, cp, option_len);
 		} else {
-			ND_PRINT(" (Length %u)", option_len);
+			ND_PRINT(C_RESET, " (Length %u)", option_len);
 			ND_TCHECK_LEN(cp, option_len);
 		}
 		cp += option_len;
@@ -299,10 +299,10 @@ ahcp1_body_print(netdissect_options *ndo,
 	len -= 2;
 
 	if (ndo->ndo_vflag) {
-		ND_PRINT("\n\t%s", tok2str(ahcp1_msg_str, "Unknown-%u", type));
+		ND_PRINT(C_RESET, "\n\t%s", tok2str(ahcp1_msg_str, "Unknown-%u", type));
 		if (mbz != 0)
-			ND_PRINT(", MBZ %u", mbz);
-		ND_PRINT(", Length %u", body_len);
+			ND_PRINT(C_RESET, ", MBZ %u", mbz);
+		ND_PRINT(C_RESET, ", Length %u", body_len);
 	}
 	if (body_len > len)
 		goto invalid;
@@ -342,7 +342,7 @@ ahcp_print(netdissect_options *ndo,
 	len -= 1;
 	switch (version) {
 		case AHCP_VERSION_1: {
-			ND_PRINT(" Version 1");
+			ND_PRINT(C_RESET, " Version 1");
 			if (len < AHCP1_HEADER_FIX_LEN - 2)
 				goto invalid;
 			if (!ndo->ndo_vflag) {
@@ -351,23 +351,23 @@ ahcp_print(netdissect_options *ndo,
 				len -= AHCP1_HEADER_FIX_LEN - 2;
 			} else {
 				/* Hopcount */
-				ND_PRINT("\n\tHopcount %u", GET_U_1(cp));
+				ND_PRINT(C_RESET, "\n\tHopcount %u", GET_U_1(cp));
 				cp += 1;
 				len -= 1;
 				/* Original Hopcount */
-				ND_PRINT(", Original Hopcount %u", GET_U_1(cp));
+				ND_PRINT(C_RESET, ", Original Hopcount %u", GET_U_1(cp));
 				cp += 1;
 				len -= 1;
 				/* Nonce */
-				ND_PRINT(", Nonce 0x%08x", GET_BE_U_4(cp));
+				ND_PRINT(C_RESET, ", Nonce 0x%08x", GET_BE_U_4(cp));
 				cp += 4;
 				len -= 4;
 				/* Source Id */
-				ND_PRINT(", Source Id %s", GET_LINKADDR_STRING(cp, LINKADDR_OTHER, 8));
+				ND_PRINT(C_RESET, ", Source Id %s", GET_LINKADDR_STRING(cp, LINKADDR_OTHER, 8));
 				cp += 8;
 				len -= 8;
 				/* Destination Id */
-				ND_PRINT(", Destination Id %s", GET_LINKADDR_STRING(cp, LINKADDR_OTHER, 8));
+				ND_PRINT(C_RESET, ", Destination Id %s", GET_LINKADDR_STRING(cp, LINKADDR_OTHER, 8));
 				cp += 8;
 				len -= 8;
 			}
@@ -376,7 +376,7 @@ ahcp_print(netdissect_options *ndo,
 			break;
 		}
 		default:
-			ND_PRINT(" Version %u (unknown)", version);
+			ND_PRINT(C_RESET, " Version %u (unknown)", version);
 			ND_TCHECK_LEN(cp, len);
 			break;
 	}

--- a/print-aodv.c
+++ b/print-aodv.c
@@ -164,15 +164,15 @@ aodv_extension(netdissect_options *ndo,
 		ND_ICHECKMSG_ZU("ext data length", length, <,
 				sizeof(struct aodv_hello));
 		if (ext_length < 4) {
-			ND_PRINT("\n\text HELLO - bad length %u", ext_length);
+			ND_PRINT(C_RESET, "\n\text HELLO - bad length %u", ext_length);
 			goto invalid;
 		}
-		ND_PRINT("\n\text HELLO %u ms",
+		ND_PRINT(C_RESET, "\n\text HELLO %u ms",
 		    GET_BE_U_4(ah->interval));
 		break;
 
 	default:
-		ND_PRINT("\n\text %u %u", ext_type, ext_length);
+		ND_PRINT(C_RESET, "\n\text %u %u", ext_type, ext_length);
 		break;
 	}
 	return;
@@ -188,7 +188,7 @@ aodv_rreq(netdissect_options *ndo, const u_char *dat, u_int length)
 	const struct aodv_rreq *ap = (const struct aodv_rreq *)dat;
 
 	ND_ICHECKMSG_ZU("message length", length, <, sizeof(*ap));
-	ND_PRINT(" %u %s%s%s%s%shops %u id 0x%08x\n"
+	ND_PRINT(C_RESET, " %u %s%s%s%s%shops %u id 0x%08x\n"
 	    "\tdst %s seq %u src %s seq %u", length,
 	    GET_U_1(ap->rreq_type) & RREQ_JOIN ? "[J]" : "",
 	    GET_U_1(ap->rreq_type) & RREQ_REPAIR ? "[R]" : "",
@@ -217,7 +217,7 @@ aodv_rrep(netdissect_options *ndo, const u_char *dat, u_int length)
 	const struct aodv_rrep *ap = (const struct aodv_rrep *)dat;
 
 	ND_ICHECKMSG_ZU("message length", length, <, sizeof(*ap));
-	ND_PRINT(" %u %s%sprefix %u hops %u\n"
+	ND_PRINT(C_RESET, " %u %s%sprefix %u hops %u\n"
 	    "\tdst %s dseq %u src %s %u ms", length,
 	    GET_U_1(ap->rrep_type) & RREP_REPAIR ? "[R]" : "",
 	    GET_U_1(ap->rrep_type) & RREP_ACK ? "[A] " : " ",
@@ -244,14 +244,14 @@ aodv_rerr(netdissect_options *ndo, const u_char *dat, u_int length)
 	const struct rerr_unreach *dp;
 
 	ND_ICHECKMSG_ZU("message length", length, <, sizeof(*ap));
-	ND_PRINT(" %s [items %u] [%u]:",
+	ND_PRINT(C_RESET, " %s [items %u] [%u]:",
 	    GET_U_1(ap->rerr_flags) & RERR_NODELETE ? "[D]" : "",
 	    GET_U_1(ap->rerr_dc), length);
 	dp = (const struct rerr_unreach *)(dat + sizeof(*ap));
 	i = length - sizeof(*ap);
 	for (dc = GET_U_1(ap->rerr_dc); dc != 0; dc--) {
 		ND_ICHECKMSG_ZU("remaining length", i, <, sizeof(*dp));
-		ND_PRINT(" {%s}(%u)", GET_IPADDR_STRING(dp->u_da),
+		ND_PRINT(C_RESET, " {%s}(%u)", GET_IPADDR_STRING(dp->u_da),
 		    GET_BE_U_4(dp->u_ds));
 		dp++;
 		i -= sizeof(*dp);
@@ -269,7 +269,7 @@ aodv_v6_rreq(netdissect_options *ndo, const u_char *dat, u_int length)
 	const struct aodv_rreq6 *ap = (const struct aodv_rreq6 *)dat;
 
 	ND_ICHECKMSG_ZU("message length", length, <, sizeof(*ap));
-	ND_PRINT(" %u %s%s%s%s%shops %u id 0x%08x\n"
+	ND_PRINT(C_RESET, " %u %s%s%s%s%shops %u id 0x%08x\n"
 	    "\tdst %s seq %u src %s seq %u", length,
 	    GET_U_1(ap->rreq_type) & RREQ_JOIN ? "[J]" : "",
 	    GET_U_1(ap->rreq_type) & RREQ_REPAIR ? "[R]" : "",
@@ -298,7 +298,7 @@ aodv_v6_rrep(netdissect_options *ndo, const u_char *dat, u_int length)
 	const struct aodv_rrep6 *ap = (const struct aodv_rrep6 *)dat;
 
 	ND_ICHECKMSG_ZU("message length", length, <, sizeof(*ap));
-	ND_PRINT(" %u %s%sprefix %u hops %u\n"
+	ND_PRINT(C_RESET, " %u %s%sprefix %u hops %u\n"
 	   "\tdst %s dseq %u src %s %u ms", length,
 	    GET_U_1(ap->rrep_type) & RREP_REPAIR ? "[R]" : "",
 	    GET_U_1(ap->rrep_type) & RREP_ACK ? "[A] " : " ",
@@ -325,14 +325,14 @@ aodv_v6_rerr(netdissect_options *ndo, const u_char *dat, u_int length)
 	const struct rerr_unreach6 *dp6;
 
 	ND_ICHECKMSG_ZU("message length", length, <, sizeof(*ap));
-	ND_PRINT(" %s [items %u] [%u]:",
+	ND_PRINT(C_RESET, " %s [items %u] [%u]:",
 	    GET_U_1(ap->rerr_flags) & RERR_NODELETE ? "[D]" : "",
 	    GET_U_1(ap->rerr_dc), length);
 	dp6 = (const struct rerr_unreach6 *)(const void *)(ap + 1);
 	i = length - sizeof(*ap);
 	for (dc = GET_U_1(ap->rerr_dc); dc != 0; dc--) {
 		ND_ICHECKMSG_ZU("remaining length", i, <, sizeof(*dp6));
-		ND_PRINT(" {%s}(%u)", GET_IP6ADDR_STRING(dp6->u_da),
+		ND_PRINT(C_RESET, " {%s}(%u)", GET_IP6ADDR_STRING(dp6->u_da),
 			 GET_BE_U_4(dp6->u_ds));
 		dp6++;
 		i -= sizeof(*dp6);
@@ -350,14 +350,14 @@ aodv_print(netdissect_options *ndo,
 	uint8_t msg_type;
 
 	ndo->ndo_protocol = "aodv";
-	ND_PRINT(" aodv");
+	ND_PRINT(C_RESET, " aodv");
 
 	/*
 	 * The message type is the first byte; make sure we have it
 	 * and then fetch it.
 	 */
 	msg_type = GET_U_1(dat);
-	ND_PRINT(" %s", tok2str(msg_type_str, "type %u", msg_type));
+	ND_PRINT(C_RESET, " %s", tok2str(msg_type_str, "type %u", msg_type));
 
 	switch (msg_type) {
 
@@ -383,10 +383,10 @@ aodv_print(netdissect_options *ndo,
 		break;
 
 	case AODV_RREP_ACK:
-		ND_PRINT(" %u", length);
+		ND_PRINT(C_RESET, " %u", length);
 		break;
 
 	default:
-		ND_PRINT(" %u", length);
+		ND_PRINT(C_RESET, " %u", length);
 	}
 }

--- a/print-aoe.c
+++ b/print-aoe.c
@@ -147,44 +147,44 @@ aoev1_issue_print(netdissect_options *ndo,
 	if (len < AOEV1_ISSUE_ARG_LEN)
 		goto invalid;
 	/* AFlags */
-	ND_PRINT("\n\tAFlags: [%s]",
+	ND_PRINT(C_RESET, "\n\tAFlags: [%s]",
 		 bittok2str(aoev1_aflag_bitmap_str, "none", GET_U_1(cp)));
 	cp += 1;
 	len -= 1;
 	/* Err/Feature */
-	ND_PRINT(", Err/Feature: %u", GET_U_1(cp));
+	ND_PRINT(C_RESET, ", Err/Feature: %u", GET_U_1(cp));
 	cp += 1;
 	len -= 1;
 	/* Sector Count (not correlated with the length) */
-	ND_PRINT(", Sector Count: %u", GET_U_1(cp));
+	ND_PRINT(C_RESET, ", Sector Count: %u", GET_U_1(cp));
 	cp += 1;
 	len -= 1;
 	/* Cmd/Status */
-	ND_PRINT(", Cmd/Status: %u", GET_U_1(cp));
+	ND_PRINT(C_RESET, ", Cmd/Status: %u", GET_U_1(cp));
 	cp += 1;
 	len -= 1;
 	/* lba0 */
-	ND_PRINT("\n\tlba0: %u", GET_U_1(cp));
+	ND_PRINT(C_RESET, "\n\tlba0: %u", GET_U_1(cp));
 	cp += 1;
 	len -= 1;
 	/* lba1 */
-	ND_PRINT(", lba1: %u", GET_U_1(cp));
+	ND_PRINT(C_RESET, ", lba1: %u", GET_U_1(cp));
 	cp += 1;
 	len -= 1;
 	/* lba2 */
-	ND_PRINT(", lba2: %u", GET_U_1(cp));
+	ND_PRINT(C_RESET, ", lba2: %u", GET_U_1(cp));
 	cp += 1;
 	len -= 1;
 	/* lba3 */
-	ND_PRINT(", lba3: %u", GET_U_1(cp));
+	ND_PRINT(C_RESET, ", lba3: %u", GET_U_1(cp));
 	cp += 1;
 	len -= 1;
 	/* lba4 */
-	ND_PRINT(", lba4: %u", GET_U_1(cp));
+	ND_PRINT(C_RESET, ", lba4: %u", GET_U_1(cp));
 	cp += 1;
 	len -= 1;
 	/* lba5 */
-	ND_PRINT(", lba5: %u", GET_U_1(cp));
+	ND_PRINT(C_RESET, ", lba5: %u", GET_U_1(cp));
 	cp += 1;
 	len -= 1;
 	/* Reserved */
@@ -193,7 +193,7 @@ aoev1_issue_print(netdissect_options *ndo,
 	len -= 2;
 	/* Data */
 	if (len)
-		ND_PRINT("\n\tData: %u bytes", len);
+		ND_PRINT(C_RESET, "\n\tData: %u bytes", len);
 	return;
 
 invalid:
@@ -210,19 +210,19 @@ aoev1_query_print(netdissect_options *ndo,
 	if (len < AOEV1_QUERY_ARG_LEN)
 		goto invalid;
 	/* Buffer Count */
-	ND_PRINT("\n\tBuffer Count: %u", GET_BE_U_2(cp));
+	ND_PRINT(C_RESET, "\n\tBuffer Count: %u", GET_BE_U_2(cp));
 	cp += 2;
 	len -= 2;
 	/* Firmware Version */
-	ND_PRINT(", Firmware Version: %u", GET_BE_U_2(cp));
+	ND_PRINT(C_RESET, ", Firmware Version: %u", GET_BE_U_2(cp));
 	cp += 2;
 	len -= 2;
 	/* Sector Count */
-	ND_PRINT(", Sector Count: %u", GET_U_1(cp));
+	ND_PRINT(C_RESET, ", Sector Count: %u", GET_U_1(cp));
 	cp += 1;
 	len -= 1;
 	/* AoE/CCmd */
-	ND_PRINT(", AoE: %u, CCmd: %s", (GET_U_1(cp) & 0xF0) >> 4,
+	ND_PRINT(C_RESET, ", AoE: %u, CCmd: %s", (GET_U_1(cp) & 0xF0) >> 4,
 	          tok2str(aoev1_ccmd_str, "Unknown (0x02x)", GET_U_1(cp) & 0x0F));
 	cp += 1;
 	len -= 1;
@@ -234,7 +234,7 @@ aoev1_query_print(netdissect_options *ndo,
 		goto invalid;
 	/* Config String */
 	if (cslen) {
-		ND_PRINT("\n\tConfig String (length %u): ", cslen);
+		ND_PRINT(C_RESET, "\n\tConfig String (length %u): ", cslen);
 		nd_printjn(ndo, cp, cslen);
 	}
 	return;
@@ -256,12 +256,12 @@ aoev1_mac_print(netdissect_options *ndo,
 	cp += 1;
 	len -= 1;
 	/* MCmd */
-	ND_PRINT("\n\tMCmd: %s",
+	ND_PRINT(C_RESET, "\n\tMCmd: %s",
 		 tok2str(aoev1_mcmd_str, "Unknown (0x%02x)", GET_U_1(cp)));
 	cp += 1;
 	len -= 1;
 	/* MError */
-	ND_PRINT(", MError: %s",
+	ND_PRINT(C_RESET, ", MError: %s",
 		 tok2str(aoev1_merror_str, "Unknown (0x%02x)", GET_U_1(cp)));
 	cp += 1;
 	len -= 1;
@@ -269,7 +269,7 @@ aoev1_mac_print(netdissect_options *ndo,
 	dircount = GET_U_1(cp);
 	cp += 1;
 	len -= 1;
-	ND_PRINT(", Dir Count: %u", dircount);
+	ND_PRINT(C_RESET, ", Dir Count: %u", dircount);
 	if (dircount * 8U > len)
 		goto invalid;
 	/* directives */
@@ -278,12 +278,12 @@ aoev1_mac_print(netdissect_options *ndo,
 		cp += 1;
 		len -= 1;
 		/* DCmd */
-		ND_PRINT("\n\t DCmd: %s",
+		ND_PRINT(C_RESET, "\n\t DCmd: %s",
 			 tok2str(aoev1_dcmd_str, "Unknown (0x%02x)", GET_U_1(cp)));
 		cp += 1;
 		len -= 1;
 		/* Ethernet Address */
-		ND_PRINT(", Ethernet Address: %s", GET_ETHERADDR_STRING(cp));
+		ND_PRINT(C_RESET, ", Ethernet Address: %s", GET_ETHERADDR_STRING(cp));
 		cp += MAC_ADDR_LEN;
 		len -= MAC_ADDR_LEN;
 	}
@@ -303,7 +303,7 @@ aoev1_reserve_print(netdissect_options *ndo,
 	if (len < AOEV1_RESERVE_ARG_LEN || (len - AOEV1_RESERVE_ARG_LEN) % MAC_ADDR_LEN)
 		goto invalid;
 	/* RCmd */
-	ND_PRINT("\n\tRCmd: %s",
+	ND_PRINT(C_RESET, "\n\tRCmd: %s",
 		 tok2str(aoev1_rcmd_str, "Unknown (0x%02x)", GET_U_1(cp)));
 	cp += 1;
 	len -= 1;
@@ -311,12 +311,12 @@ aoev1_reserve_print(netdissect_options *ndo,
 	nmacs = GET_U_1(cp);
 	cp += 1;
 	len -= 1;
-	ND_PRINT(", NMacs: %u", nmacs);
+	ND_PRINT(C_RESET, ", NMacs: %u", nmacs);
 	if (nmacs * MAC_ADDR_LEN != len)
 		goto invalid;
 	/* addresses */
 	for (i = 0; i < nmacs; i++) {
-		ND_PRINT("\n\tEthernet Address %u: %s", i, GET_ETHERADDR_STRING(cp));
+		ND_PRINT(C_RESET, "\n\tEthernet Address %u: %s", i, GET_ETHERADDR_STRING(cp));
 		cp += MAC_ADDR_LEN;
 		len -= MAC_ADDR_LEN;
 	}
@@ -339,32 +339,32 @@ aoev1_print(netdissect_options *ndo,
 		goto invalid;
 	/* Flags */
 	flags = GET_U_1(cp) & 0x0F;
-	ND_PRINT(", Flags: [%s]", bittok2str(aoev1_flag_str, "none", flags));
+	ND_PRINT(C_RESET, ", Flags: [%s]", bittok2str(aoev1_flag_str, "none", flags));
 	cp += 1;
 	len -= 1;
 	if (! ndo->ndo_vflag)
 		return;
 	/* Error */
 	if (flags & AOEV1_FLAG_E)
-		ND_PRINT("\n\tError: %s",
+		ND_PRINT(C_RESET, "\n\tError: %s",
 			 tok2str(aoev1_errcode_str, "Invalid (%u)", GET_U_1(cp)));
 	cp += 1;
 	len -= 1;
 	/* Major */
-	ND_PRINT("\n\tMajor: 0x%04x", GET_BE_U_2(cp));
+	ND_PRINT(C_RESET, "\n\tMajor: 0x%04x", GET_BE_U_2(cp));
 	cp += 2;
 	len -= 2;
 	/* Minor */
-	ND_PRINT(", Minor: 0x%02x", GET_U_1(cp));
+	ND_PRINT(C_RESET, ", Minor: 0x%02x", GET_U_1(cp));
 	cp += 1;
 	len -= 1;
 	/* Command */
 	command = GET_U_1(cp);
 	cp += 1;
 	len -= 1;
-	ND_PRINT(", Command: %s", tok2str(cmdcode_str, "Unknown (0x%02x)", command));
+	ND_PRINT(C_RESET, ", Command: %s", tok2str(cmdcode_str, "Unknown (0x%02x)", command));
 	/* Tag */
-	ND_PRINT(", Tag: 0x%08x", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, ", Tag: 0x%08x", GET_BE_U_4(cp));
 	cp += 4;
 	len -= 4;
 	/* Arg */
@@ -390,14 +390,14 @@ aoe_print(netdissect_options *ndo,
 	uint8_t ver;
 
 	ndo->ndo_protocol = "aoe";
-	ND_PRINT("AoE length %u", len);
+	ND_PRINT(C_RESET, "AoE length %u", len);
 
 	if (len < 1)
 		goto invalid;
 	/* Ver/Flags */
 	ver = (GET_U_1(cp) & 0xF0) >> 4;
 	/* Don't advance cp yet: low order 4 bits are version-specific. */
-	ND_PRINT(", Ver %u", ver);
+	ND_PRINT(C_RESET, ", Ver %u", ver);
 
 	switch (ver) {
 		case AOE_V1:

--- a/print-ap1394.c
+++ b/print-ap1394.c
@@ -64,20 +64,20 @@ ap1394_hdr_print(netdissect_options *ndo, const u_char *bp, u_int length)
 
 	fp = (const struct firewire_header *)bp;
 
-	ND_PRINT("%s > %s",
+	ND_PRINT(C_RESET, "%s > %s",
 		     fwaddr_string(ndo, fp->firewire_shost),
 		     fwaddr_string(ndo, fp->firewire_dhost));
 
 	firewire_type = GET_BE_U_2(fp->firewire_type);
 	if (!ndo->ndo_qflag) {
-		ND_PRINT(", ethertype %s (0x%04x)",
+		ND_PRINT(C_RESET, ", ethertype %s (0x%04x)",
 			       tok2str(ethertype_values,"Unknown", firewire_type),
                                firewire_type);
         } else {
-                ND_PRINT(", %s", tok2str(ethertype_values,"Unknown Ethertype (0x%04x)", firewire_type));
+                ND_PRINT(C_RESET, ", %s", tok2str(ethertype_values,"Unknown Ethertype (0x%04x)", firewire_type));
         }
 
-	ND_PRINT(", length %u: ", length);
+	ND_PRINT(C_RESET, ", length %u: ", length);
 }
 
 /*

--- a/print-arcnet.c
+++ b/print-arcnet.c
@@ -129,7 +129,7 @@ arcnet_print(netdissect_options *ndo, const u_char *bp, u_int length, int phds,
 	ap = (const struct arc_header *)bp;
 
 	if (ndo->ndo_qflag) {
-		ND_PRINT("%02x %02x %u: ",
+		ND_PRINT(C_RESET, "%02x %02x %u: ",
 			     GET_U_1(ap->arc_shost),
 			     GET_U_1(ap->arc_dhost),
 			     length);
@@ -139,7 +139,7 @@ arcnet_print(netdissect_options *ndo, const u_char *bp, u_int length, int phds,
 	arctypename = tok2str(arctypemap, "%02x", GET_U_1(ap->arc_type));
 
 	if (!phds) {
-		ND_PRINT("%02x %02x %s %u: ",
+		ND_PRINT(C_RESET, "%02x %02x %s %u: ",
 			     GET_U_1(ap->arc_shost),
 			     GET_U_1(ap->arc_dhost),
 			     arctypename,
@@ -148,7 +148,7 @@ arcnet_print(netdissect_options *ndo, const u_char *bp, u_int length, int phds,
 	}
 
 	if (flag == 0) {
-		ND_PRINT("%02x %02x %s seqid %04x %u: ",
+		ND_PRINT(C_RESET, "%02x %02x %s seqid %04x %u: ",
 			GET_U_1(ap->arc_shost),
 			GET_U_1(ap->arc_dhost),
 			arctypename, seqid,
@@ -157,14 +157,14 @@ arcnet_print(netdissect_options *ndo, const u_char *bp, u_int length, int phds,
 	}
 
 	if (flag & 1)
-		ND_PRINT("%02x %02x %s seqid %04x "
+		ND_PRINT(C_RESET, "%02x %02x %s seqid %04x "
 			"(first of %u fragments) %u: ",
 			GET_U_1(ap->arc_shost),
 			GET_U_1(ap->arc_dhost),
 			arctypename, seqid,
 			(flag + 3) / 2, length);
 	else
-		ND_PRINT("%02x %02x %s seqid %04x "
+		ND_PRINT(C_RESET, "%02x %02x %s seqid %04x "
 			"(fragment %u) %u: ",
 			GET_U_1(ap->arc_shost),
 			GET_U_1(ap->arc_dhost),
@@ -214,7 +214,7 @@ arcnet_if_print(netdissect_options *ndo, const struct pcap_pkthdr *h, const u_ch
 	if (phds) {
 		if (caplen < ARC_HDRNEWLEN) {
 			arcnet_print(ndo, p, length, 0, 0, 0);
-			ND_PRINT(" phds");
+			ND_PRINT(C_RESET, " phds");
 			ndo->ndo_ll_hdr_len += caplen;
 			nd_trunc_longjmp(ndo);
 		}
@@ -223,7 +223,7 @@ arcnet_if_print(netdissect_options *ndo, const struct pcap_pkthdr *h, const u_ch
 		if (flag == 0xff) {
 			if (caplen < ARC_HDRNEWLEN_EXC) {
 				arcnet_print(ndo, p, length, 0, 0, 0);
-				ND_PRINT(" phds extended");
+				ND_PRINT(C_RESET, " phds extended");
 				ndo->ndo_ll_hdr_len += caplen;
 				nd_trunc_longjmp(ndo);
 			}
@@ -352,7 +352,7 @@ arcnet_encap_print(netdissect_options *ndo, u_char arctype, const u_char *p,
 
 	case ARCTYPE_ATALK:	/* XXX was this ever used? */
 		if (ndo->ndo_vflag)
-			ND_PRINT("et1 ");
+			ND_PRINT(C_RESET, "et1 ");
 		atalk_print(ndo, p, length);
 		return (1);
 

--- a/print-arista.c
+++ b/print-arista.c
@@ -99,11 +99,11 @@ arista_print_date_hms_time(netdissect_options *ndo, uint32_t seconds,
 	ts = seconds + (nanoseconds / 1000000000);
 	nanoseconds %= 1000000000;
 	if (NULL == (tm = gmtime(&ts)))
-		ND_PRINT("gmtime() error");
+		ND_PRINT(C_RESET, "gmtime() error");
 	else if (0 == strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", tm))
-		ND_PRINT("strftime() error");
+		ND_PRINT(C_RESET, "strftime() error");
 	else
-		ND_PRINT("%s.%09u", buf, nanoseconds);
+		ND_PRINT(C_RESET, "%s.%09u", buf, nanoseconds);
 }
 
 int
@@ -118,7 +118,7 @@ arista_ethertype_print(netdissect_options *ndo, const u_char *bp, u_int len _U_)
 	bp += 2;
 	bytesConsumed += 2;
 
-	ND_PRINT("SubType %s (0x%04x), ",
+	ND_PRINT(C_RESET, "SubType %s (0x%04x), ",
 	         tok2str(subtype_str, "Unknown", subTypeId),
 	         subTypeId);
 
@@ -129,7 +129,7 @@ arista_ethertype_print(netdissect_options *ndo, const u_char *bp, u_int len _U_)
 		uint8_t ts_timescale = GET_U_1(bp);
 		bp += 1;
 		bytesConsumed += 1;
-		ND_PRINT("Timescale %s (%u), ",
+		ND_PRINT(C_RESET, "Timescale %s (%u), ",
 		         tok2str(ts_timescale_str, "Unknown", ts_timescale),
 		         ts_timescale);
 
@@ -139,7 +139,7 @@ arista_ethertype_print(netdissect_options *ndo, const u_char *bp, u_int len _U_)
 		bytesConsumed += 1;
 
 		// Timestamp has 32-bit lsb in nanosec and remaining msb in sec
-		ND_PRINT("Format %s (%u), HwInfo %s (%u), Timestamp ",
+		ND_PRINT(C_RESET, "Format %s (%u), HwInfo %s (%u), Timestamp ",
 		         tok2str(ts_format_str, "Unknown", ts_format),
 		         ts_format,
 		         tok2str(hw_info_str, "Unknown", hw_info),
@@ -156,7 +156,7 @@ arista_ethertype_print(netdissect_options *ndo, const u_char *bp, u_int len _U_)
 			nanoseconds = GET_BE_U_4(bp + 2);
 			seconds += nanoseconds / 1000000000;
 			nanoseconds %= 1000000000;
-			ND_PRINT("%" PRIu64 ".%09u", seconds, nanoseconds);
+			ND_PRINT(C_RESET, "%" PRIu64 ".%09u", seconds, nanoseconds);
 			bytesConsumed += 6;
 			break;
 		default:
@@ -165,6 +165,6 @@ arista_ethertype_print(netdissect_options *ndo, const u_char *bp, u_int len _U_)
 	} else {
 		return -1;
 	}
-	ND_PRINT(": ");
+	ND_PRINT(C_RESET, ": ");
 	return bytesConsumed;
 }

--- a/print-arp.c
+++ b/print-arp.c
@@ -193,11 +193,11 @@ tpaddr_print_ip(netdissect_options *ndo,
 	        const struct arp_pkthdr *ap, u_short pro)
 {
 	if (pro != ETHERTYPE_IP && pro != ETHERTYPE_TRAIL)
-		ND_PRINT(C_RESET, C_RESET "<wrong proto type>");
+		ND_PRINT(C_RESET, "<wrong proto type>");
 	else if (PROTO_LEN(ap) != 4)
-		ND_PRINT(C_RESET, C_RESET "<wrong len>");
+		ND_PRINT(C_RESET, "<wrong len>");
 	else
-		ND_PRINT(C_RESET, C_RESET "%s", GET_IPADDR_STRING(TPA(ap)));
+		ND_PRINT(C_RESET, "%s", GET_IPADDR_STRING(TPA(ap)));
 }
 
 static void
@@ -205,11 +205,11 @@ spaddr_print_ip(netdissect_options *ndo,
 	        const struct arp_pkthdr *ap, u_short pro)
 {
 	if (pro != ETHERTYPE_IP && pro != ETHERTYPE_TRAIL)
-		ND_PRINT(C_RESET, C_RESET "<wrong proto type>");
+		ND_PRINT(C_RESET, "<wrong proto type>");
 	else if (PROTO_LEN(ap) != 4)
-		ND_PRINT(C_RESET, C_RESET "<wrong len>");
+		ND_PRINT(C_RESET, "<wrong len>");
 	else
-		ND_PRINT(C_RESET, C_RESET "%s", GET_IPADDR_STRING(SPA(ap)));
+		ND_PRINT(C_RESET, "%s", GET_IPADDR_STRING(SPA(ap)));
 }
 
 static void
@@ -218,11 +218,11 @@ atmarp_addr_print(netdissect_options *ndo,
     u_int srca_len)
 {
 	if (ha_len == 0)
-		ND_PRINT(C_RESET, C_RESET "<No address>");
+		ND_PRINT(C_RESET, "<No address>");
 	else {
-		ND_PRINT(C_RESET, C_RESET "%s", GET_LINKADDR_STRING(ha, LINKADDR_ATM, ha_len));
+		ND_PRINT(C_RESET, "%s", GET_LINKADDR_STRING(ha, LINKADDR_ATM, ha_len));
 		if (srca_len != 0)
-			ND_PRINT(C_RESET, C_RESET ",%s",
+			ND_PRINT(C_RESET, ",%s",
 				  GET_LINKADDR_STRING(srca, LINKADDR_ATM, srca_len));
 	}
 }
@@ -232,11 +232,11 @@ atmarp_tpaddr_print(netdissect_options *ndo,
 		    const struct atmarp_pkthdr *ap, u_short pro)
 {
 	if (pro != ETHERTYPE_IP && pro != ETHERTYPE_TRAIL)
-		ND_PRINT(C_RESET, C_RESET "<wrong proto type>");
+		ND_PRINT(C_RESET, "<wrong proto type>");
 	else if (ATMTPROTO_LEN(ap) != 4)
-		ND_PRINT(C_RESET, C_RESET "<wrong tplen>");
+		ND_PRINT(C_RESET, "<wrong tplen>");
 	else
-		ND_PRINT(C_RESET, C_RESET "%s", GET_IPADDR_STRING(ATMTPA(ap)));
+		ND_PRINT(C_RESET, "%s", GET_IPADDR_STRING(ATMTPA(ap)));
 }
 
 static void
@@ -244,11 +244,11 @@ atmarp_spaddr_print(netdissect_options *ndo,
 		    const struct atmarp_pkthdr *ap, u_short pro)
 {
 	if (pro != ETHERTYPE_IP && pro != ETHERTYPE_TRAIL)
-		ND_PRINT(C_RESET, C_RESET "<wrong proto type>");
+		ND_PRINT(C_RESET, "<wrong proto type>");
 	else if (ATMSPROTO_LEN(ap) != 4)
-		ND_PRINT(C_RESET, C_RESET "<wrong splen>");
+		ND_PRINT(C_RESET, "<wrong splen>");
 	else
-		ND_PRINT(C_RESET, C_RESET "%s", GET_IPADDR_STRING(ATMSPA(ap)));
+		ND_PRINT(C_RESET, "%s", GET_IPADDR_STRING(ATMSPA(ap)));
 }
 
 static void
@@ -268,14 +268,14 @@ atmarp_print(netdissect_options *ndo,
 	ND_TCHECK_LEN(ATMTPA(ap), ATMTPROTO_LEN(ap));
 
         if (!ndo->ndo_eflag) {
-            ND_PRINT(C_RESET, C_RESET "ARP, ");
+            ND_PRINT(C_RESET, "ARP, ");
         }
 
 	if ((pro != ETHERTYPE_IP && pro != ETHERTYPE_TRAIL) ||
 	    ATMSPROTO_LEN(ap) != 4 ||
             ATMTPROTO_LEN(ap) != 4 ||
             ndo->ndo_vflag) {
-                ND_PRINT(C_RESET, C_RESET "%s, %s (len %u/%u)",
+                ND_PRINT(C_RESET, "%s, %s (len %u/%u)",
                           tok2str(arphrd_values, "Unknown Hardware (%u)", hrd),
                           tok2str(ethertype_values, "Unknown Protocol (0x%04x)", pro),
                           ATMSPROTO_LEN(ap),
@@ -288,37 +288,37 @@ atmarp_print(netdissect_options *ndo,
 	}
 
         /* print operation */
-        ND_PRINT(C_RESET, C_RESET "%s%s ",
+        ND_PRINT(C_RESET, "%s%s ",
                ndo->ndo_vflag ? ", " : "",
                tok2str(arpop_values, "Unknown (%u)", op));
 
 	switch (op) {
 
 	case ARPOP_REQUEST:
-		ND_PRINT(C_RESET, C_RESET "who-has ");
+		ND_PRINT(C_RESET, "who-has ");
 		atmarp_tpaddr_print(ndo, ap, pro);
 		if (ATMTHRD_LEN(ap) != 0) {
-			ND_PRINT(C_RESET, C_RESET " (");
+			ND_PRINT(C_RESET, " (");
 			atmarp_addr_print(ndo, ATMTHA(ap), ATMTHRD_LEN(ap),
 			    ATMTSA(ap), ATMTSLN(ap));
-			ND_PRINT(C_RESET, C_RESET ")");
+			ND_PRINT(C_RESET, ")");
 		}
-		ND_PRINT(C_RESET, C_RESET " tell ");
+		ND_PRINT(C_RESET, " tell ");
 		atmarp_spaddr_print(ndo, ap, pro);
 		break;
 
 	case ARPOP_REPLY:
 		atmarp_spaddr_print(ndo, ap, pro);
-		ND_PRINT(C_RESET, C_RESET " is-at ");
+		ND_PRINT(C_RESET, " is-at ");
 		atmarp_addr_print(ndo, ATMSHA(ap), ATMSHRD_LEN(ap), ATMSSA(ap),
                                   ATMSSLN(ap));
 		break;
 
 	case ARPOP_INVREQUEST:
-		ND_PRINT(C_RESET, C_RESET "who-is ");
+		ND_PRINT(C_RESET, "who-is ");
 		atmarp_addr_print(ndo, ATMTHA(ap), ATMTHRD_LEN(ap), ATMTSA(ap),
 		    ATMTSLN(ap));
-		ND_PRINT(C_RESET, C_RESET " tell ");
+		ND_PRINT(C_RESET, " tell ");
 		atmarp_addr_print(ndo, ATMSHA(ap), ATMSHRD_LEN(ap), ATMSSA(ap),
 		    ATMSSLN(ap));
 		break;
@@ -326,12 +326,12 @@ atmarp_print(netdissect_options *ndo,
 	case ARPOP_INVREPLY:
 		atmarp_addr_print(ndo, ATMSHA(ap), ATMSHRD_LEN(ap), ATMSSA(ap),
 		    ATMSSLN(ap));
-		ND_PRINT(C_RESET, C_RESET "at ");
+		ND_PRINT(C_RESET, "at ");
 		atmarp_spaddr_print(ndo, ap, pro);
 		break;
 
 	case ARPOP_NAK:
-		ND_PRINT(C_RESET, C_RESET "for ");
+		ND_PRINT(C_RESET, "for ");
 		atmarp_spaddr_print(ndo, ap, pro);
 		break;
 
@@ -341,7 +341,7 @@ atmarp_print(netdissect_options *ndo,
 	}
 
  out:
-        ND_PRINT(C_RESET, C_RESET ", length %u", length);
+        ND_PRINT(C_RESET, ", length %u", length);
 }
 
 void
@@ -380,7 +380,7 @@ arp_print(netdissect_options *ndo,
 	ND_TCHECK_LEN(TPA(ap), PROTO_LEN(ap));
 
         if (!ndo->ndo_eflag) {
-            ND_PRINT(C_RESET, C_RESET "ARP, ");
+            ND_PRINT(C_RESET, "ARP, ");
         }
 
         /* print hardware type/len and proto type/len */
@@ -388,7 +388,7 @@ arp_print(netdissect_options *ndo,
 	    PROTO_LEN(ap) != 4 ||
             HRD_LEN(ap) == 0 ||
             ndo->ndo_vflag) {
-            ND_PRINT(C_RESET, C_RESET "%s (len %u), %s (len %u)",
+            ND_PRINT(C_RESET, "%s (len %u), %s (len %u)",
                       tok2str(arphrd_values, "Unknown Hardware (%u)", hrd),
                       HRD_LEN(ap),
                       tok2str(ethertype_values, "Unknown Protocol (0x%04x)", pro),
@@ -401,25 +401,25 @@ arp_print(netdissect_options *ndo,
 	}
 
         /* print operation */
-        ND_PRINT(C_RESET, C_RESET "%s%s ",
+        ND_PRINT(C_RESET, "%s%s ",
                ndo->ndo_vflag ? ", " : "",
                tok2str(arpop_values, "Unknown (%u)", op));
 
 	switch (op) {
 
 	case ARPOP_REQUEST:
-		ND_PRINT(C_RESET, C_RESET "who-has ");
+		ND_PRINT(C_RESET, "who-has ");
 		tpaddr_print_ip(ndo, ap, pro);
 		if (isnonzero(ndo, (const u_char *)THA(ap), HRD_LEN(ap)))
-			ND_PRINT(C_RESET, C_RESET " (%s)",
+			ND_PRINT(C_RESET, " (%s)",
 				  GET_LINKADDR_STRING(THA(ap), linkaddr, HRD_LEN(ap)));
-		ND_PRINT(C_RESET, C_RESET " tell ");
+		ND_PRINT(C_RESET, " tell ");
 		spaddr_print_ip(ndo, ap, pro);
 		break;
 
 	case ARPOP_REPLY:
 		spaddr_print_ip(ndo, ap, pro);
-		ND_PRINT(C_RESET, C_RESET " is-at %s",
+		ND_PRINT(C_RESET, " is-at %s",
                           GET_LINKADDR_STRING(SHA(ap), linkaddr, HRD_LEN(ap)));
 		break;
 
@@ -427,18 +427,18 @@ arp_print(netdissect_options *ndo,
 		/*
 		 * XXX - GET_LINKADDR_STRING() may return a pointer to
 		 * a static buffer, so we only have one call to it per
-		 * ND_PRINT(C_RESET, C_RESET ) call.
+		 * ND_PRINT(C_RESET, ) call.
 		 *
 		 * This should be done in a cleaner fashion.
 		 */
-		ND_PRINT(C_RESET, C_RESET "who-is %s",
+		ND_PRINT(C_RESET, "who-is %s",
 			  GET_LINKADDR_STRING(THA(ap), linkaddr, HRD_LEN(ap)));
-		ND_PRINT(C_RESET, C_RESET " tell %s",
+		ND_PRINT(C_RESET, " tell %s",
 			  GET_LINKADDR_STRING(SHA(ap), linkaddr, HRD_LEN(ap)));
 		break;
 
 	case ARPOP_REVREPLY:
-		ND_PRINT(C_RESET, C_RESET "%s at ",
+		ND_PRINT(C_RESET, "%s at ",
 			  GET_LINKADDR_STRING(THA(ap), linkaddr, HRD_LEN(ap)));
 		tpaddr_print_ip(ndo, ap, pro);
 		break;
@@ -447,18 +447,18 @@ arp_print(netdissect_options *ndo,
 		/*
 		 * XXX - GET_LINKADDR_STRING() may return a pointer to
 		 * a static buffer, so we only have one call to it per
-		 * ND_PRINT(C_RESET, C_RESET ) call.
+		 * ND_PRINT(C_RESET, ) call.
 		 *
 		 * This should be done in a cleaner fashion.
 		 */
-		ND_PRINT(C_RESET, C_RESET "who-is %s",
+		ND_PRINT(C_RESET, "who-is %s",
 			  GET_LINKADDR_STRING(THA(ap), linkaddr, HRD_LEN(ap)));
-		ND_PRINT(C_RESET, C_RESET " tell %s",
+		ND_PRINT(C_RESET, " tell %s",
 			  GET_LINKADDR_STRING(SHA(ap), linkaddr, HRD_LEN(ap)));
 		break;
 
 	case ARPOP_INVREPLY:
-		ND_PRINT(C_RESET, C_RESET "%s at ",
+		ND_PRINT(C_RESET, "%s at ",
 			  GET_LINKADDR_STRING(SHA(ap), linkaddr, HRD_LEN(ap)));
 		spaddr_print_ip(ndo, ap, pro);
 		break;
@@ -469,5 +469,5 @@ arp_print(netdissect_options *ndo,
 	}
 
  out:
-        ND_PRINT(C_RESET, C_RESET ", length %u", length);
+        ND_PRINT(C_RESET, ", length %u", length);
 }

--- a/print-arp.c
+++ b/print-arp.c
@@ -193,11 +193,11 @@ tpaddr_print_ip(netdissect_options *ndo,
 	        const struct arp_pkthdr *ap, u_short pro)
 {
 	if (pro != ETHERTYPE_IP && pro != ETHERTYPE_TRAIL)
-		ND_PRINT("<wrong proto type>");
+		ND_PRINT(C_RESET, C_RESET "<wrong proto type>");
 	else if (PROTO_LEN(ap) != 4)
-		ND_PRINT("<wrong len>");
+		ND_PRINT(C_RESET, C_RESET "<wrong len>");
 	else
-		ND_PRINT("%s", GET_IPADDR_STRING(TPA(ap)));
+		ND_PRINT(C_RESET, C_RESET "%s", GET_IPADDR_STRING(TPA(ap)));
 }
 
 static void
@@ -205,11 +205,11 @@ spaddr_print_ip(netdissect_options *ndo,
 	        const struct arp_pkthdr *ap, u_short pro)
 {
 	if (pro != ETHERTYPE_IP && pro != ETHERTYPE_TRAIL)
-		ND_PRINT("<wrong proto type>");
+		ND_PRINT(C_RESET, C_RESET "<wrong proto type>");
 	else if (PROTO_LEN(ap) != 4)
-		ND_PRINT("<wrong len>");
+		ND_PRINT(C_RESET, C_RESET "<wrong len>");
 	else
-		ND_PRINT("%s", GET_IPADDR_STRING(SPA(ap)));
+		ND_PRINT(C_RESET, C_RESET "%s", GET_IPADDR_STRING(SPA(ap)));
 }
 
 static void
@@ -218,11 +218,11 @@ atmarp_addr_print(netdissect_options *ndo,
     u_int srca_len)
 {
 	if (ha_len == 0)
-		ND_PRINT("<No address>");
+		ND_PRINT(C_RESET, C_RESET "<No address>");
 	else {
-		ND_PRINT("%s", GET_LINKADDR_STRING(ha, LINKADDR_ATM, ha_len));
+		ND_PRINT(C_RESET, C_RESET "%s", GET_LINKADDR_STRING(ha, LINKADDR_ATM, ha_len));
 		if (srca_len != 0)
-			ND_PRINT(",%s",
+			ND_PRINT(C_RESET, C_RESET ",%s",
 				  GET_LINKADDR_STRING(srca, LINKADDR_ATM, srca_len));
 	}
 }
@@ -232,11 +232,11 @@ atmarp_tpaddr_print(netdissect_options *ndo,
 		    const struct atmarp_pkthdr *ap, u_short pro)
 {
 	if (pro != ETHERTYPE_IP && pro != ETHERTYPE_TRAIL)
-		ND_PRINT("<wrong proto type>");
+		ND_PRINT(C_RESET, C_RESET "<wrong proto type>");
 	else if (ATMTPROTO_LEN(ap) != 4)
-		ND_PRINT("<wrong tplen>");
+		ND_PRINT(C_RESET, C_RESET "<wrong tplen>");
 	else
-		ND_PRINT("%s", GET_IPADDR_STRING(ATMTPA(ap)));
+		ND_PRINT(C_RESET, C_RESET "%s", GET_IPADDR_STRING(ATMTPA(ap)));
 }
 
 static void
@@ -244,11 +244,11 @@ atmarp_spaddr_print(netdissect_options *ndo,
 		    const struct atmarp_pkthdr *ap, u_short pro)
 {
 	if (pro != ETHERTYPE_IP && pro != ETHERTYPE_TRAIL)
-		ND_PRINT("<wrong proto type>");
+		ND_PRINT(C_RESET, C_RESET "<wrong proto type>");
 	else if (ATMSPROTO_LEN(ap) != 4)
-		ND_PRINT("<wrong splen>");
+		ND_PRINT(C_RESET, C_RESET "<wrong splen>");
 	else
-		ND_PRINT("%s", GET_IPADDR_STRING(ATMSPA(ap)));
+		ND_PRINT(C_RESET, C_RESET "%s", GET_IPADDR_STRING(ATMSPA(ap)));
 }
 
 static void
@@ -268,14 +268,14 @@ atmarp_print(netdissect_options *ndo,
 	ND_TCHECK_LEN(ATMTPA(ap), ATMTPROTO_LEN(ap));
 
         if (!ndo->ndo_eflag) {
-            ND_PRINT("ARP, ");
+            ND_PRINT(C_RESET, C_RESET "ARP, ");
         }
 
 	if ((pro != ETHERTYPE_IP && pro != ETHERTYPE_TRAIL) ||
 	    ATMSPROTO_LEN(ap) != 4 ||
             ATMTPROTO_LEN(ap) != 4 ||
             ndo->ndo_vflag) {
-                ND_PRINT("%s, %s (len %u/%u)",
+                ND_PRINT(C_RESET, C_RESET "%s, %s (len %u/%u)",
                           tok2str(arphrd_values, "Unknown Hardware (%u)", hrd),
                           tok2str(ethertype_values, "Unknown Protocol (0x%04x)", pro),
                           ATMSPROTO_LEN(ap),
@@ -288,37 +288,37 @@ atmarp_print(netdissect_options *ndo,
 	}
 
         /* print operation */
-        ND_PRINT("%s%s ",
+        ND_PRINT(C_RESET, C_RESET "%s%s ",
                ndo->ndo_vflag ? ", " : "",
                tok2str(arpop_values, "Unknown (%u)", op));
 
 	switch (op) {
 
 	case ARPOP_REQUEST:
-		ND_PRINT("who-has ");
+		ND_PRINT(C_RESET, C_RESET "who-has ");
 		atmarp_tpaddr_print(ndo, ap, pro);
 		if (ATMTHRD_LEN(ap) != 0) {
-			ND_PRINT(" (");
+			ND_PRINT(C_RESET, C_RESET " (");
 			atmarp_addr_print(ndo, ATMTHA(ap), ATMTHRD_LEN(ap),
 			    ATMTSA(ap), ATMTSLN(ap));
-			ND_PRINT(")");
+			ND_PRINT(C_RESET, C_RESET ")");
 		}
-		ND_PRINT(" tell ");
+		ND_PRINT(C_RESET, C_RESET " tell ");
 		atmarp_spaddr_print(ndo, ap, pro);
 		break;
 
 	case ARPOP_REPLY:
 		atmarp_spaddr_print(ndo, ap, pro);
-		ND_PRINT(" is-at ");
+		ND_PRINT(C_RESET, C_RESET " is-at ");
 		atmarp_addr_print(ndo, ATMSHA(ap), ATMSHRD_LEN(ap), ATMSSA(ap),
                                   ATMSSLN(ap));
 		break;
 
 	case ARPOP_INVREQUEST:
-		ND_PRINT("who-is ");
+		ND_PRINT(C_RESET, C_RESET "who-is ");
 		atmarp_addr_print(ndo, ATMTHA(ap), ATMTHRD_LEN(ap), ATMTSA(ap),
 		    ATMTSLN(ap));
-		ND_PRINT(" tell ");
+		ND_PRINT(C_RESET, C_RESET " tell ");
 		atmarp_addr_print(ndo, ATMSHA(ap), ATMSHRD_LEN(ap), ATMSSA(ap),
 		    ATMSSLN(ap));
 		break;
@@ -326,12 +326,12 @@ atmarp_print(netdissect_options *ndo,
 	case ARPOP_INVREPLY:
 		atmarp_addr_print(ndo, ATMSHA(ap), ATMSHRD_LEN(ap), ATMSSA(ap),
 		    ATMSSLN(ap));
-		ND_PRINT("at ");
+		ND_PRINT(C_RESET, C_RESET "at ");
 		atmarp_spaddr_print(ndo, ap, pro);
 		break;
 
 	case ARPOP_NAK:
-		ND_PRINT("for ");
+		ND_PRINT(C_RESET, C_RESET "for ");
 		atmarp_spaddr_print(ndo, ap, pro);
 		break;
 
@@ -341,7 +341,7 @@ atmarp_print(netdissect_options *ndo,
 	}
 
  out:
-        ND_PRINT(", length %u", length);
+        ND_PRINT(C_RESET, C_RESET ", length %u", length);
 }
 
 void
@@ -380,7 +380,7 @@ arp_print(netdissect_options *ndo,
 	ND_TCHECK_LEN(TPA(ap), PROTO_LEN(ap));
 
         if (!ndo->ndo_eflag) {
-            ND_PRINT("ARP, ");
+            ND_PRINT(C_RESET, C_RESET "ARP, ");
         }
 
         /* print hardware type/len and proto type/len */
@@ -388,7 +388,7 @@ arp_print(netdissect_options *ndo,
 	    PROTO_LEN(ap) != 4 ||
             HRD_LEN(ap) == 0 ||
             ndo->ndo_vflag) {
-            ND_PRINT("%s (len %u), %s (len %u)",
+            ND_PRINT(C_RESET, C_RESET "%s (len %u), %s (len %u)",
                       tok2str(arphrd_values, "Unknown Hardware (%u)", hrd),
                       HRD_LEN(ap),
                       tok2str(ethertype_values, "Unknown Protocol (0x%04x)", pro),
@@ -401,25 +401,25 @@ arp_print(netdissect_options *ndo,
 	}
 
         /* print operation */
-        ND_PRINT("%s%s ",
+        ND_PRINT(C_RESET, C_RESET "%s%s ",
                ndo->ndo_vflag ? ", " : "",
                tok2str(arpop_values, "Unknown (%u)", op));
 
 	switch (op) {
 
 	case ARPOP_REQUEST:
-		ND_PRINT("who-has ");
+		ND_PRINT(C_RESET, C_RESET "who-has ");
 		tpaddr_print_ip(ndo, ap, pro);
 		if (isnonzero(ndo, (const u_char *)THA(ap), HRD_LEN(ap)))
-			ND_PRINT(" (%s)",
+			ND_PRINT(C_RESET, C_RESET " (%s)",
 				  GET_LINKADDR_STRING(THA(ap), linkaddr, HRD_LEN(ap)));
-		ND_PRINT(" tell ");
+		ND_PRINT(C_RESET, C_RESET " tell ");
 		spaddr_print_ip(ndo, ap, pro);
 		break;
 
 	case ARPOP_REPLY:
 		spaddr_print_ip(ndo, ap, pro);
-		ND_PRINT(" is-at %s",
+		ND_PRINT(C_RESET, C_RESET " is-at %s",
                           GET_LINKADDR_STRING(SHA(ap), linkaddr, HRD_LEN(ap)));
 		break;
 
@@ -427,18 +427,18 @@ arp_print(netdissect_options *ndo,
 		/*
 		 * XXX - GET_LINKADDR_STRING() may return a pointer to
 		 * a static buffer, so we only have one call to it per
-		 * ND_PRINT() call.
+		 * ND_PRINT(C_RESET, C_RESET ) call.
 		 *
 		 * This should be done in a cleaner fashion.
 		 */
-		ND_PRINT("who-is %s",
+		ND_PRINT(C_RESET, C_RESET "who-is %s",
 			  GET_LINKADDR_STRING(THA(ap), linkaddr, HRD_LEN(ap)));
-		ND_PRINT(" tell %s",
+		ND_PRINT(C_RESET, C_RESET " tell %s",
 			  GET_LINKADDR_STRING(SHA(ap), linkaddr, HRD_LEN(ap)));
 		break;
 
 	case ARPOP_REVREPLY:
-		ND_PRINT("%s at ",
+		ND_PRINT(C_RESET, C_RESET "%s at ",
 			  GET_LINKADDR_STRING(THA(ap), linkaddr, HRD_LEN(ap)));
 		tpaddr_print_ip(ndo, ap, pro);
 		break;
@@ -447,18 +447,18 @@ arp_print(netdissect_options *ndo,
 		/*
 		 * XXX - GET_LINKADDR_STRING() may return a pointer to
 		 * a static buffer, so we only have one call to it per
-		 * ND_PRINT() call.
+		 * ND_PRINT(C_RESET, C_RESET ) call.
 		 *
 		 * This should be done in a cleaner fashion.
 		 */
-		ND_PRINT("who-is %s",
+		ND_PRINT(C_RESET, C_RESET "who-is %s",
 			  GET_LINKADDR_STRING(THA(ap), linkaddr, HRD_LEN(ap)));
-		ND_PRINT(" tell %s",
+		ND_PRINT(C_RESET, C_RESET " tell %s",
 			  GET_LINKADDR_STRING(SHA(ap), linkaddr, HRD_LEN(ap)));
 		break;
 
 	case ARPOP_INVREPLY:
-		ND_PRINT("%s at ",
+		ND_PRINT(C_RESET, C_RESET "%s at ",
 			  GET_LINKADDR_STRING(SHA(ap), linkaddr, HRD_LEN(ap)));
 		spaddr_print_ip(ndo, ap, pro);
 		break;
@@ -469,5 +469,5 @@ arp_print(netdissect_options *ndo,
 	}
 
  out:
-        ND_PRINT(", length %u", length);
+        ND_PRINT(C_RESET, C_RESET ", length %u", length);
 }

--- a/print-ascii.c
+++ b/print-ascii.c
@@ -72,7 +72,7 @@ ascii_print(netdissect_options *ndo,
 		length = caplength;
 		truncated = TRUE;
 	}
-	ND_PRINT("\n");
+	ND_PRINT(C_RESET, "\n");
 	while (length > 0) {
 		s = GET_U_1(cp);
 		cp++;
@@ -88,13 +88,13 @@ ascii_print(netdissect_options *ndo,
 			 * In the middle of a line, just print a '.'.
 			 */
 			if (length > 1 && GET_U_1(cp) != '\n')
-				ND_PRINT(".");
+				ND_PRINT(C_RESET, ".");
 		} else {
 			if (!ND_ASCII_ISGRAPH(s) &&
 			    (s != '\t' && s != ' ' && s != '\n'))
-				ND_PRINT(".");
+				ND_PRINT(C_RESET, ".");
 			else
-				ND_PRINT("%c", s);
+				ND_PRINT(C_RESET, "%c", s);
 		}
 	}
 	if (truncated)
@@ -134,7 +134,7 @@ hex_and_ascii_print_with_offset(netdissect_options *ndo, const char *indent,
 		i++;
 		if (i >= HEXDUMP_SHORTS_PER_LINE) {
 			*hsp = *asp = '\0';
-			ND_PRINT("%s0x%04x: %-*s  %s",
+			ND_PRINT(C_RESET, "%s0x%04x: %-*s  %s",
 			    indent, offset, HEXDUMP_HEXSTUFF_PER_LINE,
 			    hexstuff, asciistuff);
 			i = 0; hsp = hexstuff; asp = asciistuff;
@@ -153,7 +153,7 @@ hex_and_ascii_print_with_offset(netdissect_options *ndo, const char *indent,
 	}
 	if (i > 0) {
 		*hsp = *asp = '\0';
-		ND_PRINT("%s0x%04x: %-*s  %s",
+		ND_PRINT(C_RESET, "%s0x%04x: %-*s  %s",
 		     indent, offset, HEXDUMP_HEXSTUFF_PER_LINE,
 		     hexstuff, asciistuff);
 	}
@@ -190,19 +190,19 @@ hex_print_with_offset(netdissect_options *ndo,
 	i = 0;
 	while (nshorts != 0) {
 		if ((i++ % 8) == 0) {
-			ND_PRINT("%s0x%04x: ", indent, offset);
+			ND_PRINT(C_RESET, "%s0x%04x: ", indent, offset);
 			offset += HEXDUMP_BYTES_PER_LINE;
 		}
 		s = GET_U_1(cp);
 		cp++;
-		ND_PRINT(" %02x%02x", s, GET_U_1(cp));
+		ND_PRINT(C_RESET, " %02x%02x", s, GET_U_1(cp));
 		cp++;
 		nshorts--;
 	}
 	if (length & 1) {
 		if ((i % 8) == 0)
-			ND_PRINT("%s0x%04x: ", indent, offset);
-		ND_PRINT(" %02x", GET_U_1(cp));
+			ND_PRINT(C_RESET, "%s0x%04x: ", indent, offset);
+		ND_PRINT(C_RESET, " %02x", GET_U_1(cp));
 	}
 	if (truncated)
 		nd_trunc_longjmp(ndo);

--- a/print-atalk.c
+++ b/print-atalk.c
@@ -177,10 +177,10 @@ llap_print(netdissect_options *ndo,
 		ndo->ndo_protocol = "sddp";
 		ND_ICHECKMSG_U("SDDP length", length, <, ddpSSize);
 		sdp = (const struct atShortDDP *)bp;
-		ND_PRINT("%s.%s",
+		ND_PRINT(C_RESET, C_RESET "%s.%s",
 		    ataddr_string(ndo, 0, GET_U_1(lp->src)),
 		    ddpskt_string(ndo, GET_U_1(sdp->srcSkt)));
-		ND_PRINT(" > %s.%s:",
+		ND_PRINT(C_RESET, C_RESET " > %s.%s:",
 		    ataddr_string(ndo, 0, GET_U_1(lp->dst)),
 		    ddpskt_string(ndo, GET_U_1(sdp->dstSkt)));
 		bp += ddpSSize;
@@ -195,10 +195,10 @@ llap_print(netdissect_options *ndo,
 		ND_ICHECKMSG_U("DDP length", length, <, ddpSize);
 		dp = (const struct atDDP *)bp;
 		snet = GET_BE_U_2(dp->srcNet);
-		ND_PRINT("%s.%s",
+		ND_PRINT(C_RESET, C_RESET "%s.%s",
 			 ataddr_string(ndo, snet, GET_U_1(dp->srcNode)),
 			 ddpskt_string(ndo, GET_U_1(dp->srcSkt)));
-		ND_PRINT(" > %s.%s:",
+		ND_PRINT(C_RESET, C_RESET " > %s.%s:",
 		    ataddr_string(ndo, GET_BE_U_2(dp->dstNet), GET_U_1(dp->dstNode)),
 		    ddpskt_string(ndo, GET_U_1(dp->dstSkt)));
 		bp += ddpSize;
@@ -209,7 +209,7 @@ llap_print(netdissect_options *ndo,
 		break;
 
 	default:
-		ND_PRINT("%u > %u at-lap#%u %u",
+		ND_PRINT(C_RESET, C_RESET "%u > %u at-lap#%u %u",
 		    GET_U_1(lp->src), GET_U_1(lp->dst), GET_U_1(lp->type),
 		    length);
 		break;
@@ -234,14 +234,14 @@ atalk_print(netdissect_options *ndo,
 
 	ndo->ndo_protocol = "atalk";
         if(!ndo->ndo_eflag)
-            ND_PRINT("AT ");
+            ND_PRINT(C_RESET, C_RESET "AT ");
 
 	ND_ICHECK_U(length, <, ddpSize);
 	dp = (const struct atDDP *)bp;
 	snet = GET_BE_U_2(dp->srcNet);
-	ND_PRINT("%s.%s", ataddr_string(ndo, snet, GET_U_1(dp->srcNode)),
+	ND_PRINT(C_RESET, C_RESET "%s.%s", ataddr_string(ndo, snet, GET_U_1(dp->srcNode)),
 		 ddpskt_string(ndo, GET_U_1(dp->srcSkt)));
-	ND_PRINT(" > %s.%s: ",
+	ND_PRINT(C_RESET, C_RESET " > %s.%s: ",
 	       ataddr_string(ndo, GET_BE_U_2(dp->dstNet), GET_U_1(dp->dstNode)),
 	       ddpskt_string(ndo, GET_U_1(dp->dstSkt)));
 	bp += ddpSize;
@@ -265,7 +265,7 @@ aarp_print(netdissect_options *ndo,
 	GET_U_1(&ap->member[3]))
 
 	ndo->ndo_protocol = "aarp";
-	ND_PRINT("aarp ");
+	ND_PRINT(C_RESET, C_RESET "aarp ");
 	ap = (const struct aarp *)bp;
 	ND_ICHECK_ZU(length, <, sizeof(*ap));
 	ND_TCHECK_SIZE(ap);
@@ -275,18 +275,18 @@ aarp_print(netdissect_options *ndo,
 		switch (GET_BE_U_2(ap->op)) {
 
 		case 1:				/* request */
-			ND_PRINT("who-has %s tell %s", AT(pdaddr), AT(psaddr));
+			ND_PRINT(C_RESET, C_RESET "who-has %s tell %s", AT(pdaddr), AT(psaddr));
 			return;
 
 		case 2:				/* response */
-			ND_PRINT("reply %s is-at %s", AT(psaddr), GET_ETHERADDR_STRING(ap->hsaddr));
+			ND_PRINT(C_RESET, C_RESET "reply %s is-at %s", AT(psaddr), GET_ETHERADDR_STRING(ap->hsaddr));
 			return;
 
 		case 3:				/* probe (oy!) */
-			ND_PRINT("probe %s tell %s", AT(pdaddr), AT(psaddr));
+			ND_PRINT(C_RESET, C_RESET "probe %s tell %s", AT(pdaddr), AT(psaddr));
 			return;
 		}
-	ND_PRINT("len %u op %u htype %u ptype %#x halen %u palen %u",
+	ND_PRINT(C_RESET, C_RESET "len %u op %u htype %u ptype %#x halen %u palen %u",
 	    length, GET_BE_U_2(ap->op), GET_BE_U_2(ap->htype),
 	    GET_BE_U_2(ap->ptype), GET_U_1(ap->halen), GET_U_1(ap->palen));
 	return;
@@ -318,7 +318,7 @@ ddp_print(netdissect_options *ndo,
 		break;
 
 	default:
-		ND_PRINT(" at-%s %u", tok2str(type2str, NULL, t), length);
+		ND_PRINT(C_RESET, C_RESET " at-%s %u", tok2str(type2str, NULL, t), length);
 		break;
 	}
 }
@@ -337,81 +337,81 @@ atp_print(netdissect_options *ndo,
 	switch (control & 0xc0) {
 
 	case atpReqCode:
-		ND_PRINT(" atp-req%s %u",
+		ND_PRINT(C_RESET, C_RESET " atp-req%s %u",
 			     control & atpXO? " " : "*",
 			     GET_BE_U_2(ap->transID));
 
 		atp_bitmap_print(ndo, GET_U_1(ap->bitmap));
 
 		if (length != 0)
-			ND_PRINT(" [len=%u]", length);
+			ND_PRINT(C_RESET, C_RESET " [len=%u]", length);
 
 		switch (control & (atpEOM|atpSTS)) {
 		case atpEOM:
-			ND_PRINT(" [EOM]");
+			ND_PRINT(C_RESET, C_RESET " [EOM]");
 			break;
 		case atpSTS:
-			ND_PRINT(" [STS]");
+			ND_PRINT(C_RESET, C_RESET " [STS]");
 			break;
 		case atpEOM|atpSTS:
-			ND_PRINT(" [EOM,STS]");
+			ND_PRINT(C_RESET, C_RESET " [EOM,STS]");
 			break;
 		}
 		break;
 
 	case atpRspCode:
-		ND_PRINT(" atp-resp%s%u:%u (%u)",
+		ND_PRINT(C_RESET, C_RESET " atp-resp%s%u:%u (%u)",
 			     control & atpEOM? "*" : " ",
 			     GET_BE_U_2(ap->transID), GET_U_1(ap->bitmap),
 			     length);
 		switch (control & (atpXO|atpSTS)) {
 		case atpXO:
-			ND_PRINT(" [XO]");
+			ND_PRINT(C_RESET, C_RESET " [XO]");
 			break;
 		case atpSTS:
-			ND_PRINT(" [STS]");
+			ND_PRINT(C_RESET, C_RESET " [STS]");
 			break;
 		case atpXO|atpSTS:
-			ND_PRINT(" [XO,STS]");
+			ND_PRINT(C_RESET, C_RESET " [XO,STS]");
 			break;
 		}
 		break;
 
 	case atpRelCode:
-		ND_PRINT(" atp-rel  %u", GET_BE_U_2(ap->transID));
+		ND_PRINT(C_RESET, C_RESET " atp-rel  %u", GET_BE_U_2(ap->transID));
 
 		atp_bitmap_print(ndo, GET_U_1(ap->bitmap));
 
 		/* length should be zero */
 		if (length)
-			ND_PRINT(" [len=%u]", length);
+			ND_PRINT(C_RESET, C_RESET " [len=%u]", length);
 
 		/* there shouldn't be any control flags */
 		if (control & (atpXO|atpEOM|atpSTS)) {
 			char c = '[';
 			if (control & atpXO) {
-				ND_PRINT("%cXO", c);
+				ND_PRINT(C_RESET, C_RESET "%cXO", c);
 				c = ',';
 			}
 			if (control & atpEOM) {
-				ND_PRINT("%cEOM", c);
+				ND_PRINT(C_RESET, C_RESET "%cEOM", c);
 				c = ',';
 			}
 			if (control & atpSTS) {
-				ND_PRINT("%cSTS", c);
+				ND_PRINT(C_RESET, C_RESET "%cSTS", c);
 			}
-			ND_PRINT("]");
+			ND_PRINT(C_RESET, C_RESET "]");
 		}
 		break;
 
 	default:
-		ND_PRINT(" atp-0x%x  %u (%u)", control,
+		ND_PRINT(C_RESET, C_RESET " atp-0x%x  %u (%u)", control,
 			     GET_BE_U_2(ap->transID), length);
 		break;
 	}
 	data = GET_BE_U_4(ap->userData);
 	if (data != 0)
-		ND_PRINT(" 0x%x", data);
+		ND_PRINT(C_RESET, C_RESET " 0x%x", data);
 	return;
 invalid:
 	nd_print_invalid(ndo);
@@ -432,19 +432,19 @@ atp_bitmap_print(netdissect_options *ndo,
 		char c = '<';
 		for (i = 0; bm; ++i) {
 			if (bm & 1) {
-				ND_PRINT("%c%u", c, i);
+				ND_PRINT(C_RESET, C_RESET "%c%u", c, i);
 				c = ',';
 			}
 			bm >>= 1;
 		}
-		ND_PRINT(">");
+		ND_PRINT(C_RESET, C_RESET ">");
 	} else {
 		for (i = 0; bm; ++i)
 			bm >>= 1;
 		if (i > 1)
-			ND_PRINT("<0-%u>", i - 1);
+			ND_PRINT(C_RESET, C_RESET "<0-%u>", i - 1);
 		else
-			ND_PRINT("<0>");
+			ND_PRINT(C_RESET, C_RESET "<0>");
 	}
 }
 
@@ -462,13 +462,13 @@ nbp_print(netdissect_options *ndo,
 	ND_ICHECKMSG_U("undersized-nbp", length, <, nbpHeaderSize + 8);
 	length -= nbpHeaderSize;
 	control = GET_U_1(np->control);
-	ND_PRINT(" nbp-%s", tok2str(nbp_str, "0x%x", control & 0xf0));
-	ND_PRINT(" %u", GET_U_1(np->id));
+	ND_PRINT(C_RESET, C_RESET " nbp-%s", tok2str(nbp_str, "0x%x", control & 0xf0));
+	ND_PRINT(C_RESET, C_RESET " %u", GET_U_1(np->id));
 	switch (control & 0xf0) {
 
 	case nbpBrRq:
 	case nbpLkUp:
-		ND_PRINT(":");
+		ND_PRINT(C_RESET, C_RESET ":");
 		(void)nbp_name_print(ndo, tp);
 		/*
 		 * look for anomalies: the spec says there can only
@@ -476,20 +476,20 @@ nbp_print(netdissect_options *ndo,
 		 * address and the enumerator should be zero.
 		 */
 		if ((control & 0xf) != 1)
-			ND_PRINT(" [ntup=%u]", control & 0xf);
+			ND_PRINT(C_RESET, C_RESET " [ntup=%u]", control & 0xf);
 		if (GET_U_1(tp->enumerator))
-			ND_PRINT(" [enum=%u]", GET_U_1(tp->enumerator));
+			ND_PRINT(C_RESET, C_RESET " [enum=%u]", GET_U_1(tp->enumerator));
 		if (GET_BE_U_2(tp->net) != snet ||
 		    GET_U_1(tp->node) != snode ||
 		    GET_U_1(tp->skt) != skt)
-			ND_PRINT(" [addr=%s.%u]",
+			ND_PRINT(C_RESET, C_RESET " [addr=%s.%u]",
 			    ataddr_string(ndo, GET_BE_U_2(tp->net),
 					  GET_U_1(tp->node)),
 			    GET_U_1(tp->skt));
 		break;
 
 	case nbpLkUpReply:
-		ND_PRINT(":");
+		ND_PRINT(C_RESET, C_RESET ":");
 
 		/* print each of the tuples in the reply */
 		for (i = control & 0xf; i != 0 && tp; i--)
@@ -497,7 +497,7 @@ nbp_print(netdissect_options *ndo,
 		break;
 
 	default:
-		ND_PRINT("  (%u)", length);
+		ND_PRINT(C_RESET, C_RESET "  (%u)", length);
 		break;
 	}
 	return;
@@ -517,7 +517,7 @@ print_cstring(netdissect_options *ndo,
 
 	/* Spec says string can be at most 32 bytes long */
 	if (length > 32) {
-		ND_PRINT("[len=%u]", length);
+		ND_PRINT(C_RESET, C_RESET "[len=%u]", length);
 		ND_TCHECK_LEN(cp, length);
 		return NULL;
 	}
@@ -536,16 +536,16 @@ nbp_tuple_print(netdissect_options *ndo,
 
 	/* if the enumerator isn't 1, print it */
 	if (GET_U_1(tp->enumerator) != 1)
-		ND_PRINT("(%u)", GET_U_1(tp->enumerator));
+		ND_PRINT(C_RESET, C_RESET "(%u)", GET_U_1(tp->enumerator));
 
 	/* if the socket doesn't match the src socket, print it */
 	if (GET_U_1(tp->skt) != skt)
-		ND_PRINT(" %u", GET_U_1(tp->skt));
+		ND_PRINT(C_RESET, C_RESET " %u", GET_U_1(tp->skt));
 
 	/* if the address doesn't match the src address, it's an anomaly */
 	if (GET_BE_U_2(tp->net) != snet ||
 	    GET_U_1(tp->node) != snode)
-		ND_PRINT(" [addr=%s]",
+		ND_PRINT(C_RESET, C_RESET " [addr=%s]",
 		    ataddr_string(ndo, GET_BE_U_2(tp->net), GET_U_1(tp->node)));
 
 	return (tpn);
@@ -557,18 +557,18 @@ nbp_name_print(netdissect_options *ndo,
 {
 	const u_char *cp = (const u_char *)tp + nbpTupleSize;
 
-	ND_PRINT(" ");
+	ND_PRINT(C_RESET, C_RESET " ");
 
 	/* Object */
-	ND_PRINT("\"");
+	ND_PRINT(C_RESET, C_RESET "\"");
 	if ((cp = print_cstring(ndo, cp)) != NULL) {
 		/* Type */
-		ND_PRINT(":");
+		ND_PRINT(C_RESET, C_RESET ":");
 		if ((cp = print_cstring(ndo, cp)) != NULL) {
 			/* Zone */
-			ND_PRINT("@");
+			ND_PRINT(C_RESET, C_RESET "@");
 			if ((cp = print_cstring(ndo, cp)) != NULL)
-				ND_PRINT("\"");
+				ND_PRINT(C_RESET, C_RESET "\"");
 		}
 	}
 	return ((const struct atNBPtuple *)cp);

--- a/print-atalk.c
+++ b/print-atalk.c
@@ -177,10 +177,10 @@ llap_print(netdissect_options *ndo,
 		ndo->ndo_protocol = "sddp";
 		ND_ICHECKMSG_U("SDDP length", length, <, ddpSSize);
 		sdp = (const struct atShortDDP *)bp;
-		ND_PRINT(C_RESET, C_RESET "%s.%s",
+		ND_PRINT(C_RESET, "%s.%s",
 		    ataddr_string(ndo, 0, GET_U_1(lp->src)),
 		    ddpskt_string(ndo, GET_U_1(sdp->srcSkt)));
-		ND_PRINT(C_RESET, C_RESET " > %s.%s:",
+		ND_PRINT(C_RESET, " > %s.%s:",
 		    ataddr_string(ndo, 0, GET_U_1(lp->dst)),
 		    ddpskt_string(ndo, GET_U_1(sdp->dstSkt)));
 		bp += ddpSSize;
@@ -195,10 +195,10 @@ llap_print(netdissect_options *ndo,
 		ND_ICHECKMSG_U("DDP length", length, <, ddpSize);
 		dp = (const struct atDDP *)bp;
 		snet = GET_BE_U_2(dp->srcNet);
-		ND_PRINT(C_RESET, C_RESET "%s.%s",
+		ND_PRINT(C_RESET, "%s.%s",
 			 ataddr_string(ndo, snet, GET_U_1(dp->srcNode)),
 			 ddpskt_string(ndo, GET_U_1(dp->srcSkt)));
-		ND_PRINT(C_RESET, C_RESET " > %s.%s:",
+		ND_PRINT(C_RESET, " > %s.%s:",
 		    ataddr_string(ndo, GET_BE_U_2(dp->dstNet), GET_U_1(dp->dstNode)),
 		    ddpskt_string(ndo, GET_U_1(dp->dstSkt)));
 		bp += ddpSize;
@@ -209,7 +209,7 @@ llap_print(netdissect_options *ndo,
 		break;
 
 	default:
-		ND_PRINT(C_RESET, C_RESET "%u > %u at-lap#%u %u",
+		ND_PRINT(C_RESET, "%u > %u at-lap#%u %u",
 		    GET_U_1(lp->src), GET_U_1(lp->dst), GET_U_1(lp->type),
 		    length);
 		break;
@@ -234,14 +234,14 @@ atalk_print(netdissect_options *ndo,
 
 	ndo->ndo_protocol = "atalk";
         if(!ndo->ndo_eflag)
-            ND_PRINT(C_RESET, C_RESET "AT ");
+            ND_PRINT(C_RESET, "AT ");
 
 	ND_ICHECK_U(length, <, ddpSize);
 	dp = (const struct atDDP *)bp;
 	snet = GET_BE_U_2(dp->srcNet);
-	ND_PRINT(C_RESET, C_RESET "%s.%s", ataddr_string(ndo, snet, GET_U_1(dp->srcNode)),
+	ND_PRINT(C_RESET, "%s.%s", ataddr_string(ndo, snet, GET_U_1(dp->srcNode)),
 		 ddpskt_string(ndo, GET_U_1(dp->srcSkt)));
-	ND_PRINT(C_RESET, C_RESET " > %s.%s: ",
+	ND_PRINT(C_RESET, " > %s.%s: ",
 	       ataddr_string(ndo, GET_BE_U_2(dp->dstNet), GET_U_1(dp->dstNode)),
 	       ddpskt_string(ndo, GET_U_1(dp->dstSkt)));
 	bp += ddpSize;
@@ -265,7 +265,7 @@ aarp_print(netdissect_options *ndo,
 	GET_U_1(&ap->member[3]))
 
 	ndo->ndo_protocol = "aarp";
-	ND_PRINT(C_RESET, C_RESET "aarp ");
+	ND_PRINT(C_RESET, "aarp ");
 	ap = (const struct aarp *)bp;
 	ND_ICHECK_ZU(length, <, sizeof(*ap));
 	ND_TCHECK_SIZE(ap);
@@ -275,18 +275,18 @@ aarp_print(netdissect_options *ndo,
 		switch (GET_BE_U_2(ap->op)) {
 
 		case 1:				/* request */
-			ND_PRINT(C_RESET, C_RESET "who-has %s tell %s", AT(pdaddr), AT(psaddr));
+			ND_PRINT(C_RESET, "who-has %s tell %s", AT(pdaddr), AT(psaddr));
 			return;
 
 		case 2:				/* response */
-			ND_PRINT(C_RESET, C_RESET "reply %s is-at %s", AT(psaddr), GET_ETHERADDR_STRING(ap->hsaddr));
+			ND_PRINT(C_RESET, "reply %s is-at %s", AT(psaddr), GET_ETHERADDR_STRING(ap->hsaddr));
 			return;
 
 		case 3:				/* probe (oy!) */
-			ND_PRINT(C_RESET, C_RESET "probe %s tell %s", AT(pdaddr), AT(psaddr));
+			ND_PRINT(C_RESET, "probe %s tell %s", AT(pdaddr), AT(psaddr));
 			return;
 		}
-	ND_PRINT(C_RESET, C_RESET "len %u op %u htype %u ptype %#x halen %u palen %u",
+	ND_PRINT(C_RESET, "len %u op %u htype %u ptype %#x halen %u palen %u",
 	    length, GET_BE_U_2(ap->op), GET_BE_U_2(ap->htype),
 	    GET_BE_U_2(ap->ptype), GET_U_1(ap->halen), GET_U_1(ap->palen));
 	return;
@@ -318,7 +318,7 @@ ddp_print(netdissect_options *ndo,
 		break;
 
 	default:
-		ND_PRINT(C_RESET, C_RESET " at-%s %u", tok2str(type2str, NULL, t), length);
+		ND_PRINT(C_RESET, " at-%s %u", tok2str(type2str, NULL, t), length);
 		break;
 	}
 }
@@ -337,81 +337,81 @@ atp_print(netdissect_options *ndo,
 	switch (control & 0xc0) {
 
 	case atpReqCode:
-		ND_PRINT(C_RESET, C_RESET " atp-req%s %u",
+		ND_PRINT(C_RESET, " atp-req%s %u",
 			     control & atpXO? " " : "*",
 			     GET_BE_U_2(ap->transID));
 
 		atp_bitmap_print(ndo, GET_U_1(ap->bitmap));
 
 		if (length != 0)
-			ND_PRINT(C_RESET, C_RESET " [len=%u]", length);
+			ND_PRINT(C_RESET, " [len=%u]", length);
 
 		switch (control & (atpEOM|atpSTS)) {
 		case atpEOM:
-			ND_PRINT(C_RESET, C_RESET " [EOM]");
+			ND_PRINT(C_RESET, " [EOM]");
 			break;
 		case atpSTS:
-			ND_PRINT(C_RESET, C_RESET " [STS]");
+			ND_PRINT(C_RESET, " [STS]");
 			break;
 		case atpEOM|atpSTS:
-			ND_PRINT(C_RESET, C_RESET " [EOM,STS]");
+			ND_PRINT(C_RESET, " [EOM,STS]");
 			break;
 		}
 		break;
 
 	case atpRspCode:
-		ND_PRINT(C_RESET, C_RESET " atp-resp%s%u:%u (%u)",
+		ND_PRINT(C_RESET, " atp-resp%s%u:%u (%u)",
 			     control & atpEOM? "*" : " ",
 			     GET_BE_U_2(ap->transID), GET_U_1(ap->bitmap),
 			     length);
 		switch (control & (atpXO|atpSTS)) {
 		case atpXO:
-			ND_PRINT(C_RESET, C_RESET " [XO]");
+			ND_PRINT(C_RESET, " [XO]");
 			break;
 		case atpSTS:
-			ND_PRINT(C_RESET, C_RESET " [STS]");
+			ND_PRINT(C_RESET, " [STS]");
 			break;
 		case atpXO|atpSTS:
-			ND_PRINT(C_RESET, C_RESET " [XO,STS]");
+			ND_PRINT(C_RESET, " [XO,STS]");
 			break;
 		}
 		break;
 
 	case atpRelCode:
-		ND_PRINT(C_RESET, C_RESET " atp-rel  %u", GET_BE_U_2(ap->transID));
+		ND_PRINT(C_RESET, " atp-rel  %u", GET_BE_U_2(ap->transID));
 
 		atp_bitmap_print(ndo, GET_U_1(ap->bitmap));
 
 		/* length should be zero */
 		if (length)
-			ND_PRINT(C_RESET, C_RESET " [len=%u]", length);
+			ND_PRINT(C_RESET, " [len=%u]", length);
 
 		/* there shouldn't be any control flags */
 		if (control & (atpXO|atpEOM|atpSTS)) {
 			char c = '[';
 			if (control & atpXO) {
-				ND_PRINT(C_RESET, C_RESET "%cXO", c);
+				ND_PRINT(C_RESET, "%cXO", c);
 				c = ',';
 			}
 			if (control & atpEOM) {
-				ND_PRINT(C_RESET, C_RESET "%cEOM", c);
+				ND_PRINT(C_RESET, "%cEOM", c);
 				c = ',';
 			}
 			if (control & atpSTS) {
-				ND_PRINT(C_RESET, C_RESET "%cSTS", c);
+				ND_PRINT(C_RESET, "%cSTS", c);
 			}
-			ND_PRINT(C_RESET, C_RESET "]");
+			ND_PRINT(C_RESET, "]");
 		}
 		break;
 
 	default:
-		ND_PRINT(C_RESET, C_RESET " atp-0x%x  %u (%u)", control,
+		ND_PRINT(C_RESET, " atp-0x%x  %u (%u)", control,
 			     GET_BE_U_2(ap->transID), length);
 		break;
 	}
 	data = GET_BE_U_4(ap->userData);
 	if (data != 0)
-		ND_PRINT(C_RESET, C_RESET " 0x%x", data);
+		ND_PRINT(C_RESET, " 0x%x", data);
 	return;
 invalid:
 	nd_print_invalid(ndo);
@@ -432,19 +432,19 @@ atp_bitmap_print(netdissect_options *ndo,
 		char c = '<';
 		for (i = 0; bm; ++i) {
 			if (bm & 1) {
-				ND_PRINT(C_RESET, C_RESET "%c%u", c, i);
+				ND_PRINT(C_RESET, "%c%u", c, i);
 				c = ',';
 			}
 			bm >>= 1;
 		}
-		ND_PRINT(C_RESET, C_RESET ">");
+		ND_PRINT(C_RESET, ">");
 	} else {
 		for (i = 0; bm; ++i)
 			bm >>= 1;
 		if (i > 1)
-			ND_PRINT(C_RESET, C_RESET "<0-%u>", i - 1);
+			ND_PRINT(C_RESET, "<0-%u>", i - 1);
 		else
-			ND_PRINT(C_RESET, C_RESET "<0>");
+			ND_PRINT(C_RESET, "<0>");
 	}
 }
 
@@ -462,13 +462,13 @@ nbp_print(netdissect_options *ndo,
 	ND_ICHECKMSG_U("undersized-nbp", length, <, nbpHeaderSize + 8);
 	length -= nbpHeaderSize;
 	control = GET_U_1(np->control);
-	ND_PRINT(C_RESET, C_RESET " nbp-%s", tok2str(nbp_str, "0x%x", control & 0xf0));
-	ND_PRINT(C_RESET, C_RESET " %u", GET_U_1(np->id));
+	ND_PRINT(C_RESET, " nbp-%s", tok2str(nbp_str, "0x%x", control & 0xf0));
+	ND_PRINT(C_RESET, " %u", GET_U_1(np->id));
 	switch (control & 0xf0) {
 
 	case nbpBrRq:
 	case nbpLkUp:
-		ND_PRINT(C_RESET, C_RESET ":");
+		ND_PRINT(C_RESET, ":");
 		(void)nbp_name_print(ndo, tp);
 		/*
 		 * look for anomalies: the spec says there can only
@@ -476,20 +476,20 @@ nbp_print(netdissect_options *ndo,
 		 * address and the enumerator should be zero.
 		 */
 		if ((control & 0xf) != 1)
-			ND_PRINT(C_RESET, C_RESET " [ntup=%u]", control & 0xf);
+			ND_PRINT(C_RESET, " [ntup=%u]", control & 0xf);
 		if (GET_U_1(tp->enumerator))
-			ND_PRINT(C_RESET, C_RESET " [enum=%u]", GET_U_1(tp->enumerator));
+			ND_PRINT(C_RESET, " [enum=%u]", GET_U_1(tp->enumerator));
 		if (GET_BE_U_2(tp->net) != snet ||
 		    GET_U_1(tp->node) != snode ||
 		    GET_U_1(tp->skt) != skt)
-			ND_PRINT(C_RESET, C_RESET " [addr=%s.%u]",
+			ND_PRINT(C_RESET, " [addr=%s.%u]",
 			    ataddr_string(ndo, GET_BE_U_2(tp->net),
 					  GET_U_1(tp->node)),
 			    GET_U_1(tp->skt));
 		break;
 
 	case nbpLkUpReply:
-		ND_PRINT(C_RESET, C_RESET ":");
+		ND_PRINT(C_RESET, ":");
 
 		/* print each of the tuples in the reply */
 		for (i = control & 0xf; i != 0 && tp; i--)
@@ -497,7 +497,7 @@ nbp_print(netdissect_options *ndo,
 		break;
 
 	default:
-		ND_PRINT(C_RESET, C_RESET "  (%u)", length);
+		ND_PRINT(C_RESET, "  (%u)", length);
 		break;
 	}
 	return;
@@ -517,7 +517,7 @@ print_cstring(netdissect_options *ndo,
 
 	/* Spec says string can be at most 32 bytes long */
 	if (length > 32) {
-		ND_PRINT(C_RESET, C_RESET "[len=%u]", length);
+		ND_PRINT(C_RESET, "[len=%u]", length);
 		ND_TCHECK_LEN(cp, length);
 		return NULL;
 	}
@@ -536,16 +536,16 @@ nbp_tuple_print(netdissect_options *ndo,
 
 	/* if the enumerator isn't 1, print it */
 	if (GET_U_1(tp->enumerator) != 1)
-		ND_PRINT(C_RESET, C_RESET "(%u)", GET_U_1(tp->enumerator));
+		ND_PRINT(C_RESET, "(%u)", GET_U_1(tp->enumerator));
 
 	/* if the socket doesn't match the src socket, print it */
 	if (GET_U_1(tp->skt) != skt)
-		ND_PRINT(C_RESET, C_RESET " %u", GET_U_1(tp->skt));
+		ND_PRINT(C_RESET, " %u", GET_U_1(tp->skt));
 
 	/* if the address doesn't match the src address, it's an anomaly */
 	if (GET_BE_U_2(tp->net) != snet ||
 	    GET_U_1(tp->node) != snode)
-		ND_PRINT(C_RESET, C_RESET " [addr=%s]",
+		ND_PRINT(C_RESET, " [addr=%s]",
 		    ataddr_string(ndo, GET_BE_U_2(tp->net), GET_U_1(tp->node)));
 
 	return (tpn);
@@ -557,18 +557,18 @@ nbp_name_print(netdissect_options *ndo,
 {
 	const u_char *cp = (const u_char *)tp + nbpTupleSize;
 
-	ND_PRINT(C_RESET, C_RESET " ");
+	ND_PRINT(C_RESET, " ");
 
 	/* Object */
-	ND_PRINT(C_RESET, C_RESET "\"");
+	ND_PRINT(C_RESET, "\"");
 	if ((cp = print_cstring(ndo, cp)) != NULL) {
 		/* Type */
-		ND_PRINT(C_RESET, C_RESET ":");
+		ND_PRINT(C_RESET, ":");
 		if ((cp = print_cstring(ndo, cp)) != NULL) {
 			/* Zone */
-			ND_PRINT(C_RESET, C_RESET "@");
+			ND_PRINT(C_RESET, "@");
 			if ((cp = print_cstring(ndo, cp)) != NULL)
-				ND_PRINT(C_RESET, C_RESET "\"");
+				ND_PRINT(C_RESET, "\"");
 		}
 	}
 	return ((const struct atNBPtuple *)cp);

--- a/print-atm.c
+++ b/print-atm.c
@@ -248,7 +248,7 @@ atm_if_print(netdissect_options *ndo,
         /* Cisco Style NLPID ? */
         if (GET_U_1(p) == LLC_UI) {
             if (ndo->ndo_eflag)
-                ND_PRINT("CNLPID ");
+                ND_PRINT(C_RESET, "CNLPID ");
             ndo->ndo_ll_hdr_len += 1;
             isoclns_print(ndo, p + 1, length - 1);
             return;
@@ -287,7 +287,7 @@ atm_if_print(netdissect_options *ndo,
 		 * new DLT_IEEE802_6 value if we added it?
 		 */
 		if (ndo->ndo_eflag)
-			ND_PRINT("%08x%08x %08x%08x ",
+			ND_PRINT(C_RESET, "%08x%08x %08x%08x ",
 			       GET_BE_U_4(p),
 			       GET_BE_U_4(p + 4),
 			       GET_BE_U_4(p + 8),
@@ -336,8 +336,8 @@ sig_print(netdissect_options *ndo,
 		 * protocol:Q.2931 for User to Network Interface
 		 * (UNI 3.1) signalling
 		 */
-		ND_PRINT("Q.2931");
-		ND_PRINT(":%s ",
+		ND_PRINT(C_RESET, "Q.2931");
+		ND_PRINT(C_RESET, ":%s ",
 		    tok2str(msgtype2str, "msgtype#%u", GET_U_1(p + MSG_TYPE_POS)));
 
 		/*
@@ -347,10 +347,10 @@ sig_print(netdissect_options *ndo,
 		 * the call reference.
 		 */
 		call_ref = GET_BE_U_3(p + CALL_REF_POS);
-		ND_PRINT("CALL_REF:0x%06x", call_ref);
+		ND_PRINT(C_RESET, "CALL_REF:0x%06x", call_ref);
 	} else {
 		/* SSCOP with some unknown protocol atop it */
-		ND_PRINT("SSCOP, proto %u ", GET_U_1(p + PROTO_POS));
+		ND_PRINT(C_RESET, "SSCOP, proto %u ", GET_U_1(p + PROTO_POS));
 	}
 }
 
@@ -364,7 +364,7 @@ atm_print(netdissect_options *ndo,
 {
 	ndo->ndo_protocol = "atm";
 	if (ndo->ndo_eflag)
-		ND_PRINT("VPI:%u VCI:%u ", vpi, vci);
+		ND_PRINT(C_RESET, "VPI:%u VCI:%u ", vpi, vci);
 
 	if (vpi == 0) {
 		switch (vci) {
@@ -374,7 +374,7 @@ atm_print(netdissect_options *ndo,
 			return;
 
 		case VCI_BCC:
-			ND_PRINT("broadcast sig: ");
+			ND_PRINT(C_RESET, "broadcast sig: ");
 			return;
 
 		case VCI_OAMF4SC: /* fall through */
@@ -383,11 +383,11 @@ atm_print(netdissect_options *ndo,
 			return;
 
 		case VCI_METAC:
-			ND_PRINT("meta: ");
+			ND_PRINT(C_RESET, "meta: ");
 			return;
 
 		case VCI_ILMIC:
-			ND_PRINT("ilmi: ");
+			ND_PRINT(C_RESET, "ilmi: ");
 			snmp_print(ndo, p, length);
 			return;
 		}
@@ -447,7 +447,7 @@ oam_print(netdissect_options *ndo,
     payload = (cell_header>>1)&0x7;
     clp = cell_header&0x1;
 
-    ND_PRINT("%s, vpi %u, vci %u, payload [ %s ], clp %u, length %u",
+    ND_PRINT(C_RESET, "%s, vpi %u, vci %u, payload [ %s ], clp %u, length %u",
            tok2str(oam_f_values, "OAM F5", vci),
            vpi, vci,
            tok2str(atm_pty_values, "Unknown", payload),
@@ -457,15 +457,15 @@ oam_print(netdissect_options *ndo,
         return;
     }
 
-    ND_PRINT("\n\tcell-type %s (%u)",
+    ND_PRINT(C_RESET, "\n\tcell-type %s (%u)",
            tok2str(oam_celltype_values, "unknown", cell_type),
            cell_type);
 
     oam_functype_str = uint2tokary(oam_celltype2tokary, cell_type);
     if (oam_functype_str == NULL)
-        ND_PRINT(", func-type unknown (%u)", func_type);
+        ND_PRINT(C_RESET, ", func-type unknown (%u)", func_type);
     else
-        ND_PRINT(", func-type %s (%u)",
+        ND_PRINT(C_RESET, ", func-type %s (%u)",
                tok2str(oam_functype_str, "none", func_type),
                func_type);
 
@@ -475,22 +475,22 @@ oam_print(netdissect_options *ndo,
     case (OAM_CELLTYPE_FM << 4 | OAM_FM_FUNCTYPE_LOOPBACK):
         oam_ptr.oam_fm_loopback = (const struct oam_fm_loopback_t *)(p + OAM_CELLTYPE_FUNCTYPE_LEN);
         ND_TCHECK_SIZE(oam_ptr.oam_fm_loopback);
-        ND_PRINT("\n\tLoopback-Indicator %s, Correlation-Tag 0x%08x",
+        ND_PRINT(C_RESET, "\n\tLoopback-Indicator %s, Correlation-Tag 0x%08x",
                tok2str(oam_fm_loopback_indicator_values,
                        "Unknown",
                        GET_U_1(oam_ptr.oam_fm_loopback->loopback_indicator) & OAM_FM_LOOPBACK_INDICATOR_MASK),
                GET_BE_U_4(oam_ptr.oam_fm_loopback->correlation_tag));
-        ND_PRINT("\n\tLocation-ID ");
+        ND_PRINT(C_RESET, "\n\tLocation-ID ");
         for (idx = 0; idx < sizeof(oam_ptr.oam_fm_loopback->loopback_id); idx++) {
             if (idx % 2) {
-                ND_PRINT("%04x ",
+                ND_PRINT(C_RESET, "%04x ",
                          GET_BE_U_2(&oam_ptr.oam_fm_loopback->loopback_id[idx]));
             }
         }
-        ND_PRINT("\n\tSource-ID   ");
+        ND_PRINT(C_RESET, "\n\tSource-ID   ");
         for (idx = 0; idx < sizeof(oam_ptr.oam_fm_loopback->source_id); idx++) {
             if (idx % 2) {
-                ND_PRINT("%04x ",
+                ND_PRINT(C_RESET, "%04x ",
                          GET_BE_U_2(&oam_ptr.oam_fm_loopback->source_id[idx]));
             }
         }
@@ -500,12 +500,12 @@ oam_print(netdissect_options *ndo,
     case (OAM_CELLTYPE_FM << 4 | OAM_FM_FUNCTYPE_RDI):
         oam_ptr.oam_fm_ais_rdi = (const struct oam_fm_ais_rdi_t *)(p + OAM_CELLTYPE_FUNCTYPE_LEN);
         ND_TCHECK_SIZE(oam_ptr.oam_fm_ais_rdi);
-        ND_PRINT("\n\tFailure-type 0x%02x",
+        ND_PRINT(C_RESET, "\n\tFailure-type 0x%02x",
                  GET_U_1(oam_ptr.oam_fm_ais_rdi->failure_type));
-        ND_PRINT("\n\tLocation-ID ");
+        ND_PRINT(C_RESET, "\n\tLocation-ID ");
         for (idx = 0; idx < sizeof(oam_ptr.oam_fm_ais_rdi->failure_location); idx++) {
             if (idx % 2) {
-                ND_PRINT("%04x ",
+                ND_PRINT(C_RESET, "%04x ",
                          GET_BE_U_2(&oam_ptr.oam_fm_ais_rdi->failure_location[idx]));
             }
         }
@@ -524,7 +524,7 @@ oam_print(netdissect_options *ndo,
         & OAM_CRC10_MASK;
     cksum_shouldbe = verify_crc10_cksum(0, p, OAM_PAYLOAD_LEN);
 
-    ND_PRINT("\n\tcksum 0x%03x (%scorrect)",
+    ND_PRINT(C_RESET, "\n\tcksum 0x%03x (%scorrect)",
            cksum,
            cksum_shouldbe == 0 ? "" : "in");
 }

--- a/print-bcm-li.c
+++ b/print-bcm-li.c
@@ -69,7 +69,7 @@ bcm_li_print(netdissect_options *ndo,
 
 	ndo->ndo_protocol = "bcm_li";
 	if (length < BCM_LI_SHIM_LEN) {
-	    ND_PRINT(" (length %u < %u)", length, BCM_LI_SHIM_LEN);
+	    ND_PRINT(C_RESET, " (length %u < %u)", length, BCM_LI_SHIM_LEN);
 	    goto invalid;
 	}
 	shim = GET_BE_U_4(bp);
@@ -82,7 +82,7 @@ bcm_li_print(netdissect_options *ndo,
 	length -= BCM_LI_SHIM_LEN;
 	bp += BCM_LI_SHIM_LEN;
 
-	ND_PRINT("%sBCM-LI-SHIM: direction %s, pkt-type %s, pkt-subtype %s, li-id %u%s",
+	ND_PRINT(C_RESET, "%sBCM-LI-SHIM: direction %s, pkt-type %s, pkt-subtype %s, li-id %u%s",
 		 ndo->ndo_vflag ? "\n    " : "",
 		 tok2str(bcm_li_direction_values, "unknown", direction),
 		 tok2str(bcm_li_pkt_type_values, "unknown", pkt_type),
@@ -115,7 +115,7 @@ bcm_li_print(netdissect_options *ndo,
 	    } else if ((GET_U_1(bp) >> 4) == 6) {
 		ip6_print(ndo, bp, length);
 	    } else {
-		ND_PRINT("unknown payload");
+		ND_PRINT(C_RESET, "unknown payload");
 	    }
 	    break;
 

--- a/print-beep.c
+++ b/print-beep.c
@@ -51,19 +51,19 @@ beep_print(netdissect_options *ndo, const u_char *bp, u_int length)
 
 	ndo->ndo_protocol = "beep";
 	if (l_strnstart(ndo, "MSG", 4, (const char *)bp, length)) /* A REQuest */
-		ND_PRINT(" BEEP MSG");
+		ND_PRINT(C_RESET, " BEEP MSG");
 	else if (l_strnstart(ndo, "RPY ", 4, (const char *)bp, length))
-		ND_PRINT(" BEEP RPY");
+		ND_PRINT(C_RESET, " BEEP RPY");
 	else if (l_strnstart(ndo, "ERR ", 4, (const char *)bp, length))
-		ND_PRINT(" BEEP ERR");
+		ND_PRINT(C_RESET, " BEEP ERR");
 	else if (l_strnstart(ndo, "ANS ", 4, (const char *)bp, length))
-		ND_PRINT(" BEEP ANS");
+		ND_PRINT(C_RESET, " BEEP ANS");
 	else if (l_strnstart(ndo, "NUL ", 4, (const char *)bp, length))
-		ND_PRINT(" BEEP NUL");
+		ND_PRINT(C_RESET, " BEEP NUL");
 	else if (l_strnstart(ndo, "SEQ ", 4, (const char *)bp, length))
-		ND_PRINT(" BEEP SEQ");
+		ND_PRINT(C_RESET, " BEEP SEQ");
 	else if (l_strnstart(ndo, "END", 4, (const char *)bp, length))
-		ND_PRINT(" BEEP END");
+		ND_PRINT(C_RESET, " BEEP END");
 	else
-		ND_PRINT(" BEEP (payload or undecoded)");
+		ND_PRINT(C_RESET, " BEEP (payload or undecoded)");
 }

--- a/print-bfd.c
+++ b/print-bfd.c
@@ -195,11 +195,11 @@ auth_print(netdissect_options *ndo, const u_char *pptr)
         ND_TCHECK_SIZE(bfd_auth_header);
         auth_type = GET_U_1(bfd_auth_header->auth_type);
         auth_len = GET_U_1(bfd_auth_header->auth_len);
-        ND_PRINT("\n\tAuthentication: %s (%u), length: %u",
+        ND_PRINT(C_RESET, "\n\tAuthentication: %s (%u), length: %u",
                  tok2str(bfd_v1_authentication_values,"Unknown",auth_type),
                  auth_type, auth_len);
                 pptr += 2;
-                ND_PRINT("\n\t  Auth Key ID: %u", GET_U_1(pptr));
+                ND_PRINT(C_RESET, "\n\t  Auth Key ID: %u", GET_U_1(pptr));
 
         switch(auth_type) {
             case AUTH_PASSWORD:
@@ -216,12 +216,12 @@ auth_print(netdissect_options *ndo, const u_char *pptr)
  */
                 if (auth_len < AUTH_PASSWORD_FIELD_MIN_LEN ||
                     auth_len > AUTH_PASSWORD_FIELD_MAX_LEN) {
-                    ND_PRINT("[invalid length %u]",
+                    ND_PRINT(C_RESET, "[invalid length %u]",
                              auth_len);
                     break;
                 }
                 pptr++;
-                ND_PRINT(", Password: ");
+                ND_PRINT(C_RESET, ", Password: ");
                 /* the length is equal to the password length plus three */
                 nd_printjn(ndo, pptr, auth_len - 3);
                 break;
@@ -243,17 +243,17 @@ auth_print(netdissect_options *ndo, const u_char *pptr)
  *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  */
                 if (auth_len != AUTH_MD5_FIELD_LEN) {
-                    ND_PRINT("[invalid length %u]",
+                    ND_PRINT(C_RESET, "[invalid length %u]",
                              auth_len);
                     break;
                 }
                 pptr += 2;
-                ND_PRINT(", Sequence Number: 0x%08x", GET_BE_U_4(pptr));
+                ND_PRINT(C_RESET, ", Sequence Number: 0x%08x", GET_BE_U_4(pptr));
                 pptr += 4;
                 ND_TCHECK_LEN(pptr, AUTH_MD5_HASH_LEN);
-                ND_PRINT("\n\t  Digest: ");
+                ND_PRINT(C_RESET, "\n\t  Digest: ");
                 for(i = 0; i < AUTH_MD5_HASH_LEN; i++)
-                    ND_PRINT("%02x", GET_U_1(pptr + i));
+                    ND_PRINT(C_RESET, "%02x", GET_U_1(pptr + i));
                 break;
             case AUTH_SHA1:
             case AUTH_MET_SHA1:
@@ -273,17 +273,17 @@ auth_print(netdissect_options *ndo, const u_char *pptr)
  *    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  */
                 if (auth_len != AUTH_SHA1_FIELD_LEN) {
-                    ND_PRINT("[invalid length %u]",
+                    ND_PRINT(C_RESET, "[invalid length %u]",
                              auth_len);
                     break;
                 }
                 pptr += 2;
-                ND_PRINT(", Sequence Number: 0x%08x", GET_BE_U_4(pptr));
+                ND_PRINT(C_RESET, ", Sequence Number: 0x%08x", GET_BE_U_4(pptr));
                 pptr += 4;
                 ND_TCHECK_LEN(pptr, AUTH_SHA1_HASH_LEN);
-                ND_PRINT("\n\t  Hash: ");
+                ND_PRINT(C_RESET, "\n\t  Hash: ");
                 for(i = 0; i < AUTH_SHA1_HASH_LEN; i++)
-                    ND_PRINT("%02x", GET_U_1(pptr + i));
+                    ND_PRINT(C_RESET, "%02x", GET_U_1(pptr + i));
                 break;
         }
 }
@@ -317,33 +317,33 @@ bfd_print(netdissect_options *ndo, const u_char *pptr,
             case 0:
                 if (ndo->ndo_vflag < 1)
                 {
-                    ND_PRINT("BFDv0, Control, Flags: [%s], length: %u",
+                    ND_PRINT(C_RESET, "BFDv0, Control, Flags: [%s], length: %u",
                            bittok2str(bfd_v0_flag_values, "none", flags),
                            len);
                     return;
                 }
 
-                ND_PRINT("BFDv0, length: %u\n\tControl, Flags: [%s], Diagnostic: %s (0x%02x)",
+                ND_PRINT(C_RESET, "BFDv0, length: %u\n\tControl, Flags: [%s], Diagnostic: %s (0x%02x)",
                        len,
                        bittok2str(bfd_v0_flag_values, "none", flags),
                        tok2str(bfd_diag_values,"unknown",BFD_EXTRACT_DIAG(version_diag)),
                        BFD_EXTRACT_DIAG(version_diag));
 
-                ND_PRINT("\n\tDetection Timer Multiplier: %u (%u ms Detection time), BFD Length: %u",
+                ND_PRINT(C_RESET, "\n\tDetection Timer Multiplier: %u (%u ms Detection time), BFD Length: %u",
                        GET_U_1(bfd_header->detect_time_multiplier),
                        GET_U_1(bfd_header->detect_time_multiplier) * GET_BE_U_4(bfd_header->desired_min_tx_interval)/1000,
                        GET_U_1(bfd_header->length));
 
 
-                ND_PRINT("\n\tMy Discriminator: 0x%08x",
+                ND_PRINT(C_RESET, "\n\tMy Discriminator: 0x%08x",
                          GET_BE_U_4(bfd_header->my_discriminator));
-                ND_PRINT(", Your Discriminator: 0x%08x",
+                ND_PRINT(C_RESET, ", Your Discriminator: 0x%08x",
                          GET_BE_U_4(bfd_header->your_discriminator));
-                ND_PRINT("\n\t  Desired min Tx Interval:    %4u ms",
+                ND_PRINT(C_RESET, "\n\t  Desired min Tx Interval:    %4u ms",
                          GET_BE_U_4(bfd_header->desired_min_tx_interval)/1000);
-                ND_PRINT("\n\t  Required min Rx Interval:   %4u ms",
+                ND_PRINT(C_RESET, "\n\t  Required min Rx Interval:   %4u ms",
                          GET_BE_U_4(bfd_header->required_min_rx_interval)/1000);
-                ND_PRINT("\n\t  Required min Echo Interval: %4u ms",
+                ND_PRINT(C_RESET, "\n\t  Required min Echo Interval: %4u ms",
                          GET_BE_U_4(bfd_header->required_min_echo_interval)/1000);
 
                 if (flags & BFD_FLAG_AUTH) {
@@ -355,7 +355,7 @@ bfd_print(netdissect_options *ndo, const u_char *pptr,
             case 1:
                 if (ndo->ndo_vflag < 1)
                 {
-                    ND_PRINT("BFDv1, %s, State %s, Flags: [%s], length: %u",
+                    ND_PRINT(C_RESET, "BFDv1, %s, State %s, Flags: [%s], length: %u",
                            tok2str(bfd_port_values, "unknown (%u)", port),
                            tok2str(bfd_v1_state_values, "unknown (%u)", (flags & 0xc0) >> 6),
                            bittok2str(bfd_v1_flag_values, "none", flags & 0x3f),
@@ -363,7 +363,7 @@ bfd_print(netdissect_options *ndo, const u_char *pptr,
                     return;
                 }
 
-                ND_PRINT("BFDv1, length: %u\n\t%s, State %s, Flags: [%s], Diagnostic: %s (0x%02x)",
+                ND_PRINT(C_RESET, "BFDv1, length: %u\n\t%s, State %s, Flags: [%s], Diagnostic: %s (0x%02x)",
                        len,
                        tok2str(bfd_port_values, "unknown (%u)", port),
                        tok2str(bfd_v1_state_values, "unknown (%u)", (flags & 0xc0) >> 6),
@@ -371,21 +371,21 @@ bfd_print(netdissect_options *ndo, const u_char *pptr,
                        tok2str(bfd_diag_values,"unknown",BFD_EXTRACT_DIAG(version_diag)),
                        BFD_EXTRACT_DIAG(version_diag));
 
-                ND_PRINT("\n\tDetection Timer Multiplier: %u (%u ms Detection time), BFD Length: %u",
+                ND_PRINT(C_RESET, "\n\tDetection Timer Multiplier: %u (%u ms Detection time), BFD Length: %u",
                        GET_U_1(bfd_header->detect_time_multiplier),
                        GET_U_1(bfd_header->detect_time_multiplier) * GET_BE_U_4(bfd_header->desired_min_tx_interval)/1000,
                        GET_U_1(bfd_header->length));
 
 
-                ND_PRINT("\n\tMy Discriminator: 0x%08x",
+                ND_PRINT(C_RESET, "\n\tMy Discriminator: 0x%08x",
                          GET_BE_U_4(bfd_header->my_discriminator));
-                ND_PRINT(", Your Discriminator: 0x%08x",
+                ND_PRINT(C_RESET, ", Your Discriminator: 0x%08x",
                          GET_BE_U_4(bfd_header->your_discriminator));
-                ND_PRINT("\n\t  Desired min Tx Interval:    %4u ms",
+                ND_PRINT(C_RESET, "\n\t  Desired min Tx Interval:    %4u ms",
                          GET_BE_U_4(bfd_header->desired_min_tx_interval)/1000);
-                ND_PRINT("\n\t  Required min Rx Interval:   %4u ms",
+                ND_PRINT(C_RESET, "\n\t  Required min Rx Interval:   %4u ms",
                          GET_BE_U_4(bfd_header->required_min_rx_interval)/1000);
-                ND_PRINT("\n\t  Required min Echo Interval: %4u ms",
+                ND_PRINT(C_RESET, "\n\t  Required min Echo Interval: %4u ms",
                          GET_BE_U_4(bfd_header->required_min_echo_interval)/1000);
 
                 if (flags & BFD_FLAG_AUTH) {
@@ -394,7 +394,7 @@ bfd_print(netdissect_options *ndo, const u_char *pptr,
                 break;
 
             default:
-                ND_PRINT("BFDv%u, Control, length: %u",
+                ND_PRINT(C_RESET, "BFDv%u, Control, length: %u",
                        version,
                        len);
                 if (ndo->ndo_vflag >= 1) {
@@ -407,7 +407,7 @@ bfd_print(netdissect_options *ndo, const u_char *pptr,
             /*
              * Echo packet.
              */
-            ND_PRINT("BFD, Echo, length: %u",
+            ND_PRINT(C_RESET, "BFD, Echo, length: %u",
                    len);
             if (ndo->ndo_vflag >= 1) {
                 if(!print_unknown_data(ndo, pptr,"\n\t",len))
@@ -417,7 +417,7 @@ bfd_print(netdissect_options *ndo, const u_char *pptr,
             /*
              * Unknown packet type.
              */
-            ND_PRINT("BFD, unknown (%u), length: %u",
+            ND_PRINT(C_RESET, "BFD, unknown (%u), length: %u",
                    port,
                    len);
             if (ndo->ndo_vflag >= 1) {

--- a/print-bgp.c
+++ b/print-bgp.c
@@ -888,7 +888,7 @@ bgp_extended_community_print(netdissect_options *ndo,
     case BGP_EXT_COM_RT_0:
     case BGP_EXT_COM_RO_0:
     case BGP_EXT_COM_L2VPN_RT_0:
-        ND_PRINT("%u:%u (= %s)",
+        ND_PRINT(C_RESET, "%u:%u (= %s)",
                  GET_BE_U_2(pptr + 2),
                  GET_BE_U_4(pptr + 4),
                  GET_IPADDR_STRING(pptr+4));
@@ -898,21 +898,21 @@ bgp_extended_community_print(netdissect_options *ndo,
     case BGP_EXT_COM_RO_1:
     case BGP_EXT_COM_L2VPN_RT_1:
     case BGP_EXT_COM_VRF_RT_IMP:
-        ND_PRINT("%s:%u",
+        ND_PRINT(C_RESET, "%s:%u",
                  GET_IPADDR_STRING(pptr+2),
                  GET_BE_U_2(pptr + 6));
         break;
 
     case BGP_EXT_COM_RT_2:
         case BGP_EXT_COM_RO_2:
-            ND_PRINT("%s:%u",
+            ND_PRINT(C_RESET, "%s:%u",
                      as_printf(ndo, astostr, sizeof(astostr),
                      GET_BE_U_4(pptr + 2)), GET_BE_U_2(pptr + 6));
             break;
 
     case BGP_EXT_COM_LINKBAND:
             bw.i = GET_BE_U_4(pptr + 4);
-            ND_PRINT("bandwidth: %.3f Mbps",
+            ND_PRINT(C_RESET, "bandwidth: %.3f Mbps",
                      bw.f*8/1000000);
             break;
 
@@ -924,9 +924,9 @@ bgp_extended_community_print(netdissect_options *ndo,
             uint64_t reserved = GET_BE_U_5(pptr + 2);
 
             if (reserved)
-                ND_PRINT("[the reserved field 0x%" PRIx64 " MUST be 0] ",
+                ND_PRINT(C_RESET, "[the reserved field 0x%" PRIx64 " MUST be 0] ",
                          reserved);
-            ND_PRINT("ovs: %s",
+            ND_PRINT(C_RESET, "ovs: %s",
                      tok2str(bgp_prefix_origin_validation_state,
                              "unknown origin validation state",
                              GET_U_1(pptr + 7)));
@@ -939,12 +939,12 @@ bgp_extended_community_print(netdissect_options *ndo,
     case BGP_EXT_COM_VPN_ORIGIN4:
     case BGP_EXT_COM_OSPF_RID:
     case BGP_EXT_COM_OSPF_RID2:
-        ND_PRINT("%s", GET_IPADDR_STRING(pptr+2));
+        ND_PRINT(C_RESET, "%s", GET_IPADDR_STRING(pptr+2));
         break;
 
     case BGP_EXT_COM_OSPF_RTYPE:
     case BGP_EXT_COM_OSPF_RTYPE2:
-        ND_PRINT("area:%s, router-type:%s, metric-type:%s%s",
+        ND_PRINT(C_RESET, "area:%s, router-type:%s, metric-type:%s%s",
                  GET_IPADDR_STRING(pptr+2),
                  tok2str(bgp_extd_comm_ospf_rtype_values,
                          "unknown (0x%02x)",
@@ -954,7 +954,7 @@ bgp_extended_community_print(netdissect_options *ndo,
         break;
 
     case BGP_EXT_COM_L2INFO:
-        ND_PRINT("%s Control Flags [0x%02x]:MTU %u",
+        ND_PRINT(C_RESET, "%s Control Flags [0x%02x]:MTU %u",
                  tok2str(l2vpn_encaps_values,
                          "unknown encaps",
                          GET_U_1((pptr + 2))),
@@ -963,17 +963,17 @@ bgp_extended_community_print(netdissect_options *ndo,
         break;
 
     case BGP_EXT_COM_SOURCE_AS:
-        ND_PRINT("AS %u", GET_BE_U_2(pptr + 2));
+        ND_PRINT(C_RESET, "AS %u", GET_BE_U_2(pptr + 2));
         break;
 
     case BGP_EXT_COM_ENCAP:
-        ND_PRINT("Tunnel type: %s", tok2str(bgp_extd_comm_encap_tunnel_values,
+        ND_PRINT(C_RESET, "Tunnel type: %s", tok2str(bgp_extd_comm_encap_tunnel_values,
                                            "unknown encaps",
                                            GET_BE_U_2(pptr + 6)));
         break;
 
     default:
-        ND_PRINT("%02x%02x%02x%02x%02x%02x",
+        ND_PRINT(C_RESET, "%02x%02x%02x%02x%02x%02x",
                  GET_U_1(pptr + 2),
                  GET_U_1(pptr + 3),
                  GET_U_1(pptr + 4),
@@ -1092,12 +1092,12 @@ decode_rt_routing_info(netdissect_options *ndo,
      */
     if (0 == plen) {
         /* Without "origin AS", without "route target". */
-        ND_PRINT("\n\t      default route target");
+        ND_PRINT(C_RESET, "\n\t      default route target");
         return 1;
     }
 
     if (32 > plen) {
-        ND_PRINT("\n\t      (illegal prefix length)");
+        ND_PRINT(C_RESET, "\n\t      (illegal prefix length)");
         return -1;
     }
 
@@ -1107,7 +1107,7 @@ decode_rt_routing_info(netdissect_options *ndo,
     plen -= 32; /* adjust prefix length */
 
     if (64 < plen) {
-        ND_PRINT("\n\t      (illegal prefix length)");
+        ND_PRINT(C_RESET, "\n\t      (illegal prefix length)");
         return -1;
     }
 
@@ -1123,7 +1123,7 @@ decode_rt_routing_info(netdissect_options *ndo,
         ((u_char *)&route_target)[num_octets - 1] &=
             ((0xff00 >> (plen % 8)) & 0xff);
     }
-    ND_PRINT("\n\t      origin AS: %s, %s",
+    ND_PRINT(C_RESET, "\n\t      origin AS: %s, %s",
              astostr,
              bgp_rt_prefix_print(ndo, (u_char *)&route_target, plen));
 
@@ -1749,7 +1749,7 @@ bgp_mp_af_print(netdissect_options *ndo,
         safi = GET_U_1(tptr + 2);
 	*safip = safi;
 
-        ND_PRINT("\n\t    AFI: %s (%u), %sSAFI: %s (%u)",
+        ND_PRINT(C_RESET, "\n\t    AFI: %s (%u), %sSAFI: %s (%u)",
                   tok2str(af_values, "Unknown AFI", af),
                   af,
                   (safi>128) ? "vendor specific " : "", /* 128 is meanwhile wellknown */
@@ -1787,7 +1787,7 @@ bgp_mp_af_print(netdissect_options *ndo,
             break;
         default:
             ND_TCHECK_LEN(tptr, tlen);
-            ND_PRINT("\n\t    no AFI %u / SAFI %u decoder", af, safi);
+            ND_PRINT(C_RESET, "\n\t    no AFI %u / SAFI %u decoder", af, safi);
             if (ndo->ndo_vflag <= 1)
                 print_unknown_data(ndo, tptr, "\n\t    ", tlen);
             return -1;
@@ -1816,35 +1816,35 @@ bgp_nlri_print(netdissect_options *ndo, uint16_t af, uint8_t safi,
                 }
                 advance = decode_prefix4(ndo, tptr, len, buf, buflen);
                 if (advance == -1)
-                    ND_PRINT("\n\t    (illegal prefix length)");
+                    ND_PRINT(C_RESET, "\n\t    (illegal prefix length)");
                 else if (advance == -2)
                     break; /* bytes left, but not enough */
                 else
-                    ND_PRINT("\n\t      %s", buf);
+                    ND_PRINT(C_RESET, "\n\t      %s", buf);
                 if (add_path4) {
-                    ND_PRINT("   Path Id: %u", path_id);
+                    ND_PRINT(C_RESET, "   Path Id: %u", path_id);
 		    advance += 4;
                 }
                 break;
             case (AFNUM_INET<<8 | SAFNUM_LABUNICAST):
                 advance = decode_labeled_prefix4(ndo, tptr, len, buf, buflen);
                 if (advance == -1)
-                    ND_PRINT("\n\t    (illegal prefix length)");
+                    ND_PRINT(C_RESET, "\n\t    (illegal prefix length)");
                 else if (advance == -2)
                     goto trunc;
                 else if (advance == -3)
                     break; /* bytes left, but not enough */
                 else
-                    ND_PRINT("\n\t      %s", buf);
+                    ND_PRINT(C_RESET, "\n\t      %s", buf);
                 break;
             case (AFNUM_INET<<8 | SAFNUM_VPNUNICAST):
             case (AFNUM_INET<<8 | SAFNUM_VPNMULTICAST):
             case (AFNUM_INET<<8 | SAFNUM_VPNUNIMULTICAST):
                 advance = decode_labeled_vpn_prefix4(ndo, tptr, buf, buflen);
                 if (advance == -1)
-                    ND_PRINT("\n\t    (illegal prefix length)");
+                    ND_PRINT(C_RESET, "\n\t    (illegal prefix length)");
                 else
-                    ND_PRINT("\n\t      %s", buf);
+                    ND_PRINT(C_RESET, "\n\t      %s", buf);
                 break;
             case (AFNUM_INET<<8 | SAFNUM_RT_ROUTING_INFO):
                 advance = decode_rt_routing_info(ndo, tptr);
@@ -1853,21 +1853,21 @@ bgp_nlri_print(netdissect_options *ndo, uint16_t af, uint8_t safi,
             case (AFNUM_INET6<<8 | SAFNUM_MULTICAST_VPN):
                 advance = decode_multicast_vpn(ndo, tptr, buf, buflen);
                 if (advance == -1)
-                    ND_PRINT("\n\t    (illegal prefix length)");
+                    ND_PRINT(C_RESET, "\n\t    (illegal prefix length)");
                 else if (advance == -2)
                     goto trunc;
                 else
-                    ND_PRINT("\n\t      %s", buf);
+                    ND_PRINT(C_RESET, "\n\t      %s", buf);
                 break;
 
             case (AFNUM_INET<<8 | SAFNUM_MDT):
                 advance = decode_mdt_vpn_nlri(ndo, tptr, buf, buflen);
                 if (advance == -1)
-                    ND_PRINT("\n\t    (illegal prefix length)");
+                    ND_PRINT(C_RESET, "\n\t    (illegal prefix length)");
                 else if (advance == -2)
                     goto trunc;
                 else
-                    ND_PRINT("\n\t      %s", buf);
+                    ND_PRINT(C_RESET, "\n\t      %s", buf);
                 break;
             case (AFNUM_INET6<<8 | SAFNUM_UNICAST):
             case (AFNUM_INET6<<8 | SAFNUM_MULTICAST):
@@ -1878,35 +1878,35 @@ bgp_nlri_print(netdissect_options *ndo, uint16_t af, uint8_t safi,
                 }
                 advance = decode_prefix6(ndo, tptr, len, buf, buflen);
                 if (advance == -1)
-                    ND_PRINT("\n\t    (illegal prefix length)");
+                    ND_PRINT(C_RESET, "\n\t    (illegal prefix length)");
                 else if (advance == -2)
                     break; /* bytes left, but not enough */
                 else
-                    ND_PRINT("\n\t      %s", buf);
+                    ND_PRINT(C_RESET, "\n\t      %s", buf);
                 if (add_path6) {
-                    ND_PRINT("   Path Id: %u", path_id);
+                    ND_PRINT(C_RESET, "   Path Id: %u", path_id);
 		    advance += 4;
                 }
                 break;
             case (AFNUM_INET6<<8 | SAFNUM_LABUNICAST):
                 advance = decode_labeled_prefix6(ndo, tptr, len, buf, buflen);
                 if (advance == -1)
-                    ND_PRINT("\n\t    (illegal prefix length)");
+                    ND_PRINT(C_RESET, "\n\t    (illegal prefix length)");
                 else if (advance == -2)
                     goto trunc;
                 else if (advance == -3)
                     break; /* bytes left, but not enough */
                 else
-                    ND_PRINT("\n\t      %s", buf);
+                    ND_PRINT(C_RESET, "\n\t      %s", buf);
                 break;
             case (AFNUM_INET6<<8 | SAFNUM_VPNUNICAST):
             case (AFNUM_INET6<<8 | SAFNUM_VPNMULTICAST):
             case (AFNUM_INET6<<8 | SAFNUM_VPNUNIMULTICAST):
                 advance = decode_labeled_vpn_prefix6(ndo, tptr, buf, buflen);
                 if (advance == -1)
-                    ND_PRINT("\n\t    (illegal prefix length)");
+                    ND_PRINT(C_RESET, "\n\t    (illegal prefix length)");
                 else
-                    ND_PRINT("\n\t      %s", buf);
+                    ND_PRINT(C_RESET, "\n\t      %s", buf);
                 break;
             case (AFNUM_VPLS<<8 | SAFNUM_VPLS):
             case (AFNUM_L2VPN<<8 | SAFNUM_VPNUNICAST):
@@ -1914,36 +1914,36 @@ bgp_nlri_print(netdissect_options *ndo, uint16_t af, uint8_t safi,
             case (AFNUM_L2VPN<<8 | SAFNUM_VPNUNIMULTICAST):
                 advance = decode_labeled_vpn_l2(ndo, tptr, buf, buflen);
                 if (advance == -1)
-                    ND_PRINT("\n\t    (illegal length)");
+                    ND_PRINT(C_RESET, "\n\t    (illegal length)");
                 else if (advance == -2)
                     goto trunc;
                 else
-                    ND_PRINT("\n\t      %s", buf);
+                    ND_PRINT(C_RESET, "\n\t      %s", buf);
                 break;
             case (AFNUM_NSAP<<8 | SAFNUM_UNICAST):
             case (AFNUM_NSAP<<8 | SAFNUM_MULTICAST):
             case (AFNUM_NSAP<<8 | SAFNUM_UNIMULTICAST):
                 advance = decode_clnp_prefix(ndo, tptr, buf, buflen);
                 if (advance == -1)
-                    ND_PRINT("\n\t    (illegal prefix length)");
+                    ND_PRINT(C_RESET, "\n\t    (illegal prefix length)");
                 else
-                    ND_PRINT("\n\t      %s", buf);
+                    ND_PRINT(C_RESET, "\n\t      %s", buf);
                 break;
             case (AFNUM_NSAP<<8 | SAFNUM_VPNUNICAST):
             case (AFNUM_NSAP<<8 | SAFNUM_VPNMULTICAST):
             case (AFNUM_NSAP<<8 | SAFNUM_VPNUNIMULTICAST):
                 advance = decode_labeled_vpn_clnp_prefix(ndo, tptr, buf, buflen);
                 if (advance == -1)
-                    ND_PRINT("\n\t    (illegal prefix length)");
+                    ND_PRINT(C_RESET, "\n\t    (illegal prefix length)");
                 else
-                    ND_PRINT("\n\t      %s", buf);
+                    ND_PRINT(C_RESET, "\n\t      %s", buf);
                 break;
             default:
 		/*
 		 * This should not happen, we should have been protected
 		 * by bgp_mp_af_print()'s return value.
 		 */
-                ND_PRINT("\n\t    ERROR: no AFI %u / SAFI %u decoder", af, safi);
+                ND_PRINT(C_RESET, "\n\t    ERROR: no AFI %u / SAFI %u decoder", af, safi);
                 advance = -4;
                 break;
 	}
@@ -1984,9 +1984,9 @@ bgp_attr_print(netdissect_options *ndo,
     switch (atype) {
     case BGPTYPE_ORIGIN:
         if (len != 1)
-            ND_PRINT("invalid len");
+            ND_PRINT(C_RESET, "invalid len");
         else {
-            ND_PRINT("%s", tok2str(bgp_origin_values,
+            ND_PRINT(C_RESET, "%s", tok2str(bgp_origin_values,
                       "Unknown Origin Typecode",
                       GET_U_1(tptr)));
         }
@@ -1998,11 +1998,11 @@ bgp_attr_print(netdissect_options *ndo,
     case BGPTYPE_AS4_PATH:
     case BGPTYPE_AS_PATH:
         if (len % 2) {
-            ND_PRINT("invalid len");
+            ND_PRINT(C_RESET, "invalid len");
             break;
         }
         if (!len) {
-            ND_PRINT("empty");
+            ND_PRINT(C_RESET, "empty");
             break;
         }
 
@@ -2017,39 +2017,39 @@ bgp_attr_print(netdissect_options *ndo,
         as_size = bgp_attr_get_as_size(ndo, atype, pptr, len);
 
         while (tptr < pptr + len) {
-            ND_PRINT("%s", tok2str(bgp_as_path_segment_open_values,
+            ND_PRINT(C_RESET, "%s", tok2str(bgp_as_path_segment_open_values,
                       "?", GET_U_1(tptr)));
             for (i = 0; i < GET_U_1(tptr + 1) * as_size; i += as_size) {
                 ND_TCHECK_LEN(tptr + 2 + i, as_size);
-                ND_PRINT("%s ",
+                ND_PRINT(C_RESET, "%s ",
                           as_printf(ndo, astostr, sizeof(astostr),
                           as_size == 2 ?
                               GET_BE_U_2(tptr + i + 2) :
                               GET_BE_U_4(tptr + i + 2)));
             }
-            ND_PRINT("%s", tok2str(bgp_as_path_segment_close_values,
+            ND_PRINT(C_RESET, "%s", tok2str(bgp_as_path_segment_close_values,
                       "?", GET_U_1(tptr)));
             tptr += 2 + GET_U_1(tptr + 1) * as_size;
         }
         break;
     case BGPTYPE_NEXT_HOP:
         if (len != 4)
-            ND_PRINT("invalid len");
+            ND_PRINT(C_RESET, "invalid len");
         else {
-            ND_PRINT("%s", GET_IPADDR_STRING(tptr));
+            ND_PRINT(C_RESET, "%s", GET_IPADDR_STRING(tptr));
         }
         break;
     case BGPTYPE_MULTI_EXIT_DISC:
     case BGPTYPE_LOCAL_PREF:
         if (len != 4)
-            ND_PRINT("invalid len");
+            ND_PRINT(C_RESET, "invalid len");
         else {
-            ND_PRINT("%u", GET_BE_U_4(tptr));
+            ND_PRINT(C_RESET, "%u", GET_BE_U_4(tptr));
         }
         break;
     case BGPTYPE_ATOMIC_AGGREGATE:
         if (len != 0)
-            ND_PRINT("invalid len");
+            ND_PRINT(C_RESET, "invalid len");
         break;
     case BGPTYPE_AGGREGATOR:
 
@@ -2058,32 +2058,32 @@ bgp_attr_print(netdissect_options *ndo,
          * the length of this PA can be either 6 bytes or 8 bytes.
          */
         if (len != 6 && len != 8) {
-            ND_PRINT("invalid len");
+            ND_PRINT(C_RESET, "invalid len");
             break;
         }
         ND_TCHECK_LEN(tptr, len);
         if (len == 6) {
-            ND_PRINT(" AS #%s, origin %s",
+            ND_PRINT(C_RESET, " AS #%s, origin %s",
                       as_printf(ndo, astostr, sizeof(astostr), GET_BE_U_2(tptr)),
                       GET_IPADDR_STRING(tptr + 2));
         } else {
-            ND_PRINT(" AS #%s, origin %s",
+            ND_PRINT(C_RESET, " AS #%s, origin %s",
                       as_printf(ndo, astostr, sizeof(astostr),
                       GET_BE_U_4(tptr)), GET_IPADDR_STRING(tptr + 4));
         }
         break;
     case BGPTYPE_AGGREGATOR4:
         if (len != 8) {
-            ND_PRINT("invalid len");
+            ND_PRINT(C_RESET, "invalid len");
             break;
         }
-        ND_PRINT(" AS #%s, origin %s",
+        ND_PRINT(C_RESET, " AS #%s, origin %s",
                   as_printf(ndo, astostr, sizeof(astostr), GET_BE_U_4(tptr)),
                   GET_IPADDR_STRING(tptr + 4));
         break;
     case BGPTYPE_COMMUNITIES:
         if (len % 4) {
-            ND_PRINT("invalid len");
+            ND_PRINT(C_RESET, "invalid len");
             break;
         }
         while (tlen != 0) {
@@ -2094,16 +2094,16 @@ bgp_attr_print(netdissect_options *ndo,
             comm = GET_BE_U_4(tptr);
             switch (comm) {
             case BGP_COMMUNITY_NO_EXPORT:
-                ND_PRINT(" NO_EXPORT");
+                ND_PRINT(C_RESET, " NO_EXPORT");
                 break;
             case BGP_COMMUNITY_NO_ADVERT:
-                ND_PRINT(" NO_ADVERTISE");
+                ND_PRINT(C_RESET, " NO_ADVERTISE");
                 break;
             case BGP_COMMUNITY_NO_EXPORT_SUBCONFED:
-                ND_PRINT(" NO_EXPORT_SUBCONFED");
+                ND_PRINT(C_RESET, " NO_EXPORT_SUBCONFED");
                 break;
             default:
-                ND_PRINT("%u:%u%s",
+                ND_PRINT(C_RESET, "%u:%u%s",
                          (comm >> 16) & 0xffff,
                          comm & 0xffff,
                          (tlen>4) ? ", " : "");
@@ -2115,20 +2115,20 @@ bgp_attr_print(netdissect_options *ndo,
         break;
     case BGPTYPE_ORIGINATOR_ID:
         if (len != 4) {
-            ND_PRINT("invalid len");
+            ND_PRINT(C_RESET, "invalid len");
             break;
         }
-        ND_PRINT("%s",GET_IPADDR_STRING(tptr));
+        ND_PRINT(C_RESET, "%s",GET_IPADDR_STRING(tptr));
         break;
     case BGPTYPE_CLUSTER_LIST:
         if (len % 4) {
-            ND_PRINT("invalid len");
+            ND_PRINT(C_RESET, "invalid len");
             break;
         }
         while (tlen != 0) {
             if (tlen < 4)
                 goto trunc;
-            ND_PRINT("%s%s",
+            ND_PRINT(C_RESET, "%s%s",
                       GET_IPADDR_STRING(tptr),
                       (tlen>4) ? ", " : "");
             tlen -=4;
@@ -2160,10 +2160,10 @@ bgp_attr_print(netdissect_options *ndo,
             uint8_t tnhlen = nhlen;
             if (tlen < tnhlen)
                 goto trunc;
-            ND_PRINT("\n\t    nexthop: ");
+            ND_PRINT(C_RESET, "\n\t    nexthop: ");
             while (tnhlen != 0) {
                 if (nnh++ > 0) {
-                    ND_PRINT(", " );
+                    ND_PRINT(C_RESET, ", " );
                 }
                 switch(af<<8 | safi) {
                 case (AFNUM_INET<<8 | SAFNUM_UNICAST):
@@ -2174,12 +2174,12 @@ bgp_attr_print(netdissect_options *ndo,
                 case (AFNUM_INET<<8 | SAFNUM_MULTICAST_VPN):
                 case (AFNUM_INET<<8 | SAFNUM_MDT):
                     if (tnhlen < sizeof(nd_ipv4)) {
-                        ND_PRINT("invalid len");
+                        ND_PRINT(C_RESET, "invalid len");
                         tptr += tnhlen;
                         tlen -= tnhlen;
                         tnhlen = 0;
                     } else {
-                        ND_PRINT("%s",GET_IPADDR_STRING(tptr));
+                        ND_PRINT(C_RESET, "%s",GET_IPADDR_STRING(tptr));
                         tptr += sizeof(nd_ipv4);
                         tnhlen -= sizeof(nd_ipv4);
                         tlen -= sizeof(nd_ipv4);
@@ -2189,12 +2189,12 @@ bgp_attr_print(netdissect_options *ndo,
                 case (AFNUM_INET<<8 | SAFNUM_VPNMULTICAST):
                 case (AFNUM_INET<<8 | SAFNUM_VPNUNIMULTICAST):
                     if (tnhlen < sizeof(nd_ipv4)+BGP_VPN_RD_LEN) {
-                        ND_PRINT("invalid len");
+                        ND_PRINT(C_RESET, "invalid len");
                         tptr += tnhlen;
                         tlen -= tnhlen;
                         tnhlen = 0;
                     } else {
-                        ND_PRINT("RD: %s, %s",
+                        ND_PRINT(C_RESET, "RD: %s, %s",
                                   bgp_vpn_rd_print(ndo, tptr),
                                   GET_IPADDR_STRING(tptr+BGP_VPN_RD_LEN));
                         tptr += (sizeof(nd_ipv4)+BGP_VPN_RD_LEN);
@@ -2207,12 +2207,12 @@ bgp_attr_print(netdissect_options *ndo,
                 case (AFNUM_INET6<<8 | SAFNUM_UNIMULTICAST):
                 case (AFNUM_INET6<<8 | SAFNUM_LABUNICAST):
                     if (tnhlen < sizeof(nd_ipv6)) {
-                        ND_PRINT("invalid len");
+                        ND_PRINT(C_RESET, "invalid len");
                         tptr += tnhlen;
                         tlen -= tnhlen;
                         tnhlen = 0;
                     } else {
-                        ND_PRINT("%s", GET_IP6ADDR_STRING(tptr));
+                        ND_PRINT(C_RESET, "%s", GET_IP6ADDR_STRING(tptr));
                         tptr += sizeof(nd_ipv6);
                         tlen -= sizeof(nd_ipv6);
                         tnhlen -= sizeof(nd_ipv6);
@@ -2222,12 +2222,12 @@ bgp_attr_print(netdissect_options *ndo,
                 case (AFNUM_INET6<<8 | SAFNUM_VPNMULTICAST):
                 case (AFNUM_INET6<<8 | SAFNUM_VPNUNIMULTICAST):
                     if (tnhlen < sizeof(nd_ipv6)+BGP_VPN_RD_LEN) {
-                        ND_PRINT("invalid len");
+                        ND_PRINT(C_RESET, "invalid len");
                         tptr += tnhlen;
                         tlen -= tnhlen;
                         tnhlen = 0;
                     } else {
-                        ND_PRINT("RD: %s, %s",
+                        ND_PRINT(C_RESET, "RD: %s, %s",
                                   bgp_vpn_rd_print(ndo, tptr),
                                   GET_IP6ADDR_STRING(tptr+BGP_VPN_RD_LEN));
                         tptr += (sizeof(nd_ipv6)+BGP_VPN_RD_LEN);
@@ -2240,12 +2240,12 @@ bgp_attr_print(netdissect_options *ndo,
                 case (AFNUM_L2VPN<<8 | SAFNUM_VPNMULTICAST):
                 case (AFNUM_L2VPN<<8 | SAFNUM_VPNUNIMULTICAST):
                     if (tnhlen < sizeof(nd_ipv4)) {
-                        ND_PRINT("invalid len");
+                        ND_PRINT(C_RESET, "invalid len");
                         tptr += tnhlen;
                         tlen -= tnhlen;
                         tnhlen = 0;
                     } else {
-                        ND_PRINT("%s", GET_IPADDR_STRING(tptr));
+                        ND_PRINT(C_RESET, "%s", GET_IPADDR_STRING(tptr));
                         tptr += (sizeof(nd_ipv4));
                         tlen -= (sizeof(nd_ipv4));
                         tnhlen -= (sizeof(nd_ipv4));
@@ -2254,7 +2254,7 @@ bgp_attr_print(netdissect_options *ndo,
                 case (AFNUM_NSAP<<8 | SAFNUM_UNICAST):
                 case (AFNUM_NSAP<<8 | SAFNUM_MULTICAST):
                 case (AFNUM_NSAP<<8 | SAFNUM_UNIMULTICAST):
-                    ND_PRINT("%s", GET_ISONSAP_STRING(tptr, tnhlen));
+                    ND_PRINT(C_RESET, "%s", GET_ISONSAP_STRING(tptr, tnhlen));
                     tptr += tnhlen;
                     tlen -= tnhlen;
                     tnhlen = 0;
@@ -2264,21 +2264,21 @@ bgp_attr_print(netdissect_options *ndo,
                 case (AFNUM_NSAP<<8 | SAFNUM_VPNMULTICAST):
                 case (AFNUM_NSAP<<8 | SAFNUM_VPNUNIMULTICAST):
                     if (tnhlen < BGP_VPN_RD_LEN+1) {
-                        ND_PRINT("invalid len");
+                        ND_PRINT(C_RESET, "invalid len");
                         tptr += tnhlen;
                         tlen -= tnhlen;
                         tnhlen = 0;
                     } else {
                         ND_TCHECK_LEN(tptr, tnhlen);
-                        ND_PRINT("RD: %s, %s",
+                        ND_PRINT(C_RESET, "RD: %s, %s",
                                   bgp_vpn_rd_print(ndo, tptr),
                                   GET_ISONSAP_STRING(tptr+BGP_VPN_RD_LEN,tnhlen-BGP_VPN_RD_LEN));
                         /* rfc986 mapped IPv4 address ? */
                         if (GET_BE_U_4(tptr + BGP_VPN_RD_LEN) ==  0x47000601)
-                            ND_PRINT(" = %s", GET_IPADDR_STRING(tptr+BGP_VPN_RD_LEN+4));
+                            ND_PRINT(C_RESET, " = %s", GET_IPADDR_STRING(tptr+BGP_VPN_RD_LEN+4));
                         /* rfc1888 mapped IPv6 address ? */
                         else if (GET_BE_U_3(tptr + BGP_VPN_RD_LEN) ==  0x350000)
-                            ND_PRINT(" = %s", GET_IP6ADDR_STRING(tptr+BGP_VPN_RD_LEN+3));
+                            ND_PRINT(C_RESET, " = %s", GET_IP6ADDR_STRING(tptr+BGP_VPN_RD_LEN+3));
                         tptr += tnhlen;
                         tlen -= tnhlen;
                         tnhlen = 0;
@@ -2289,7 +2289,7 @@ bgp_attr_print(netdissect_options *ndo,
 		     * bgp_mp_af_print() should have saved us from
 		     * an unsupported AFI/SAFI.
 		     */
-                    ND_PRINT("ERROR: no AFI %u/SAFI %u nexthop decoder", af, safi);
+                    ND_PRINT(C_RESET, "ERROR: no AFI %u/SAFI %u nexthop decoder", af, safi);
                     tptr += tnhlen;
                     tlen -= tnhlen;
                     tnhlen = 0;
@@ -2298,7 +2298,7 @@ bgp_attr_print(netdissect_options *ndo,
                 }
             }
         }
-        ND_PRINT(", nh-length: %u", nhlen);
+        ND_PRINT(C_RESET, ", nh-length: %u", nhlen);
 
         /* As per RFC 2858; this is reserved in RFC 4760 */
         if (tlen < 1)
@@ -2308,13 +2308,13 @@ bgp_attr_print(netdissect_options *ndo,
         tlen--;
 
         if (snpa) {
-            ND_PRINT("\n\t    %u SNPA", snpa);
+            ND_PRINT(C_RESET, "\n\t    %u SNPA", snpa);
             for (/*nothing*/; snpa != 0; snpa--) {
                 uint8_t snpalen;
             	if (tlen < 1)
             	    goto trunc;
                 snpalen = GET_U_1(tptr);
-                ND_PRINT("\n\t      %u bytes", snpalen);
+                ND_PRINT(C_RESET, "\n\t      %u bytes", snpalen);
                 tptr++;
                 tlen--;
                 if (tlen < snpalen)
@@ -2324,7 +2324,7 @@ bgp_attr_print(netdissect_options *ndo,
                 tlen -= snpalen;
             }
         } else {
-            ND_PRINT(", no SNPA");
+            ND_PRINT(C_RESET, ", no SNPA");
         }
 
         add_path4 = check_add_path(ndo, tptr, (len-ND_BYTES_BETWEEN(tptr, pptr)), 32);
@@ -2350,7 +2350,7 @@ bgp_attr_print(netdissect_options *ndo,
 	    break;
 
         if (len == BGP_MP_NLRI_MINSIZE)
-            ND_PRINT("\n\t      End-of-Rib Marker (empty NLRI)");
+            ND_PRINT(C_RESET, "\n\t      End-of-Rib Marker (empty NLRI)");
 
         tptr += 3;
 
@@ -2369,7 +2369,7 @@ bgp_attr_print(netdissect_options *ndo,
         break;
     case BGPTYPE_EXTD_COMMUNITIES:
         if (len % 8) {
-            ND_PRINT("invalid len");
+            ND_PRINT(C_RESET, "invalid len");
             break;
         }
         while (tlen != 0) {
@@ -2380,7 +2380,7 @@ bgp_attr_print(netdissect_options *ndo,
                 goto trunc;
             extd_comm=GET_BE_U_2(tptr);
 
-            ND_PRINT("\n\t    %s (0x%04x), Flags [%s]",
+            ND_PRINT(C_RESET, "\n\t    %s (0x%04x), Flags [%s]",
                       tok2str(bgp_extd_comm_subtype_values,
                               "unknown extd community typecode",
                               extd_comm),
@@ -2390,7 +2390,7 @@ bgp_attr_print(netdissect_options *ndo,
             ND_TCHECK_8(tptr);
             if (tlen < 8)
                 goto trunc;
-            ND_PRINT(": ");
+            ND_PRINT(C_RESET, ": ");
             bgp_extended_community_print(ndo, tptr);
             tlen -= 8;
             tptr += 8;
@@ -2407,7 +2407,7 @@ bgp_attr_print(netdissect_options *ndo,
         flags = GET_U_1(tptr);
         tunnel_type = GET_U_1(tptr + 1);
 
-        ND_PRINT("\n\t    Tunnel-type %s (%u), Flags [%s], MPLS Label %u",
+        ND_PRINT(C_RESET, "\n\t    Tunnel-type %s (%u), Flags [%s], MPLS Label %u",
                   tok2str(bgp_pmsi_tunnel_values, "Unknown", tunnel_type),
                   tunnel_type,
                   bittok2str(bgp_pmsi_flag_values, "none", flags),
@@ -2419,28 +2419,28 @@ bgp_attr_print(netdissect_options *ndo,
         switch (tunnel_type) {
         case BGP_PMSI_TUNNEL_PIM_SM: /* fall through */
         case BGP_PMSI_TUNNEL_PIM_BIDIR:
-            ND_PRINT("\n\t      Sender %s, P-Group %s",
+            ND_PRINT(C_RESET, "\n\t      Sender %s, P-Group %s",
                       GET_IPADDR_STRING(tptr),
                       GET_IPADDR_STRING(tptr+4));
             break;
 
         case BGP_PMSI_TUNNEL_PIM_SSM:
-            ND_PRINT("\n\t      Root-Node %s, P-Group %s",
+            ND_PRINT(C_RESET, "\n\t      Root-Node %s, P-Group %s",
                       GET_IPADDR_STRING(tptr),
                       GET_IPADDR_STRING(tptr+4));
             break;
         case BGP_PMSI_TUNNEL_INGRESS:
-            ND_PRINT("\n\t      Tunnel-Endpoint %s",
+            ND_PRINT(C_RESET, "\n\t      Tunnel-Endpoint %s",
                       GET_IPADDR_STRING(tptr));
             break;
         case BGP_PMSI_TUNNEL_LDP_P2MP: /* fall through */
         case BGP_PMSI_TUNNEL_LDP_MP2MP:
-            ND_PRINT("\n\t      Root-Node %s, LSP-ID 0x%08x",
+            ND_PRINT(C_RESET, "\n\t      Root-Node %s, LSP-ID 0x%08x",
                       GET_IPADDR_STRING(tptr),
                       GET_BE_U_4(tptr + 4));
             break;
         case BGP_PMSI_TUNNEL_RSVP_P2MP:
-            ND_PRINT("\n\t      Extended-Tunnel-ID %s, P2MP-ID 0x%08x",
+            ND_PRINT(C_RESET, "\n\t      Extended-Tunnel-ID %s, P2MP-ID 0x%08x",
                       GET_IPADDR_STRING(tptr),
                       GET_BE_U_4(tptr + 4));
             break;
@@ -2462,7 +2462,7 @@ bgp_attr_print(netdissect_options *ndo,
             tptr += 3;
             tlen -= 3;
 
-            ND_PRINT("\n\t    %s TLV (%u), length %u",
+            ND_PRINT(C_RESET, "\n\t    %s TLV (%u), length %u",
                       tok2str(bgp_aigp_values, "Unknown", type),
                       type, length);
 
@@ -2481,7 +2481,7 @@ bgp_attr_print(netdissect_options *ndo,
             case BGP_AIGP_TLV:
                 if (length < 8)
                     goto trunc;
-                ND_PRINT(", metric %" PRIu64,
+                ND_PRINT(C_RESET, ", metric %" PRIu64,
                           GET_BE_U_8(tptr));
                 break;
 
@@ -2500,7 +2500,7 @@ bgp_attr_print(netdissect_options *ndo,
         ND_TCHECK_4(tptr);
         if (len < 4)
             goto trunc;
-        ND_PRINT("\n\t    Origin AS: %s",
+        ND_PRINT(C_RESET, "\n\t    Origin AS: %s",
                   as_printf(ndo, astostr, sizeof(astostr), GET_BE_U_4(tptr)));
         tptr += 4;
         len -= 4;
@@ -2510,7 +2510,7 @@ bgp_attr_print(netdissect_options *ndo,
 
             ND_TCHECK_2(tptr);
             if (len < 2) {
-                ND_PRINT(" [path attr too short]");
+                ND_PRINT(C_RESET, " [path attr too short]");
                 tptr += len;
                 break;
             }
@@ -2521,7 +2521,7 @@ bgp_attr_print(netdissect_options *ndo,
             alenlen = bgp_attr_lenlen(aflags, tptr);
             ND_TCHECK_LEN(tptr, alenlen);
             if (len < alenlen) {
-                ND_PRINT(" [path attr too short]");
+                ND_PRINT(C_RESET, " [path attr too short]");
                 tptr += len;
                 break;
             }
@@ -2529,22 +2529,22 @@ bgp_attr_print(netdissect_options *ndo,
             tptr += alenlen;
             len -= alenlen;
 
-            ND_PRINT("\n\t      %s (%u), length: %u",
+            ND_PRINT(C_RESET, "\n\t      %s (%u), length: %u",
                       tok2str(bgp_attr_values,
                               "Unknown Attribute", atype),
                       atype,
                       alen);
 
             if (aflags) {
-                ND_PRINT(", Flags [%s",
+                ND_PRINT(C_RESET, ", Flags [%s",
                          bittok2str_nosep(bgp_flags, "", aflags));
                 if (aflags & 0xf)
-                    ND_PRINT("+%x", aflags & 0xf);
-                ND_PRINT("]");
+                    ND_PRINT(C_RESET, "+%x", aflags & 0xf);
+                ND_PRINT(C_RESET, "]");
             }
-            ND_PRINT(": ");
+            ND_PRINT(C_RESET, ": ");
             if (len < alen) {
-                ND_PRINT(" [path attr too short]");
+                ND_PRINT(C_RESET, " [path attr too short]");
                 tptr += len;
                 break;
             }
@@ -2558,7 +2558,7 @@ bgp_attr_print(netdissect_options *ndo,
              * you can find the spec with respective normative text.
              */
             if (attr_set_level == 10)
-                ND_PRINT("(too many nested levels, not recursing)");
+                ND_PRINT(C_RESET, "(too many nested levels, not recursing)");
             else if (!bgp_attr_print(ndo, atype, tptr, alen, attr_set_level + 1))
                 return 0;
             tptr += alen;
@@ -2568,12 +2568,12 @@ bgp_attr_print(netdissect_options *ndo,
 
     case BGPTYPE_LARGE_COMMUNITY:
         if (len == 0 || len % 12) {
-            ND_PRINT("invalid len");
+            ND_PRINT(C_RESET, "invalid len");
             break;
         }
-        ND_PRINT("\n\t    ");
+        ND_PRINT(C_RESET, "\n\t    ");
         while (len != 0) {
-            ND_PRINT("%u:%u:%u%s",
+            ND_PRINT(C_RESET, "%u:%u:%u%s",
                       GET_BE_U_4(tptr),
                       GET_BE_U_4(tptr + 4),
                       GET_BE_U_4(tptr + 8),
@@ -2599,13 +2599,13 @@ bgp_attr_print(netdissect_options *ndo,
          */
         ND_ICHECKMSG_U("secure path length", splen, <, 8);
 
-        ND_PRINT("\n\t    Secure Path Length: %u", splen);
+        ND_PRINT(C_RESET, "\n\t    Secure Path Length: %u", splen);
 
         tptr += 2;
         splen -= 2;
         /* Make sure the secure path length does not signal trailing bytes */
         if (splen % 6) {
-            ND_PRINT(" [total segments length %u != N x 6]", splen);
+            ND_PRINT(C_RESET, " [total segments length %u != N x 6]", splen);
             goto invalid;
         }
 
@@ -2614,7 +2614,7 @@ bgp_attr_print(netdissect_options *ndo,
             uint8_t pcount = GET_U_1(tptr);
             uint8_t flags = GET_U_1(tptr + 1);
             uint32_t asn = GET_BE_U_4(tptr + 2);
-            ND_PRINT("\n\t      Secure Path Segment: pCount: %u, Flags: [%s] (0x%02x), AS: %u",
+            ND_PRINT(C_RESET, "\n\t      Secure Path Segment: pCount: %u, Flags: [%s] (0x%02x), AS: %u",
                      pcount,
                      bittok2str(bgp_bgpsec_bitmap_str, "none", flags),
                      flags,
@@ -2625,7 +2625,7 @@ bgp_attr_print(netdissect_options *ndo,
 
         sblen = GET_BE_U_2(tptr);
 
-        ND_PRINT("\n\t    Signature Block: Length: %u, Algo ID: %u",
+        ND_PRINT(C_RESET, "\n\t    Signature Block: Length: %u, Algo ID: %u",
                  sblen,
                  GET_U_1(tptr + 2));
 
@@ -2635,7 +2635,7 @@ bgp_attr_print(netdissect_options *ndo,
         while (sblen > 0) {
             uint16_t siglen;
 
-            ND_PRINT("\n\t      Signature Segment:\n\t        SKI: ");
+            ND_PRINT(C_RESET, "\n\t      Signature Segment:\n\t        SKI: ");
             ND_ICHECKMSG_U("remaining length", sblen, <, 20);
             hex_print(ndo, "\n\t          ", tptr, 20);
             tptr += 20;
@@ -2645,9 +2645,9 @@ bgp_attr_print(netdissect_options *ndo,
             tptr += 2;
             sblen -= 2;
 
-            ND_PRINT("\n\t        Length: %u", siglen);
+            ND_PRINT(C_RESET, "\n\t        Length: %u", siglen);
             ND_ICHECKMSG_U("remaining length", sblen, <, siglen);
-            ND_PRINT("\n\t        Signature:");
+            ND_PRINT(C_RESET, "\n\t        Signature:");
             hex_print(ndo, "\n\t          ", tptr, siglen);
             tptr += siglen;
             sblen -= siglen;
@@ -2656,7 +2656,7 @@ bgp_attr_print(netdissect_options *ndo,
     }
     default:
         ND_TCHECK_LEN(pptr, len);
-        ND_PRINT("\n\t    no Attribute %u decoder", atype); /* we have no decoder for the attribute */
+        ND_PRINT(C_RESET, "\n\t    no Attribute %u decoder", atype); /* we have no decoder for the attribute */
         if (ndo->ndo_vflag <= 1)
             print_unknown_data(ndo, pptr, "\n\t    ", len);
         break;
@@ -2689,7 +2689,7 @@ bgp_capabilities_print(netdissect_options *ndo,
         ND_TCHECK_LEN(opt + i, BGP_CAP_HEADER_SIZE);
         cap_type=GET_U_1(opt + i);
         cap_len=GET_U_1(opt + i + 1);
-        ND_PRINT("\n\t      %s (%u), length: %u",
+        ND_PRINT(C_RESET, "\n\t      %s (%u), length: %u",
                   tok2str(bgp_capcode_values, "Unknown", cap_type),
                   cap_type,
                   cap_len);
@@ -2698,10 +2698,10 @@ bgp_capabilities_print(netdissect_options *ndo,
         case BGP_CAPCODE_MP:
             /* AFI (16 bits), Reserved (8 bits), SAFI (8 bits) */
             if (cap_len < 4) {
-                ND_PRINT(" (too short, < 4)");
+                ND_PRINT(C_RESET, " (too short, < 4)");
                 return;
             }
-            ND_PRINT("\n\t\tAFI %s (%u), SAFI %s (%u)",
+            ND_PRINT(C_RESET, "\n\t\tAFI %s (%u), SAFI %s (%u)",
                tok2str(af_values, "Unknown", GET_BE_U_2(opt + i + 2)),
                GET_BE_U_2(opt + i + 2),
                tok2str(bgp_safi_values, "Unknown", GET_U_1(opt + i + 5)),
@@ -2712,11 +2712,11 @@ bgp_capabilities_print(netdissect_options *ndo,
             cap_offset = 1;
             /* The capability length [...] MUST be set to 3. */
             if (cap_len != 3) {
-                ND_PRINT(" [%u != 3]", cap_len);
+                ND_PRINT(C_RESET, " [%u != 3]", cap_len);
                 return;
             }
 
-            ND_PRINT("\n\t\tVersion %u, Direction %s (%u), AFI %s (%u)",
+            ND_PRINT(C_RESET, "\n\t\tVersion %u, Direction %s (%u), AFI %s (%u)",
                       GET_U_1(opt + i + 2)&0xf0,
                       (GET_U_1(opt + i + 2)&0x08) ? "Send" : "Receive",
                       (GET_U_1(opt + i + 2)&0x08)>>3,
@@ -2728,7 +2728,7 @@ bgp_capabilities_print(netdissect_options *ndo,
             cap_offset = 2;
             tcap_len = cap_len;
             while (tcap_len >= 4) {
-                ND_PRINT( "\n\t\tAFI %s (%u), SAFI %s (%u), Count: %u",
+                ND_PRINT(C_RESET,  "\n\t\tAFI %s (%u), SAFI %s (%u), Count: %u",
                        tok2str(af_values, "Unknown",
                                   GET_BE_U_2(opt + i + cap_offset)),
                        GET_BE_U_2(opt + i + cap_offset),
@@ -2743,18 +2743,18 @@ bgp_capabilities_print(netdissect_options *ndo,
         case BGP_CAPCODE_RESTART:
             /* Restart Flags (4 bits), Restart Time in seconds (12 bits) */
             if (cap_len < 2) {
-                ND_PRINT(" (too short, < 2)");
+                ND_PRINT(C_RESET, " (too short, < 2)");
                 return;
             }
             tcap_len=cap_len;
-            ND_PRINT("\n\t\tRestart Flags: [%s], Restart Time %us",
+            ND_PRINT(C_RESET, "\n\t\tRestart Flags: [%s], Restart Time %us",
                       bittok2str(bgp_graceful_restart_comm_flag_values,
                                  "none", GET_U_1(opt + i + 2) >> 4),
                       GET_BE_U_2(opt + i + 2)&0xfff);
             tcap_len-=2;
             cap_offset=4;
             while(tcap_len>=4) {
-                ND_PRINT("\n\t\t  AFI %s (%u), SAFI %s (%u), Forwarding state preserved: %s",
+                ND_PRINT(C_RESET, "\n\t\t  AFI %s (%u), SAFI %s (%u), Forwarding state preserved: %s",
                           tok2str(af_values,"Unknown",
                                   GET_BE_U_2(opt + i + cap_offset)),
                           GET_BE_U_2(opt + i + cap_offset),
@@ -2777,16 +2777,16 @@ bgp_capabilities_print(netdissect_options *ndo,
              * Extract the 4 byte AS number encoded.
              */
             if (cap_len < 4) {
-                ND_PRINT(" (too short, < 4)");
+                ND_PRINT(C_RESET, " (too short, < 4)");
                 return;
             }
-            ND_PRINT("\n\t\t 4 Byte AS %s",
+            ND_PRINT(C_RESET, "\n\t\t 4 Byte AS %s",
                       as_printf(ndo, astostr, sizeof(astostr),
                       GET_BE_U_4(opt + i + 2)));
             break;
         case BGP_CAPCODE_ADD_PATH:
             if (cap_len == 0) {
-                ND_PRINT(" (bogus)"); /* length */
+                ND_PRINT(C_RESET, " (bogus)"); /* length */
                 break;
             }
             tcap_len=cap_len;
@@ -2796,7 +2796,7 @@ bgp_capabilities_print(netdissect_options *ndo,
                     nd_print_invalid(ndo);
                     break;
                 }
-                ND_PRINT("\n\t\tAFI %s (%u), SAFI %s (%u), Send/Receive: %s",
+                ND_PRINT(C_RESET, "\n\t\tAFI %s (%u), SAFI %s (%u), Send/Receive: %s",
                           tok2str(af_values,"Unknown",GET_BE_U_2(opt + i + cap_offset)),
                           GET_BE_U_2(opt + i + cap_offset),
                           tok2str(bgp_safi_values,"Unknown",GET_U_1(opt + i + cap_offset + 2)),
@@ -2808,7 +2808,7 @@ bgp_capabilities_print(netdissect_options *ndo,
             }
             break;
         default:
-            ND_PRINT("\n\t\tno decoder for Capability %u",
+            ND_PRINT(C_RESET, "\n\t\tno decoder for Capability %u",
                       cap_type);
             if (ndo->ndo_vflag <= 1)
                 print_unknown_data(ndo, opt + i + 2, "\n\t\t",
@@ -2848,13 +2848,13 @@ bgp_open_print(netdissect_options *ndo,
 
     bgp_open_header = (const struct bgp_open *)dat;
 
-    ND_PRINT("\n\t  Version %u, ",
+    ND_PRINT(C_RESET, "\n\t  Version %u, ",
         GET_U_1(bgp_open_header->bgpo_version));
-    ND_PRINT("my AS %s, ",
+    ND_PRINT(C_RESET, "my AS %s, ",
         as_printf(ndo, astostr, sizeof(astostr), GET_BE_U_2(bgp_open_header->bgpo_myas)));
-    ND_PRINT("Holdtime %us, ",
+    ND_PRINT(C_RESET, "Holdtime %us, ",
         GET_BE_U_2(bgp_open_header->bgpo_holdtime));
-    ND_PRINT("ID %s", GET_IPADDR_STRING(bgp_open_header->bgpo_id));
+    ND_PRINT(C_RESET, "ID %s", GET_IPADDR_STRING(bgp_open_header->bgpo_id));
     optslen = GET_U_1(bgp_open_header->bgpo_optlen);
     opsttype = GET_U_1(bgp_open_header->bgpo_opttype);
     if (opsttype == BGP_OPEN_NON_EXT_OPT_TYPE_EXTENDED_LENGTH) {
@@ -2863,7 +2863,7 @@ bgp_open_print(netdissect_options *ndo,
         open_size += 3;
         opt_size += 1;
     }
-    ND_PRINT("\n\t  Optional parameters%s, length: %u",
+    ND_PRINT(C_RESET, "\n\t  Optional parameters%s, length: %u",
              extended_opt_params ? " (Extended)" : "", optslen);
 
     opt = dat + open_size;
@@ -2882,12 +2882,12 @@ bgp_open_print(netdissect_options *ndo,
         opt_len = extended_opt_params ? GET_BE_U_2(bgpopt->bgpopt_len)
                                       : GET_U_1(bgpopt->bgpopt_len);
         if (opt_size + i + opt_len > optslen) {
-            ND_PRINT("\n\t     Option %u, length: %u, goes past the end of the options",
+            ND_PRINT(C_RESET, "\n\t     Option %u, length: %u, goes past the end of the options",
                       opt_type, opt_len);
             break;
         }
 
-        ND_PRINT("\n\t    Option %s (%u), length: %u",
+        ND_PRINT(C_RESET, "\n\t    Option %s (%u), length: %u",
                   tok2str(bgp_opt_values,"Unknown",opt_type),
                   opt_type,
                   opt_len);
@@ -2902,7 +2902,7 @@ bgp_open_print(netdissect_options *ndo,
 
         case BGP_OPT_AUTH:
         default:
-               ND_PRINT("\n\t      no decoder for option %u",
+               ND_PRINT(C_RESET, "\n\t      no decoder for option %u",
                opt_type);
                break;
         }
@@ -2948,7 +2948,7 @@ bgp_update_print(netdissect_options *ndo,
         ND_TCHECK_LEN(p, withdrawn_routes_len);
         if (length < withdrawn_routes_len)
             goto trunc;
-        ND_PRINT("\n\t  Withdrawn routes:");
+        ND_PRINT(C_RESET, "\n\t  Withdrawn routes:");
         add_path = check_add_path(ndo, p, withdrawn_routes_len, 32);
         while (withdrawn_routes_len != 0) {
             if (add_path) {
@@ -2964,14 +2964,14 @@ bgp_update_print(netdissect_options *ndo,
             }
             wpfx = decode_prefix4(ndo, p, withdrawn_routes_len, buf, sizeof(buf));
             if (wpfx == -1) {
-                ND_PRINT("\n\t    (illegal prefix length)");
+                ND_PRINT(C_RESET, "\n\t    (illegal prefix length)");
                 break;
             } else if (wpfx == -2)
                 goto trunc; /* bytes left, but not enough */
             else {
-                ND_PRINT("\n\t    %s", buf);
+                ND_PRINT(C_RESET, "\n\t    %s", buf);
                 if (add_path) {
-                    ND_PRINT("   Path Id: %u", path_id);
+                    ND_PRINT(C_RESET, "   Path Id: %u", path_id);
                 }
                 p += wpfx;
                 length -= wpfx;
@@ -2995,7 +2995,7 @@ bgp_update_print(netdissect_options *ndo,
 
     if (withdrawn_routes_len == 0 && len == 0 && length == 0) {
         /* No withdrawn routes, no path attributes, no NLRI */
-        ND_PRINT("\n\t  End-of-Rib Marker (empty NLRI)");
+        ND_PRINT(C_RESET, "\n\t  End-of-Rib Marker (empty NLRI)");
         return;
     }
 
@@ -3012,7 +3012,7 @@ bgp_update_print(netdissect_options *ndo,
             if (length < 2)
                 goto trunc;
             if (len < 2) {
-                ND_PRINT("\n\t  [path attrs too short]");
+                ND_PRINT(C_RESET, "\n\t  [path attrs too short]");
                 p += len;
                 length -= len;
                 break;
@@ -3027,7 +3027,7 @@ bgp_update_print(netdissect_options *ndo,
             if (length < alenlen)
                 goto trunc;
             if (len < alenlen) {
-                ND_PRINT("\n\t  [path attrs too short]");
+                ND_PRINT(C_RESET, "\n\t  [path attrs too short]");
                 p += len;
                 length -= len;
                 break;
@@ -3037,20 +3037,20 @@ bgp_update_print(netdissect_options *ndo,
             len -= alenlen;
             length -= alenlen;
 
-            ND_PRINT("\n\t  %s (%u), length: %u",
+            ND_PRINT(C_RESET, "\n\t  %s (%u), length: %u",
                       tok2str(bgp_attr_values, "Unknown Attribute", atype),
                       atype,
                       alen);
 
             if (aflags) {
-                ND_PRINT(", Flags [%s",
+                ND_PRINT(C_RESET, ", Flags [%s",
                          bittok2str_nosep(bgp_flags, "", aflags));
                 if (aflags & 0xf)
-                    ND_PRINT("+%x", aflags & 0xf);
-                ND_PRINT("]: ");
+                    ND_PRINT(C_RESET, "+%x", aflags & 0xf);
+                ND_PRINT(C_RESET, "]: ");
             }
             if (len < alen) {
-                ND_PRINT(" [path attrs too short]");
+                ND_PRINT(C_RESET, " [path attrs too short]");
                 p += len;
                 length -= len;
                 break;
@@ -3067,7 +3067,7 @@ bgp_update_print(netdissect_options *ndo,
 
     if (length) {
         add_path = check_add_path(ndo, p, length, 32);
-        ND_PRINT("\n\t  Updated routes:");
+        ND_PRINT(C_RESET, "\n\t  Updated routes:");
         while (length != 0) {
             if (add_path) {
                 ND_TCHECK_4(p);
@@ -3079,14 +3079,14 @@ bgp_update_print(netdissect_options *ndo,
             }
             i = decode_prefix4(ndo, p, length, buf, sizeof(buf));
             if (i == -1) {
-                ND_PRINT("\n\t    (illegal prefix length)");
+                ND_PRINT(C_RESET, "\n\t    (illegal prefix length)");
                 break;
             } else if (i == -2)
                 goto trunc; /* bytes left, but not enough */
             else {
-                ND_PRINT("\n\t    %s", buf);
+                ND_PRINT(C_RESET, "\n\t    %s", buf);
                 if (add_path) {
-                    ND_PRINT("   Path Id: %u", path_id);
+                    ND_PRINT(C_RESET, "   Path Id: %u", path_id);
                 }
                 p += i;
                 length -= i;
@@ -3103,7 +3103,7 @@ bgp_notification_print_code(netdissect_options *ndo,
                             const u_char *dat, u_int length,
                             uint8_t bgpn_major, uint8_t bgpn_minor)
 {
-    ND_PRINT(", %s (%u)",
+    ND_PRINT(C_RESET, ", %s (%u)",
               tok2str(bgp_notify_major_values, "Unknown Error",
                       bgpn_major),
               bgpn_major);
@@ -3111,37 +3111,37 @@ bgp_notification_print_code(netdissect_options *ndo,
     switch (bgpn_major) {
 
     case BGP_NOTIFY_MAJOR_MSG:
-        ND_PRINT(", subcode %s (%u)",
+        ND_PRINT(C_RESET, ", subcode %s (%u)",
                   tok2str(bgp_notify_minor_msg_values, "Unknown",
                           bgpn_minor),
                   bgpn_minor);
         break;
     case BGP_NOTIFY_MAJOR_OPEN:
-        ND_PRINT(", subcode %s (%u)",
+        ND_PRINT(C_RESET, ", subcode %s (%u)",
                   tok2str(bgp_notify_minor_open_values, "Unknown",
                           bgpn_minor),
                   bgpn_minor);
         break;
     case BGP_NOTIFY_MAJOR_UPDATE:
-        ND_PRINT(", subcode %s (%u)",
+        ND_PRINT(C_RESET, ", subcode %s (%u)",
                   tok2str(bgp_notify_minor_update_values, "Unknown",
                           bgpn_minor),
                   bgpn_minor);
         break;
     case BGP_NOTIFY_MAJOR_FSM:
-        ND_PRINT(" subcode %s (%u)",
+        ND_PRINT(C_RESET, " subcode %s (%u)",
                   tok2str(bgp_notify_minor_fsm_values, "Unknown",
                           bgpn_minor),
                   bgpn_minor);
         break;
     case BGP_NOTIFY_MAJOR_CAP:
-        ND_PRINT(" subcode %s (%u)",
+        ND_PRINT(C_RESET, " subcode %s (%u)",
                   tok2str(bgp_notify_minor_cap_values, "Unknown",
                           bgpn_minor),
                   bgpn_minor);
         break;
     case BGP_NOTIFY_MAJOR_CEASE:
-        ND_PRINT(", subcode %s (%u)",
+        ND_PRINT(C_RESET, ", subcode %s (%u)",
                   tok2str(bgp_notify_minor_cease_values, "Unknown",
                           bgpn_minor),
                   bgpn_minor);
@@ -3150,7 +3150,7 @@ bgp_notification_print_code(netdissect_options *ndo,
          * for the maxprefix subtype, which may contain AFI, SAFI and MAXPREFIXES
          */
         if(bgpn_minor == BGP_NOTIFY_MINOR_CEASE_MAXPRFX && length >= 7) {
-            ND_PRINT(", AFI %s (%u), SAFI %s (%u), Max Prefixes: %u",
+            ND_PRINT(C_RESET, ", AFI %s (%u), SAFI %s (%u), Max Prefixes: %u",
                       tok2str(af_values, "Unknown", GET_BE_U_2(dat)),
                       GET_BE_U_2(dat),
                       tok2str(bgp_safi_values, "Unknown", GET_U_1((dat + 2))),
@@ -3168,22 +3168,22 @@ bgp_notification_print_code(netdissect_options *ndo,
             uint8_t remainder_offset = 0;
             /* garbage, hexdump it all */
             if (shutdown_comm_length > length - 1) {
-                ND_PRINT(", invalid Shutdown Communication length");
+                ND_PRINT(C_RESET, ", invalid Shutdown Communication length");
             }
             else if (shutdown_comm_length == 0) {
-                ND_PRINT(", empty Shutdown Communication");
+                ND_PRINT(C_RESET, ", empty Shutdown Communication");
                 remainder_offset += 1;
             }
             /* a proper shutdown communication */
             else {
-                ND_PRINT(", Shutdown Communication (length: %u): \"", shutdown_comm_length);
+                ND_PRINT(C_RESET, ", Shutdown Communication (length: %u): \"", shutdown_comm_length);
                 nd_printjn(ndo, dat+1, shutdown_comm_length);
-                ND_PRINT("\"");
+                ND_PRINT(C_RESET, "\"");
                 remainder_offset += shutdown_comm_length + 1;
             }
             /* if there is trailing data, hexdump it */
             if(length - remainder_offset > 0) {
-                ND_PRINT(", Data: (length: %u)", length - remainder_offset);
+                ND_PRINT(C_RESET, ", Data: (length: %u)", length - remainder_offset);
                 hex_print(ndo, "\n\t\t", dat + remainder_offset, length - remainder_offset);
             }
         }
@@ -3200,7 +3200,7 @@ bgp_notification_print_code(netdissect_options *ndo,
         break;
     default:
         if (bgpn_minor != 0) {
-            ND_PRINT(", subcode %u", bgpn_minor);
+            ND_PRINT(C_RESET, ", subcode %u", bgpn_minor);
         }
         break;
     }
@@ -3241,7 +3241,7 @@ bgp_route_refresh_print(netdissect_options *ndo,
 
     bgp_route_refresh_header = (const struct bgp_route_refresh *)pptr;
 
-    ND_PRINT("\n\t  AFI %s (%u), SAFI %s (%u), Subtype %s (%u)",
+    ND_PRINT(C_RESET, "\n\t  AFI %s (%u), SAFI %s (%u), Subtype %s (%u)",
              tok2str(af_values, "Unknown",
                      GET_BE_U_2(bgp_route_refresh_header->afi)),
              GET_BE_U_2(bgp_route_refresh_header->afi),
@@ -3259,7 +3259,7 @@ bgp_route_refresh_print(netdissect_options *ndo,
         orf_header =
           (const struct bgp_route_refresh_orf *)(pptr + BGP_ROUTE_REFRESH_SIZE);
 
-        ND_PRINT("\n\t  ORF refresh %s (%u), ORF type %s (%u), ORF length %u",
+        ND_PRINT(C_RESET, "\n\t  ORF refresh %s (%u), ORF type %s (%u), ORF length %u",
                  tok2str(bgp_orf_refresh_type, "Unknown",
                          GET_U_1(orf_header->refresh)),
                  GET_U_1(orf_header->refresh),
@@ -3288,7 +3288,7 @@ bgp_pdu_print(netdissect_options *ndo,
     bgp_header = (const struct bgp *)dat;
     bgp_type = GET_U_1(bgp_header->bgp_type);
 
-    ND_PRINT("\n\t%s Message (%u), length: %u",
+    ND_PRINT(C_RESET, "\n\t%s Message (%u), length: %u",
               tok2str(bgp_msg_values, "Unknown", bgp_type),
               bgp_type,
               length);
@@ -3311,7 +3311,7 @@ bgp_pdu_print(netdissect_options *ndo,
     default:
         /* we have no decoder for the BGP message */
         ND_TCHECK_LEN(dat, length);
-        ND_PRINT("\n\t  no Message %u decoder", bgp_type);
+        ND_PRINT(C_RESET, "\n\t  no Message %u decoder", bgp_type);
         print_unknown_data(ndo, dat, "\n\t  ", length);
         break;
     }
@@ -3336,7 +3336,7 @@ bgp_print(netdissect_options *ndo,
     uint16_t hlen;
 
     ndo->ndo_protocol = "bgp";
-    ND_PRINT(": BGP");
+    ND_PRINT(C_RESET, ": BGP");
 
     if (ndo->ndo_vflag < 1) /* lets be less chatty */
         return;
@@ -3367,7 +3367,7 @@ bgp_print(netdissect_options *ndo,
 
         hlen = GET_BE_U_2(bgp_header->bgp_len);
         if (hlen < BGP_SIZE) {
-            ND_PRINT("\nmessage length %u < %u", hlen, BGP_SIZE);
+            ND_PRINT(C_RESET, "\nmessage length %u < %u", hlen, BGP_SIZE);
             nd_print_invalid(ndo);
             break;
         }
@@ -3378,7 +3378,7 @@ bgp_print(netdissect_options *ndo,
             p += hlen;
             start = p;
         } else {
-            ND_PRINT("\n[|BGP %s]",
+            ND_PRINT(C_RESET, "\n[|BGP %s]",
                       tok2str(bgp_msg_values,
                               "Unknown Message Type",
                               GET_U_1(bgp_header->bgp_type)));

--- a/print-bootp.c
+++ b/print-bootp.c
@@ -298,16 +298,16 @@ bootp_print(netdissect_options *ndo,
 	ndo->ndo_protocol = "bootp";
 	bp = (const struct bootp *)cp;
 	bp_op = GET_U_1(bp->bp_op);
-	ND_PRINT("BOOTP/DHCP, %s",
+	ND_PRINT(C_RESET, "BOOTP/DHCP, %s",
 		  tok2str(bootp_op_values, "unknown (0x%02x)", bp_op));
 
 	bp_htype = GET_U_1(bp->bp_htype);
 	bp_hlen = GET_U_1(bp->bp_hlen);
 	if (bp_htype == 1 && bp_hlen == MAC_ADDR_LEN && bp_op == BOOTPREQUEST) {
-		ND_PRINT(" from %s", GET_ETHERADDR_STRING(bp->bp_chaddr));
+		ND_PRINT(C_RESET, " from %s", GET_ETHERADDR_STRING(bp->bp_chaddr));
 	}
 
-	ND_PRINT(", length %u", length);
+	ND_PRINT(C_RESET, ", length %u", length);
 
 	if (!ndo->ndo_vflag)
 		return;
@@ -316,65 +316,65 @@ bootp_print(netdissect_options *ndo,
 
 	/* The usual hardware address type is 1 (10Mb Ethernet) */
 	if (bp_htype != 1)
-		ND_PRINT(", htype %u", bp_htype);
+		ND_PRINT(C_RESET, ", htype %u", bp_htype);
 
 	/* The usual length for 10Mb Ethernet address is 6 bytes */
 	if (bp_htype != 1 || bp_hlen != MAC_ADDR_LEN)
-		ND_PRINT(", hlen %u", bp_hlen);
+		ND_PRINT(C_RESET, ", hlen %u", bp_hlen);
 
 	/* Only print interesting fields */
 	if (GET_U_1(bp->bp_hops))
-		ND_PRINT(", hops %u", GET_U_1(bp->bp_hops));
+		ND_PRINT(C_RESET, ", hops %u", GET_U_1(bp->bp_hops));
 	if (GET_BE_U_4(bp->bp_xid))
-		ND_PRINT(", xid 0x%x", GET_BE_U_4(bp->bp_xid));
+		ND_PRINT(C_RESET, ", xid 0x%x", GET_BE_U_4(bp->bp_xid));
 	if (GET_BE_U_2(bp->bp_secs))
-		ND_PRINT(", secs %u", GET_BE_U_2(bp->bp_secs));
+		ND_PRINT(C_RESET, ", secs %u", GET_BE_U_2(bp->bp_secs));
 
-	ND_PRINT(", Flags [%s]",
+	ND_PRINT(C_RESET, ", Flags [%s]",
 		  bittok2str(bootp_flag_values, "none", GET_BE_U_2(bp->bp_flags)));
 	if (ndo->ndo_vflag > 1)
-		ND_PRINT(" (0x%04x)", GET_BE_U_2(bp->bp_flags));
+		ND_PRINT(C_RESET, " (0x%04x)", GET_BE_U_2(bp->bp_flags));
 
 	/* Client's ip address */
 	if (GET_IPV4_TO_NETWORK_ORDER(bp->bp_ciaddr))
-		ND_PRINT("\n\t  Client-IP %s", GET_IPADDR_STRING(bp->bp_ciaddr));
+		ND_PRINT(C_RESET, "\n\t  Client-IP %s", GET_IPADDR_STRING(bp->bp_ciaddr));
 
 	/* 'your' ip address (bootp client) */
 	if (GET_IPV4_TO_NETWORK_ORDER(bp->bp_yiaddr))
-		ND_PRINT("\n\t  Your-IP %s", GET_IPADDR_STRING(bp->bp_yiaddr));
+		ND_PRINT(C_RESET, "\n\t  Your-IP %s", GET_IPADDR_STRING(bp->bp_yiaddr));
 
 	/* Server's ip address */
 	if (GET_IPV4_TO_NETWORK_ORDER(bp->bp_siaddr))
-		ND_PRINT("\n\t  Server-IP %s", GET_IPADDR_STRING(bp->bp_siaddr));
+		ND_PRINT(C_RESET, "\n\t  Server-IP %s", GET_IPADDR_STRING(bp->bp_siaddr));
 
 	/* Gateway's ip address */
 	if (GET_IPV4_TO_NETWORK_ORDER(bp->bp_giaddr))
-		ND_PRINT("\n\t  Gateway-IP %s", GET_IPADDR_STRING(bp->bp_giaddr));
+		ND_PRINT(C_RESET, "\n\t  Gateway-IP %s", GET_IPADDR_STRING(bp->bp_giaddr));
 
 	/* Client's Ethernet address */
 	if (bp_htype == 1 && bp_hlen == MAC_ADDR_LEN) {
-		ND_PRINT("\n\t  Client-Ethernet-Address %s", GET_ETHERADDR_STRING(bp->bp_chaddr));
+		ND_PRINT(C_RESET, "\n\t  Client-Ethernet-Address %s", GET_ETHERADDR_STRING(bp->bp_chaddr));
 	}
 
 	if (GET_U_1(bp->bp_sname)) {	/* get first char only */
-		ND_PRINT("\n\t  sname \"");
+		ND_PRINT(C_RESET, "\n\t  sname \"");
 		if (nd_printztn(ndo, bp->bp_sname, (u_int)sizeof(bp->bp_sname),
 				NULL) == 0) {
 			/* Within the buffer, but not NUL-terminated. */
-			ND_PRINT("\"");
+			ND_PRINT(C_RESET, "\"");
 			goto invalid;
 		}
-		ND_PRINT("\"");
+		ND_PRINT(C_RESET, "\"");
 	}
 	if (GET_U_1(bp->bp_file)) {	/* get first char only */
-		ND_PRINT("\n\t  file \"");
+		ND_PRINT(C_RESET, "\n\t  file \"");
 		if (nd_printztn(ndo, bp->bp_file, (u_int)sizeof(bp->bp_file),
 				NULL) == 0) {
 			/* Ditto. */
-			ND_PRINT("\"");
+			ND_PRINT(C_RESET, "\"");
 			goto invalid;
 		}
-		ND_PRINT("\"");
+		ND_PRINT(C_RESET, "\"");
 	}
 
 	/* Decode the vendor buffer */
@@ -390,7 +390,7 @@ bootp_print(netdissect_options *ndo,
 
 		ul = GET_BE_U_4(bp->bp_vend);
 		if (ul != 0)
-			ND_PRINT("\n\t  Vendor-#0x%x", ul);
+			ND_PRINT(C_RESET, "\n\t  Vendor-#0x%x", ul);
 	}
 	return;
 invalid:
@@ -597,10 +597,10 @@ rfc1048_print(netdissect_options *ndo,
 	int first, idx;
 	uint8_t subopt, suboptlen;
 
-	ND_PRINT("\n\t  Vendor-rfc1048 Extensions");
+	ND_PRINT(C_RESET, "\n\t  Vendor-rfc1048 Extensions");
 
 	/* Step over magic cookie */
-	ND_PRINT("\n\t    Magic Cookie 0x%08x", GET_BE_U_4(bp));
+	ND_PRINT(C_RESET, "\n\t    Magic Cookie 0x%08x", GET_BE_U_4(bp));
 	bp += sizeof(int32_t);
 
 	/* Loop while we there is a tag left in the buffer */
@@ -622,7 +622,7 @@ rfc1048_print(netdissect_options *ndo,
 			bp++;
 		}
 
-		ND_PRINT("\n\t    %s (%u), length %u%s", cp, tag, len,
+		ND_PRINT(C_RESET, "\n\t    %s (%u), length %u%s", cp, tag, len,
 			  len > 0 ? ": " : "");
 
 		if (tag == TAG_PAD && ndo->ndo_vflag > 2) {
@@ -633,13 +633,13 @@ rfc1048_print(netdissect_options *ndo,
 				ntag++;
 			}
 			if (ntag > 1)
-				ND_PRINT(", occurs %u", ntag);
+				ND_PRINT(C_RESET, ", occurs %u", ntag);
 		}
 
 		ND_TCHECK_LEN(bp, len);
 
 		if (tag == TAG_DHCP_MESSAGE && len == 1) {
-			ND_PRINT("%s",
+			ND_PRINT(C_RESET, "%s",
 				 tok2str(dhcp_msg_values, "Unknown (%u)", GET_U_1(bp)));
 			bp++;
 			continue;
@@ -653,10 +653,10 @@ rfc1048_print(netdissect_options *ndo,
 				len--;
 				cp = tok2str(tag2str, "?Unknown", innertag);
 				if (idx % 4 == 0)
-					ND_PRINT("\n\t      ");
+					ND_PRINT(C_RESET, "\n\t      ");
 				else
-					ND_PRINT(", ");
-				ND_PRINT("%s (%u)", cp + 1, innertag);
+					ND_PRINT(C_RESET, ", ");
+				ND_PRINT(C_RESET, "%s (%u)", cp + 1, innertag);
 				idx++;
 			}
 			continue;
@@ -677,9 +677,9 @@ rfc1048_print(netdissect_options *ndo,
 
 		case 'a':
 			/* ASCII strings */
-			ND_PRINT("\"");
+			ND_PRINT(C_RESET, "\"");
 			nd_printjn(ndo, bp, len);
-			ND_PRINT("\"");
+			ND_PRINT(C_RESET, "\"");
 			bp += len;
 			len = 0;
 			break;
@@ -690,13 +690,13 @@ rfc1048_print(netdissect_options *ndo,
 			/* ip addresses/32-bit words */
 			while (len >= 4) {
 				if (!first)
-					ND_PRINT(",");
+					ND_PRINT(C_RESET, ",");
 				if (c == 'i')
-					ND_PRINT("%s", GET_IPADDR_STRING(bp));
+					ND_PRINT(C_RESET, "%s", GET_IPADDR_STRING(bp));
 				else if (c == 'L')
-					ND_PRINT("%d", GET_BE_S_4(bp));
+					ND_PRINT(C_RESET, "%d", GET_BE_S_4(bp));
 				else
-					ND_PRINT("%u", GET_BE_U_4(bp));
+					ND_PRINT(C_RESET, "%u", GET_BE_U_4(bp));
 				bp += 4;
 				len -= 4;
 				first = 0;
@@ -707,11 +707,11 @@ rfc1048_print(netdissect_options *ndo,
 			/* IP address pairs */
 			while (len >= 2*4) {
 				if (!first)
-					ND_PRINT(",");
-				ND_PRINT("(%s:", GET_IPADDR_STRING(bp));
+					ND_PRINT(C_RESET, ",");
+				ND_PRINT(C_RESET, "(%s:", GET_IPADDR_STRING(bp));
 				bp += 4;
 				len -= 4;
-				ND_PRINT("%s)", GET_IPADDR_STRING(bp));
+				ND_PRINT(C_RESET, "%s)", GET_IPADDR_STRING(bp));
 				bp += 4;
 				len -= 4;
 				first = 0;
@@ -722,8 +722,8 @@ rfc1048_print(netdissect_options *ndo,
 			/* shorts */
 			while (len >= 2) {
 				if (!first)
-					ND_PRINT(",");
-				ND_PRINT("%u", GET_BE_U_2(bp));
+					ND_PRINT(C_RESET, ",");
+				ND_PRINT(C_RESET, "%u", GET_BE_U_2(bp));
 				bp += 2;
 				len -= 2;
 				first = 0;
@@ -735,17 +735,17 @@ rfc1048_print(netdissect_options *ndo,
 			while (len > 0) {
 				uint8_t bool_value;
 				if (!first)
-					ND_PRINT(",");
+					ND_PRINT(C_RESET, ",");
 				bool_value = GET_U_1(bp);
 				switch (bool_value) {
 				case 0:
-					ND_PRINT("N");
+					ND_PRINT(C_RESET, "N");
 					break;
 				case 1:
-					ND_PRINT("Y");
+					ND_PRINT(C_RESET, "Y");
 					break;
 				default:
-					ND_PRINT("%u?", bool_value);
+					ND_PRINT(C_RESET, "%u?", bool_value);
 					break;
 				}
 				++bp;
@@ -761,12 +761,15 @@ rfc1048_print(netdissect_options *ndo,
 			while (len > 0) {
 				uint8_t byte_value;
 				if (!first)
-					ND_PRINT(c == 'x' ? ":" : ".");
+					if(c == 'x')
+						ND_PRINT(C_RESET, ":");
+					else
+						ND_PRINT(C_RESET, ".");
 				byte_value = GET_U_1(bp);
 				if (c == 'x')
-					ND_PRINT("%02x", byte_value);
+					ND_PRINT(C_RESET, "%02x", byte_value);
 				else
-					ND_PRINT("%u", byte_value);
+					ND_PRINT(C_RESET, "%u", byte_value);
 				++bp;
 				--len;
 				first = 0;
@@ -780,50 +783,50 @@ rfc1048_print(netdissect_options *ndo,
 			case TAG_NETBIOS_NODE:
 				/* this option should be at least 1 byte long */
 				if (len < 1) {
-					ND_PRINT("[ERROR: length < 1 bytes]");
+					ND_PRINT(C_RESET, "[ERROR: length < 1 bytes]");
 					break;
 				}
 				tag = GET_U_1(bp);
 				++bp;
 				--len;
-				ND_PRINT("%s", tok2str(nbo2str, NULL, tag));
+				ND_PRINT(C_RESET, "%s", tok2str(nbo2str, NULL, tag));
 				break;
 
 			case TAG_OPT_OVERLOAD:
 				/* this option should be at least 1 byte long */
 				if (len < 1) {
-					ND_PRINT("[ERROR: length < 1 bytes]");
+					ND_PRINT(C_RESET, "[ERROR: length < 1 bytes]");
 					break;
 				}
 				tag = GET_U_1(bp);
 				++bp;
 				--len;
-				ND_PRINT("%s", tok2str(oo2str, NULL, tag));
+				ND_PRINT(C_RESET, "%s", tok2str(oo2str, NULL, tag));
 				break;
 
 			case TAG_CLIENT_FQDN:
 				/* this option should be at least 3 bytes long */
 				if (len < 3) {
-					ND_PRINT("[ERROR: length < 3 bytes]");
+					ND_PRINT(C_RESET, "[ERROR: length < 3 bytes]");
 					bp += len;
 					len = 0;
 					break;
 				}
 				if (GET_U_1(bp) & 0xf0) {
-					ND_PRINT("[ERROR: MBZ nibble 0x%x != 0] ",
+					ND_PRINT(C_RESET, "[ERROR: MBZ nibble 0x%x != 0] ",
 						 (GET_U_1(bp) & 0xf0) >> 4);
 				}
 				if (GET_U_1(bp) & 0x0f)
-					ND_PRINT("[%s] ",
+					ND_PRINT(C_RESET, "[%s] ",
 						 bittok2str_nosep(fqdn_flags_bm, "", (GET_U_1(bp))));
 				bp++;
 				if (GET_U_1(bp) || GET_U_1(bp + 1))
-					ND_PRINT("%u/%u ", GET_U_1(bp),
+					ND_PRINT(C_RESET, "%u/%u ", GET_U_1(bp),
 						 GET_U_1(bp + 1));
 				bp += 2;
-				ND_PRINT("\"");
+				ND_PRINT(C_RESET, "\"");
 				nd_printjn(ndo, bp, len - 3);
-				ND_PRINT("\"");
+				ND_PRINT(C_RESET, "\"");
 				bp += len - 3;
 				len = 0;
 				break;
@@ -834,25 +837,25 @@ rfc1048_print(netdissect_options *ndo,
 
 				/* this option should be at least 1 byte long */
 				if (len < 1) {
-					ND_PRINT("[ERROR: length < 1 bytes]");
+					ND_PRINT(C_RESET, "[ERROR: length < 1 bytes]");
 					break;
 				}
 				type = GET_U_1(bp);
 				bp++;
 				len--;
 				if (type == 0) {
-					ND_PRINT("\"");
+					ND_PRINT(C_RESET, "\"");
 					nd_printjn(ndo, bp, len);
-					ND_PRINT("\"");
+					ND_PRINT(C_RESET, "\"");
 					bp += len;
 					len = 0;
 					break;
 				} else {
-					ND_PRINT("%s ", tok2str(arp2str, "hardware-type %u,", type));
+					ND_PRINT(C_RESET, "%s ", tok2str(arp2str, "hardware-type %u,", type));
 					while (len > 0) {
 						if (!first)
-							ND_PRINT(":");
-						ND_PRINT("%02x", GET_U_1(bp));
+							ND_PRINT(C_RESET, ":");
+						ND_PRINT(C_RESET, "%02x", GET_U_1(bp));
 						++bp;
 						--len;
 						first = 0;
@@ -868,7 +871,7 @@ rfc1048_print(netdissect_options *ndo,
 					bp += 2;
 					len -= 2;
 					if (suboptlen > len) {
-						ND_PRINT("\n\t      %s SubOption %u, length %u: length goes past end of option",
+						ND_PRINT(C_RESET, "\n\t      %s SubOption %u, length %u: length goes past end of option",
 							  tok2str(agent_suboption_values, "Unknown", subopt),
 							  subopt,
 							  suboptlen);
@@ -876,7 +879,7 @@ rfc1048_print(netdissect_options *ndo,
 						len = 0;
 						break;
 					}
-					ND_PRINT("\n\t      %s SubOption %u, length %u: ",
+					ND_PRINT(C_RESET, "\n\t      %s SubOption %u, length %u: ",
 						  tok2str(agent_suboption_values, "Unknown", subopt),
 						  subopt,
 						  suboptlen);
@@ -904,20 +907,20 @@ rfc1048_print(netdissect_options *ndo,
 
 				/* this option should be at least 5 bytes long */
 				if (len < 5) {
-					ND_PRINT("[ERROR: length < 5 bytes]");
+					ND_PRINT(C_RESET, "[ERROR: length < 5 bytes]");
 					bp += len;
 					len = 0;
 					break;
 				}
 				while (len > 0) {
 					if (!first)
-						ND_PRINT(",");
+						ND_PRINT(C_RESET, ",");
 					mask_width = GET_U_1(bp);
 					bp++;
 					len--;
 					/* mask_width <= 32 */
 					if (mask_width > 32) {
-						ND_PRINT("[ERROR: Mask width (%u) > 32]", mask_width);
+						ND_PRINT(C_RESET, "[ERROR: Mask width (%u) > 32]", mask_width);
 						bp += len;
 						len = 0;
 						break;
@@ -925,27 +928,27 @@ rfc1048_print(netdissect_options *ndo,
 					significant_octets = (mask_width + 7) / 8;
 					/* significant octets + router(4) */
 					if (len < significant_octets + 4) {
-						ND_PRINT("[ERROR: Remaining length (%u) < %u bytes]", len, significant_octets + 4);
+						ND_PRINT(C_RESET, "[ERROR: Remaining length (%u) < %u bytes]", len, significant_octets + 4);
 						bp += len;
 						len = 0;
 						break;
 					}
-					ND_PRINT("(");
+					ND_PRINT(C_RESET, "(");
 					if (mask_width == 0)
-						ND_PRINT("default");
+						ND_PRINT(C_RESET, "default");
 					else {
 						for (i = 0; i < significant_octets ; i++) {
 							if (i > 0)
-								ND_PRINT(".");
-							ND_PRINT("%u",
+								ND_PRINT(C_RESET, ".");
+							ND_PRINT(C_RESET, "%u",
 								 GET_U_1(bp));
 							bp++;
 						}
 						for (i = significant_octets ; i < 4 ; i++)
-							ND_PRINT(".0");
-						ND_PRINT("/%u", mask_width);
+							ND_PRINT(C_RESET, ".0");
+						ND_PRINT(C_RESET, "/%u", mask_width);
 					}
-					ND_PRINT(":%s)", GET_IPADDR_STRING(bp));
+					ND_PRINT(C_RESET, ":%s)", GET_IPADDR_STRING(bp));
 					bp += 4;
 					len -= (significant_octets + 4);
 					first = 0;
@@ -959,7 +962,7 @@ rfc1048_print(netdissect_options *ndo,
 
 				first = 1;
 				if (len < 2) {
-					ND_PRINT("[ERROR: length < 2 bytes]");
+					ND_PRINT(C_RESET, "[ERROR: length < 2 bytes]");
 					bp += len;
 					len = 0;
 					break;
@@ -968,24 +971,24 @@ rfc1048_print(netdissect_options *ndo,
 					suboptlen = GET_U_1(bp);
 					bp++;
 					len--;
-					ND_PRINT("\n\t      ");
-					ND_PRINT("instance#%u: ", suboptnumber);
+					ND_PRINT(C_RESET, "\n\t      ");
+					ND_PRINT(C_RESET, "instance#%u: ", suboptnumber);
 					if (suboptlen == 0) {
-						ND_PRINT("[ERROR: suboption length must be non-zero]");
+						ND_PRINT(C_RESET, "[ERROR: suboption length must be non-zero]");
 						bp += len;
 						len = 0;
 						break;
 					}
 					if (len < suboptlen) {
-						ND_PRINT("[ERROR: invalid option]");
+						ND_PRINT(C_RESET, "[ERROR: invalid option]");
 						bp += len;
 						len = 0;
 						break;
 					}
-					ND_PRINT("\"");
+					ND_PRINT(C_RESET, "\"");
 					nd_printjn(ndo, bp, suboptlen);
-					ND_PRINT("\"");
-					ND_PRINT(", length %u", suboptlen);
+					ND_PRINT(C_RESET, "\"");
+					ND_PRINT(C_RESET, ", length %u", suboptlen);
 					suboptnumber++;
 					len -= suboptlen;
 					bp += suboptlen;
@@ -994,7 +997,7 @@ rfc1048_print(netdissect_options *ndo,
 			    }
 
 			default:
-				ND_PRINT("[unknown special tag %u, size %u]",
+				ND_PRINT(C_RESET, "[unknown special tag %u, size %u]",
 					  tag, len);
 				bp += len;
 				len = 0;
@@ -1004,7 +1007,7 @@ rfc1048_print(netdissect_options *ndo,
 		}
 		/* Data left over? */
 		if (len) {
-			ND_PRINT("\n\t  trailing data length %u", len);
+			ND_PRINT(C_RESET, "\n\t  trailing data length %u", len);
 			bp += len;
 		}
 	}
@@ -1012,7 +1015,7 @@ rfc1048_print(netdissect_options *ndo,
 
 #define PRINTCMUADDR(m, s) { ND_TCHECK_4(cmu->m); \
     if (GET_IPV4_TO_NETWORK_ORDER(cmu->m) != 0) \
-	ND_PRINT(" %s:%s", s, GET_IPADDR_STRING(cmu->m)); }
+	ND_PRINT(C_RESET, " %s:%s", s, GET_IPADDR_STRING(cmu->m)); }
 
 static void
 cmu_print(netdissect_options *ndo,
@@ -1021,14 +1024,14 @@ cmu_print(netdissect_options *ndo,
 	const struct cmu_vend *cmu;
 	uint8_t v_flags;
 
-	ND_PRINT(" vend-cmu");
+	ND_PRINT(C_RESET, " vend-cmu");
 	cmu = (const struct cmu_vend *)bp;
 
 	/* Only print if there are unknown bits */
 	ND_TCHECK_4(cmu->v_flags);
 	v_flags = GET_U_1(cmu->v_flags);
 	if ((v_flags & ~(VF_SMASK)) != 0)
-		ND_PRINT(" F:0x%x", v_flags);
+		ND_PRINT(C_RESET, " F:0x%x", v_flags);
 	PRINTCMUADDR(v_dgate, "DG");
 	PRINTCMUADDR(v_smask, v_flags & VF_SMASK ? "SM" : "SM*");
 	PRINTCMUADDR(v_dns1, "NS1");

--- a/print-brcmtag.c
+++ b/print-brcmtag.c
@@ -88,27 +88,27 @@ brcm_tag_print(netdissect_options *ndo, const u_char *bp)
 	for (i = 0; i < BRCM_TAG_LEN; i++)
 		tag[i] = GET_U_1(bp + i);
 
-	ND_PRINT("BRCM tag OP: %s", tag[0] ? "IG" : "EG");
+	ND_PRINT(C_RESET, "BRCM tag OP: %s", tag[0] ? "IG" : "EG");
 	if (tag[0] & (1 << BRCM_OPCODE_SHIFT)) {
 		/* Ingress Broadcom tag */
-		ND_PRINT(", TC: %d", (tag[1] >> BRCM_IG_TC_SHIFT) &
+		ND_PRINT(C_RESET, ", TC: %d", (tag[1] >> BRCM_IG_TC_SHIFT) &
 			 BRCM_IG_TC_MASK);
-		ND_PRINT(", TE: %s",
+		ND_PRINT(C_RESET, ", TE: %s",
 			 tok2str(brcm_tag_te_values, "unknown",
 				 (tag[1] & BRCM_IG_TE_MASK)));
-		ND_PRINT(", TS: %d", tag[1] >> BRCM_IG_TS_SHIFT);
+		ND_PRINT(C_RESET, ", TS: %d", tag[1] >> BRCM_IG_TS_SHIFT);
 		dst_map = (uint16_t)tag[2] << 8 | tag[3];
-		ND_PRINT(", DST map: 0x%04x", dst_map & BRCM_IG_DSTMAP_MASK);
+		ND_PRINT(C_RESET, ", DST map: 0x%04x", dst_map & BRCM_IG_DSTMAP_MASK);
 	} else {
 		/* Egress Broadcom tag */
-		ND_PRINT(", CID: %d", tag[1]);
-		ND_PRINT(", RC: %s", tok2str(brcm_tag_rc_values,
+		ND_PRINT(C_RESET, ", CID: %d", tag[1]);
+		ND_PRINT(C_RESET, ", RC: %s", tok2str(brcm_tag_rc_values,
 			 "reserved", tag[2]));
-		ND_PRINT(", TC: %d", (tag[3] >> BRCM_EG_TC_SHIFT) &
+		ND_PRINT(C_RESET, ", TC: %d", (tag[3] >> BRCM_EG_TC_SHIFT) &
 			 BRCM_EG_TC_MASK);
-		ND_PRINT(", port: %d", tag[3] & BRCM_EG_PID_MASK);
+		ND_PRINT(C_RESET, ", port: %d", tag[3] & BRCM_EG_PID_MASK);
 	}
-	ND_PRINT(", ");
+	ND_PRINT(C_RESET, ", ");
 }
 
 void

--- a/print-bt.c
+++ b/print-bt.c
@@ -62,7 +62,7 @@ bt_if_print(netdissect_options *ndo, const struct pcap_pkthdr *h, const u_char *
 	length -= BT_HDRLEN;
 	p += BT_HDRLEN;
 	if (ndo->ndo_eflag)
-		ND_PRINT(", hci length %u, direction %s", length,
+		ND_PRINT(C_RESET, ", hci length %u, direction %s", length,
 			 (GET_BE_U_4(hdr->direction)&0x1) ? "in" : "out");
 
 	if (!ndo->ndo_suppress_default_print)

--- a/print-calm-fast.c
+++ b/print-calm-fast.c
@@ -43,21 +43,21 @@ calm_fast_print(netdissect_options *ndo, const u_char *bp, u_int length, const s
 {
 	ndo->ndo_protocol = "calm_fast";
 
-	ND_PRINT("CALM FAST");
+	ND_PRINT(C_RESET, "CALM FAST");
 	if (src != NULL)
-		ND_PRINT(" src:%s", (src->addr_string)(ndo, src->addr));
-	ND_PRINT("; ");
+		ND_PRINT(C_RESET, " src:%s", (src->addr_string)(ndo, src->addr));
+	ND_PRINT(C_RESET, "; ");
 
 	if (length < 2) {
-		ND_PRINT(" (length %u < 2)", length);
+		ND_PRINT(C_RESET, " (length %u < 2)", length);
 		goto invalid;
 	}
 
-	ND_PRINT("SrcNwref:%u; ", GET_U_1(bp));
+	ND_PRINT(C_RESET, "SrcNwref:%u; ", GET_U_1(bp));
 	length -= 1;
 	bp += 1;
 
-	ND_PRINT("DstNwref:%u; ", GET_U_1(bp));
+	ND_PRINT(C_RESET, "DstNwref:%u; ", GET_U_1(bp));
 	length -= 1;
 	bp += 1;
 

--- a/print-carp.c
+++ b/print-carp.c
@@ -58,12 +58,12 @@ carp_print(netdissect_options *ndo, const u_char *bp, u_int len, u_int ttl)
 		type_s = "advertise";
 	else
 		type_s = "unknown";
-	ND_PRINT("CARPv%u-%s %u: ", version, type_s, len);
+	ND_PRINT(C_RESET, "CARPv%u-%s %u: ", version, type_s, len);
 	if (ttl != 255)
-		ND_PRINT("[ttl=%u!] ", ttl);
+		ND_PRINT(C_RESET, "[ttl=%u!] ", ttl);
 	if (version != 2 || type != 1)
 		return;
-	ND_PRINT("vhid=%u advbase=%u advskew=%u authlen=%u ",
+	ND_PRINT(C_RESET, "vhid=%u advbase=%u advskew=%u authlen=%u ",
 	    GET_U_1(bp + 1), GET_U_1(bp + 5), GET_U_1(bp + 2),
 	    GET_U_1(bp + 3));
 	if (ndo->ndo_vflag) {
@@ -71,8 +71,8 @@ carp_print(netdissect_options *ndo, const u_char *bp, u_int len, u_int ttl)
 		vec[0].ptr = (const uint8_t *)bp;
 		vec[0].len = len;
 		if (ND_TTEST_LEN(bp, len) && in_cksum(vec, 1))
-			ND_PRINT(" (bad carp cksum %x!)",
+			ND_PRINT(C_RESET, " (bad carp cksum %x!)",
 				GET_BE_U_2(bp + 6));
 	}
-	ND_PRINT("counter=%" PRIu64, GET_BE_U_8(bp + 8));
+	ND_PRINT(C_RESET, "counter=%" PRIu64, GET_BE_U_8(bp + 8));
 }

--- a/print-cdp.c
+++ b/print-cdp.c
@@ -68,9 +68,9 @@ static void
 cdp_print_string(netdissect_options *ndo,
                  const u_char *cp, const u_int len)
 {
-	ND_PRINT("'");
+	ND_PRINT(C_RESET, C_RESET "'");
 	nd_printjn(ndo, cp, len);
-	ND_PRINT("'");
+	ND_PRINT(C_RESET, C_RESET "'");
 }
 
 static void
@@ -90,7 +90,7 @@ cdp_print_power(netdissect_options *ndo,
 		val = GET_BE_U_3(cp);
 		break;
 	}
-	ND_PRINT("%1.2fW", val / 1000.0);
+	ND_PRINT(C_RESET, C_RESET "%1.2fW", val / 1000.0);
 }
 
 static void
@@ -99,7 +99,7 @@ cdp_print_capability(netdissect_options *ndo,
 {
 	uint32_t val = GET_BE_U_4(cp);
 
-	ND_PRINT("(0x%08x): %s", val,
+	ND_PRINT(C_RESET, C_RESET "(0x%08x): %s", val,
 	         bittok2str(cdp_capability_values, "none", val));
 }
 
@@ -110,12 +110,12 @@ cdp_print_version(netdissect_options *ndo,
 {
 	unsigned i;
 
-	ND_PRINT("\n\t  ");
+	ND_PRINT(C_RESET, C_RESET "\n\t  ");
 	for (i = 0; i < len; i++) {
 		u_char c = GET_U_1(cp + i);
 
 		if (c == '\n')
-			ND_PRINT("\n\t  ");
+			ND_PRINT(C_RESET, C_RESET "\n\t  ");
 		else
 			fn_print_char(ndo, c);
 	}
@@ -125,14 +125,14 @@ static void
 cdp_print_uint16(netdissect_options *ndo,
                  const u_char *cp, const u_int len _U_)
 {
-	ND_PRINT("%u", GET_BE_U_2(cp));
+	ND_PRINT(C_RESET, C_RESET "%u", GET_BE_U_2(cp));
 }
 
 static void
 cdp_print_duplex(netdissect_options *ndo,
                  const u_char *cp, const u_int len _U_)
 {
-	ND_PRINT("%s", GET_U_1(cp) ? "full": "half");
+	ND_PRINT(C_RESET, C_RESET "%s", GET_U_1(cp) ? "full": "half");
 }
 
 /* https://www.cisco.com/c/en/us/td/docs/voice_ip_comm/cata/186/2_12_m/english/release/notes/186rn21m.html
@@ -152,32 +152,32 @@ cdp_print_ata186(netdissect_options *ndo,
                  const u_char *cp, const u_int len)
 {
 	if (len == 2)
-		ND_PRINT("unknown 0x%04x", GET_BE_U_2(cp));
+		ND_PRINT(C_RESET, C_RESET "unknown 0x%04x", GET_BE_U_2(cp));
 	else
-		ND_PRINT("app %u, vlan %u", GET_U_1(cp), GET_BE_U_2(cp + 1));
+		ND_PRINT(C_RESET, C_RESET "app %u, vlan %u", GET_U_1(cp), GET_BE_U_2(cp + 1));
 }
 
 static void
 cdp_print_mtu(netdissect_options *ndo,
               const u_char *cp, const u_int len _U_)
 {
-	ND_PRINT("%u bytes", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, C_RESET "%u bytes", GET_BE_U_4(cp));
 }
 
 static void
 cdp_print_uint8x(netdissect_options *ndo,
                  const u_char *cp, const u_int len _U_)
 {
-	ND_PRINT("0x%02x", GET_U_1(cp));
+	ND_PRINT(C_RESET, C_RESET "0x%02x", GET_U_1(cp));
 }
 
 static void
 cdp_print_phys_loc(netdissect_options *ndo,
                    const u_char *cp, const u_int len)
 {
-	ND_PRINT("0x%02x", GET_U_1(cp));
+	ND_PRINT(C_RESET, C_RESET "0x%02x", GET_U_1(cp));
 	if (len > 1) {
-		ND_PRINT("/");
+		ND_PRINT(C_RESET, C_RESET "/");
 		nd_printjn(ndo, cp + 1, len - 1);
 	}
 }
@@ -240,15 +240,15 @@ cdp_print(netdissect_options *ndo,
 	ndo->ndo_protocol = "cdp";
 
 	if (length < CDP_HEADER_LEN) {
-		ND_PRINT(" (packet length %u < %u)", length, CDP_HEADER_LEN);
+		ND_PRINT(C_RESET, C_RESET " (packet length %u < %u)", length, CDP_HEADER_LEN);
 		goto invalid;
 	}
-	ND_PRINT("CDPv%u, ttl: %us",
+	ND_PRINT(C_RESET, C_RESET "CDPv%u, ttl: %us",
 	         GET_U_1(tptr + CDP_HEADER_VERSION_OFFSET),
 	         GET_U_1(tptr + CDP_HEADER_TTL_OFFSET));
 	checksum = GET_BE_U_2(tptr + CDP_HEADER_CHECKSUM_OFFSET);
 	if (ndo->ndo_vflag)
-		ND_PRINT(", checksum: 0x%04x (unverified), length %u",
+		ND_PRINT(C_RESET, C_RESET ", checksum: 0x%04x (unverified), length %u",
 		         checksum, orig_length);
 	tptr += CDP_HEADER_LEN;
 	length -= CDP_HEADER_LEN;
@@ -260,7 +260,7 @@ cdp_print(netdissect_options *ndo,
 		u_char covered = 0;
 
 		if (length < CDP_TLV_HEADER_LEN) {
-			ND_PRINT(" (remaining packet length %u < %u)",
+			ND_PRINT(C_RESET, C_RESET " (remaining packet length %u < %u)",
 			         length, CDP_TLV_HEADER_LEN);
 			goto invalid;
 		}
@@ -270,15 +270,15 @@ cdp_print(netdissect_options *ndo,
 		name = (info && info->name) ? info->name : "unknown field type";
 		if (len < CDP_TLV_HEADER_LEN) {
 			if (ndo->ndo_vflag)
-				ND_PRINT("\n\t%s (0x%02x), TLV length: %u byte%s (too short)",
+				ND_PRINT(C_RESET, C_RESET "\n\t%s (0x%02x), TLV length: %u byte%s (too short)",
 				         name, type, len, PLURAL_SUFFIX(len));
 			else
-				ND_PRINT(", %s TLV length %u too short",
+				ND_PRINT(C_RESET, C_RESET ", %s TLV length %u too short",
 				         name, len);
 			goto invalid;
 		}
 		if (len > length) {
-			ND_PRINT(" (TLV length %u > %u)", len, length);
+			ND_PRINT(C_RESET, C_RESET " (TLV length %u > %u)", len, length);
 			goto invalid;
 		}
 		tptr += CDP_TLV_HEADER_LEN;
@@ -287,15 +287,15 @@ cdp_print(netdissect_options *ndo,
 
 		/* In non-verbose mode just print Device-ID. */
 		if (!ndo->ndo_vflag && type == T_DEV_ID)
-			ND_PRINT(", Device-ID ");
+			ND_PRINT(C_RESET, C_RESET ", Device-ID ");
 		else if (ndo->ndo_vflag)
-			ND_PRINT("\n\t%s (0x%02x), value length: %u byte%s: ",
+			ND_PRINT(C_RESET, C_RESET "\n\t%s (0x%02x), value length: %u byte%s: ",
 			         name, type, len, PLURAL_SUFFIX(len));
 
 		if (info) {
 			if ((info->min_len > 0 && len < (unsigned)info->min_len) ||
 			    (info->max_len > 0 && len > (unsigned)info->max_len))
-				ND_PRINT(" (malformed TLV)");
+				ND_PRINT(C_RESET, C_RESET " (malformed TLV)");
 			else if (ndo->ndo_vflag || type == T_DEV_ID) {
 				if (info->printer)
 					info->printer(ndo, tptr, len);
@@ -317,7 +317,7 @@ cdp_print(netdissect_options *ndo,
 		length -= len;
 	}
 	if (ndo->ndo_vflag < 1)
-		ND_PRINT(", length %u", orig_length);
+		ND_PRINT(C_RESET, C_RESET ", length %u", orig_length);
 
 	return;
 invalid:
@@ -346,7 +346,7 @@ cdp_print_addr(netdissect_options *ndo,
 	};
 
 	if (l < 4) {
-		ND_PRINT(" (not enough space for num)");
+		ND_PRINT(C_RESET, C_RESET " (not enough space for num)");
 		goto invalid;
 	}
 	num = GET_BE_U_4(p);
@@ -357,7 +357,7 @@ cdp_print_addr(netdissect_options *ndo,
 		u_int pt, pl, al;
 
 		if (l < 2) {
-			ND_PRINT(" (not enough space for PT+PL)");
+			ND_PRINT(C_RESET, C_RESET " (not enough space for PT+PL)");
 			goto invalid;
 		}
 		pt = GET_U_1(p);		/* type of "protocol" field */
@@ -366,7 +366,7 @@ cdp_print_addr(netdissect_options *ndo,
 		l -= 2;
 
 		if (l < pl + 2) {
-			ND_PRINT(" (not enough space for P+AL)");
+			ND_PRINT(C_RESET, C_RESET " (not enough space for P+AL)");
 			goto invalid;
 		}
 		/* Skip the protocol for now. */
@@ -383,10 +383,10 @@ cdp_print_addr(netdissect_options *ndo,
 			l -= pl + 2;
 			/* p is just beyond al now. */
 			if (l < al) {
-				ND_PRINT(" (not enough space for A)");
+				ND_PRINT(C_RESET, C_RESET " (not enough space for A)");
 				goto invalid;
 			}
-			ND_PRINT("IPv4 (%u) %s", num, GET_IPADDR_STRING(p));
+			ND_PRINT(C_RESET, C_RESET "IPv4 (%u) %s", num, GET_IPADDR_STRING(p));
 			p += al;
 			l -= al;
 		}
@@ -402,10 +402,10 @@ cdp_print_addr(netdissect_options *ndo,
 			l -= pl + 2;
 			/* p is just beyond al now. */
 			if (l < al) {
-				ND_PRINT(" (not enough space for A)");
+				ND_PRINT(C_RESET, C_RESET " (not enough space for A)");
 				goto invalid;
 			}
-			ND_PRINT("IPv6 (%u) %s", num, GET_IP6ADDR_STRING(p));
+			ND_PRINT(C_RESET, C_RESET "IPv6 (%u) %s", num, GET_IP6ADDR_STRING(p));
 			p += al;
 			l -= al;
 		}
@@ -413,23 +413,23 @@ cdp_print_addr(netdissect_options *ndo,
 			/*
 			 * Generic case: just print raw data
 			 */
-			ND_PRINT("pt=0x%02x, pl=%u, pb=", pt, pl);
+			ND_PRINT(C_RESET, C_RESET "pt=0x%02x, pl=%u, pb=", pt, pl);
 			while (pl != 0) {
-				ND_PRINT(" %02x", GET_U_1(p));
+				ND_PRINT(C_RESET, C_RESET " %02x", GET_U_1(p));
 				p++;
 				l--;
 				pl--;
 			}
-			ND_PRINT(", al=%u, a=", al);
+			ND_PRINT(C_RESET, C_RESET ", al=%u, a=", al);
 			p += 2;
 			l -= 2;
 			/* p is just beyond al now. */
 			if (l < al) {
-				ND_PRINT(" (not enough space for A)");
+				ND_PRINT(C_RESET, C_RESET " (not enough space for A)");
 				goto invalid;
 			}
 			while (al != 0) {
-				ND_PRINT(" %02x", GET_U_1(p));
+				ND_PRINT(C_RESET, C_RESET " %02x", GET_U_1(p));
 				p++;
 				l--;
 				al--;
@@ -437,10 +437,10 @@ cdp_print_addr(netdissect_options *ndo,
 		}
 		num--;
 		if (num)
-			ND_PRINT(" ");
+			ND_PRINT(C_RESET, C_RESET " ");
 	}
 	if (l)
-		ND_PRINT(" (%u bytes of stray data)", l);
+		ND_PRINT(C_RESET, C_RESET " (%u bytes of stray data)", l);
 	return;
 
 invalid:
@@ -452,14 +452,14 @@ cdp_print_prefixes(netdissect_options *ndo,
                    const u_char * p, u_int l)
 {
 	if (l % 5) {
-		ND_PRINT(" [length %u is not a multiple of 5]", l);
+		ND_PRINT(C_RESET, C_RESET " [length %u is not a multiple of 5]", l);
 		goto invalid;
 	}
 
-	ND_PRINT(" IPv4 Prefixes (%u):", l / 5);
+	ND_PRINT(C_RESET, C_RESET " IPv4 Prefixes (%u):", l / 5);
 
 	while (l > 0) {
-		ND_PRINT(" %u.%u.%u.%u/%u",
+		ND_PRINT(C_RESET, C_RESET " %u.%u.%u.%u/%u",
 		         GET_U_1(p), GET_U_1(p + 1), GET_U_1(p + 2),
 		         GET_U_1(p + 3), GET_U_1(p + 4));
 		l -= 5;

--- a/print-cdp.c
+++ b/print-cdp.c
@@ -68,9 +68,9 @@ static void
 cdp_print_string(netdissect_options *ndo,
                  const u_char *cp, const u_int len)
 {
-	ND_PRINT(C_RESET, C_RESET "'");
+	ND_PRINT(C_RESET, "'");
 	nd_printjn(ndo, cp, len);
-	ND_PRINT(C_RESET, C_RESET "'");
+	ND_PRINT(C_RESET, "'");
 }
 
 static void
@@ -90,7 +90,7 @@ cdp_print_power(netdissect_options *ndo,
 		val = GET_BE_U_3(cp);
 		break;
 	}
-	ND_PRINT(C_RESET, C_RESET "%1.2fW", val / 1000.0);
+	ND_PRINT(C_RESET, "%1.2fW", val / 1000.0);
 }
 
 static void
@@ -99,7 +99,7 @@ cdp_print_capability(netdissect_options *ndo,
 {
 	uint32_t val = GET_BE_U_4(cp);
 
-	ND_PRINT(C_RESET, C_RESET "(0x%08x): %s", val,
+	ND_PRINT(C_RESET, "(0x%08x): %s", val,
 	         bittok2str(cdp_capability_values, "none", val));
 }
 
@@ -110,12 +110,12 @@ cdp_print_version(netdissect_options *ndo,
 {
 	unsigned i;
 
-	ND_PRINT(C_RESET, C_RESET "\n\t  ");
+	ND_PRINT(C_RESET, "\n\t  ");
 	for (i = 0; i < len; i++) {
 		u_char c = GET_U_1(cp + i);
 
 		if (c == '\n')
-			ND_PRINT(C_RESET, C_RESET "\n\t  ");
+			ND_PRINT(C_RESET, "\n\t  ");
 		else
 			fn_print_char(ndo, c);
 	}
@@ -125,14 +125,14 @@ static void
 cdp_print_uint16(netdissect_options *ndo,
                  const u_char *cp, const u_int len _U_)
 {
-	ND_PRINT(C_RESET, C_RESET "%u", GET_BE_U_2(cp));
+	ND_PRINT(C_RESET, "%u", GET_BE_U_2(cp));
 }
 
 static void
 cdp_print_duplex(netdissect_options *ndo,
                  const u_char *cp, const u_int len _U_)
 {
-	ND_PRINT(C_RESET, C_RESET "%s", GET_U_1(cp) ? "full": "half");
+	ND_PRINT(C_RESET, "%s", GET_U_1(cp) ? "full": "half");
 }
 
 /* https://www.cisco.com/c/en/us/td/docs/voice_ip_comm/cata/186/2_12_m/english/release/notes/186rn21m.html
@@ -152,32 +152,32 @@ cdp_print_ata186(netdissect_options *ndo,
                  const u_char *cp, const u_int len)
 {
 	if (len == 2)
-		ND_PRINT(C_RESET, C_RESET "unknown 0x%04x", GET_BE_U_2(cp));
+		ND_PRINT(C_RESET, "unknown 0x%04x", GET_BE_U_2(cp));
 	else
-		ND_PRINT(C_RESET, C_RESET "app %u, vlan %u", GET_U_1(cp), GET_BE_U_2(cp + 1));
+		ND_PRINT(C_RESET, "app %u, vlan %u", GET_U_1(cp), GET_BE_U_2(cp + 1));
 }
 
 static void
 cdp_print_mtu(netdissect_options *ndo,
               const u_char *cp, const u_int len _U_)
 {
-	ND_PRINT(C_RESET, C_RESET "%u bytes", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, "%u bytes", GET_BE_U_4(cp));
 }
 
 static void
 cdp_print_uint8x(netdissect_options *ndo,
                  const u_char *cp, const u_int len _U_)
 {
-	ND_PRINT(C_RESET, C_RESET "0x%02x", GET_U_1(cp));
+	ND_PRINT(C_RESET, "0x%02x", GET_U_1(cp));
 }
 
 static void
 cdp_print_phys_loc(netdissect_options *ndo,
                    const u_char *cp, const u_int len)
 {
-	ND_PRINT(C_RESET, C_RESET "0x%02x", GET_U_1(cp));
+	ND_PRINT(C_RESET, "0x%02x", GET_U_1(cp));
 	if (len > 1) {
-		ND_PRINT(C_RESET, C_RESET "/");
+		ND_PRINT(C_RESET, "/");
 		nd_printjn(ndo, cp + 1, len - 1);
 	}
 }
@@ -240,15 +240,15 @@ cdp_print(netdissect_options *ndo,
 	ndo->ndo_protocol = "cdp";
 
 	if (length < CDP_HEADER_LEN) {
-		ND_PRINT(C_RESET, C_RESET " (packet length %u < %u)", length, CDP_HEADER_LEN);
+		ND_PRINT(C_RESET, " (packet length %u < %u)", length, CDP_HEADER_LEN);
 		goto invalid;
 	}
-	ND_PRINT(C_RESET, C_RESET "CDPv%u, ttl: %us",
+	ND_PRINT(C_RESET, "CDPv%u, ttl: %us",
 	         GET_U_1(tptr + CDP_HEADER_VERSION_OFFSET),
 	         GET_U_1(tptr + CDP_HEADER_TTL_OFFSET));
 	checksum = GET_BE_U_2(tptr + CDP_HEADER_CHECKSUM_OFFSET);
 	if (ndo->ndo_vflag)
-		ND_PRINT(C_RESET, C_RESET ", checksum: 0x%04x (unverified), length %u",
+		ND_PRINT(C_RESET, ", checksum: 0x%04x (unverified), length %u",
 		         checksum, orig_length);
 	tptr += CDP_HEADER_LEN;
 	length -= CDP_HEADER_LEN;
@@ -260,7 +260,7 @@ cdp_print(netdissect_options *ndo,
 		u_char covered = 0;
 
 		if (length < CDP_TLV_HEADER_LEN) {
-			ND_PRINT(C_RESET, C_RESET " (remaining packet length %u < %u)",
+			ND_PRINT(C_RESET, " (remaining packet length %u < %u)",
 			         length, CDP_TLV_HEADER_LEN);
 			goto invalid;
 		}
@@ -270,15 +270,15 @@ cdp_print(netdissect_options *ndo,
 		name = (info && info->name) ? info->name : "unknown field type";
 		if (len < CDP_TLV_HEADER_LEN) {
 			if (ndo->ndo_vflag)
-				ND_PRINT(C_RESET, C_RESET "\n\t%s (0x%02x), TLV length: %u byte%s (too short)",
+				ND_PRINT(C_RESET, "\n\t%s (0x%02x), TLV length: %u byte%s (too short)",
 				         name, type, len, PLURAL_SUFFIX(len));
 			else
-				ND_PRINT(C_RESET, C_RESET ", %s TLV length %u too short",
+				ND_PRINT(C_RESET, ", %s TLV length %u too short",
 				         name, len);
 			goto invalid;
 		}
 		if (len > length) {
-			ND_PRINT(C_RESET, C_RESET " (TLV length %u > %u)", len, length);
+			ND_PRINT(C_RESET, " (TLV length %u > %u)", len, length);
 			goto invalid;
 		}
 		tptr += CDP_TLV_HEADER_LEN;
@@ -287,15 +287,15 @@ cdp_print(netdissect_options *ndo,
 
 		/* In non-verbose mode just print Device-ID. */
 		if (!ndo->ndo_vflag && type == T_DEV_ID)
-			ND_PRINT(C_RESET, C_RESET ", Device-ID ");
+			ND_PRINT(C_RESET, ", Device-ID ");
 		else if (ndo->ndo_vflag)
-			ND_PRINT(C_RESET, C_RESET "\n\t%s (0x%02x), value length: %u byte%s: ",
+			ND_PRINT(C_RESET, "\n\t%s (0x%02x), value length: %u byte%s: ",
 			         name, type, len, PLURAL_SUFFIX(len));
 
 		if (info) {
 			if ((info->min_len > 0 && len < (unsigned)info->min_len) ||
 			    (info->max_len > 0 && len > (unsigned)info->max_len))
-				ND_PRINT(C_RESET, C_RESET " (malformed TLV)");
+				ND_PRINT(C_RESET, " (malformed TLV)");
 			else if (ndo->ndo_vflag || type == T_DEV_ID) {
 				if (info->printer)
 					info->printer(ndo, tptr, len);
@@ -317,7 +317,7 @@ cdp_print(netdissect_options *ndo,
 		length -= len;
 	}
 	if (ndo->ndo_vflag < 1)
-		ND_PRINT(C_RESET, C_RESET ", length %u", orig_length);
+		ND_PRINT(C_RESET, ", length %u", orig_length);
 
 	return;
 invalid:
@@ -346,7 +346,7 @@ cdp_print_addr(netdissect_options *ndo,
 	};
 
 	if (l < 4) {
-		ND_PRINT(C_RESET, C_RESET " (not enough space for num)");
+		ND_PRINT(C_RESET, " (not enough space for num)");
 		goto invalid;
 	}
 	num = GET_BE_U_4(p);
@@ -357,7 +357,7 @@ cdp_print_addr(netdissect_options *ndo,
 		u_int pt, pl, al;
 
 		if (l < 2) {
-			ND_PRINT(C_RESET, C_RESET " (not enough space for PT+PL)");
+			ND_PRINT(C_RESET, " (not enough space for PT+PL)");
 			goto invalid;
 		}
 		pt = GET_U_1(p);		/* type of "protocol" field */
@@ -366,7 +366,7 @@ cdp_print_addr(netdissect_options *ndo,
 		l -= 2;
 
 		if (l < pl + 2) {
-			ND_PRINT(C_RESET, C_RESET " (not enough space for P+AL)");
+			ND_PRINT(C_RESET, " (not enough space for P+AL)");
 			goto invalid;
 		}
 		/* Skip the protocol for now. */
@@ -383,10 +383,10 @@ cdp_print_addr(netdissect_options *ndo,
 			l -= pl + 2;
 			/* p is just beyond al now. */
 			if (l < al) {
-				ND_PRINT(C_RESET, C_RESET " (not enough space for A)");
+				ND_PRINT(C_RESET, " (not enough space for A)");
 				goto invalid;
 			}
-			ND_PRINT(C_RESET, C_RESET "IPv4 (%u) %s", num, GET_IPADDR_STRING(p));
+			ND_PRINT(C_RESET, "IPv4 (%u) %s", num, GET_IPADDR_STRING(p));
 			p += al;
 			l -= al;
 		}
@@ -402,10 +402,10 @@ cdp_print_addr(netdissect_options *ndo,
 			l -= pl + 2;
 			/* p is just beyond al now. */
 			if (l < al) {
-				ND_PRINT(C_RESET, C_RESET " (not enough space for A)");
+				ND_PRINT(C_RESET, " (not enough space for A)");
 				goto invalid;
 			}
-			ND_PRINT(C_RESET, C_RESET "IPv6 (%u) %s", num, GET_IP6ADDR_STRING(p));
+			ND_PRINT(C_RESET, "IPv6 (%u) %s", num, GET_IP6ADDR_STRING(p));
 			p += al;
 			l -= al;
 		}
@@ -413,23 +413,23 @@ cdp_print_addr(netdissect_options *ndo,
 			/*
 			 * Generic case: just print raw data
 			 */
-			ND_PRINT(C_RESET, C_RESET "pt=0x%02x, pl=%u, pb=", pt, pl);
+			ND_PRINT(C_RESET, "pt=0x%02x, pl=%u, pb=", pt, pl);
 			while (pl != 0) {
-				ND_PRINT(C_RESET, C_RESET " %02x", GET_U_1(p));
+				ND_PRINT(C_RESET, " %02x", GET_U_1(p));
 				p++;
 				l--;
 				pl--;
 			}
-			ND_PRINT(C_RESET, C_RESET ", al=%u, a=", al);
+			ND_PRINT(C_RESET, ", al=%u, a=", al);
 			p += 2;
 			l -= 2;
 			/* p is just beyond al now. */
 			if (l < al) {
-				ND_PRINT(C_RESET, C_RESET " (not enough space for A)");
+				ND_PRINT(C_RESET, " (not enough space for A)");
 				goto invalid;
 			}
 			while (al != 0) {
-				ND_PRINT(C_RESET, C_RESET " %02x", GET_U_1(p));
+				ND_PRINT(C_RESET, " %02x", GET_U_1(p));
 				p++;
 				l--;
 				al--;
@@ -437,10 +437,10 @@ cdp_print_addr(netdissect_options *ndo,
 		}
 		num--;
 		if (num)
-			ND_PRINT(C_RESET, C_RESET " ");
+			ND_PRINT(C_RESET, " ");
 	}
 	if (l)
-		ND_PRINT(C_RESET, C_RESET " (%u bytes of stray data)", l);
+		ND_PRINT(C_RESET, " (%u bytes of stray data)", l);
 	return;
 
 invalid:
@@ -452,14 +452,14 @@ cdp_print_prefixes(netdissect_options *ndo,
                    const u_char * p, u_int l)
 {
 	if (l % 5) {
-		ND_PRINT(C_RESET, C_RESET " [length %u is not a multiple of 5]", l);
+		ND_PRINT(C_RESET, " [length %u is not a multiple of 5]", l);
 		goto invalid;
 	}
 
-	ND_PRINT(C_RESET, C_RESET " IPv4 Prefixes (%u):", l / 5);
+	ND_PRINT(C_RESET, " IPv4 Prefixes (%u):", l / 5);
 
 	while (l > 0) {
-		ND_PRINT(C_RESET, C_RESET " %u.%u.%u.%u/%u",
+		ND_PRINT(C_RESET, " %u.%u.%u.%u/%u",
 		         GET_U_1(p), GET_U_1(p + 1), GET_U_1(p + 2),
 		         GET_U_1(p + 3), GET_U_1(p + 4));
 		l -= 5;

--- a/print-cfm.c
+++ b/print-cfm.c
@@ -226,12 +226,12 @@ cfm_network_addr_print(netdissect_options *ndo,
      * is only one octet.
      */
     if (length < 1) {
-        ND_PRINT("\n\t  Network Address Type (invalid, no data");
+        ND_PRINT(C_RESET, C_RESET "\n\t  Network Address Type (invalid, no data");
         return hexdump;
     }
     /* The calling function must make any due ND_TCHECK calls. */
     network_addr_type = GET_U_1(tptr);
-    ND_PRINT("\n\t  Network Address Type %s (%u)",
+    ND_PRINT(C_RESET, C_RESET "\n\t  Network Address Type %s (%u)",
            tok2str(af_values, "Unknown", network_addr_type),
            network_addr_type);
 
@@ -241,20 +241,20 @@ cfm_network_addr_print(netdissect_options *ndo,
     switch(network_addr_type) {
     case AFNUM_INET:
         if (length != 1 + 4) {
-            ND_PRINT("(invalid IPv4 address length %u)", length - 1);
+            ND_PRINT(C_RESET, C_RESET "(invalid IPv4 address length %u)", length - 1);
             hexdump = TRUE;
             break;
         }
-        ND_PRINT(", %s", GET_IPADDR_STRING(tptr + 1));
+        ND_PRINT(C_RESET, C_RESET ", %s", GET_IPADDR_STRING(tptr + 1));
         break;
 
     case AFNUM_INET6:
         if (length != 1 + 16) {
-            ND_PRINT("(invalid IPv6 address length %u)", length - 1);
+            ND_PRINT(C_RESET, C_RESET "(invalid IPv6 address length %u)", length - 1);
             hexdump = TRUE;
             break;
         }
-        ND_PRINT(", %s", GET_IP6ADDR_STRING(tptr + 1));
+        ND_PRINT(C_RESET, C_RESET ", %s", GET_IP6ADDR_STRING(tptr + 1));
         break;
 
     default:
@@ -301,13 +301,13 @@ cfm_print(netdissect_options *ndo,
      */
     mdlevel_version = GET_U_1(cfm_common_header->mdlevel_version);
     if (CFM_EXTRACT_VERSION(mdlevel_version) != CFM_VERSION) {
-	ND_PRINT("CFMv%u not supported, length %u",
+	ND_PRINT(C_RESET, C_RESET "CFMv%u not supported, length %u",
                CFM_EXTRACT_VERSION(mdlevel_version), length);
 	return;
     }
 
     opcode = GET_U_1(cfm_common_header->opcode);
-    ND_PRINT("CFMv%u %s, MD Level %u, length %u",
+    ND_PRINT(C_RESET, C_RESET "CFMv%u %s, MD Level %u, length %u",
            CFM_EXTRACT_VERSION(mdlevel_version),
            tok2str(cfm_opcode_values, "unknown (%u)", opcode),
            CFM_EXTRACT_MD_LEVEL(mdlevel_version),
@@ -322,7 +322,7 @@ cfm_print(netdissect_options *ndo,
 
     flags = GET_U_1(cfm_common_header->flags);
     first_tlv_offset = GET_U_1(cfm_common_header->first_tlv_offset);
-    ND_PRINT("\n\tFirst TLV offset %u", first_tlv_offset);
+    ND_PRINT(C_RESET, C_RESET "\n\tFirst TLV offset %u", first_tlv_offset);
 
     tptr += sizeof(struct cfm_common_header_t);
     tlen = length - sizeof(struct cfm_common_header_t);
@@ -331,7 +331,7 @@ cfm_print(netdissect_options *ndo,
      * Sanity check the first TLV offset.
      */
     if (first_tlv_offset > tlen) {
-        ND_PRINT(" (too large, must be <= %u)", tlen);
+        ND_PRINT(C_RESET, C_RESET " (too large, must be <= %u)", tlen);
         return;
     }
 
@@ -339,7 +339,7 @@ cfm_print(netdissect_options *ndo,
     case CFM_OPCODE_CCM:
         msg_ptr.cfm_ccm = (const struct cfm_ccm_t *)tptr;
         if (first_tlv_offset < sizeof(*msg_ptr.cfm_ccm)) {
-            ND_PRINT(" (too small 1, must be >= %zu)",
+            ND_PRINT(C_RESET, C_RESET " (too small 1, must be >= %zu)",
                      sizeof(*msg_ptr.cfm_ccm));
             return;
         }
@@ -348,7 +348,7 @@ cfm_print(netdissect_options *ndo,
         ND_TCHECK_SIZE(msg_ptr.cfm_ccm);
 
         ccm_interval = CFM_EXTRACT_CCM_INTERVAL(flags);
-        ND_PRINT(", Flags [CCM Interval %u%s]",
+        ND_PRINT(C_RESET, C_RESET ", Flags [CCM Interval %u%s]",
                ccm_interval,
                flags & CFM_CCM_RDI_FLAG ?
                ", RDI" : "");
@@ -357,14 +357,14 @@ cfm_print(netdissect_options *ndo,
          * Resolve the CCM interval field.
          */
         if (ccm_interval) {
-            ND_PRINT("\n\t  CCM Interval %.3fs"
+            ND_PRINT(C_RESET, C_RESET "\n\t  CCM Interval %.3fs"
                    ", min CCM Lifetime %.3fs, max CCM Lifetime %.3fs",
                    ccm_interval_base[ccm_interval],
                    ccm_interval_base[ccm_interval] * CCM_INTERVAL_MIN_MULTIPLIER,
                    ccm_interval_base[ccm_interval] * CCM_INTERVAL_MAX_MULTIPLIER);
         }
 
-        ND_PRINT("\n\t  Sequence Number 0x%08x, MA-End-Point-ID 0x%04x",
+        ND_PRINT(C_RESET, C_RESET "\n\t  Sequence Number 0x%08x, MA-End-Point-ID 0x%04x",
                GET_BE_U_4(msg_ptr.cfm_ccm->sequence),
                GET_BE_U_2(msg_ptr.cfm_ccm->ma_epi));
 
@@ -381,7 +381,7 @@ cfm_print(netdissect_options *ndo,
             md_namelength = GET_U_1(namesp);
             namesp++;
             names_data_remaining--; /* We know this is !=0 */
-            ND_PRINT("\n\t  MD Name Format %s (%u), MD Name length %u",
+            ND_PRINT(C_RESET, C_RESET "\n\t  MD Name Format %s (%u), MD Name length %u",
                    tok2str(cfm_md_nameformat_values, "Unknown",
                            md_nameformat),
                    md_nameformat,
@@ -392,12 +392,12 @@ cfm_print(netdissect_options *ndo,
              * of MA short name.
              */
             if (md_namelength > names_data_remaining - 3) {
-                ND_PRINT(" (too large, must be <= %u)", names_data_remaining - 2);
+                ND_PRINT(C_RESET, C_RESET " (too large, must be <= %u)", names_data_remaining - 2);
                 return;
             }
 
             md_name = namesp;
-            ND_PRINT("\n\t  MD Name: ");
+            ND_PRINT(C_RESET, C_RESET "\n\t  MD Name: ");
             switch (md_nameformat) {
             case CFM_CCM_MD_FORMAT_DNS:
             case CFM_CCM_MD_FORMAT_CHAR:
@@ -406,9 +406,9 @@ cfm_print(netdissect_options *ndo,
 
             case CFM_CCM_MD_FORMAT_MAC:
                 if (md_namelength == MAC_ADDR_LEN) {
-                    ND_PRINT("\n\t  MAC %s", GET_ETHERADDR_STRING(md_name));
+                    ND_PRINT(C_RESET, C_RESET "\n\t  MAC %s", GET_ETHERADDR_STRING(md_name));
                 } else {
-                    ND_PRINT("\n\t  MAC (length invalid)");
+                    ND_PRINT(C_RESET, C_RESET "\n\t  MAC (length invalid)");
                 }
                 break;
 
@@ -421,7 +421,7 @@ cfm_print(netdissect_options *ndo,
             namesp += md_namelength;
             names_data_remaining -= md_namelength;
         } else {
-            ND_PRINT("\n\t  MD Name Format %s (%u)",
+            ND_PRINT(C_RESET, C_RESET "\n\t  MD Name Format %s (%u)",
                    tok2str(cfm_md_nameformat_values, "Unknown",
                            md_nameformat),
                    md_nameformat);
@@ -437,19 +437,19 @@ cfm_print(netdissect_options *ndo,
         ma_namelength = GET_U_1(namesp);
         namesp++;
         names_data_remaining--; /* We know this is != 0 */
-        ND_PRINT("\n\t  MA Name-Format %s (%u), MA name length %u",
+        ND_PRINT(C_RESET, C_RESET "\n\t  MA Name-Format %s (%u), MA name length %u",
                tok2str(cfm_ma_nameformat_values, "Unknown",
                        ma_nameformat),
                ma_nameformat,
                ma_namelength);
 
         if (ma_namelength > names_data_remaining) {
-            ND_PRINT(" (too large, must be <= %u)", names_data_remaining);
+            ND_PRINT(C_RESET, C_RESET " (too large, must be <= %u)", names_data_remaining);
             return;
         }
 
         ma_name = namesp;
-        ND_PRINT("\n\t  MA Name: ");
+        ND_PRINT(C_RESET, C_RESET "\n\t  MA Name: ");
         switch (ma_nameformat) {
         case CFM_CCM_MA_FORMAT_CHAR:
             nd_printjnp(ndo, ma_name, ma_namelength);
@@ -468,7 +468,7 @@ cfm_print(netdissect_options *ndo,
     case CFM_OPCODE_LTM:
         msg_ptr.cfm_ltm = (const struct cfm_ltm_t *)tptr;
         if (first_tlv_offset < sizeof(*msg_ptr.cfm_ltm)) {
-            ND_PRINT(" (too small 4, must be >= %zu)",
+            ND_PRINT(C_RESET, C_RESET " (too small 4, must be >= %zu)",
                      sizeof(*msg_ptr.cfm_ltm));
             return;
         }
@@ -476,14 +476,14 @@ cfm_print(netdissect_options *ndo,
             goto tooshort;
         ND_TCHECK_SIZE(msg_ptr.cfm_ltm);
 
-        ND_PRINT(", Flags [%s]",
+        ND_PRINT(C_RESET, C_RESET ", Flags [%s]",
                bittok2str(cfm_ltm_flag_values, "none", flags));
 
-        ND_PRINT("\n\t  Transaction-ID 0x%08x, ttl %u",
+        ND_PRINT(C_RESET, C_RESET "\n\t  Transaction-ID 0x%08x, ttl %u",
                GET_BE_U_4(msg_ptr.cfm_ltm->transaction_id),
                GET_U_1(msg_ptr.cfm_ltm->ttl));
 
-        ND_PRINT("\n\t  Original-MAC %s, Target-MAC %s",
+        ND_PRINT(C_RESET, C_RESET "\n\t  Original-MAC %s, Target-MAC %s",
                GET_ETHERADDR_STRING(msg_ptr.cfm_ltm->original_mac),
                GET_ETHERADDR_STRING(msg_ptr.cfm_ltm->target_mac));
         break;
@@ -491,7 +491,7 @@ cfm_print(netdissect_options *ndo,
     case CFM_OPCODE_LTR:
         msg_ptr.cfm_ltr = (const struct cfm_ltr_t *)tptr;
         if (first_tlv_offset < sizeof(*msg_ptr.cfm_ltr)) {
-            ND_PRINT(" (too small 5, must be >= %zu)",
+            ND_PRINT(C_RESET, C_RESET " (too small 5, must be >= %zu)",
                      sizeof(*msg_ptr.cfm_ltr));
             return;
         }
@@ -499,14 +499,14 @@ cfm_print(netdissect_options *ndo,
             goto tooshort;
         ND_TCHECK_SIZE(msg_ptr.cfm_ltr);
 
-        ND_PRINT(", Flags [%s]",
+        ND_PRINT(C_RESET, C_RESET ", Flags [%s]",
                bittok2str(cfm_ltr_flag_values, "none", flags));
 
-        ND_PRINT("\n\t  Transaction-ID 0x%08x, ttl %u",
+        ND_PRINT(C_RESET, C_RESET "\n\t  Transaction-ID 0x%08x, ttl %u",
                GET_BE_U_4(msg_ptr.cfm_ltr->transaction_id),
                GET_U_1(msg_ptr.cfm_ltr->ttl));
 
-        ND_PRINT("\n\t  Replay-Action %s (%u)",
+        ND_PRINT(C_RESET, C_RESET "\n\t  Replay-Action %s (%u)",
                tok2str(cfm_ltr_replay_action_values,
                        "Unknown",
                        GET_U_1(msg_ptr.cfm_ltr->replay_action)),
@@ -534,7 +534,7 @@ cfm_print(netdissect_options *ndo,
         /* Enough to read the tlv type ? */
         cfm_tlv_type = GET_U_1(cfm_tlv_header->type);
 
-        ND_PRINT("\n\t%s TLV (0x%02x)",
+        ND_PRINT(C_RESET, C_RESET "\n\t%s TLV (0x%02x)",
                tok2str(cfm_tlv_values, "Unknown", cfm_tlv_type),
                cfm_tlv_type);
 
@@ -549,7 +549,7 @@ cfm_print(netdissect_options *ndo,
         ND_TCHECK_LEN(tptr, sizeof(struct cfm_tlv_header_t));
         cfm_tlv_len=GET_BE_U_2(cfm_tlv_header->length);
 
-        ND_PRINT(", length %u", cfm_tlv_len);
+        ND_PRINT(C_RESET, C_RESET ", length %u", cfm_tlv_len);
 
         tptr += sizeof(struct cfm_tlv_header_t);
         tlen -= sizeof(struct cfm_tlv_header_t);
@@ -564,30 +564,30 @@ cfm_print(netdissect_options *ndo,
         switch(cfm_tlv_type) {
         case CFM_TLV_PORT_STATUS:
             if (cfm_tlv_len < 1) {
-                ND_PRINT(" (too short, must be >= 1)");
+                ND_PRINT(C_RESET, C_RESET " (too short, must be >= 1)");
                 return;
             }
-            ND_PRINT(", Status: %s (%u)",
+            ND_PRINT(C_RESET, C_RESET ", Status: %s (%u)",
                    tok2str(cfm_tlv_port_status_values, "Unknown", GET_U_1(tptr)),
                    GET_U_1(tptr));
             break;
 
         case CFM_TLV_INTERFACE_STATUS:
             if (cfm_tlv_len < 1) {
-                ND_PRINT(" (too short, must be >= 1)");
+                ND_PRINT(C_RESET, C_RESET " (too short, must be >= 1)");
                 return;
             }
-            ND_PRINT(", Status: %s (%u)",
+            ND_PRINT(C_RESET, C_RESET ", Status: %s (%u)",
                    tok2str(cfm_tlv_interface_status_values, "Unknown", GET_U_1(tptr)),
                    GET_U_1(tptr));
             break;
 
         case CFM_TLV_PRIVATE:
             if (cfm_tlv_len < 4) {
-                ND_PRINT(" (too short, must be >= 4)");
+                ND_PRINT(C_RESET, C_RESET " (too short, must be >= 4)");
                 return;
             }
-            ND_PRINT(", Vendor: %s (%u), Sub-Type %u",
+            ND_PRINT(C_RESET, C_RESET ", Vendor: %s (%u), Sub-Type %u",
                    tok2str(oui_values,"Unknown", GET_BE_U_3(tptr)),
                    GET_BE_U_3(tptr),
                    GET_U_1(tptr + 3));
@@ -600,7 +600,7 @@ cfm_print(netdissect_options *ndo,
             u_int mgmt_addr_length;
 
             if (cfm_tlv_len < 1) {
-                ND_PRINT(" (too short, must be >= 1)");
+                ND_PRINT(C_RESET, C_RESET " (too short, must be >= 1)");
                 goto next_tlv;
             }
 
@@ -620,12 +620,12 @@ cfm_print(netdissect_options *ndo,
                  * IEEE 802.1AB-2016 Section 8.5.2.2: chassis ID subtype
                  */
                 if (cfm_tlv_len < 1) {
-                    ND_PRINT("\n\t  (TLV too short)");
+                    ND_PRINT(C_RESET, C_RESET "\n\t  (TLV too short)");
                     goto next_tlv;
                 }
                 chassis_id_type = GET_U_1(tptr);
                 cfm_tlv_len--;
-                ND_PRINT("\n\t  Chassis-ID Type %s (%u), Chassis-ID length %u",
+                ND_PRINT(C_RESET, C_RESET "\n\t  Chassis-ID Type %s (%u), Chassis-ID length %u",
                        tok2str(cfm_tlv_senderid_chassisid_values,
                                "Unknown",
                                chassis_id_type),
@@ -633,7 +633,7 @@ cfm_print(netdissect_options *ndo,
                        chassis_id_length);
 
                 if (cfm_tlv_len < chassis_id_length) {
-                    ND_PRINT("\n\t  (TLV too short)");
+                    ND_PRINT(C_RESET, C_RESET "\n\t  (TLV too short)");
                     goto next_tlv;
                 }
 
@@ -641,11 +641,11 @@ cfm_print(netdissect_options *ndo,
                 switch (chassis_id_type) {
                 case CFM_CHASSIS_ID_MAC_ADDRESS:
                     if (chassis_id_length != MAC_ADDR_LEN) {
-                        ND_PRINT(" (invalid MAC address length)");
+                        ND_PRINT(C_RESET, C_RESET " (invalid MAC address length)");
                         hexdump = TRUE;
                         break;
                     }
-                    ND_PRINT("\n\t  MAC %s", GET_ETHERADDR_STRING(tptr + 1));
+                    ND_PRINT(C_RESET, C_RESET "\n\t  MAC %s", GET_ETHERADDR_STRING(tptr + 1));
                     break;
 
                 case CFM_CHASSIS_ID_NETWORK_ADDRESS:
@@ -686,11 +686,11 @@ cfm_print(netdissect_options *ndo,
             tptr++;
             tlen--;
             cfm_tlv_len--;
-            ND_PRINT("\n\t  Management Address Domain Length %u", mgmt_addr_length);
+            ND_PRINT(C_RESET, C_RESET "\n\t  Management Address Domain Length %u", mgmt_addr_length);
             if (mgmt_addr_length) {
                 /* IEEE 802.1Q-2014 Section 21.5.3.5: Management Address Domain */
                 if (cfm_tlv_len < mgmt_addr_length) {
-                    ND_PRINT("\n\t  (TLV too short)");
+                    ND_PRINT(C_RESET, C_RESET "\n\t  (TLV too short)");
                     goto next_tlv;
                 }
                 cfm_tlv_len -= mgmt_addr_length;
@@ -706,7 +706,7 @@ cfm_print(netdissect_options *ndo,
                  * This field is present if Management Address Domain Length is not 0.
                  */
                 if (cfm_tlv_len < 1) {
-                    ND_PRINT(" (Management Address Length is missing)");
+                    ND_PRINT(C_RESET, C_RESET " (Management Address Length is missing)");
                     hexdump = TRUE;
                     break;
                 }
@@ -716,11 +716,11 @@ cfm_print(netdissect_options *ndo,
                 tptr++;
                 tlen--;
                 cfm_tlv_len--;
-                ND_PRINT("\n\t  Management Address Length %u", mgmt_addr_length);
+                ND_PRINT(C_RESET, C_RESET "\n\t  Management Address Length %u", mgmt_addr_length);
                 if (mgmt_addr_length) {
                     /* IEEE 802.1Q-2014 Section 21.5.3.7: Management Address */
                     if (cfm_tlv_len < mgmt_addr_length) {
-                        ND_PRINT("\n\t  (TLV too short)");
+                        ND_PRINT(C_RESET, C_RESET "\n\t  (TLV too short)");
                         return;
                     }
                     cfm_tlv_len -= mgmt_addr_length;
@@ -758,7 +758,7 @@ next_tlv:
     return;
 
 tooshort:
-    ND_PRINT("\n\t\t packet is too short");
+    ND_PRINT(C_RESET, C_RESET "\n\t\t packet is too short");
     return;
 
 trunc:

--- a/print-cfm.c
+++ b/print-cfm.c
@@ -226,12 +226,12 @@ cfm_network_addr_print(netdissect_options *ndo,
      * is only one octet.
      */
     if (length < 1) {
-        ND_PRINT(C_RESET, C_RESET "\n\t  Network Address Type (invalid, no data");
+        ND_PRINT(C_RESET, "\n\t  Network Address Type (invalid, no data");
         return hexdump;
     }
     /* The calling function must make any due ND_TCHECK calls. */
     network_addr_type = GET_U_1(tptr);
-    ND_PRINT(C_RESET, C_RESET "\n\t  Network Address Type %s (%u)",
+    ND_PRINT(C_RESET, "\n\t  Network Address Type %s (%u)",
            tok2str(af_values, "Unknown", network_addr_type),
            network_addr_type);
 
@@ -241,20 +241,20 @@ cfm_network_addr_print(netdissect_options *ndo,
     switch(network_addr_type) {
     case AFNUM_INET:
         if (length != 1 + 4) {
-            ND_PRINT(C_RESET, C_RESET "(invalid IPv4 address length %u)", length - 1);
+            ND_PRINT(C_RESET, "(invalid IPv4 address length %u)", length - 1);
             hexdump = TRUE;
             break;
         }
-        ND_PRINT(C_RESET, C_RESET ", %s", GET_IPADDR_STRING(tptr + 1));
+        ND_PRINT(C_RESET, ", %s", GET_IPADDR_STRING(tptr + 1));
         break;
 
     case AFNUM_INET6:
         if (length != 1 + 16) {
-            ND_PRINT(C_RESET, C_RESET "(invalid IPv6 address length %u)", length - 1);
+            ND_PRINT(C_RESET, "(invalid IPv6 address length %u)", length - 1);
             hexdump = TRUE;
             break;
         }
-        ND_PRINT(C_RESET, C_RESET ", %s", GET_IP6ADDR_STRING(tptr + 1));
+        ND_PRINT(C_RESET, ", %s", GET_IP6ADDR_STRING(tptr + 1));
         break;
 
     default:
@@ -301,13 +301,13 @@ cfm_print(netdissect_options *ndo,
      */
     mdlevel_version = GET_U_1(cfm_common_header->mdlevel_version);
     if (CFM_EXTRACT_VERSION(mdlevel_version) != CFM_VERSION) {
-	ND_PRINT(C_RESET, C_RESET "CFMv%u not supported, length %u",
+	ND_PRINT(C_RESET, "CFMv%u not supported, length %u",
                CFM_EXTRACT_VERSION(mdlevel_version), length);
 	return;
     }
 
     opcode = GET_U_1(cfm_common_header->opcode);
-    ND_PRINT(C_RESET, C_RESET "CFMv%u %s, MD Level %u, length %u",
+    ND_PRINT(C_RESET, "CFMv%u %s, MD Level %u, length %u",
            CFM_EXTRACT_VERSION(mdlevel_version),
            tok2str(cfm_opcode_values, "unknown (%u)", opcode),
            CFM_EXTRACT_MD_LEVEL(mdlevel_version),
@@ -322,7 +322,7 @@ cfm_print(netdissect_options *ndo,
 
     flags = GET_U_1(cfm_common_header->flags);
     first_tlv_offset = GET_U_1(cfm_common_header->first_tlv_offset);
-    ND_PRINT(C_RESET, C_RESET "\n\tFirst TLV offset %u", first_tlv_offset);
+    ND_PRINT(C_RESET, "\n\tFirst TLV offset %u", first_tlv_offset);
 
     tptr += sizeof(struct cfm_common_header_t);
     tlen = length - sizeof(struct cfm_common_header_t);
@@ -331,7 +331,7 @@ cfm_print(netdissect_options *ndo,
      * Sanity check the first TLV offset.
      */
     if (first_tlv_offset > tlen) {
-        ND_PRINT(C_RESET, C_RESET " (too large, must be <= %u)", tlen);
+        ND_PRINT(C_RESET, " (too large, must be <= %u)", tlen);
         return;
     }
 
@@ -339,7 +339,7 @@ cfm_print(netdissect_options *ndo,
     case CFM_OPCODE_CCM:
         msg_ptr.cfm_ccm = (const struct cfm_ccm_t *)tptr;
         if (first_tlv_offset < sizeof(*msg_ptr.cfm_ccm)) {
-            ND_PRINT(C_RESET, C_RESET " (too small 1, must be >= %zu)",
+            ND_PRINT(C_RESET, " (too small 1, must be >= %zu)",
                      sizeof(*msg_ptr.cfm_ccm));
             return;
         }
@@ -348,7 +348,7 @@ cfm_print(netdissect_options *ndo,
         ND_TCHECK_SIZE(msg_ptr.cfm_ccm);
 
         ccm_interval = CFM_EXTRACT_CCM_INTERVAL(flags);
-        ND_PRINT(C_RESET, C_RESET ", Flags [CCM Interval %u%s]",
+        ND_PRINT(C_RESET, ", Flags [CCM Interval %u%s]",
                ccm_interval,
                flags & CFM_CCM_RDI_FLAG ?
                ", RDI" : "");
@@ -357,14 +357,14 @@ cfm_print(netdissect_options *ndo,
          * Resolve the CCM interval field.
          */
         if (ccm_interval) {
-            ND_PRINT(C_RESET, C_RESET "\n\t  CCM Interval %.3fs"
+            ND_PRINT(C_RESET, "\n\t  CCM Interval %.3fs"
                    ", min CCM Lifetime %.3fs, max CCM Lifetime %.3fs",
                    ccm_interval_base[ccm_interval],
                    ccm_interval_base[ccm_interval] * CCM_INTERVAL_MIN_MULTIPLIER,
                    ccm_interval_base[ccm_interval] * CCM_INTERVAL_MAX_MULTIPLIER);
         }
 
-        ND_PRINT(C_RESET, C_RESET "\n\t  Sequence Number 0x%08x, MA-End-Point-ID 0x%04x",
+        ND_PRINT(C_RESET, "\n\t  Sequence Number 0x%08x, MA-End-Point-ID 0x%04x",
                GET_BE_U_4(msg_ptr.cfm_ccm->sequence),
                GET_BE_U_2(msg_ptr.cfm_ccm->ma_epi));
 
@@ -381,7 +381,7 @@ cfm_print(netdissect_options *ndo,
             md_namelength = GET_U_1(namesp);
             namesp++;
             names_data_remaining--; /* We know this is !=0 */
-            ND_PRINT(C_RESET, C_RESET "\n\t  MD Name Format %s (%u), MD Name length %u",
+            ND_PRINT(C_RESET, "\n\t  MD Name Format %s (%u), MD Name length %u",
                    tok2str(cfm_md_nameformat_values, "Unknown",
                            md_nameformat),
                    md_nameformat,
@@ -392,12 +392,12 @@ cfm_print(netdissect_options *ndo,
              * of MA short name.
              */
             if (md_namelength > names_data_remaining - 3) {
-                ND_PRINT(C_RESET, C_RESET " (too large, must be <= %u)", names_data_remaining - 2);
+                ND_PRINT(C_RESET, " (too large, must be <= %u)", names_data_remaining - 2);
                 return;
             }
 
             md_name = namesp;
-            ND_PRINT(C_RESET, C_RESET "\n\t  MD Name: ");
+            ND_PRINT(C_RESET, "\n\t  MD Name: ");
             switch (md_nameformat) {
             case CFM_CCM_MD_FORMAT_DNS:
             case CFM_CCM_MD_FORMAT_CHAR:
@@ -406,9 +406,9 @@ cfm_print(netdissect_options *ndo,
 
             case CFM_CCM_MD_FORMAT_MAC:
                 if (md_namelength == MAC_ADDR_LEN) {
-                    ND_PRINT(C_RESET, C_RESET "\n\t  MAC %s", GET_ETHERADDR_STRING(md_name));
+                    ND_PRINT(C_RESET, "\n\t  MAC %s", GET_ETHERADDR_STRING(md_name));
                 } else {
-                    ND_PRINT(C_RESET, C_RESET "\n\t  MAC (length invalid)");
+                    ND_PRINT(C_RESET, "\n\t  MAC (length invalid)");
                 }
                 break;
 
@@ -421,7 +421,7 @@ cfm_print(netdissect_options *ndo,
             namesp += md_namelength;
             names_data_remaining -= md_namelength;
         } else {
-            ND_PRINT(C_RESET, C_RESET "\n\t  MD Name Format %s (%u)",
+            ND_PRINT(C_RESET, "\n\t  MD Name Format %s (%u)",
                    tok2str(cfm_md_nameformat_values, "Unknown",
                            md_nameformat),
                    md_nameformat);
@@ -437,19 +437,19 @@ cfm_print(netdissect_options *ndo,
         ma_namelength = GET_U_1(namesp);
         namesp++;
         names_data_remaining--; /* We know this is != 0 */
-        ND_PRINT(C_RESET, C_RESET "\n\t  MA Name-Format %s (%u), MA name length %u",
+        ND_PRINT(C_RESET, "\n\t  MA Name-Format %s (%u), MA name length %u",
                tok2str(cfm_ma_nameformat_values, "Unknown",
                        ma_nameformat),
                ma_nameformat,
                ma_namelength);
 
         if (ma_namelength > names_data_remaining) {
-            ND_PRINT(C_RESET, C_RESET " (too large, must be <= %u)", names_data_remaining);
+            ND_PRINT(C_RESET, " (too large, must be <= %u)", names_data_remaining);
             return;
         }
 
         ma_name = namesp;
-        ND_PRINT(C_RESET, C_RESET "\n\t  MA Name: ");
+        ND_PRINT(C_RESET, "\n\t  MA Name: ");
         switch (ma_nameformat) {
         case CFM_CCM_MA_FORMAT_CHAR:
             nd_printjnp(ndo, ma_name, ma_namelength);
@@ -468,7 +468,7 @@ cfm_print(netdissect_options *ndo,
     case CFM_OPCODE_LTM:
         msg_ptr.cfm_ltm = (const struct cfm_ltm_t *)tptr;
         if (first_tlv_offset < sizeof(*msg_ptr.cfm_ltm)) {
-            ND_PRINT(C_RESET, C_RESET " (too small 4, must be >= %zu)",
+            ND_PRINT(C_RESET, " (too small 4, must be >= %zu)",
                      sizeof(*msg_ptr.cfm_ltm));
             return;
         }
@@ -476,14 +476,14 @@ cfm_print(netdissect_options *ndo,
             goto tooshort;
         ND_TCHECK_SIZE(msg_ptr.cfm_ltm);
 
-        ND_PRINT(C_RESET, C_RESET ", Flags [%s]",
+        ND_PRINT(C_RESET, ", Flags [%s]",
                bittok2str(cfm_ltm_flag_values, "none", flags));
 
-        ND_PRINT(C_RESET, C_RESET "\n\t  Transaction-ID 0x%08x, ttl %u",
+        ND_PRINT(C_RESET, "\n\t  Transaction-ID 0x%08x, ttl %u",
                GET_BE_U_4(msg_ptr.cfm_ltm->transaction_id),
                GET_U_1(msg_ptr.cfm_ltm->ttl));
 
-        ND_PRINT(C_RESET, C_RESET "\n\t  Original-MAC %s, Target-MAC %s",
+        ND_PRINT(C_RESET, "\n\t  Original-MAC %s, Target-MAC %s",
                GET_ETHERADDR_STRING(msg_ptr.cfm_ltm->original_mac),
                GET_ETHERADDR_STRING(msg_ptr.cfm_ltm->target_mac));
         break;
@@ -491,7 +491,7 @@ cfm_print(netdissect_options *ndo,
     case CFM_OPCODE_LTR:
         msg_ptr.cfm_ltr = (const struct cfm_ltr_t *)tptr;
         if (first_tlv_offset < sizeof(*msg_ptr.cfm_ltr)) {
-            ND_PRINT(C_RESET, C_RESET " (too small 5, must be >= %zu)",
+            ND_PRINT(C_RESET, " (too small 5, must be >= %zu)",
                      sizeof(*msg_ptr.cfm_ltr));
             return;
         }
@@ -499,14 +499,14 @@ cfm_print(netdissect_options *ndo,
             goto tooshort;
         ND_TCHECK_SIZE(msg_ptr.cfm_ltr);
 
-        ND_PRINT(C_RESET, C_RESET ", Flags [%s]",
+        ND_PRINT(C_RESET, ", Flags [%s]",
                bittok2str(cfm_ltr_flag_values, "none", flags));
 
-        ND_PRINT(C_RESET, C_RESET "\n\t  Transaction-ID 0x%08x, ttl %u",
+        ND_PRINT(C_RESET, "\n\t  Transaction-ID 0x%08x, ttl %u",
                GET_BE_U_4(msg_ptr.cfm_ltr->transaction_id),
                GET_U_1(msg_ptr.cfm_ltr->ttl));
 
-        ND_PRINT(C_RESET, C_RESET "\n\t  Replay-Action %s (%u)",
+        ND_PRINT(C_RESET, "\n\t  Replay-Action %s (%u)",
                tok2str(cfm_ltr_replay_action_values,
                        "Unknown",
                        GET_U_1(msg_ptr.cfm_ltr->replay_action)),
@@ -534,7 +534,7 @@ cfm_print(netdissect_options *ndo,
         /* Enough to read the tlv type ? */
         cfm_tlv_type = GET_U_1(cfm_tlv_header->type);
 
-        ND_PRINT(C_RESET, C_RESET "\n\t%s TLV (0x%02x)",
+        ND_PRINT(C_RESET, "\n\t%s TLV (0x%02x)",
                tok2str(cfm_tlv_values, "Unknown", cfm_tlv_type),
                cfm_tlv_type);
 
@@ -549,7 +549,7 @@ cfm_print(netdissect_options *ndo,
         ND_TCHECK_LEN(tptr, sizeof(struct cfm_tlv_header_t));
         cfm_tlv_len=GET_BE_U_2(cfm_tlv_header->length);
 
-        ND_PRINT(C_RESET, C_RESET ", length %u", cfm_tlv_len);
+        ND_PRINT(C_RESET, ", length %u", cfm_tlv_len);
 
         tptr += sizeof(struct cfm_tlv_header_t);
         tlen -= sizeof(struct cfm_tlv_header_t);
@@ -564,30 +564,30 @@ cfm_print(netdissect_options *ndo,
         switch(cfm_tlv_type) {
         case CFM_TLV_PORT_STATUS:
             if (cfm_tlv_len < 1) {
-                ND_PRINT(C_RESET, C_RESET " (too short, must be >= 1)");
+                ND_PRINT(C_RESET, " (too short, must be >= 1)");
                 return;
             }
-            ND_PRINT(C_RESET, C_RESET ", Status: %s (%u)",
+            ND_PRINT(C_RESET, ", Status: %s (%u)",
                    tok2str(cfm_tlv_port_status_values, "Unknown", GET_U_1(tptr)),
                    GET_U_1(tptr));
             break;
 
         case CFM_TLV_INTERFACE_STATUS:
             if (cfm_tlv_len < 1) {
-                ND_PRINT(C_RESET, C_RESET " (too short, must be >= 1)");
+                ND_PRINT(C_RESET, " (too short, must be >= 1)");
                 return;
             }
-            ND_PRINT(C_RESET, C_RESET ", Status: %s (%u)",
+            ND_PRINT(C_RESET, ", Status: %s (%u)",
                    tok2str(cfm_tlv_interface_status_values, "Unknown", GET_U_1(tptr)),
                    GET_U_1(tptr));
             break;
 
         case CFM_TLV_PRIVATE:
             if (cfm_tlv_len < 4) {
-                ND_PRINT(C_RESET, C_RESET " (too short, must be >= 4)");
+                ND_PRINT(C_RESET, " (too short, must be >= 4)");
                 return;
             }
-            ND_PRINT(C_RESET, C_RESET ", Vendor: %s (%u), Sub-Type %u",
+            ND_PRINT(C_RESET, ", Vendor: %s (%u), Sub-Type %u",
                    tok2str(oui_values,"Unknown", GET_BE_U_3(tptr)),
                    GET_BE_U_3(tptr),
                    GET_U_1(tptr + 3));
@@ -600,7 +600,7 @@ cfm_print(netdissect_options *ndo,
             u_int mgmt_addr_length;
 
             if (cfm_tlv_len < 1) {
-                ND_PRINT(C_RESET, C_RESET " (too short, must be >= 1)");
+                ND_PRINT(C_RESET, " (too short, must be >= 1)");
                 goto next_tlv;
             }
 
@@ -620,12 +620,12 @@ cfm_print(netdissect_options *ndo,
                  * IEEE 802.1AB-2016 Section 8.5.2.2: chassis ID subtype
                  */
                 if (cfm_tlv_len < 1) {
-                    ND_PRINT(C_RESET, C_RESET "\n\t  (TLV too short)");
+                    ND_PRINT(C_RESET, "\n\t  (TLV too short)");
                     goto next_tlv;
                 }
                 chassis_id_type = GET_U_1(tptr);
                 cfm_tlv_len--;
-                ND_PRINT(C_RESET, C_RESET "\n\t  Chassis-ID Type %s (%u), Chassis-ID length %u",
+                ND_PRINT(C_RESET, "\n\t  Chassis-ID Type %s (%u), Chassis-ID length %u",
                        tok2str(cfm_tlv_senderid_chassisid_values,
                                "Unknown",
                                chassis_id_type),
@@ -633,7 +633,7 @@ cfm_print(netdissect_options *ndo,
                        chassis_id_length);
 
                 if (cfm_tlv_len < chassis_id_length) {
-                    ND_PRINT(C_RESET, C_RESET "\n\t  (TLV too short)");
+                    ND_PRINT(C_RESET, "\n\t  (TLV too short)");
                     goto next_tlv;
                 }
 
@@ -641,11 +641,11 @@ cfm_print(netdissect_options *ndo,
                 switch (chassis_id_type) {
                 case CFM_CHASSIS_ID_MAC_ADDRESS:
                     if (chassis_id_length != MAC_ADDR_LEN) {
-                        ND_PRINT(C_RESET, C_RESET " (invalid MAC address length)");
+                        ND_PRINT(C_RESET, " (invalid MAC address length)");
                         hexdump = TRUE;
                         break;
                     }
-                    ND_PRINT(C_RESET, C_RESET "\n\t  MAC %s", GET_ETHERADDR_STRING(tptr + 1));
+                    ND_PRINT(C_RESET, "\n\t  MAC %s", GET_ETHERADDR_STRING(tptr + 1));
                     break;
 
                 case CFM_CHASSIS_ID_NETWORK_ADDRESS:
@@ -686,11 +686,11 @@ cfm_print(netdissect_options *ndo,
             tptr++;
             tlen--;
             cfm_tlv_len--;
-            ND_PRINT(C_RESET, C_RESET "\n\t  Management Address Domain Length %u", mgmt_addr_length);
+            ND_PRINT(C_RESET, "\n\t  Management Address Domain Length %u", mgmt_addr_length);
             if (mgmt_addr_length) {
                 /* IEEE 802.1Q-2014 Section 21.5.3.5: Management Address Domain */
                 if (cfm_tlv_len < mgmt_addr_length) {
-                    ND_PRINT(C_RESET, C_RESET "\n\t  (TLV too short)");
+                    ND_PRINT(C_RESET, "\n\t  (TLV too short)");
                     goto next_tlv;
                 }
                 cfm_tlv_len -= mgmt_addr_length;
@@ -706,7 +706,7 @@ cfm_print(netdissect_options *ndo,
                  * This field is present if Management Address Domain Length is not 0.
                  */
                 if (cfm_tlv_len < 1) {
-                    ND_PRINT(C_RESET, C_RESET " (Management Address Length is missing)");
+                    ND_PRINT(C_RESET, " (Management Address Length is missing)");
                     hexdump = TRUE;
                     break;
                 }
@@ -716,11 +716,11 @@ cfm_print(netdissect_options *ndo,
                 tptr++;
                 tlen--;
                 cfm_tlv_len--;
-                ND_PRINT(C_RESET, C_RESET "\n\t  Management Address Length %u", mgmt_addr_length);
+                ND_PRINT(C_RESET, "\n\t  Management Address Length %u", mgmt_addr_length);
                 if (mgmt_addr_length) {
                     /* IEEE 802.1Q-2014 Section 21.5.3.7: Management Address */
                     if (cfm_tlv_len < mgmt_addr_length) {
-                        ND_PRINT(C_RESET, C_RESET "\n\t  (TLV too short)");
+                        ND_PRINT(C_RESET, "\n\t  (TLV too short)");
                         return;
                     }
                     cfm_tlv_len -= mgmt_addr_length;
@@ -758,7 +758,7 @@ next_tlv:
     return;
 
 tooshort:
-    ND_PRINT(C_RESET, C_RESET "\n\t\t packet is too short");
+    ND_PRINT(C_RESET, "\n\t\t packet is too short");
     return;
 
 trunc:

--- a/print-chdlc.c
+++ b/print-chdlc.c
@@ -63,7 +63,7 @@ chdlc_print(netdissect_options *ndo, const u_char *p, u_int length)
 	ND_ICHECK_U(length, <, CHDLC_HDRLEN);
 	proto = GET_BE_U_2(p + 2);
 	if (ndo->ndo_eflag) {
-                ND_PRINT("%s, ethertype %s (0x%04x), length %u: ",
+                ND_PRINT(C_RESET, "%s, ethertype %s (0x%04x), length %u: ",
                        tok2str(chdlc_cast_values, "0x%02x", GET_U_1(p)),
                        tok2str(ethertype_values, "Unknown", proto),
                        proto,
@@ -99,7 +99,7 @@ chdlc_print(netdissect_options *ndo, const u_char *p, u_int length)
                 break;
 	default:
                 if (!ndo->ndo_eflag)
-                        ND_PRINT("unknown CHDLC protocol (0x%04x)", proto);
+                        ND_PRINT(C_RESET, "unknown CHDLC protocol (0x%04x)", proto);
                 break;
 	}
 
@@ -140,15 +140,15 @@ chdlc_slarp_print(netdissect_options *ndo, const u_char *cp, u_int length)
         u_int sec,min,hrs,days;
 
 	ndo->ndo_protocol = "chdlc_slarp";
-	ND_PRINT("SLARP");
+	ND_PRINT(C_RESET, "SLARP");
 	ND_ICHECK_U(length, <, SLARP_MIN_LEN);
-	ND_PRINT(" (length: %u), ",length);
+	ND_PRINT(C_RESET, " (length: %u), ",length);
 
 	slarp = (const struct cisco_slarp *)cp;
 	ND_TCHECK_LEN(slarp, SLARP_MIN_LEN);
 	switch (GET_BE_U_4(slarp->code)) {
 	case SLARP_REQUEST:
-		ND_PRINT("request");
+		ND_PRINT(C_RESET, "request");
 		/*
 		 * At least according to William "Chops" Westfield's
 		 * message in
@@ -160,12 +160,12 @@ chdlc_slarp_print(netdissect_options *ndo, const u_char *cp, u_int length)
 		 */
 		break;
 	case SLARP_REPLY:
-		ND_PRINT("reply %s/%s",
+		ND_PRINT(C_RESET, "reply %s/%s",
 			GET_IPADDR_STRING(slarp->un.addr.addr),
 			GET_IPADDR_STRING(slarp->un.addr.mask));
 		break;
 	case SLARP_KEEPALIVE:
-		ND_PRINT("keepalive: mineseen=0x%08x, yourseen=0x%08x, reliability=0x%04x",
+		ND_PRINT(C_RESET, "keepalive: mineseen=0x%08x, yourseen=0x%08x, reliability=0x%04x",
                        GET_BE_U_4(slarp->un.keep.myseq),
                        GET_BE_U_4(slarp->un.keep.yourseq),
                        GET_BE_U_2(slarp->un.keep.rel));
@@ -176,18 +176,18 @@ chdlc_slarp_print(netdissect_options *ndo, const u_char *cp, u_int length)
                         min = sec / 60; sec -= min * 60;
                         hrs = min / 60; min -= hrs * 60;
                         days = hrs / 24; hrs -= days * 24;
-                        ND_PRINT(", link uptime=%ud%uh%um%us",days,hrs,min,sec);
+                        ND_PRINT(C_RESET, ", link uptime=%ud%uh%um%us",days,hrs,min,sec);
                 }
 		break;
 	default:
-		ND_PRINT("0x%02x unknown", GET_BE_U_4(slarp->code));
+		ND_PRINT(C_RESET, "0x%02x unknown", GET_BE_U_4(slarp->code));
                 if (ndo->ndo_vflag <= 1)
                     print_unknown_data(ndo,cp+4,"\n\t",length-4);
 		break;
 	}
 
 	if (SLARP_MAX_LEN < length && ndo->ndo_vflag)
-		ND_PRINT(", (trailing junk: %u bytes)", length - SLARP_MAX_LEN);
+		ND_PRINT(C_RESET, ", (trailing junk: %u bytes)", length - SLARP_MAX_LEN);
         if (ndo->ndo_vflag > 1)
             print_unknown_data(ndo,cp+4,"\n\t",length-4);
 	return;

--- a/print-cip.c
+++ b/print-cip.c
@@ -61,7 +61,7 @@ cip_if_print(netdissect_options *ndo, const struct pcap_pkthdr *h, const u_char 
 		/*
 		 * There is no MAC-layer header, so just print the length.
 		 */
-		ND_PRINT("%u: ", length);
+		ND_PRINT(C_RESET, "%u: ", length);
 
 	ND_TCHECK_LEN(p, sizeof(rfcllc));
 	if (memcmp(rfcllc, p, sizeof(rfcllc)) == 0) {

--- a/print-cnfp.c
+++ b/print-cnfp.c
@@ -177,48 +177,48 @@ cnfp_v1_print(netdissect_options *ndo, const u_char *cp)
 	t = GET_BE_U_4(nh->utc_sec);
 #endif
 
-	ND_PRINT("NetFlow v%x, %u.%03u uptime, %u.%09u, ", ver,
+	ND_PRINT(C_RESET, C_RESET "NetFlow v%x, %u.%03u uptime, %u.%09u, ", ver,
 	       GET_BE_U_4(nh->msys_uptime)/1000,
 	       GET_BE_U_4(nh->msys_uptime)%1000,
 	       GET_BE_U_4(nh->utc_sec), GET_BE_U_4(nh->utc_nsec));
 
 	nr = (const struct nfrec_v1 *)&nh[1];
 
-	ND_PRINT("%2u recs", nrecs);
+	ND_PRINT(C_RESET, C_RESET "%2u recs", nrecs);
 
 	for (; nrecs != 0; nr++, nrecs--) {
-		ND_PRINT("\n  started %u.%03u, last %u.%03u",
+		ND_PRINT(C_RESET, C_RESET "\n  started %u.%03u, last %u.%03u",
 		       GET_BE_U_4(nr->start_time)/1000,
 		       GET_BE_U_4(nr->start_time)%1000,
 		       GET_BE_U_4(nr->last_time)/1000,
 		       GET_BE_U_4(nr->last_time)%1000);
 
-		ND_PRINT("\n    %s:%u ",
+		ND_PRINT(C_RESET, C_RESET "\n    %s:%u ",
 			intoa(GET_IPV4_TO_NETWORK_ORDER(nr->src_ina)),
 			GET_BE_U_2(nr->srcport));
 
-		ND_PRINT("> %s:%u ",
+		ND_PRINT(C_RESET, C_RESET "> %s:%u ",
 			intoa(GET_IPV4_TO_NETWORK_ORDER(nr->dst_ina)),
 			GET_BE_U_2(nr->dstport));
 
-		ND_PRINT(">> %s\n    ",
+		ND_PRINT(C_RESET, C_RESET ">> %s\n    ",
 			intoa(GET_IPV4_TO_NETWORK_ORDER(nr->nhop_ina)));
 
 		proto = GET_U_1(nr->proto);
 		if (!ndo->ndo_nflag && (p_name = netdb_protoname(proto)) != NULL)
-			ND_PRINT("%s ", p_name);
+			ND_PRINT(C_RESET, C_RESET "%s ", p_name);
 		else
-			ND_PRINT("%u ", proto);
+			ND_PRINT(C_RESET, C_RESET "%u ", proto);
 
 		/* tcp flags for tcp only */
 		if (proto == IPPROTO_TCP) {
 			u_int flags;
 			flags = GET_U_1(nr->tcp_flags);
 			if (flags)
-				ND_PRINT("%s ", bittok2str_nosep(tcp_flag_values, "", flags));
+				ND_PRINT(C_RESET, C_RESET "%s ", bittok2str_nosep(tcp_flag_values, "", flags));
 		}
 
-		ND_PRINT("tos %u, %u (%u octets)",
+		ND_PRINT(C_RESET, C_RESET "tos %u, %u (%u octets)",
 		       GET_U_1(nr->tos),
 		       GET_BE_U_4(nr->packets),
 		       GET_BE_U_4(nr->octets));
@@ -252,53 +252,53 @@ cnfp_v5_print(netdissect_options *ndo, const u_char *cp)
 	t = GET_BE_U_4(nh->utc_sec);
 #endif
 
-	ND_PRINT("NetFlow v%x, %u.%03u uptime, %u.%09u, ", ver,
+	ND_PRINT(C_RESET, C_RESET "NetFlow v%x, %u.%03u uptime, %u.%09u, ", ver,
 	       GET_BE_U_4(nh->msys_uptime)/1000,
 	       GET_BE_U_4(nh->msys_uptime)%1000,
 	       GET_BE_U_4(nh->utc_sec), GET_BE_U_4(nh->utc_nsec));
 
-	ND_PRINT("#%u, ", GET_BE_U_4(nh->sequence));
+	ND_PRINT(C_RESET, C_RESET "#%u, ", GET_BE_U_4(nh->sequence));
 	/* This was not all of struct nfhdr_v5. */
 	ND_TCHECK_SIZE(nh);
 	nr = (const struct nfrec_v5 *)&nh[1];
 
-	ND_PRINT("%2u recs", nrecs);
+	ND_PRINT(C_RESET, C_RESET "%2u recs", nrecs);
 
 	for (; nrecs != 0; nr++, nrecs--) {
-		ND_PRINT("\n  started %u.%03u, last %u.%03u",
+		ND_PRINT(C_RESET, C_RESET "\n  started %u.%03u, last %u.%03u",
 		       GET_BE_U_4(nr->start_time)/1000,
 		       GET_BE_U_4(nr->start_time)%1000,
 		       GET_BE_U_4(nr->last_time)/1000,
 		       GET_BE_U_4(nr->last_time)%1000);
 
-		ND_PRINT("\n    %s/%u:%u:%u ",
+		ND_PRINT(C_RESET, C_RESET "\n    %s/%u:%u:%u ",
 			intoa(GET_IPV4_TO_NETWORK_ORDER(nr->src_ina)),
 			GET_U_1(nr->src_mask), GET_BE_U_2(nr->src_as),
 			GET_BE_U_2(nr->srcport));
 
-		ND_PRINT("> %s/%u:%u:%u ",
+		ND_PRINT(C_RESET, C_RESET "> %s/%u:%u:%u ",
 			intoa(GET_IPV4_TO_NETWORK_ORDER(nr->dst_ina)),
 			GET_U_1(nr->dst_mask), GET_BE_U_2(nr->dst_as),
 			GET_BE_U_2(nr->dstport));
 
-		ND_PRINT(">> %s\n    ",
+		ND_PRINT(C_RESET, C_RESET ">> %s\n    ",
 			intoa(GET_IPV4_TO_NETWORK_ORDER(nr->nhop_ina)));
 
 		proto = GET_U_1(nr->proto);
 		if (!ndo->ndo_nflag && (p_name = netdb_protoname(proto)) != NULL)
-			ND_PRINT("%s ", p_name);
+			ND_PRINT(C_RESET, C_RESET "%s ", p_name);
 		else
-			ND_PRINT("%u ", proto);
+			ND_PRINT(C_RESET, C_RESET "%u ", proto);
 
 		/* tcp flags for tcp only */
 		if (proto == IPPROTO_TCP) {
 			u_int flags;
 			flags = GET_U_1(nr->tcp_flags);
 			if (flags)
-				ND_PRINT("%s ", bittok2str_nosep(tcp_flag_values, "", flags));
+				ND_PRINT(C_RESET, C_RESET "%s ", bittok2str_nosep(tcp_flag_values, "", flags));
 		}
 
-		ND_PRINT("tos %u, %u (%u octets)",
+		ND_PRINT(C_RESET, C_RESET "tos %u, %u (%u octets)",
 		       GET_U_1(nr->tos),
 		       GET_BE_U_4(nr->packets),
 		       GET_BE_U_4(nr->octets));
@@ -332,53 +332,53 @@ cnfp_v6_print(netdissect_options *ndo, const u_char *cp)
 	t = GET_BE_U_4(nh->utc_sec);
 #endif
 
-	ND_PRINT("NetFlow v%x, %u.%03u uptime, %u.%09u, ", ver,
+	ND_PRINT(C_RESET, C_RESET "NetFlow v%x, %u.%03u uptime, %u.%09u, ", ver,
 	       GET_BE_U_4(nh->msys_uptime)/1000,
 	       GET_BE_U_4(nh->msys_uptime)%1000,
 	       GET_BE_U_4(nh->utc_sec), GET_BE_U_4(nh->utc_nsec));
 
-	ND_PRINT("#%u, ", GET_BE_U_4(nh->sequence));
+	ND_PRINT(C_RESET, C_RESET "#%u, ", GET_BE_U_4(nh->sequence));
 	/* This was not all of struct nfhdr_v6. */
 	ND_TCHECK_SIZE(nh);
 	nr = (const struct nfrec_v6 *)&nh[1];
 
-	ND_PRINT("%2u recs", nrecs);
+	ND_PRINT(C_RESET, C_RESET "%2u recs", nrecs);
 
 	for (; nrecs != 0; nr++, nrecs--) {
-		ND_PRINT("\n  started %u.%03u, last %u.%03u",
+		ND_PRINT(C_RESET, C_RESET "\n  started %u.%03u, last %u.%03u",
 		       GET_BE_U_4(nr->start_time)/1000,
 		       GET_BE_U_4(nr->start_time)%1000,
 		       GET_BE_U_4(nr->last_time)/1000,
 		       GET_BE_U_4(nr->last_time)%1000);
 
-		ND_PRINT("\n    %s/%u:%u:%u ",
+		ND_PRINT(C_RESET, C_RESET "\n    %s/%u:%u:%u ",
 			intoa(GET_IPV4_TO_NETWORK_ORDER(nr->src_ina)),
 			GET_U_1(nr->src_mask), GET_BE_U_2(nr->src_as),
 			GET_BE_U_2(nr->srcport));
 
-		ND_PRINT("> %s/%u:%u:%u ",
+		ND_PRINT(C_RESET, C_RESET "> %s/%u:%u:%u ",
 			intoa(GET_IPV4_TO_NETWORK_ORDER(nr->dst_ina)),
 			GET_U_1(nr->dst_mask), GET_BE_U_2(nr->dst_as),
 			GET_BE_U_2(nr->dstport));
 
-		ND_PRINT(">> %s\n    ",
+		ND_PRINT(C_RESET, C_RESET ">> %s\n    ",
 			intoa(GET_IPV4_TO_NETWORK_ORDER(nr->nhop_ina)));
 
 		proto = GET_U_1(nr->proto);
 		if (!ndo->ndo_nflag && (p_name = netdb_protoname(proto)) != NULL)
-			ND_PRINT("%s ", p_name);
+			ND_PRINT(C_RESET, C_RESET "%s ", p_name);
 		else
-			ND_PRINT("%u ", proto);
+			ND_PRINT(C_RESET, C_RESET "%u ", proto);
 
 		/* tcp flags for tcp only */
 		if (proto == IPPROTO_TCP) {
 			u_int flags;
 			flags = GET_U_1(nr->tcp_flags);
 			if (flags)
-				ND_PRINT("%s ", bittok2str_nosep(tcp_flag_values, "", flags));
+				ND_PRINT(C_RESET, C_RESET "%s ", bittok2str_nosep(tcp_flag_values, "", flags));
 		}
 
-		ND_PRINT("tos %u, %u (%u octets) (%u<>%u encaps)",
+		ND_PRINT(C_RESET, C_RESET "tos %u, %u (%u octets) (%u<>%u encaps)",
 		       GET_U_1(nr->tos),
 		       GET_BE_U_4(nr->packets),
 		       GET_BE_U_4(nr->octets),
@@ -414,7 +414,7 @@ cnfp_print(netdissect_options *ndo, const u_char *cp)
 		break;
 
 	default:
-		ND_PRINT("NetFlow v%x", ver);
+		ND_PRINT(C_RESET, C_RESET "NetFlow v%x", ver);
 		break;
 	}
 }

--- a/print-cnfp.c
+++ b/print-cnfp.c
@@ -177,48 +177,48 @@ cnfp_v1_print(netdissect_options *ndo, const u_char *cp)
 	t = GET_BE_U_4(nh->utc_sec);
 #endif
 
-	ND_PRINT(C_RESET, C_RESET "NetFlow v%x, %u.%03u uptime, %u.%09u, ", ver,
+	ND_PRINT(C_RESET, "NetFlow v%x, %u.%03u uptime, %u.%09u, ", ver,
 	       GET_BE_U_4(nh->msys_uptime)/1000,
 	       GET_BE_U_4(nh->msys_uptime)%1000,
 	       GET_BE_U_4(nh->utc_sec), GET_BE_U_4(nh->utc_nsec));
 
 	nr = (const struct nfrec_v1 *)&nh[1];
 
-	ND_PRINT(C_RESET, C_RESET "%2u recs", nrecs);
+	ND_PRINT(C_RESET, "%2u recs", nrecs);
 
 	for (; nrecs != 0; nr++, nrecs--) {
-		ND_PRINT(C_RESET, C_RESET "\n  started %u.%03u, last %u.%03u",
+		ND_PRINT(C_RESET, "\n  started %u.%03u, last %u.%03u",
 		       GET_BE_U_4(nr->start_time)/1000,
 		       GET_BE_U_4(nr->start_time)%1000,
 		       GET_BE_U_4(nr->last_time)/1000,
 		       GET_BE_U_4(nr->last_time)%1000);
 
-		ND_PRINT(C_RESET, C_RESET "\n    %s:%u ",
+		ND_PRINT(C_RESET, "\n    %s:%u ",
 			intoa(GET_IPV4_TO_NETWORK_ORDER(nr->src_ina)),
 			GET_BE_U_2(nr->srcport));
 
-		ND_PRINT(C_RESET, C_RESET "> %s:%u ",
+		ND_PRINT(C_RESET, "> %s:%u ",
 			intoa(GET_IPV4_TO_NETWORK_ORDER(nr->dst_ina)),
 			GET_BE_U_2(nr->dstport));
 
-		ND_PRINT(C_RESET, C_RESET ">> %s\n    ",
+		ND_PRINT(C_RESET, ">> %s\n    ",
 			intoa(GET_IPV4_TO_NETWORK_ORDER(nr->nhop_ina)));
 
 		proto = GET_U_1(nr->proto);
 		if (!ndo->ndo_nflag && (p_name = netdb_protoname(proto)) != NULL)
-			ND_PRINT(C_RESET, C_RESET "%s ", p_name);
+			ND_PRINT(C_RESET, "%s ", p_name);
 		else
-			ND_PRINT(C_RESET, C_RESET "%u ", proto);
+			ND_PRINT(C_RESET, "%u ", proto);
 
 		/* tcp flags for tcp only */
 		if (proto == IPPROTO_TCP) {
 			u_int flags;
 			flags = GET_U_1(nr->tcp_flags);
 			if (flags)
-				ND_PRINT(C_RESET, C_RESET "%s ", bittok2str_nosep(tcp_flag_values, "", flags));
+				ND_PRINT(C_RESET, "%s ", bittok2str_nosep(tcp_flag_values, "", flags));
 		}
 
-		ND_PRINT(C_RESET, C_RESET "tos %u, %u (%u octets)",
+		ND_PRINT(C_RESET, "tos %u, %u (%u octets)",
 		       GET_U_1(nr->tos),
 		       GET_BE_U_4(nr->packets),
 		       GET_BE_U_4(nr->octets));
@@ -252,53 +252,53 @@ cnfp_v5_print(netdissect_options *ndo, const u_char *cp)
 	t = GET_BE_U_4(nh->utc_sec);
 #endif
 
-	ND_PRINT(C_RESET, C_RESET "NetFlow v%x, %u.%03u uptime, %u.%09u, ", ver,
+	ND_PRINT(C_RESET, "NetFlow v%x, %u.%03u uptime, %u.%09u, ", ver,
 	       GET_BE_U_4(nh->msys_uptime)/1000,
 	       GET_BE_U_4(nh->msys_uptime)%1000,
 	       GET_BE_U_4(nh->utc_sec), GET_BE_U_4(nh->utc_nsec));
 
-	ND_PRINT(C_RESET, C_RESET "#%u, ", GET_BE_U_4(nh->sequence));
+	ND_PRINT(C_RESET, "#%u, ", GET_BE_U_4(nh->sequence));
 	/* This was not all of struct nfhdr_v5. */
 	ND_TCHECK_SIZE(nh);
 	nr = (const struct nfrec_v5 *)&nh[1];
 
-	ND_PRINT(C_RESET, C_RESET "%2u recs", nrecs);
+	ND_PRINT(C_RESET, "%2u recs", nrecs);
 
 	for (; nrecs != 0; nr++, nrecs--) {
-		ND_PRINT(C_RESET, C_RESET "\n  started %u.%03u, last %u.%03u",
+		ND_PRINT(C_RESET, "\n  started %u.%03u, last %u.%03u",
 		       GET_BE_U_4(nr->start_time)/1000,
 		       GET_BE_U_4(nr->start_time)%1000,
 		       GET_BE_U_4(nr->last_time)/1000,
 		       GET_BE_U_4(nr->last_time)%1000);
 
-		ND_PRINT(C_RESET, C_RESET "\n    %s/%u:%u:%u ",
+		ND_PRINT(C_RESET, "\n    %s/%u:%u:%u ",
 			intoa(GET_IPV4_TO_NETWORK_ORDER(nr->src_ina)),
 			GET_U_1(nr->src_mask), GET_BE_U_2(nr->src_as),
 			GET_BE_U_2(nr->srcport));
 
-		ND_PRINT(C_RESET, C_RESET "> %s/%u:%u:%u ",
+		ND_PRINT(C_RESET, "> %s/%u:%u:%u ",
 			intoa(GET_IPV4_TO_NETWORK_ORDER(nr->dst_ina)),
 			GET_U_1(nr->dst_mask), GET_BE_U_2(nr->dst_as),
 			GET_BE_U_2(nr->dstport));
 
-		ND_PRINT(C_RESET, C_RESET ">> %s\n    ",
+		ND_PRINT(C_RESET, ">> %s\n    ",
 			intoa(GET_IPV4_TO_NETWORK_ORDER(nr->nhop_ina)));
 
 		proto = GET_U_1(nr->proto);
 		if (!ndo->ndo_nflag && (p_name = netdb_protoname(proto)) != NULL)
-			ND_PRINT(C_RESET, C_RESET "%s ", p_name);
+			ND_PRINT(C_RESET, "%s ", p_name);
 		else
-			ND_PRINT(C_RESET, C_RESET "%u ", proto);
+			ND_PRINT(C_RESET, "%u ", proto);
 
 		/* tcp flags for tcp only */
 		if (proto == IPPROTO_TCP) {
 			u_int flags;
 			flags = GET_U_1(nr->tcp_flags);
 			if (flags)
-				ND_PRINT(C_RESET, C_RESET "%s ", bittok2str_nosep(tcp_flag_values, "", flags));
+				ND_PRINT(C_RESET, "%s ", bittok2str_nosep(tcp_flag_values, "", flags));
 		}
 
-		ND_PRINT(C_RESET, C_RESET "tos %u, %u (%u octets)",
+		ND_PRINT(C_RESET, "tos %u, %u (%u octets)",
 		       GET_U_1(nr->tos),
 		       GET_BE_U_4(nr->packets),
 		       GET_BE_U_4(nr->octets));
@@ -332,53 +332,53 @@ cnfp_v6_print(netdissect_options *ndo, const u_char *cp)
 	t = GET_BE_U_4(nh->utc_sec);
 #endif
 
-	ND_PRINT(C_RESET, C_RESET "NetFlow v%x, %u.%03u uptime, %u.%09u, ", ver,
+	ND_PRINT(C_RESET, "NetFlow v%x, %u.%03u uptime, %u.%09u, ", ver,
 	       GET_BE_U_4(nh->msys_uptime)/1000,
 	       GET_BE_U_4(nh->msys_uptime)%1000,
 	       GET_BE_U_4(nh->utc_sec), GET_BE_U_4(nh->utc_nsec));
 
-	ND_PRINT(C_RESET, C_RESET "#%u, ", GET_BE_U_4(nh->sequence));
+	ND_PRINT(C_RESET, "#%u, ", GET_BE_U_4(nh->sequence));
 	/* This was not all of struct nfhdr_v6. */
 	ND_TCHECK_SIZE(nh);
 	nr = (const struct nfrec_v6 *)&nh[1];
 
-	ND_PRINT(C_RESET, C_RESET "%2u recs", nrecs);
+	ND_PRINT(C_RESET, "%2u recs", nrecs);
 
 	for (; nrecs != 0; nr++, nrecs--) {
-		ND_PRINT(C_RESET, C_RESET "\n  started %u.%03u, last %u.%03u",
+		ND_PRINT(C_RESET, "\n  started %u.%03u, last %u.%03u",
 		       GET_BE_U_4(nr->start_time)/1000,
 		       GET_BE_U_4(nr->start_time)%1000,
 		       GET_BE_U_4(nr->last_time)/1000,
 		       GET_BE_U_4(nr->last_time)%1000);
 
-		ND_PRINT(C_RESET, C_RESET "\n    %s/%u:%u:%u ",
+		ND_PRINT(C_RESET, "\n    %s/%u:%u:%u ",
 			intoa(GET_IPV4_TO_NETWORK_ORDER(nr->src_ina)),
 			GET_U_1(nr->src_mask), GET_BE_U_2(nr->src_as),
 			GET_BE_U_2(nr->srcport));
 
-		ND_PRINT(C_RESET, C_RESET "> %s/%u:%u:%u ",
+		ND_PRINT(C_RESET, "> %s/%u:%u:%u ",
 			intoa(GET_IPV4_TO_NETWORK_ORDER(nr->dst_ina)),
 			GET_U_1(nr->dst_mask), GET_BE_U_2(nr->dst_as),
 			GET_BE_U_2(nr->dstport));
 
-		ND_PRINT(C_RESET, C_RESET ">> %s\n    ",
+		ND_PRINT(C_RESET, ">> %s\n    ",
 			intoa(GET_IPV4_TO_NETWORK_ORDER(nr->nhop_ina)));
 
 		proto = GET_U_1(nr->proto);
 		if (!ndo->ndo_nflag && (p_name = netdb_protoname(proto)) != NULL)
-			ND_PRINT(C_RESET, C_RESET "%s ", p_name);
+			ND_PRINT(C_RESET, "%s ", p_name);
 		else
-			ND_PRINT(C_RESET, C_RESET "%u ", proto);
+			ND_PRINT(C_RESET, "%u ", proto);
 
 		/* tcp flags for tcp only */
 		if (proto == IPPROTO_TCP) {
 			u_int flags;
 			flags = GET_U_1(nr->tcp_flags);
 			if (flags)
-				ND_PRINT(C_RESET, C_RESET "%s ", bittok2str_nosep(tcp_flag_values, "", flags));
+				ND_PRINT(C_RESET, "%s ", bittok2str_nosep(tcp_flag_values, "", flags));
 		}
 
-		ND_PRINT(C_RESET, C_RESET "tos %u, %u (%u octets) (%u<>%u encaps)",
+		ND_PRINT(C_RESET, "tos %u, %u (%u octets) (%u<>%u encaps)",
 		       GET_U_1(nr->tos),
 		       GET_BE_U_4(nr->packets),
 		       GET_BE_U_4(nr->octets),
@@ -414,7 +414,7 @@ cnfp_print(netdissect_options *ndo, const u_char *cp)
 		break;
 
 	default:
-		ND_PRINT(C_RESET, C_RESET "NetFlow v%x", ver);
+		ND_PRINT(C_RESET, "NetFlow v%x", ver);
 		break;
 	}
 }

--- a/print-dccp.c
+++ b/print-dccp.c
@@ -248,7 +248,7 @@ static void dccp_print_ack_no(netdissect_options *ndo, const u_char *bp)
 		ackno = GET_BE_U_3(ackp + 1);
 	}
 
-	ND_PRINT("(ack=%" PRIu64 ") ", ackno);
+	ND_PRINT(C_RESET, "(ack=%" PRIu64 ") ", ackno);
 }
 
 static u_int dccp_print_option(netdissect_options *, const u_char *, u_int);
@@ -294,11 +294,11 @@ dccp_print(netdissect_options *ndo, const u_char *bp, const u_char *data2,
 	hlen = GET_U_1(dh->dccph_doff) * 4;
 
 	if (ip6) {
-		ND_PRINT("%s.%u > %s.%u: ",
+		ND_PRINT(C_RESET, "%s.%u > %s.%u: ",
 			  GET_IP6ADDR_STRING(ip6->ip6_src), sport,
 			  GET_IP6ADDR_STRING(ip6->ip6_dst), dport);
 	} else {
-		ND_PRINT("%s.%u > %s.%u: ",
+		ND_PRINT(C_RESET, "%s.%u > %s.%u: ",
 			  GET_IPADDR_STRING(ip->ip_src), sport,
 			  GET_IPADDR_STRING(ip->ip_dst), dport);
 	}
@@ -307,33 +307,33 @@ dccp_print(netdissect_options *ndo, const u_char *bp, const u_char *data2,
 
 	if (ndo->ndo_qflag) {
 		ND_ICHECK_U(length, <, hlen);
-		ND_PRINT(" %u", length - hlen);
+		ND_PRINT(C_RESET, " %u", length - hlen);
 		return;
 	}
 
 	/* other variables in generic header */
 	if (ndo->ndo_vflag) {
-		ND_PRINT(" (CCVal %u, CsCov %u", DCCPH_CCVAL(dh), DCCPH_CSCOV(dh));
+		ND_PRINT(C_RESET, " (CCVal %u, CsCov %u", DCCPH_CCVAL(dh), DCCPH_CSCOV(dh));
 		/* checksum calculation */
 		if (ND_TTEST_LEN(bp, length)) {
 			uint16_t sum = 0, dccp_sum;
 
 			dccp_sum = GET_BE_U_2(dh->dccph_checksum);
-			ND_PRINT(", cksum 0x%04x ", dccp_sum);
+			ND_PRINT(C_RESET, ", cksum 0x%04x ", dccp_sum);
 			if (IP_V(ip) == 4)
 				sum = dccp_cksum(ndo, ip, dh, length);
 			else if (IP_V(ip) == 6)
 				sum = dccp6_cksum(ndo, ip6, dh, length);
 			if (sum != 0)
-				ND_PRINT("(incorrect -> 0x%04x)",in_cksum_shouldbe(dccp_sum, sum));
+				ND_PRINT(C_RESET, "(incorrect -> 0x%04x)",in_cksum_shouldbe(dccp_sum, sum));
 			else
-				ND_PRINT("(correct)");
+				ND_PRINT(C_RESET, "(correct)");
 		}
-		ND_PRINT(")");
+		ND_PRINT(C_RESET, ")");
 	}
 
 	dccph_type = DCCPH_TYPE(dh);
-	ND_PRINT(" %s ", tok2str(dccp_pkt_type_str, "packet-type-%u",
+	ND_PRINT(C_RESET, " %s ", tok2str(dccp_pkt_type_str, "packet-type-%u",
 		 dccph_type));
 	switch (dccph_type) {
 	case DCCP_PKT_REQUEST: {
@@ -341,7 +341,7 @@ dccp_print(netdissect_options *ndo, const u_char *bp, const u_char *data2,
 			(const struct dccp_hdr_request *)(bp + fixed_hdrlen);
 		fixed_hdrlen += 4;
 		ND_ICHECK_U(length, <, fixed_hdrlen);
-		ND_PRINT("(service=%u) ", GET_BE_U_4(dhr->dccph_req_service));
+		ND_PRINT(C_RESET, "(service=%u) ", GET_BE_U_4(dhr->dccph_req_service));
 		break;
 	}
 	case DCCP_PKT_RESPONSE: {
@@ -349,7 +349,7 @@ dccp_print(netdissect_options *ndo, const u_char *bp, const u_char *data2,
 			(const struct dccp_hdr_response *)(bp + fixed_hdrlen);
 		fixed_hdrlen += 12;
 		ND_ICHECK_U(length, <, fixed_hdrlen);
-		ND_PRINT("(service=%u) ", GET_BE_U_4(dhr->dccph_resp_service));
+		ND_PRINT(C_RESET, "(service=%u) ", GET_BE_U_4(dhr->dccph_resp_service));
 		break;
 	}
 	case DCCP_PKT_DATA:
@@ -378,7 +378,7 @@ dccp_print(netdissect_options *ndo, const u_char *bp, const u_char *data2,
 		fixed_hdrlen += 12;
 		ND_ICHECK_U(length, <, fixed_hdrlen);
 		ND_TCHECK_SIZE(dhr);
-		ND_PRINT("(code=%s) ", tok2str(dccp_reset_code_str,
+		ND_PRINT(C_RESET, "(code=%s) ", tok2str(dccp_reset_code_str,
 			 "reset-code-%u (invalid)", GET_U_1(dhr->dccph_reset_code)));
 		break;
 	}
@@ -402,13 +402,13 @@ dccp_print(netdissect_options *ndo, const u_char *bp, const u_char *data2,
 	if (ndo->ndo_vflag < 2)
 		return;
 
-	ND_PRINT("seq %" PRIu64, dccp_seqno(ndo, bp));
+	ND_PRINT(C_RESET, "seq %" PRIu64, dccp_seqno(ndo, bp));
 
 	/* process options */
 	if (hlen > fixed_hdrlen){
 		u_int optlen;
 		cp = bp + fixed_hdrlen;
-		ND_PRINT(" <");
+		ND_PRINT(C_RESET, " <");
 
 		hlen -= fixed_hdrlen;
 		while(1){
@@ -419,9 +419,9 @@ dccp_print(netdissect_options *ndo, const u_char *bp, const u_char *data2,
 				break;
 			hlen -= optlen;
 			cp += optlen;
-			ND_PRINT(", ");
+			ND_PRINT(C_RESET, ", ");
 		}
-		ND_PRINT(">");
+		ND_PRINT(C_RESET, ">");
 	}
 	return;
 invalid:
@@ -474,9 +474,9 @@ dccp_print_option(netdissect_options *ndo, const u_char *bp, u_int hlen)
 
 	option = GET_U_1(bp);
 	if (option >= 128)
-		ND_PRINT("CCID option %u", option);
+		ND_PRINT(C_RESET, "CCID option %u", option);
 	else
-		ND_PRINT("%s",
+		ND_PRINT(C_RESET, "%s",
 			 tok2str(dccp_option_values, "option-type-%u", option));
 	if (option >= 32) {
 		optlen = GET_U_1(bp + 1);
@@ -489,15 +489,15 @@ dccp_print_option(netdissect_options *ndo, const u_char *bp, u_int hlen)
 	if (option >= 128) {
 		switch (optlen) {
 			case 4:
-				ND_PRINT(" %u", GET_BE_U_2(bp + 2));
+				ND_PRINT(C_RESET, " %u", GET_BE_U_2(bp + 2));
 				break;
 			case 6:
-				ND_PRINT(" %u", GET_BE_U_4(bp + 2));
+				ND_PRINT(C_RESET, " %u", GET_BE_U_4(bp + 2));
 				break;
 			default:
-				ND_PRINT(" 0x");
+				ND_PRINT(C_RESET, " 0x");
 				for (i = 0; i < optlen - 2; i++)
-					ND_PRINT("%02x", GET_U_1(bp + 2 + i));
+					ND_PRINT(C_RESET, "%02x", GET_U_1(bp + 2 + i));
 				break;
 		}
 	} else {
@@ -510,43 +510,43 @@ dccp_print_option(netdissect_options *ndo, const u_char *bp, u_int hlen)
 		case DCCP_OPTION_CHANGE_L:
 		case DCCP_OPTION_CHANGE_R:
 			ND_ICHECK_U(optlen, <, 4);
-			ND_PRINT(" %s", tok2str(dccp_feature_num_str,
+			ND_PRINT(C_RESET, " %s", tok2str(dccp_feature_num_str,
 						"feature-number-%u (invalid)", GET_U_1(bp + 2)));
 			for (i = 0; i < optlen - 3; i++)
-				ND_PRINT(" %u", GET_U_1(bp + 3 + i));
+				ND_PRINT(C_RESET, " %u", GET_U_1(bp + 3 + i));
 			break;
 		case DCCP_OPTION_CONFIRM_L:
 		case DCCP_OPTION_CONFIRM_R:
 			ND_ICHECK_U(optlen, <, 3);
-			ND_PRINT(" %s", tok2str(dccp_feature_num_str,
+			ND_PRINT(C_RESET, " %s", tok2str(dccp_feature_num_str,
 						"feature-number-%u (invalid)", GET_U_1(bp + 2)));
 			for (i = 0; i < optlen - 3; i++)
-				ND_PRINT(" %u", GET_U_1(bp + 3 + i));
+				ND_PRINT(C_RESET, " %u", GET_U_1(bp + 3 + i));
 			break;
 		case DCCP_OPTION_INIT_COOKIE:
 			ND_ICHECK_U(optlen, <, 3);
-			ND_PRINT(" 0x");
+			ND_PRINT(C_RESET, " 0x");
 			for (i = 0; i < optlen - 2; i++)
-				ND_PRINT("%02x", GET_U_1(bp + 2 + i));
+				ND_PRINT(C_RESET, "%02x", GET_U_1(bp + 2 + i));
 			break;
 		case DCCP_OPTION_NDP_COUNT:
 			ND_ICHECK_U(optlen, <, 3);
 			ND_ICHECK_U(optlen, >, 8);
 			for (i = 0; i < optlen - 2; i++)
-				ND_PRINT(" %u", GET_U_1(bp + 2 + i));
+				ND_PRINT(C_RESET, " %u", GET_U_1(bp + 2 + i));
 			break;
 		case DCCP_OPTION_ACK_VECTOR_NONCE_0:
 		case DCCP_OPTION_ACK_VECTOR_NONCE_1:
 			ND_ICHECK_U(optlen, <, 3);
-			ND_PRINT(" 0x");
+			ND_PRINT(C_RESET, " 0x");
 			for (i = 0; i < optlen - 2; i++)
-				ND_PRINT("%02x", GET_U_1(bp + 2 + i));
+				ND_PRINT(C_RESET, "%02x", GET_U_1(bp + 2 + i));
 			break;
 		case DCCP_OPTION_DATA_DROPPED:
 			ND_ICHECK_U(optlen, <, 3);
-			ND_PRINT(" 0x");
+			ND_PRINT(C_RESET, " 0x");
 			for (i = 0; i < optlen - 2; i++)
-				ND_PRINT("%02x", GET_U_1(bp + 2 + i));
+				ND_PRINT(C_RESET, "%02x", GET_U_1(bp + 2 + i));
 			break;
 		case DCCP_OPTION_TIMESTAMP:
 		/*
@@ -558,7 +558,7 @@ dccp_print_option(netdissect_options *ndo, const u_char *bp, u_int hlen)
 		 *   Type=41  Length=6
 		 */
 			ND_ICHECK_U(optlen, !=, 6);
-			ND_PRINT(" %u", GET_BE_U_4(bp + 2));
+			ND_PRINT(C_RESET, " %u", GET_BE_U_4(bp + 2));
 			break;
 		case DCCP_OPTION_TIMESTAMP_ECHO:
 		/*
@@ -581,20 +581,20 @@ dccp_print_option(netdissect_options *ndo, const u_char *bp, u_int hlen)
 		 */
 			switch (optlen) {
 			case 6:
-				ND_PRINT(" %u", GET_BE_U_4(bp + 2));
+				ND_PRINT(C_RESET, " %u", GET_BE_U_4(bp + 2));
 				break;
 			case 8:
-				ND_PRINT(" %u", GET_BE_U_4(bp + 2));
-				ND_PRINT(" (elapsed time %u)",
+				ND_PRINT(C_RESET, " %u", GET_BE_U_4(bp + 2));
+				ND_PRINT(C_RESET, " (elapsed time %u)",
 					 GET_BE_U_2(bp + 6));
 				break;
 			case 10:
-				ND_PRINT(" %u", GET_BE_U_4(bp + 2));
-				ND_PRINT(" (elapsed time %u)",
+				ND_PRINT(C_RESET, " %u", GET_BE_U_4(bp + 2));
+				ND_PRINT(C_RESET, " (elapsed time %u)",
 					 GET_BE_U_4(bp + 6));
 				break;
 			default:
-				ND_PRINT(" [optlen != 6 or 8 or 10]");
+				ND_PRINT(C_RESET, " [optlen != 6 or 8 or 10]");
 				goto invalid;
 				break;
 			}
@@ -602,21 +602,21 @@ dccp_print_option(netdissect_options *ndo, const u_char *bp, u_int hlen)
 		case DCCP_OPTION_ELAPSED_TIME:
 			switch (optlen) {
 			case 4:
-				ND_PRINT(" %u", GET_BE_U_2(bp + 2));
+				ND_PRINT(C_RESET, " %u", GET_BE_U_2(bp + 2));
 				break;
 			case 6:
-				ND_PRINT(" %u", GET_BE_U_4(bp + 2));
+				ND_PRINT(C_RESET, " %u", GET_BE_U_4(bp + 2));
 				break;
 			default:
-				ND_PRINT(" [optlen != 4 or 6]");
+				ND_PRINT(C_RESET, " [optlen != 4 or 6]");
 				goto invalid;
 			}
 			break;
 		case DCCP_OPTION_DATA_CHECKSUM:
 			ND_ICHECK_U(optlen, !=, 6);
-			ND_PRINT(" 0x");
+			ND_PRINT(C_RESET, " 0x");
 			for (i = 0; i < optlen - 2; i++)
-				ND_PRINT("%02x", GET_U_1(bp + 2 + i));
+				ND_PRINT(C_RESET, "%02x", GET_U_1(bp + 2 + i));
 			break;
 		default:
 			goto invalid;

--- a/print-decnet.c
+++ b/print-decnet.c
@@ -478,17 +478,17 @@ decnet_print(netdissect_options *ndo,
 
 	ndo->ndo_protocol = "decnet";
 	if (length < sizeof(struct shorthdr)) {
-		ND_PRINT(" (length %u < %zu)", length, sizeof(struct shorthdr));
+		ND_PRINT(C_RESET, " (length %u < %zu)", length, sizeof(struct shorthdr));
 		goto invalid;
 	}
 
 	pktlen = GET_LE_U_2(ap);
 	if (pktlen < sizeof(struct shorthdr)) {
-		ND_PRINT(" (pktlen %u < %zu)", pktlen, sizeof(struct shorthdr));
+		ND_PRINT(C_RESET, " (pktlen %u < %zu)", pktlen, sizeof(struct shorthdr));
 		goto invalid;
 	}
 	if (pktlen > length) {
-		ND_PRINT(" (pktlen %u > %u)", pktlen, length);
+		ND_PRINT(C_RESET, " (pktlen %u > %u)", pktlen, length);
 		goto invalid;
 	}
 	length = pktlen;
@@ -500,9 +500,9 @@ decnet_print(netdissect_options *ndo,
 	    /* pad bytes of some sort in front of message */
 	    u_int padlen = mflags & RMF_PADMASK;
 	    if (ndo->ndo_vflag)
-		ND_PRINT("[pad:%u] ", padlen);
+		ND_PRINT(C_RESET, "[pad:%u] ", padlen);
 	    if (length < padlen + 2) {
-		ND_PRINT(" (length %u < %u)", length, padlen + 2);
+		ND_PRINT(C_RESET, " (length %u < %u)", length, padlen + 2);
 		goto invalid;
 	    }
 	    ND_TCHECK_LEN(ap + sizeof(short), padlen);
@@ -514,7 +514,7 @@ decnet_print(netdissect_options *ndo,
 	}
 
 	if (mflags & RMF_FVER) {
-		ND_PRINT("future-version-decnet");
+		ND_PRINT(C_RESET, "future-version-decnet");
 		ND_DEFAULTPRINT(ap, ND_MIN(length, caplen));
 		return;
 	}
@@ -529,7 +529,7 @@ decnet_print(netdissect_options *ndo,
 	switch (mflags & RMF_MASK) {
 	case RMF_LONG:
 	    if (length < sizeof(struct longhdr)) {
-		ND_PRINT(" (length %u < %zu)", length, sizeof(struct longhdr));
+		ND_PRINT(C_RESET, " (length %u < %zu)", length, sizeof(struct longhdr));
 		goto invalid;
 	    }
 	    ND_TCHECK_SIZE(&rhp->rh_long);
@@ -549,21 +549,21 @@ decnet_print(netdissect_options *ndo,
 	    nsplen = length - sizeof(struct shorthdr);
 	    break;
 	default:
-	    ND_PRINT("unknown message flags under mask");
+	    ND_PRINT(C_RESET, "unknown message flags under mask");
 	    ND_DEFAULTPRINT((const u_char *)ap, ND_MIN(length, caplen));
 	    return;
 	}
 
-	ND_PRINT("%s > %s %u ",
+	ND_PRINT(C_RESET, "%s > %s %u ",
 			dnaddr_string(ndo, src), dnaddr_string(ndo, dst), pktlen);
 	if (ndo->ndo_vflag) {
 	    if (mflags & RMF_RQR)
-		ND_PRINT("RQR ");
+		ND_PRINT(C_RESET, "RQR ");
 	    if (mflags & RMF_RTS)
-		ND_PRINT("RTS ");
+		ND_PRINT(C_RESET, "RTS ");
 	    if (mflags & RMF_IE)
-		ND_PRINT("IE ");
-	    ND_PRINT("%u hops ", hops);
+		ND_PRINT(C_RESET, "IE ");
+	    ND_PRINT(C_RESET, "%u hops ", hops);
 	}
 
 	if (!print_nsp(ndo, nspp, nsplen))
@@ -589,7 +589,7 @@ print_decnet_ctlmsg(netdissect_options *ndo,
 
 	switch (mflags & RMF_CTLMASK) {
 	case RMF_INIT:
-	    ND_PRINT("init ");
+	    ND_PRINT(C_RESET, "init ");
 	    if (length < sizeof(struct initmsg))
 		goto invalid;
 	    ND_TCHECK_SIZE(&cmp->cm_init);
@@ -601,48 +601,48 @@ print_decnet_ctlmsg(netdissect_options *ndo,
 	    ueco = GET_U_1(cmp->cm_init.in_ueco);
 	    hello = GET_LE_U_2(cmp->cm_init.in_hello);
 	    print_t_info(ndo, info);
-	    ND_PRINT("src %sblksize %u vers %u eco %u ueco %u hello %u",
+	    ND_PRINT(C_RESET, "src %sblksize %u vers %u eco %u ueco %u hello %u",
 			dnaddr_string(ndo, src), blksize, vers, eco, ueco,
 			hello);
 	    break;
 	case RMF_VER:
-	    ND_PRINT("verification ");
+	    ND_PRINT(C_RESET, "verification ");
 	    if (length < sizeof(struct verifmsg))
 		goto invalid;
 	    src = GET_LE_U_2(cmp->cm_ver.ve_src);
 	    other = GET_U_1(cmp->cm_ver.ve_fcnval);
-	    ND_PRINT("src %s fcnval %o", dnaddr_string(ndo, src), other);
+	    ND_PRINT(C_RESET, "src %s fcnval %o", dnaddr_string(ndo, src), other);
 	    break;
 	case RMF_TEST:
-	    ND_PRINT("test ");
+	    ND_PRINT(C_RESET, "test ");
 	    if (length < sizeof(struct testmsg))
 		goto invalid;
 	    src = GET_LE_U_2(cmp->cm_test.te_src);
 	    other = GET_U_1(cmp->cm_test.te_data);
-	    ND_PRINT("src %s data %o", dnaddr_string(ndo, src), other);
+	    ND_PRINT(C_RESET, "src %s data %o", dnaddr_string(ndo, src), other);
 	    break;
 	case RMF_L1ROUT:
-	    ND_PRINT("lev-1-routing ");
+	    ND_PRINT(C_RESET, "lev-1-routing ");
 	    if (length < sizeof(struct l1rout))
 		goto invalid;
 	    ND_TCHECK_SIZE(&cmp->cm_l1rou);
 	    src = GET_LE_U_2(cmp->cm_l1rou.r1_src);
-	    ND_PRINT("src %s ", dnaddr_string(ndo, src));
+	    ND_PRINT(C_RESET, "src %s ", dnaddr_string(ndo, src));
 	    print_l1_routes(ndo, &(rhpx[sizeof(struct l1rout)]),
 				length - sizeof(struct l1rout));
 	    break;
 	case RMF_L2ROUT:
-	    ND_PRINT("lev-2-routing ");
+	    ND_PRINT(C_RESET, "lev-2-routing ");
 	    if (length < sizeof(struct l2rout))
 		goto invalid;
 	    ND_TCHECK_SIZE(&cmp->cm_l2rout);
 	    src = GET_LE_U_2(cmp->cm_l2rout.r2_src);
-	    ND_PRINT("src %s ", dnaddr_string(ndo, src));
+	    ND_PRINT(C_RESET, "src %s ", dnaddr_string(ndo, src));
 	    print_l2_routes(ndo, &(rhpx[sizeof(struct l2rout)]),
 				length - sizeof(struct l2rout));
 	    break;
 	case RMF_RHELLO:
-	    ND_PRINT("router-hello ");
+	    ND_PRINT(C_RESET, "router-hello ");
 	    if (length < sizeof(struct rhellomsg))
 		goto invalid;
 	    ND_TCHECK_SIZE(&cmp->cm_rhello);
@@ -656,14 +656,14 @@ print_decnet_ctlmsg(netdissect_options *ndo,
 	    priority = GET_U_1(cmp->cm_rhello.rh_priority);
 	    hello = GET_LE_U_2(cmp->cm_rhello.rh_hello);
 	    print_i_info(ndo, info);
-	    ND_PRINT("vers %u eco %u ueco %u src %s blksize %u pri %u hello %u",
+	    ND_PRINT(C_RESET, "vers %u eco %u ueco %u src %s blksize %u pri %u hello %u",
 			vers, eco, ueco, dnaddr_string(ndo, src),
 			blksize, priority, hello);
 	    print_elist(&(rhpx[sizeof(struct rhellomsg)]),
 				length - sizeof(struct rhellomsg));
 	    break;
 	case RMF_EHELLO:
-	    ND_PRINT("endnode-hello ");
+	    ND_PRINT(C_RESET, "endnode-hello ");
 	    if (length < sizeof(struct ehellomsg))
 		goto invalid;
 	    vers = GET_U_1(cmp->cm_ehello.eh_vers);
@@ -679,13 +679,13 @@ print_decnet_ctlmsg(netdissect_options *ndo,
 	    hello = GET_LE_U_2(cmp->cm_ehello.eh_hello);
 	    other = GET_U_1(cmp->cm_ehello.eh_data);
 	    print_i_info(ndo, info);
-	    ND_PRINT("vers %u eco %u ueco %u src %s blksize %u rtr %s hello %u data %o",
+	    ND_PRINT(C_RESET, "vers %u eco %u ueco %u src %s blksize %u rtr %s hello %u data %o",
 			vers, eco, ueco, dnaddr_string(ndo, src),
 			blksize, dnaddr_string(ndo, dst), hello, other);
 	    break;
 
 	default:
-	    ND_PRINT("unknown control message");
+	    ND_PRINT(C_RESET, "unknown control message");
 	    ND_DEFAULTPRINT((const u_char *)rhp, ND_MIN(length, caplen));
 	    break;
 	}
@@ -701,15 +701,15 @@ print_t_info(netdissect_options *ndo,
 {
 	u_int ntype = info & 3;
 	switch (ntype) {
-	case 0: ND_PRINT("reserved-ntype? "); break;
-	case TI_L2ROUT: ND_PRINT("l2rout "); break;
-	case TI_L1ROUT: ND_PRINT("l1rout "); break;
-	case TI_ENDNODE: ND_PRINT("endnode "); break;
+	case 0: ND_PRINT(C_RESET, "reserved-ntype? "); break;
+	case TI_L2ROUT: ND_PRINT(C_RESET, "l2rout "); break;
+	case TI_L1ROUT: ND_PRINT(C_RESET, "l1rout "); break;
+	case TI_ENDNODE: ND_PRINT(C_RESET, "endnode "); break;
 	}
 	if (info & TI_VERIF)
-	    ND_PRINT("verif ");
+	    ND_PRINT(C_RESET, "verif ");
 	if (info & TI_BLOCK)
-	    ND_PRINT("blo ");
+	    ND_PRINT(C_RESET, "blo ");
 }
 
 static void
@@ -734,7 +734,7 @@ print_l1_routes(netdissect_options *ndo,
 	    info = GET_LE_U_2(rp);
 	    rp += sizeof(short);
 	    len -= sizeof(short);
-	    ND_PRINT("{ids %u-%u cost %u hops %u} ", id, id + count,
+	    ND_PRINT(C_RESET, "{ids %u-%u cost %u hops %u} ", id, id + count,
 			    RI_COST(info), RI_HOPS(info));
 	}
 }
@@ -761,7 +761,7 @@ print_l2_routes(netdissect_options *ndo,
 	    info = GET_LE_U_2(rp);
 	    rp += sizeof(short);
 	    len -= sizeof(short);
-	    ND_PRINT("{areas %u-%u cost %u hops %u} ", area, area + count,
+	    ND_PRINT(C_RESET, "{areas %u-%u cost %u hops %u} ", area, area + count,
 			    RI_COST(info), RI_HOPS(info));
 	}
 }
@@ -772,17 +772,17 @@ print_i_info(netdissect_options *ndo,
 {
 	u_int ntype = info & II_TYPEMASK;
 	switch (ntype) {
-	case 0: ND_PRINT("reserved-ntype? "); break;
-	case II_L2ROUT: ND_PRINT("l2rout "); break;
-	case II_L1ROUT: ND_PRINT("l1rout "); break;
-	case II_ENDNODE: ND_PRINT("endnode "); break;
+	case 0: ND_PRINT(C_RESET, "reserved-ntype? "); break;
+	case II_L2ROUT: ND_PRINT(C_RESET, "l2rout "); break;
+	case II_L1ROUT: ND_PRINT(C_RESET, "l1rout "); break;
+	case II_ENDNODE: ND_PRINT(C_RESET, "endnode "); break;
 	}
 	if (info & II_VERIF)
-	    ND_PRINT("verif ");
+	    ND_PRINT(C_RESET, "verif ");
 	if (info & II_NOMCAST)
-	    ND_PRINT("nomcast ");
+	    ND_PRINT(C_RESET, "nomcast ");
 	if (info & II_BLOCK)
-	    ND_PRINT("blo ");
+	    ND_PRINT(C_RESET, "blo ");
 }
 
 static void
@@ -799,7 +799,7 @@ print_nsp(netdissect_options *ndo,
 	u_int dst, src, flags;
 
 	if (nsplen < sizeof(struct nsphdr)) {
-		ND_PRINT(" (nsplen %u < %zu)", nsplen, sizeof(struct nsphdr));
+		ND_PRINT(C_RESET, " (nsplen %u < %zu)", nsplen, sizeof(struct nsphdr));
 		goto invalid;
 	}
 	flags = GET_U_1(nsphp->nh_flags);
@@ -813,7 +813,7 @@ print_nsp(netdissect_options *ndo,
 	    case MFS_MOM:
 	    case MFS_EOM:
 	    case MFS_BOM+MFS_EOM:
-		ND_PRINT("data %u>%u ", src, dst);
+		ND_PRINT(C_RESET, "data %u>%u ", src, dst);
 		{
 		    const struct seghdr *shp = (const struct seghdr *)nspp;
 		    u_int ack;
@@ -824,29 +824,29 @@ print_nsp(netdissect_options *ndo,
 		    ack = GET_LE_U_2(shp->sh_seq[0]);
 		    if (ack & SGQ_ACK) {	/* acknum field */
 			if ((ack & SGQ_NAK) == SGQ_NAK)
-			    ND_PRINT("nak %u ", ack & SGQ_MASK);
+			    ND_PRINT(C_RESET, "nak %u ", ack & SGQ_MASK);
 			else
-			    ND_PRINT("ack %u ", ack & SGQ_MASK);
+			    ND_PRINT(C_RESET, "ack %u ", ack & SGQ_MASK);
 			data_off += sizeof(short);
 			if (nsplen < data_off)
 			    goto invalid;
 		        ack = GET_LE_U_2(shp->sh_seq[1]);
 			if (ack & SGQ_OACK) {	/* ackoth field */
 			    if ((ack & SGQ_ONAK) == SGQ_ONAK)
-				ND_PRINT("onak %u ", ack & SGQ_MASK);
+				ND_PRINT(C_RESET, "onak %u ", ack & SGQ_MASK);
 			    else
-				ND_PRINT("oack %u ", ack & SGQ_MASK);
+				ND_PRINT(C_RESET, "oack %u ", ack & SGQ_MASK);
 			    data_off += sizeof(short);
 			    if (nsplen < data_off)
 				goto invalid;
 			    ack = GET_LE_U_2(shp->sh_seq[2]);
 			}
 		    }
-		    ND_PRINT("seg %u ", ack & SGQ_MASK);
+		    ND_PRINT(C_RESET, "seg %u ", ack & SGQ_MASK);
 		}
 		break;
 	    case MFS_ILS+MFS_INT:
-		ND_PRINT("intr ");
+		ND_PRINT(C_RESET, "intr ");
 		{
 		    const struct seghdr *shp = (const struct seghdr *)nspp;
 		    u_int ack;
@@ -857,29 +857,29 @@ print_nsp(netdissect_options *ndo,
 		    ack = GET_LE_U_2(shp->sh_seq[0]);
 		    if (ack & SGQ_ACK) {	/* acknum field */
 			if ((ack & SGQ_NAK) == SGQ_NAK)
-			    ND_PRINT("nak %u ", ack & SGQ_MASK);
+			    ND_PRINT(C_RESET, "nak %u ", ack & SGQ_MASK);
 			else
-			    ND_PRINT("ack %u ", ack & SGQ_MASK);
+			    ND_PRINT(C_RESET, "ack %u ", ack & SGQ_MASK);
 			data_off += sizeof(short);
 			if (nsplen < data_off)
 			    goto invalid;
 		        ack = GET_LE_U_2(shp->sh_seq[1]);
 			if (ack & SGQ_OACK) {	/* ackdat field */
 			    if ((ack & SGQ_ONAK) == SGQ_ONAK)
-				ND_PRINT("nakdat %u ", ack & SGQ_MASK);
+				ND_PRINT(C_RESET, "nakdat %u ", ack & SGQ_MASK);
 			    else
-				ND_PRINT("ackdat %u ", ack & SGQ_MASK);
+				ND_PRINT(C_RESET, "ackdat %u ", ack & SGQ_MASK);
 			    data_off += sizeof(short);
 			    if (nsplen < data_off)
 				goto invalid;
 			    ack = GET_LE_U_2(shp->sh_seq[2]);
 			}
 		    }
-		    ND_PRINT("seg %u ", ack & SGQ_MASK);
+		    ND_PRINT(C_RESET, "seg %u ", ack & SGQ_MASK);
 		}
 		break;
 	    case MFS_ILS:
-		ND_PRINT("link-service %u>%u ", src, dst);
+		ND_PRINT(C_RESET, "link-service %u>%u ", src, dst);
 		{
 		    const struct seghdr *shp = (const struct seghdr *)nspp;
 		    const struct lsmsg *lsmp =
@@ -892,56 +892,56 @@ print_nsp(netdissect_options *ndo,
 		    ack = GET_LE_U_2(shp->sh_seq[0]);
 		    if (ack & SGQ_ACK) {	/* acknum field */
 			if ((ack & SGQ_NAK) == SGQ_NAK)
-			    ND_PRINT("nak %u ", ack & SGQ_MASK);
+			    ND_PRINT(C_RESET, "nak %u ", ack & SGQ_MASK);
 			else
-			    ND_PRINT("ack %u ", ack & SGQ_MASK);
+			    ND_PRINT(C_RESET, "ack %u ", ack & SGQ_MASK);
 		        ack = GET_LE_U_2(shp->sh_seq[1]);
 			if (ack & SGQ_OACK) {	/* ackdat field */
 			    if ((ack & SGQ_ONAK) == SGQ_ONAK)
-				ND_PRINT("nakdat %u ", ack & SGQ_MASK);
+				ND_PRINT(C_RESET, "nakdat %u ", ack & SGQ_MASK);
 			    else
-				ND_PRINT("ackdat %u ", ack & SGQ_MASK);
+				ND_PRINT(C_RESET, "ackdat %u ", ack & SGQ_MASK);
 			    ack = GET_LE_U_2(shp->sh_seq[2]);
 			}
 		    }
-		    ND_PRINT("seg %u ", ack & SGQ_MASK);
+		    ND_PRINT(C_RESET, "seg %u ", ack & SGQ_MASK);
 		    lsflags = GET_U_1(lsmp->ls_lsflags);
 		    fcval = GET_U_1(lsmp->ls_fcval);
 		    switch (lsflags & LSI_MASK) {
 		    case LSI_DATA:
-			ND_PRINT("dat seg count %u ", fcval);
+			ND_PRINT(C_RESET, "dat seg count %u ", fcval);
 			switch (lsflags & LSM_MASK) {
 			case LSM_NOCHANGE:
 			    break;
 			case LSM_DONOTSEND:
-			    ND_PRINT("donotsend-data ");
+			    ND_PRINT(C_RESET, "donotsend-data ");
 			    break;
 			case LSM_SEND:
-			    ND_PRINT("send-data ");
+			    ND_PRINT(C_RESET, "send-data ");
 			    break;
 			default:
-			    ND_PRINT("reserved-fcmod? %x", lsflags);
+			    ND_PRINT(C_RESET, "reserved-fcmod? %x", lsflags);
 			    break;
 			}
 			break;
 		    case LSI_INTR:
-			ND_PRINT("intr req count %u ", fcval);
+			ND_PRINT(C_RESET, "intr req count %u ", fcval);
 			break;
 		    default:
-			ND_PRINT("reserved-fcval-int? %x", lsflags);
+			ND_PRINT(C_RESET, "reserved-fcval-int? %x", lsflags);
 			break;
 		    }
 		}
 		break;
 	    default:
-		ND_PRINT("reserved-subtype? %x %u > %u", flags, src, dst);
+		ND_PRINT(C_RESET, "reserved-subtype? %x %u > %u", flags, src, dst);
 		break;
 	    }
 	    break;
 	case MFT_ACK:
 	    switch (flags & NSP_SUBMASK) {
 	    case MFS_DACK:
-		ND_PRINT("data-ack %u>%u ", src, dst);
+		ND_PRINT(C_RESET, "data-ack %u>%u ", src, dst);
 		{
 		    const struct ackmsg *amp = (const struct ackmsg *)nspp;
 		    u_int ack;
@@ -952,21 +952,21 @@ print_nsp(netdissect_options *ndo,
 		    ack = GET_LE_U_2(amp->ak_acknum[0]);
 		    if (ack & SGQ_ACK) {	/* acknum field */
 			if ((ack & SGQ_NAK) == SGQ_NAK)
-			    ND_PRINT("nak %u ", ack & SGQ_MASK);
+			    ND_PRINT(C_RESET, "nak %u ", ack & SGQ_MASK);
 			else
-			    ND_PRINT("ack %u ", ack & SGQ_MASK);
+			    ND_PRINT(C_RESET, "ack %u ", ack & SGQ_MASK);
 		        ack = GET_LE_U_2(amp->ak_acknum[1]);
 			if (ack & SGQ_OACK) {	/* ackoth field */
 			    if ((ack & SGQ_ONAK) == SGQ_ONAK)
-				ND_PRINT("onak %u ", ack & SGQ_MASK);
+				ND_PRINT(C_RESET, "onak %u ", ack & SGQ_MASK);
 			    else
-				ND_PRINT("oack %u ", ack & SGQ_MASK);
+				ND_PRINT(C_RESET, "oack %u ", ack & SGQ_MASK);
 			}
 		    }
 		}
 		break;
 	    case MFS_IACK:
-		ND_PRINT("ils-ack %u>%u ", src, dst);
+		ND_PRINT(C_RESET, "ils-ack %u>%u ", src, dst);
 		{
 		    const struct ackmsg *amp = (const struct ackmsg *)nspp;
 		    u_int ack;
@@ -977,24 +977,24 @@ print_nsp(netdissect_options *ndo,
 		    ack = GET_LE_U_2(amp->ak_acknum[0]);
 		    if (ack & SGQ_ACK) {	/* acknum field */
 			if ((ack & SGQ_NAK) == SGQ_NAK)
-			    ND_PRINT("nak %u ", ack & SGQ_MASK);
+			    ND_PRINT(C_RESET, "nak %u ", ack & SGQ_MASK);
 			else
-			    ND_PRINT("ack %u ", ack & SGQ_MASK);
+			    ND_PRINT(C_RESET, "ack %u ", ack & SGQ_MASK);
 		        ack = GET_LE_U_2(amp->ak_acknum[1]);
 			if (ack & SGQ_OACK) {	/* ackdat field */
 			    if ((ack & SGQ_ONAK) == SGQ_ONAK)
-				ND_PRINT("nakdat %u ", ack & SGQ_MASK);
+				ND_PRINT(C_RESET, "nakdat %u ", ack & SGQ_MASK);
 			    else
-				ND_PRINT("ackdat %u ", ack & SGQ_MASK);
+				ND_PRINT(C_RESET, "ackdat %u ", ack & SGQ_MASK);
 			}
 		    }
 		}
 		break;
 	    case MFS_CACK:
-		ND_PRINT("conn-ack %u", dst);
+		ND_PRINT(C_RESET, "conn-ack %u", dst);
 		break;
 	    default:
-		ND_PRINT("reserved-acktype? %x %u > %u", flags, src, dst);
+		ND_PRINT(C_RESET, "reserved-acktype? %x %u > %u", flags, src, dst);
 		break;
 	    }
 	    break;
@@ -1003,10 +1003,10 @@ print_nsp(netdissect_options *ndo,
 	    case MFS_CI:
 	    case MFS_RCI:
 		if ((flags & NSP_SUBMASK) == MFS_CI)
-		    ND_PRINT("conn-initiate ");
+		    ND_PRINT(C_RESET, "conn-initiate ");
 		else
-		    ND_PRINT("retrans-conn-initiate ");
-		ND_PRINT("%u>%u ", src, dst);
+		    ND_PRINT(C_RESET, "retrans-conn-initiate ");
+		ND_PRINT(C_RESET, "%u>%u ", src, dst);
 		{
 		    const struct cimsg *cimp = (const struct cimsg *)nspp;
 		    u_int services, info, segsize;
@@ -1021,31 +1021,31 @@ print_nsp(netdissect_options *ndo,
 		    case COS_NONE:
 			break;
 		    case COS_SEGMENT:
-			ND_PRINT("seg ");
+			ND_PRINT(C_RESET, "seg ");
 			break;
 		    case COS_MESSAGE:
-			ND_PRINT("msg ");
+			ND_PRINT(C_RESET, "msg ");
 			break;
 		    }
 		    switch (info & COI_MASK) {
 		    case COI_32:
-			ND_PRINT("ver 3.2 ");
+			ND_PRINT(C_RESET, "ver 3.2 ");
 			break;
 		    case COI_31:
-			ND_PRINT("ver 3.1 ");
+			ND_PRINT(C_RESET, "ver 3.1 ");
 			break;
 		    case COI_40:
-			ND_PRINT("ver 4.0 ");
+			ND_PRINT(C_RESET, "ver 4.0 ");
 			break;
 		    case COI_41:
-			ND_PRINT("ver 4.1 ");
+			ND_PRINT(C_RESET, "ver 4.1 ");
 			break;
 		    }
-		    ND_PRINT("segsize %u ", segsize);
+		    ND_PRINT(C_RESET, "segsize %u ", segsize);
 		}
 		break;
 	    case MFS_CC:
-		ND_PRINT("conn-confirm %u>%u ", src, dst);
+		ND_PRINT(C_RESET, "conn-confirm %u>%u ", src, dst);
 		{
 		    const struct ccmsg *ccmp = (const struct ccmsg *)nspp;
 		    u_int services, info;
@@ -1062,34 +1062,34 @@ print_nsp(netdissect_options *ndo,
 		    case COS_NONE:
 			break;
 		    case COS_SEGMENT:
-			ND_PRINT("seg ");
+			ND_PRINT(C_RESET, "seg ");
 			break;
 		    case COS_MESSAGE:
-			ND_PRINT("msg ");
+			ND_PRINT(C_RESET, "msg ");
 			break;
 		    }
 		    switch (info & COI_MASK) {
 		    case COI_32:
-			ND_PRINT("ver 3.2 ");
+			ND_PRINT(C_RESET, "ver 3.2 ");
 			break;
 		    case COI_31:
-			ND_PRINT("ver 3.1 ");
+			ND_PRINT(C_RESET, "ver 3.1 ");
 			break;
 		    case COI_40:
-			ND_PRINT("ver 4.0 ");
+			ND_PRINT(C_RESET, "ver 4.0 ");
 			break;
 		    case COI_41:
-			ND_PRINT("ver 4.1 ");
+			ND_PRINT(C_RESET, "ver 4.1 ");
 			break;
 		    }
-		    ND_PRINT("segsize %u ", segsize);
+		    ND_PRINT(C_RESET, "segsize %u ", segsize);
 		    if (optlen) {
-			ND_PRINT("optlen %u ", optlen);
+			ND_PRINT(C_RESET, "optlen %u ", optlen);
 		    }
 		}
 		break;
 	    case MFS_DI:
-		ND_PRINT("disconn-initiate %u>%u ", src, dst);
+		ND_PRINT(C_RESET, "disconn-initiate %u>%u ", src, dst);
 		{
 		    const struct dimsg *dimp = (const struct dimsg *)nspp;
 		    u_int reason;
@@ -1102,12 +1102,12 @@ print_nsp(netdissect_options *ndo,
 
 		    print_reason(ndo, reason);
 		    if (optlen) {
-			ND_PRINT("optlen %u ", optlen);
+			ND_PRINT(C_RESET, "optlen %u ", optlen);
 		    }
 		}
 		break;
 	    case MFS_DC:
-		ND_PRINT("disconn-confirm %u>%u ", src, dst);
+		ND_PRINT(C_RESET, "disconn-confirm %u>%u ", src, dst);
 		{
 		    const struct dcmsg *dcmp = (const struct dcmsg *)nspp;
 		    u_int reason;
@@ -1118,12 +1118,12 @@ print_nsp(netdissect_options *ndo,
 		}
 		break;
 	    default:
-		ND_PRINT("reserved-ctltype? %x %u > %u", flags, src, dst);
+		ND_PRINT(C_RESET, "reserved-ctltype? %x %u > %u", flags, src, dst);
 		break;
 	    }
 	    break;
 	default:
-	    ND_PRINT("reserved-type? %x %u > %u", flags, src, dst);
+	    ND_PRINT(C_RESET, "reserved-type? %x %u > %u", flags, src, dst);
 	    break;
 	}
 	return (1);
@@ -1162,7 +1162,7 @@ static void
 print_reason(netdissect_options *ndo,
              u_int reason)
 {
-	ND_PRINT("%s ", tok2str(reason2str, "reason-%u", reason));
+	ND_PRINT(C_RESET, "%s ", tok2str(reason2str, "reason-%u", reason));
 }
 
 const char *

--- a/print-dhcp6.c
+++ b/print-dhcp6.c
@@ -302,116 +302,116 @@ dhcp6opt_print(netdissect_options *ndo,
 		if (ep < cp + sizeof(*dh6o) + optlen)
 			goto trunc;
 		opttype = GET_BE_U_2(dh6o->dh6opt_type);
-		ND_PRINT(" (%s", tok2str(dh6opt_str, "opt_%u", opttype));
+		ND_PRINT(C_RESET, " (%s", tok2str(dh6opt_str, "opt_%u", opttype));
 		ND_TCHECK_LEN(cp + sizeof(*dh6o), optlen);
 		switch (opttype) {
 		case DH6OPT_CLIENTID:
 		case DH6OPT_SERVERID:
 			if (optlen < 2) {
 				/*(*/
-				ND_PRINT(" ?)");
+				ND_PRINT(C_RESET, " ?)");
 				break;
 			}
 			tp = (const u_char *)(dh6o + 1);
 			switch (GET_BE_U_2(tp)) {
 			case 1:
 				if (optlen >= 2 + 6) {
-					ND_PRINT(" hwaddr/time type %u time %u ",
+					ND_PRINT(C_RESET, " hwaddr/time type %u time %u ",
 					    GET_BE_U_2(tp + 2),
 					    GET_BE_U_4(tp + 4));
 					for (i = 8; i < optlen; i++)
-						ND_PRINT("%02x",
+						ND_PRINT(C_RESET, "%02x",
 							 GET_U_1(tp + i));
 					/*(*/
-					ND_PRINT(")");
+					ND_PRINT(C_RESET, ")");
 				} else {
 					/*(*/
-					ND_PRINT(" ?)");
+					ND_PRINT(C_RESET, " ?)");
 				}
 				break;
 			case 2:
 				if (optlen >= 2 + 8) {
-					ND_PRINT(" vid ");
+					ND_PRINT(C_RESET, " vid ");
 					for (i = 2; i < 2 + 8; i++)
-						ND_PRINT("%02x",
+						ND_PRINT(C_RESET, "%02x",
 							 GET_U_1(tp + i));
 					/*(*/
-					ND_PRINT(")");
+					ND_PRINT(C_RESET, ")");
 				} else {
 					/*(*/
-					ND_PRINT(" ?)");
+					ND_PRINT(C_RESET, " ?)");
 				}
 				break;
 			case 3:
 				if (optlen >= 2 + 2) {
-					ND_PRINT(" hwaddr type %u ",
+					ND_PRINT(C_RESET, " hwaddr type %u ",
 					    GET_BE_U_2(tp + 2));
 					for (i = 4; i < optlen; i++)
-						ND_PRINT("%02x",
+						ND_PRINT(C_RESET, "%02x",
 							 GET_U_1(tp + i));
 					/*(*/
-					ND_PRINT(")");
+					ND_PRINT(C_RESET, ")");
 				} else {
 					/*(*/
-					ND_PRINT(" ?)");
+					ND_PRINT(C_RESET, " ?)");
 				}
 				break;
 			default:
-				ND_PRINT(" type %u)", GET_BE_U_2(tp));
+				ND_PRINT(C_RESET, " type %u)", GET_BE_U_2(tp));
 				break;
 			}
 			break;
 		case DH6OPT_IA_ADDR:
 			if (optlen < 24) {
 				/*(*/
-				ND_PRINT(" ?)");
+				ND_PRINT(C_RESET, " ?)");
 				break;
 			}
 			tp = (const u_char *)(dh6o + 1);
-			ND_PRINT(" %s", GET_IP6ADDR_STRING(tp));
-			ND_PRINT(" pltime:%u vltime:%u",
+			ND_PRINT(C_RESET, " %s", GET_IP6ADDR_STRING(tp));
+			ND_PRINT(C_RESET, " pltime:%u vltime:%u",
 			    GET_BE_U_4(tp + 16),
 			    GET_BE_U_4(tp + 20));
 			if (optlen > 24) {
 				/* there are sub-options */
 				dhcp6opt_print(ndo, tp + 24, tp + optlen);
 			}
-			ND_PRINT(")");
+			ND_PRINT(C_RESET, ")");
 			break;
 		case DH6OPT_ORO:
 		case DH6OPT_ERO:
 			if (optlen % 2) {
-				ND_PRINT(" ?)");
+				ND_PRINT(C_RESET, " ?)");
 				break;
 			}
 			tp = (const u_char *)(dh6o + 1);
 			for (i = 0; i < optlen; i += 2) {
-				ND_PRINT(" %s",
+				ND_PRINT(C_RESET, " %s",
 				    tok2str(dh6opt_str, "opt_%u", GET_BE_U_2(tp + i)));
 			}
-			ND_PRINT(")");
+			ND_PRINT(C_RESET, ")");
 			break;
 		case DH6OPT_PREFERENCE:
 			if (optlen != 1) {
-				ND_PRINT(" ?)");
+				ND_PRINT(C_RESET, " ?)");
 				break;
 			}
 			tp = (const u_char *)(dh6o + 1);
-			ND_PRINT(" %u)", GET_U_1(tp));
+			ND_PRINT(C_RESET, " %u)", GET_U_1(tp));
 			break;
 		case DH6OPT_ELAPSED_TIME:
 			if (optlen != 2) {
-				ND_PRINT(" ?)");
+				ND_PRINT(C_RESET, " ?)");
 				break;
 			}
 			tp = (const u_char *)(dh6o + 1);
-			ND_PRINT(" %u)", GET_BE_U_2(tp));
+			ND_PRINT(C_RESET, " %u)", GET_BE_U_2(tp));
 			break;
 		case DH6OPT_RELAY_MSG:
 		    {
 			const u_char *snapend_save;
 
-			ND_PRINT(" (");
+			ND_PRINT(C_RESET, " (");
 			tp = (const u_char *)(dh6o + 1);
 			/*
 			 * Update the snapend to the end of the option before
@@ -425,25 +425,25 @@ dhcp6opt_print(netdissect_options *ndo,
 			ndo->ndo_snapend = ND_MIN(tp + optlen, ndo->ndo_snapend);
 			dhcp6_print(ndo, tp, optlen);
 			ndo->ndo_snapend = snapend_save;
-			ND_PRINT(")");
+			ND_PRINT(C_RESET, ")");
 			break;
 		    }
 		case DH6OPT_AUTH:
 			if (optlen < 11) {
-				ND_PRINT(" ?)");
+				ND_PRINT(C_RESET, " ?)");
 				break;
 			}
 			tp = (const u_char *)(dh6o + 1);
 			auth_proto = GET_U_1(tp);
 			switch (auth_proto) {
 			case DH6OPT_AUTHPROTO_DELAYED:
-				ND_PRINT(" proto: delayed");
+				ND_PRINT(C_RESET, " proto: delayed");
 				break;
 			case DH6OPT_AUTHPROTO_RECONFIG:
-				ND_PRINT(" proto: reconfigure");
+				ND_PRINT(C_RESET, " proto: reconfigure");
 				break;
 			default:
-				ND_PRINT(" proto: %u", auth_proto);
+				ND_PRINT(C_RESET, " proto: %u", auth_proto);
 				break;
 			}
 			tp++;
@@ -451,26 +451,26 @@ dhcp6opt_print(netdissect_options *ndo,
 			switch (auth_alg) {
 			case DH6OPT_AUTHALG_HMACMD5:
 				/* XXX: may depend on the protocol */
-				ND_PRINT(", alg: HMAC-MD5");
+				ND_PRINT(C_RESET, ", alg: HMAC-MD5");
 				break;
 			default:
-				ND_PRINT(", alg: %u", auth_alg);
+				ND_PRINT(C_RESET, ", alg: %u", auth_alg);
 				break;
 			}
 			tp++;
 			auth_rdm = GET_U_1(tp);
 			switch (auth_rdm) {
 			case DH6OPT_AUTHRDM_MONOCOUNTER:
-				ND_PRINT(", RDM: mono");
+				ND_PRINT(C_RESET, ", RDM: mono");
 				break;
 			default:
-				ND_PRINT(", RDM: %u", auth_rdm);
+				ND_PRINT(C_RESET, ", RDM: %u", auth_rdm);
 				break;
 			}
 			tp++;
-			ND_PRINT(", RD:");
+			ND_PRINT(C_RESET, ", RD:");
 			for (i = 0; i < 4; i++, tp += 2)
-				ND_PRINT(" %04x", GET_BE_U_2(tp));
+				ND_PRINT(C_RESET, " %04x", GET_BE_U_2(tp));
 
 			/* protocol dependent part */
 			authinfolen = optlen - 11;
@@ -479,51 +479,51 @@ dhcp6opt_print(netdissect_options *ndo,
 				if (authinfolen == 0)
 					break;
 				if (authinfolen < 20) {
-					ND_PRINT(" ??");
+					ND_PRINT(C_RESET, " ??");
 					break;
 				}
 				authrealmlen = authinfolen - 20;
 				if (authrealmlen > 0) {
-					ND_PRINT(", realm: ");
+					ND_PRINT(C_RESET, ", realm: ");
 				}
 				for (i = 0; i < authrealmlen; i++, tp++)
-					ND_PRINT("%02x", GET_U_1(tp));
-				ND_PRINT(", key ID: %08x", GET_BE_U_4(tp));
+					ND_PRINT(C_RESET, "%02x", GET_U_1(tp));
+				ND_PRINT(C_RESET, ", key ID: %08x", GET_BE_U_4(tp));
 				tp += 4;
-				ND_PRINT(", HMAC-MD5:");
+				ND_PRINT(C_RESET, ", HMAC-MD5:");
 				for (i = 0; i < 4; i++, tp+= 4)
-					ND_PRINT(" %08x", GET_BE_U_4(tp));
+					ND_PRINT(C_RESET, " %08x", GET_BE_U_4(tp));
 				break;
 			case DH6OPT_AUTHPROTO_RECONFIG:
 				if (authinfolen != 17) {
-					ND_PRINT(" ??");
+					ND_PRINT(C_RESET, " ??");
 					break;
 				}
 				switch (GET_U_1(tp)) {
 				case DH6OPT_AUTHRECONFIG_KEY:
-					ND_PRINT(" reconfig-key");
+					ND_PRINT(C_RESET, " reconfig-key");
 					break;
 				case DH6OPT_AUTHRECONFIG_HMACMD5:
-					ND_PRINT(" type: HMAC-MD5");
+					ND_PRINT(C_RESET, " type: HMAC-MD5");
 					break;
 				default:
-					ND_PRINT(" type: ??");
+					ND_PRINT(C_RESET, " type: ??");
 					break;
 				}
 				tp++;
-				ND_PRINT(" value:");
+				ND_PRINT(C_RESET, " value:");
 				for (i = 0; i < 4; i++, tp+= 4)
-					ND_PRINT(" %08x", GET_BE_U_4(tp));
+					ND_PRINT(C_RESET, " %08x", GET_BE_U_4(tp));
 				break;
 			default:
-				ND_PRINT(" ??");
+				ND_PRINT(C_RESET, " ??");
 				break;
 			}
 
-			ND_PRINT(")");
+			ND_PRINT(C_RESET, ")");
 			break;
 		case DH6OPT_RAPID_COMMIT: /* nothing todo */
-			ND_PRINT(")");
+			ND_PRINT(C_RESET, ")");
 			break;
 		case DH6OPT_INTERFACE_ID:
 		case DH6OPT_SUBSCRIBER_ID:
@@ -532,32 +532,32 @@ dhcp6opt_print(netdissect_options *ndo,
 			 * at most 10 characters.
 			 */
 			tp = (const u_char *)(dh6o + 1);
-			ND_PRINT(" ");
+			ND_PRINT(C_RESET, " ");
 			for (i = 0; i < optlen && i < 10; i++)
-				ND_PRINT("%02x", GET_U_1(tp + i));
-			ND_PRINT("...)");
+				ND_PRINT(C_RESET, "%02x", GET_U_1(tp + i));
+			ND_PRINT(C_RESET, "...)");
 			break;
 		case DH6OPT_RECONF_MSG:
 			if (optlen != 1) {
-				ND_PRINT(" ?)");
+				ND_PRINT(C_RESET, " ?)");
 				break;
 			}
 			tp = (const u_char *)(dh6o + 1);
 			dh6_reconf_type = GET_U_1(tp);
 			switch (dh6_reconf_type) {
 			case DH6_RENEW:
-				ND_PRINT(" for renew)");
+				ND_PRINT(C_RESET, " for renew)");
 				break;
 			case DH6_INFORM_REQ:
-				ND_PRINT(" for inf-req)");
+				ND_PRINT(C_RESET, " for inf-req)");
 				break;
 			default:
-				ND_PRINT(" for ?\?\?(%02x))", dh6_reconf_type);
+				ND_PRINT(C_RESET, " for ?\?\?(%02x))", dh6_reconf_type);
 				break;
 			}
 			break;
 		case DH6OPT_RECONF_ACCEPT: /* nothing todo */
-			ND_PRINT(")");
+			ND_PRINT(C_RESET, ")");
 			break;
 		case DH6OPT_SIP_SERVER_A:
 		case DH6OPT_DNS_SERVERS:
@@ -568,40 +568,40 @@ dhcp6opt_print(netdissect_options *ndo,
 		case DH6OPT_PANA_AGENT:
 		case DH6OPT_LQ_CLIENT_LINK:
 			if (optlen % 16) {
-				ND_PRINT(" ?)");
+				ND_PRINT(C_RESET, " ?)");
 				break;
 			}
 			tp = (const u_char *)(dh6o + 1);
 			for (i = 0; i < optlen; i += 16)
-				ND_PRINT(" %s", GET_IP6ADDR_STRING(tp + i));
-			ND_PRINT(")");
+				ND_PRINT(C_RESET, " %s", GET_IP6ADDR_STRING(tp + i));
+			ND_PRINT(C_RESET, ")");
 			break;
 		case DH6OPT_SIP_SERVER_D:
 		case DH6OPT_DOMAIN_LIST:
 			tp = (const u_char *)(dh6o + 1);
 			while (tp < cp + sizeof(*dh6o) + optlen) {
-				ND_PRINT(" ");
+				ND_PRINT(C_RESET, " ");
 				if ((tp = fqdn_print(ndo, tp, cp + sizeof(*dh6o) + optlen)) == NULL)
 					goto trunc;
 			}
-			ND_PRINT(")");
+			ND_PRINT(C_RESET, ")");
 			break;
 		case DH6OPT_STATUS_CODE:
 			if (optlen < 2) {
-				ND_PRINT(" ?)");
+				ND_PRINT(C_RESET, " ?)");
 				break;
 			}
 			tp = (const u_char *)(dh6o + 1);
-			ND_PRINT(" %s)", dhcp6stcode(GET_BE_U_2(tp)));
+			ND_PRINT(C_RESET, " %s)", dhcp6stcode(GET_BE_U_2(tp)));
 			break;
 		case DH6OPT_IA_NA:
 		case DH6OPT_IA_PD:
 			if (optlen < 12) {
-				ND_PRINT(" ?)");
+				ND_PRINT(C_RESET, " ?)");
 				break;
 			}
 			tp = (const u_char *)(dh6o + 1);
-			ND_PRINT(" IAID:%u T1:%u T2:%u",
+			ND_PRINT(C_RESET, " IAID:%u T1:%u T2:%u",
 			    GET_BE_U_4(tp),
 			    GET_BE_U_4(tp + 4),
 			    GET_BE_U_4(tp + 8));
@@ -609,85 +609,85 @@ dhcp6opt_print(netdissect_options *ndo,
 				/* there are sub-options */
 				dhcp6opt_print(ndo, tp + 12, tp + optlen);
 			}
-			ND_PRINT(")");
+			ND_PRINT(C_RESET, ")");
 			break;
 		case DH6OPT_IA_TA:
 			if (optlen < 4) {
-				ND_PRINT(" ?)");
+				ND_PRINT(C_RESET, " ?)");
 				break;
 			}
 			tp = (const u_char *)(dh6o + 1);
-			ND_PRINT(" IAID:%u", GET_BE_U_4(tp));
+			ND_PRINT(C_RESET, " IAID:%u", GET_BE_U_4(tp));
 			if (optlen > 4) {
 				/* there are sub-options */
 				dhcp6opt_print(ndo, tp + 4, tp + optlen);
 			}
-			ND_PRINT(")");
+			ND_PRINT(C_RESET, ")");
 			break;
 		case DH6OPT_IA_PD_PREFIX:
 			if (optlen < 25) {
-				ND_PRINT(" ?)");
+				ND_PRINT(C_RESET, " ?)");
 				break;
 			}
 			tp = (const u_char *)(dh6o + 1);
-			ND_PRINT(" %s/%u", GET_IP6ADDR_STRING(tp + 9),
+			ND_PRINT(C_RESET, " %s/%u", GET_IP6ADDR_STRING(tp + 9),
 				 GET_U_1(tp + 8));
-			ND_PRINT(" pltime:%u vltime:%u",
+			ND_PRINT(C_RESET, " pltime:%u vltime:%u",
 			    GET_BE_U_4(tp),
 			    GET_BE_U_4(tp + 4));
 			if (optlen > 25) {
 				/* there are sub-options */
 				dhcp6opt_print(ndo, tp + 25, tp + optlen);
 			}
-			ND_PRINT(")");
+			ND_PRINT(C_RESET, ")");
 			break;
 		case DH6OPT_LIFETIME:
 		case DH6OPT_CLT_TIME:
 			if (optlen != 4) {
-				ND_PRINT(" ?)");
+				ND_PRINT(C_RESET, " ?)");
 				break;
 			}
 			tp = (const u_char *)(dh6o + 1);
-			ND_PRINT(" %u)", GET_BE_U_4(tp));
+			ND_PRINT(C_RESET, " %u)", GET_BE_U_4(tp));
 			break;
 		case DH6OPT_REMOTE_ID:
 			if (optlen < 4) {
-				ND_PRINT(" ?)");
+				ND_PRINT(C_RESET, " ?)");
 				break;
 			}
 			tp = (const u_char *)(dh6o + 1);
-			ND_PRINT(" %u ", GET_BE_U_4(tp));
+			ND_PRINT(C_RESET, " %u ", GET_BE_U_4(tp));
 			/*
 			 * Print hex dump first 10 characters.
 			 */
 			for (i = 4; i < optlen && i < 14; i++)
-				ND_PRINT("%02x", GET_U_1(tp + i));
-			ND_PRINT("...)");
+				ND_PRINT(C_RESET, "%02x", GET_U_1(tp + i));
+			ND_PRINT(C_RESET, "...)");
 			break;
 		case DH6OPT_LQ_QUERY:
 			if (optlen < 17) {
-				ND_PRINT(" ?)");
+				ND_PRINT(C_RESET, " ?)");
 				break;
 			}
 			tp = (const u_char *)(dh6o + 1);
 			dh6_lq_query_type = GET_U_1(tp);
 			switch (dh6_lq_query_type) {
 			case 1:
-				ND_PRINT(" by-address");
+				ND_PRINT(C_RESET, " by-address");
 				break;
 			case 2:
-				ND_PRINT(" by-clientID");
+				ND_PRINT(C_RESET, " by-clientID");
 				break;
 			default:
-				ND_PRINT(" type_%u", dh6_lq_query_type);
+				ND_PRINT(C_RESET, " type_%u", dh6_lq_query_type);
 				break;
 			}
-			ND_PRINT(" %s", GET_IP6ADDR_STRING(tp + 1));
+			ND_PRINT(C_RESET, " %s", GET_IP6ADDR_STRING(tp + 1));
 			if (optlen > 17) {
 				/* there are query-options */
 				dhcp6opt_print(ndo, tp + 17, tp + optlen);
 			}
-			ND_PRINT(")");
+			ND_PRINT(C_RESET, ")");
 			break;
 		case DH6OPT_CLIENT_DATA:
 			tp = (const u_char *)(dh6o + 1);
@@ -695,25 +695,25 @@ dhcp6opt_print(netdissect_options *ndo,
 				/* there are encapsulated options */
 				dhcp6opt_print(ndo, tp, tp + optlen);
 			}
-			ND_PRINT(")");
+			ND_PRINT(C_RESET, ")");
 			break;
 		case DH6OPT_LQ_RELAY_DATA:
 			if (optlen < 16) {
-				ND_PRINT(" ?)");
+				ND_PRINT(C_RESET, " ?)");
 				break;
 			}
 			tp = (const u_char *)(dh6o + 1);
-			ND_PRINT(" %s ", GET_IP6ADDR_STRING(tp));
+			ND_PRINT(C_RESET, " %s ", GET_IP6ADDR_STRING(tp));
 			/*
 			 * Print hex dump first 10 characters.
 			 */
 			for (i = 16; i < optlen && i < 26; i++)
-				ND_PRINT("%02x", GET_U_1(tp + i));
-			ND_PRINT("...)");
+				ND_PRINT(C_RESET, "%02x", GET_U_1(tp + i));
+			ND_PRINT(C_RESET, "...)");
 			break;
 		case DH6OPT_NTP_SERVER:
 			if (optlen < 4) {
-				ND_PRINT(" ?)");
+				ND_PRINT(C_RESET, " ?)");
 				break;
 			}
 			tp = (const u_char *)(dh6o + 1);
@@ -724,37 +724,37 @@ dhcp6opt_print(netdissect_options *ndo,
 				tp += 2;
 				if (tp + subopt_len > cp + sizeof(*dh6o) + optlen)
 					goto trunc;
-				ND_PRINT(" subopt:%u", subopt_code);
+				ND_PRINT(C_RESET, " subopt:%u", subopt_code);
 				switch (subopt_code) {
 				case DH6OPT_NTP_SUBOPTION_SRV_ADDR:
 				case DH6OPT_NTP_SUBOPTION_MC_ADDR:
 					if (subopt_len != 16) {
-						ND_PRINT(" ?");
+						ND_PRINT(C_RESET, " ?");
 						break;
 					}
-					ND_PRINT(" %s", GET_IP6ADDR_STRING(tp));
+					ND_PRINT(C_RESET, " %s", GET_IP6ADDR_STRING(tp));
 					break;
 				case DH6OPT_NTP_SUBOPTION_SRV_FQDN:
-					ND_PRINT(" ");
+					ND_PRINT(C_RESET, " ");
 					if (fqdn_print(ndo, tp, tp + subopt_len) == NULL)
 						goto trunc;
 					break;
 				default:
-					ND_PRINT(" ?");
+					ND_PRINT(C_RESET, " ?");
 					break;
 				}
 				tp += subopt_len;
 			}
-			ND_PRINT(")");
+			ND_PRINT(C_RESET, ")");
 			break;
 		case DH6OPT_AFTR_NAME:
 			if (optlen < 3) {
-				ND_PRINT(" ?)");
+				ND_PRINT(C_RESET, " ?)");
 				break;
 			}
 			tp = (const u_char *)(dh6o + 1);
 			remain_len = optlen;
-			ND_PRINT(" ");
+			ND_PRINT(C_RESET, " ");
 			/* Encoding is described in section 3.1 of RFC 1035 */
 			while (remain_len && GET_U_1(tp)) {
 				label_len = GET_U_1(tp);
@@ -763,29 +763,29 @@ dhcp6opt_print(netdissect_options *ndo,
 					nd_printjnp(ndo, tp, label_len);
 					tp += label_len;
 					remain_len -= (label_len + 1);
-					if(GET_U_1(tp)) ND_PRINT(".");
+					if(GET_U_1(tp)) ND_PRINT(C_RESET, ".");
 				} else {
-					ND_PRINT(" ?");
+					ND_PRINT(C_RESET, " ?");
 					break;
 				}
 			}
-			ND_PRINT(")");
+			ND_PRINT(C_RESET, ")");
 			break;
 		case DH6OPT_NEW_POSIX_TIMEZONE: /* all three of these options */
 		case DH6OPT_NEW_TZDB_TIMEZONE:	/* are encoded similarly */
 		case DH6OPT_MUDURL:		/* although GMT might not work */
 		        if (optlen < 5) {
-				ND_PRINT(" ?)");
+				ND_PRINT(C_RESET, " ?)");
 				break;
 			}
 			tp = (const u_char *)(dh6o + 1);
-			ND_PRINT(" ");
+			ND_PRINT(C_RESET, " ");
 			nd_printjnp(ndo, tp, optlen);
-			ND_PRINT(")");
+			ND_PRINT(C_RESET, ")");
 			break;
 
 		default:
-			ND_PRINT(")");
+			ND_PRINT(C_RESET, ")");
 			break;
 		}
 
@@ -812,7 +812,7 @@ dhcp6_print(netdissect_options *ndo,
 	const char *name;
 
 	ndo->ndo_protocol = "dhcp6";
-	ND_PRINT("dhcp6");
+	ND_PRINT(C_RESET, "dhcp6");
 
 	ep = ndo->ndo_snapend;
 	if (cp + length < ep)
@@ -825,27 +825,27 @@ dhcp6_print(netdissect_options *ndo,
 	name = tok2str(dh6_msgtype_str, "msgtype-%u", msgtype);
 
 	if (!ndo->ndo_vflag) {
-		ND_PRINT(" %s", name);
+		ND_PRINT(C_RESET, " %s", name);
 		return;
 	}
 
 	/* XXX relay agent messages have to be handled differently */
 
-	ND_PRINT(" %s (", name);	/*)*/
+	ND_PRINT(C_RESET, " %s (", name);	/*)*/
 	if (msgtype != DH6_RELAY_FORW && msgtype != DH6_RELAY_REPLY) {
-		ND_PRINT("xid=%x",
+		ND_PRINT(C_RESET, "xid=%x",
 			 GET_BE_U_4(dh6->dh6_msgtypexid.xid) & DH6_XIDMASK);
 		extp = (const u_char *)(dh6 + 1);
 		dhcp6opt_print(ndo, extp, ep);
 	} else {		/* relay messages */
-		ND_PRINT("linkaddr=%s", GET_IP6ADDR_STRING(dh6relay->dh6relay_linkaddr));
+		ND_PRINT(C_RESET, "linkaddr=%s", GET_IP6ADDR_STRING(dh6relay->dh6relay_linkaddr));
 
-		ND_PRINT(" peeraddr=%s", GET_IP6ADDR_STRING(dh6relay->dh6relay_peeraddr));
+		ND_PRINT(C_RESET, " peeraddr=%s", GET_IP6ADDR_STRING(dh6relay->dh6relay_peeraddr));
 
 		dhcp6opt_print(ndo, (const u_char *)(dh6relay + 1), ep);
 	}
 	/*(*/
-	ND_PRINT(")");
+	ND_PRINT(C_RESET, ")");
 	return;
 
 trunc:

--- a/print-domain.c
+++ b/print-domain.c
@@ -125,20 +125,20 @@ blabel_print(netdissect_options *ndo,
 	lim = cp + 1 + slen;
 
 	/* print the bit string as a hex string */
-	ND_PRINT("\\[x");
+	ND_PRINT(C_RESET, "\\[x");
 	for (bitp = cp + 1, b = bitlen; bitp < lim && b > 7; b -= 8, bitp++) {
-		ND_PRINT("%02x", GET_U_1(bitp));
+		ND_PRINT(C_RESET, "%02x", GET_U_1(bitp));
 	}
 	if (b > 4) {
 		tc = GET_U_1(bitp);
 		bitp++;
-		ND_PRINT("%02x", tc & (0xff << (8 - b)));
+		ND_PRINT(C_RESET, "%02x", tc & (0xff << (8 - b)));
 	} else if (b > 0) {
 		tc = GET_U_1(bitp);
 		bitp++;
-		ND_PRINT("%1x", ((tc >> 4) & 0x0f) & (0x0f << (4 - b)));
+		ND_PRINT(C_RESET, "%1x", ((tc >> 4) & 0x0f) & (0x0f << (4 - b)));
 	}
-	ND_PRINT("/%u]", bitlen);
+	ND_PRINT(C_RESET, "/%u]", bitlen);
 	return lim;
 }
 
@@ -156,7 +156,7 @@ labellen(netdissect_options *ndo,
 	case TYPE_EDNS0: {
 		u_int bitlen, elt;
 		if ((elt = (i & ~TYPE_MASK)) != EDNS0_ELT_BITLABEL) {
-			ND_PRINT("<ELT %d>", elt);
+			ND_PRINT(C_RESET, "<ELT %d>", elt);
 			return(-1);
 		}
 		if (!ND_TTEST_1(cp + 1))
@@ -175,7 +175,7 @@ labellen(netdissect_options *ndo,
 		 * TYPE_RESERVED, but we use default to suppress compiler
 		 * warnings about falling out of the switch statement.
 		 */
-		ND_PRINT("<BAD LABEL TYPE>");
+		ND_PRINT(C_RESET, "<BAD LABEL TYPE>");
 		return(-1);
 	}
 }
@@ -227,7 +227,7 @@ fqdn_print(netdissect_options *ndo,
 				 * the packet).
 				 */
 				if (offset >= max_offset) {
-					ND_PRINT("<BAD PTR>");
+					ND_PRINT(C_RESET, "<BAD PTR>");
 					return(NULL);
 				}
 				max_offset = offset;
@@ -249,13 +249,13 @@ fqdn_print(netdissect_options *ndo,
 					break;
 				default:
 					/* unknown ELT */
-					ND_PRINT("<ELT %u>", elt);
+					ND_PRINT(C_RESET, "<ELT %u>", elt);
 					return(NULL);
 				}
 				break;
 
 			case TYPE_RESERVED:
-				ND_PRINT("<BAD LABEL TYPE>");
+				ND_PRINT(C_RESET, "<BAD LABEL TYPE>");
 				return(NULL);
 
 			case TYPE_LABEL:
@@ -273,7 +273,7 @@ fqdn_print(netdissect_options *ndo,
 
 			cp += l;
 			if (name_chars <= MAXCDNAME)
-				ND_PRINT(".");
+				ND_PRINT(C_RESET, ".");
 			name_chars++;
 			if (!ND_TTEST_1(cp))
 				return(NULL);
@@ -285,9 +285,9 @@ fqdn_print(netdissect_options *ndo,
 				rp += l + 1;
 		}
 		if (name_chars > MAXCDNAME)
-			ND_PRINT("<DOMAIN NAME TOO LONG>");
+			ND_PRINT(C_RESET, "<DOMAIN NAME TOO LONG>");
 	} else
-		ND_PRINT(".");
+		ND_PRINT(C_RESET, ".");
 	return (rp);
 }
 
@@ -354,10 +354,10 @@ print_eopt_ecs(netdissect_options *ndo, const u_char *cp,
 
 
     if (family == 1)
-        ND_PRINT("%s/%d/%d", addrtostr(padded, addr, INET_ADDRSTRLEN),
+        ND_PRINT(C_RESET, "%s/%d/%d", addrtostr(padded, addr, INET_ADDRSTRLEN),
                 src_len, scope_len);
     else
-        ND_PRINT("%s/%d/%d", addrtostr6(padded, addr, INET6_ADDRSTRLEN),
+        ND_PRINT(C_RESET, "%s/%d/%d", addrtostr6(padded, addr, INET6_ADDRSTRLEN),
                 src_len, scope_len);
 
 }
@@ -379,7 +379,7 @@ eopt_print(netdissect_options *ndo,
         return (NULL);
     opt = GET_BE_U_2(cp);
     cp += 2;
-    ND_PRINT("%s", tok2str(edns_opt2str, "Opt%u", opt));
+    ND_PRINT(C_RESET, "%s", tok2str(edns_opt2str, "Opt%u", opt));
     if (!ND_TTEST_2(cp))
         return (NULL);
     data_len = GET_BE_U_2(cp);
@@ -388,7 +388,7 @@ eopt_print(netdissect_options *ndo,
     ND_TCHECK_LEN(cp, data_len);
 
     if (data_len > 0) {
-        ND_PRINT(" ");
+        ND_PRINT(C_RESET, " ");
         switch (opt) {
 
         case E_ECS:
@@ -401,8 +401,8 @@ eopt_print(netdissect_options *ndo,
                 for (i = 0; i < data_len; ++i) {
                     /* split client and server cookie */
                     if (i == 8)
-                        ND_PRINT(" ");
-                    ND_PRINT("%02x", GET_U_1(cp + i));
+                        ND_PRINT(C_RESET, " ");
+                    ND_PRINT(C_RESET, "%02x", GET_U_1(cp + i));
                 }
             }
             break;
@@ -411,17 +411,17 @@ eopt_print(netdissect_options *ndo,
                 nd_print_invalid(ndo);
             else
                 /* keepalive is in increments of 100ms. Convert to seconds */
-                ND_PRINT("%0.1f sec", (GET_BE_U_2(cp) / 10.0));
+                ND_PRINT(C_RESET, "%0.1f sec", (GET_BE_U_2(cp) / 10.0));
             break;
         case E_EXPIRE:
             if (data_len != 4)
                 nd_print_invalid(ndo);
             else
-                ND_PRINT("%u sec", GET_BE_U_4(cp));
+                ND_PRINT(C_RESET, "%u sec", GET_BE_U_4(cp));
             break;
         case E_PADDING:
             /* ignore contents and just print length */
-            ND_PRINT("(%u)", data_len);
+            ND_PRINT(C_RESET, "(%u)", data_len);
             break;
         case E_KEYTAG:
             if (data_len % 2 != 0)
@@ -429,29 +429,29 @@ eopt_print(netdissect_options *ndo,
             else
                 for (i = 0; i < data_len; i += 2) {
                     if (i > 0)
-                        ND_PRINT(" ");
-                    ND_PRINT("%u", GET_BE_U_2(cp + i));
+                        ND_PRINT(C_RESET, " ");
+                    ND_PRINT(C_RESET, "%u", GET_BE_U_2(cp + i));
                 }
             break;
         case E_DAU:
             for (i = 0; i < data_len; ++i) {
                 if (i > 0)
-                    ND_PRINT(" ");
-                ND_PRINT("%s", tok2str(dau_alg2str, "Alg_%u", GET_U_1(cp + i)));
+                    ND_PRINT(C_RESET, " ");
+                ND_PRINT(C_RESET, "%s", tok2str(dau_alg2str, "Alg_%u", GET_U_1(cp + i)));
             }
             break;
         case E_DHU:
             for (i = 0; i < data_len; ++i) {
                 if (i > 0)
-                    ND_PRINT(" ");
-                ND_PRINT("%s", tok2str(dhu_alg2str, "Alg_%u", GET_U_1(cp + i)));
+                    ND_PRINT(C_RESET, " ");
+                ND_PRINT(C_RESET, "%s", tok2str(dhu_alg2str, "Alg_%u", GET_U_1(cp + i)));
             }
             break;
         case E_N3U:
             for (i = 0; i < data_len; ++i) {
                 if (i > 0)
-                    ND_PRINT(" ");
-                ND_PRINT("%s", tok2str(n3u_alg2str, "Alg_%u", GET_U_1(cp + i)));
+                    ND_PRINT(C_RESET, " ");
+                ND_PRINT(C_RESET, "%s", tok2str(n3u_alg2str, "Alg_%u", GET_U_1(cp + i)));
             }
             break;
         case E_CHAIN:
@@ -461,7 +461,7 @@ eopt_print(netdissect_options *ndo,
             /* intentional fall-through. NSID is an undefined byte string */
         default:
             for (i = 0; i < data_len; ++i)
-                ND_PRINT("%02x", GET_U_1(cp + i));
+                ND_PRINT(C_RESET, "%02x", GET_U_1(cp + i));
             break;
         }
     }
@@ -649,7 +649,7 @@ ns_qprint(netdissect_options *ndo,
 	/* print the qtype */
 	i = GET_BE_U_2(cp);
 	cp += 2;
-	ND_PRINT(" %s", tok2str(ns_type2str, "Type%u", i));
+	ND_PRINT(C_RESET, " %s", tok2str(ns_type2str, "Type%u", i));
 	/* print the qclass (if it's not IN) */
 	i = GET_BE_U_2(cp);
 	cp += 2;
@@ -658,12 +658,15 @@ ns_qprint(netdissect_options *ndo,
 	else
 		class = i;
 	if (class != C_IN)
-		ND_PRINT(" %s", tok2str(ns_class2str, "(Class %u)", class));
+		ND_PRINT(C_RESET, " %s", tok2str(ns_class2str, "(Class %u)", class));
 	if (is_mdns) {
-		ND_PRINT(i & C_QU ? " (QU)" : " (QM)");
+		if(i & C_QU)
+			ND_PRINT(C_RESET, " (QU)");
+		else
+			ND_PRINT(C_RESET, " (QM)");
 	}
 
-	ND_PRINT("? ");
+	ND_PRINT(C_RESET, "? ");
 	cp = fqdn_print(ndo, np, bp);
 	return(cp ? cp + 4 : NULL);
 }
@@ -678,7 +681,7 @@ ns_rprint(netdissect_options *ndo,
 	const u_char *rp;
 
 	if (ndo->ndo_vflag) {
-		ND_PRINT(" ");
+		ND_PRINT(C_RESET, " ");
 		if ((cp = fqdn_print(ndo, cp, bp)) == NULL)
 			return NULL;
 	} else
@@ -698,10 +701,10 @@ ns_rprint(netdissect_options *ndo,
 	else
 		class = i;
 	if (class != C_IN && typ != T_OPT)
-		ND_PRINT(" %s", tok2str(ns_class2str, "(Class %u)", class));
+		ND_PRINT(C_RESET, " %s", tok2str(ns_class2str, "(Class %u)", class));
 	if (is_mdns) {
 		if (i & C_CACHE_FLUSH)
-			ND_PRINT(" (Cache flush)");
+			ND_PRINT(C_RESET, " (Cache flush)");
 	}
 
 	if (typ == T_OPT) {
@@ -712,9 +715,9 @@ ns_rprint(netdissect_options *ndo,
 		cp += 2;
 	} else if (ndo->ndo_vflag > 2) {
 		/* print ttl */
-		ND_PRINT(" [");
+		ND_PRINT(C_RESET, " [");
 		unsigned_relts_print(ndo, GET_BE_U_4(cp));
-		ND_PRINT("]");
+		ND_PRINT(C_RESET, "]");
 		cp += 4;
 	} else {
 		/* ignore ttl */
@@ -726,7 +729,7 @@ ns_rprint(netdissect_options *ndo,
 
 	rp = cp + len;
 
-	ND_PRINT(" %s", tok2str(ns_type2str, "Type%u", typ));
+	ND_PRINT(C_RESET, " %s", tok2str(ns_type2str, "Type%u", typ));
 	if (rp > ndo->ndo_snapend)
 		return(NULL);
 
@@ -734,14 +737,14 @@ ns_rprint(netdissect_options *ndo,
 	case T_A:
 		if (!ND_TTEST_LEN(cp, sizeof(nd_ipv4)))
 			return(NULL);
-		ND_PRINT(" %s", intoa(GET_IPV4_TO_NETWORK_ORDER(cp)));
+		ND_PRINT(C_RESET, " %s", intoa(GET_IPV4_TO_NETWORK_ORDER(cp)));
 		break;
 
 	case T_NS:
 	case T_CNAME:
 	case T_PTR:
 	case T_DNAME:
-		ND_PRINT(" ");
+		ND_PRINT(C_RESET, " ");
 		if (fqdn_print(ndo, cp, bp) == NULL)
 			return(NULL);
 		break;
@@ -749,51 +752,51 @@ ns_rprint(netdissect_options *ndo,
 	case T_SOA:
 		if (!ndo->ndo_vflag)
 			break;
-		ND_PRINT(" ");
+		ND_PRINT(C_RESET, " ");
 		if ((cp = fqdn_print(ndo, cp, bp)) == NULL)
 			return(NULL);
-		ND_PRINT(" ");
+		ND_PRINT(C_RESET, " ");
 		if ((cp = fqdn_print(ndo, cp, bp)) == NULL)
 			return(NULL);
 		if (!ND_TTEST_LEN(cp, 5 * 4))
 			return(NULL);
-		ND_PRINT(" %u", GET_BE_U_4(cp));
+		ND_PRINT(C_RESET, " %u", GET_BE_U_4(cp));
 		cp += 4;
-		ND_PRINT(" %u", GET_BE_U_4(cp));
+		ND_PRINT(C_RESET, " %u", GET_BE_U_4(cp));
 		cp += 4;
-		ND_PRINT(" %u", GET_BE_U_4(cp));
+		ND_PRINT(C_RESET, " %u", GET_BE_U_4(cp));
 		cp += 4;
-		ND_PRINT(" %u", GET_BE_U_4(cp));
+		ND_PRINT(C_RESET, " %u", GET_BE_U_4(cp));
 		cp += 4;
-		ND_PRINT(" %u", GET_BE_U_4(cp));
+		ND_PRINT(C_RESET, " %u", GET_BE_U_4(cp));
 		cp += 4;
 		break;
 	case T_MX:
-		ND_PRINT(" ");
+		ND_PRINT(C_RESET, " ");
 		if (!ND_TTEST_2(cp))
 			return(NULL);
 		if (fqdn_print(ndo, cp + 2, bp) == NULL)
 			return(NULL);
-		ND_PRINT(" %u", GET_BE_U_2(cp));
+		ND_PRINT(C_RESET, " %u", GET_BE_U_2(cp));
 		break;
 
 	case T_TXT:
 		while (cp < rp) {
-			ND_PRINT(" \"");
+			ND_PRINT(C_RESET, " \"");
 			cp = ns_cprint(ndo, cp);
 			if (cp == NULL)
 				return(NULL);
-			ND_PRINT("\"");
+			ND_PRINT(C_RESET, "\"");
 		}
 		break;
 
 	case T_SRV:
-		ND_PRINT(" ");
+		ND_PRINT(C_RESET, " ");
 		if (!ND_TTEST_6(cp))
 			return(NULL);
 		if (fqdn_print(ndo, cp + 6, bp) == NULL)
 			return(NULL);
-		ND_PRINT(":%u %u %u", GET_BE_U_2(cp + 4),
+		ND_PRINT(C_RESET, ":%u %u %u", GET_BE_U_2(cp + 4),
 			  GET_BE_U_2(cp), GET_BE_U_2(cp + 2));
 		break;
 
@@ -803,7 +806,7 @@ ns_rprint(netdissect_options *ndo,
 
 		if (!ND_TTEST_LEN(cp, sizeof(nd_ipv6)))
 			return(NULL);
-		ND_PRINT(" %s",
+		ND_PRINT(C_RESET, " %s",
 		    addrtostr6(cp, ntop_buf, sizeof(ntop_buf)));
 
 		break;
@@ -820,16 +823,16 @@ ns_rprint(netdissect_options *ndo,
 		pbit = GET_U_1(cp);
 		pbyte = (pbit & ~7) / 8;
 		if (pbit > 128) {
-			ND_PRINT(" %u(bad plen)", pbit);
+			ND_PRINT(C_RESET, " %u(bad plen)", pbit);
 			break;
 		} else if (pbit < 128) {
 			memset(a, 0, sizeof(a));
 			GET_CPY_BYTES(a + pbyte, cp + 1, sizeof(a) - pbyte);
-			ND_PRINT(" %u %s", pbit,
+			ND_PRINT(C_RESET, " %u %s", pbit,
 			    addrtostr6(&a, ntop_buf, sizeof(ntop_buf)));
 		}
 		if (pbit > 0) {
-			ND_PRINT(" ");
+			ND_PRINT(C_RESET, " ");
 			if (fqdn_print(ndo, cp + 1 + sizeof(a) - pbyte, bp) == NULL)
 				return(NULL);
 		}
@@ -839,25 +842,25 @@ ns_rprint(netdissect_options *ndo,
 	case T_URI:
 		if (!ND_TTEST_LEN(cp, len))
 			return(NULL);
-		ND_PRINT(" %u %u ", GET_BE_U_2(cp), GET_BE_U_2(cp + 2));
+		ND_PRINT(C_RESET, " %u %u ", GET_BE_U_2(cp), GET_BE_U_2(cp + 2));
 		if (nd_printn(ndo, cp + 4, len - 4, ndo->ndo_snapend))
 			return(NULL);
 		break;
 
 	case T_OPT:
-		ND_PRINT(" UDPsize=%u", class);
+		ND_PRINT(C_RESET, " UDPsize=%u", class);
 		if (opt_flags & 0x8000)
-			ND_PRINT(" DO");
+			ND_PRINT(C_RESET, " DO");
         if (cp < rp) {
-            ND_PRINT(" [");
+            ND_PRINT(C_RESET, " [");
             while (cp < rp) {
                 cp = eopt_print(ndo, cp);
                 if (cp == NULL)
                     return(NULL);
                 if (cp < rp)
-                    ND_PRINT(",");
+                    ND_PRINT(C_RESET, ",");
             }
-            ND_PRINT("]");
+            ND_PRINT(C_RESET, "]");
         }
 		break;
 
@@ -867,29 +870,29 @@ ns_rprint(netdissect_options *ndo,
 			return(NULL);
 		if (!ndo->ndo_vflag)
 			break;
-		ND_PRINT(" ");
+		ND_PRINT(C_RESET, " ");
 		if ((cp = fqdn_print(ndo, cp, bp)) == NULL)
 			return(NULL);
 		cp += 6;
 		if (!ND_TTEST_2(cp))
 			return(NULL);
-		ND_PRINT(" fudge=%u", GET_BE_U_2(cp));
+		ND_PRINT(C_RESET, " fudge=%u", GET_BE_U_2(cp));
 		cp += 2;
 		if (!ND_TTEST_2(cp))
 			return(NULL);
-		ND_PRINT(" maclen=%u", GET_BE_U_2(cp));
+		ND_PRINT(C_RESET, " maclen=%u", GET_BE_U_2(cp));
 		cp += 2 + GET_BE_U_2(cp);
 		if (!ND_TTEST_2(cp))
 			return(NULL);
-		ND_PRINT(" origid=%u", GET_BE_U_2(cp));
+		ND_PRINT(C_RESET, " origid=%u", GET_BE_U_2(cp));
 		cp += 2;
 		if (!ND_TTEST_2(cp))
 			return(NULL);
-		ND_PRINT(" error=%u", GET_BE_U_2(cp));
+		ND_PRINT(C_RESET, " error=%u", GET_BE_U_2(cp));
 		cp += 2;
 		if (!ND_TTEST_2(cp))
 			return(NULL);
-		ND_PRINT(" otherlen=%u", GET_BE_U_2(cp));
+		ND_PRINT(C_RESET, " otherlen=%u", GET_BE_U_2(cp));
 		cp += 2;
 	    }
 	}
@@ -916,13 +919,13 @@ domain_print(netdissect_options *ndo,
 		 * length field. (RFC 1035 - 4.2.2. TCP usage)
 		 */
 		if (length < 2) {
-			ND_PRINT(" [DNS over TCP: length %u < 2]", length);
+			ND_PRINT(C_RESET, " [DNS over TCP: length %u < 2]", length);
 			nd_print_invalid(ndo);
 			return;
 		} else {
 			length -= 2; /* excluding the two byte length field */
 			if (GET_BE_U_2(bp) != length) {
-				ND_PRINT(" [prefix length(%u) != length(%u)]",
+				ND_PRINT(C_RESET, " [prefix length(%u) != length(%u)]",
 					 GET_BE_U_2(bp), length);
 				nd_print_invalid(ndo);
 				return;
@@ -931,7 +934,7 @@ domain_print(netdissect_options *ndo,
 				/* in over TCP case, we need to prepend a space
 				 * (not needed in over UDP case)
 				 */
-				ND_PRINT(" ");
+				ND_PRINT(C_RESET, " ");
 			}
 		}
 	}
@@ -940,7 +943,7 @@ domain_print(netdissect_options *ndo,
 
 	if(length < sizeof(*np)) {
 		nd_print_protocol(ndo);
-		ND_PRINT(" [length %u < %zu]", length, sizeof(*np));
+		ND_PRINT(C_RESET, " [length %u < %zu]", length, sizeof(*np));
 		nd_print_invalid(ndo);
 		return;
 	}
@@ -999,7 +1002,7 @@ domain_print(netdissect_options *ndo,
  print:
 	if (DNS_QR(flags)) {
 		/* this is a response */
-		ND_PRINT("%u%s%s%s%s%s%s",
+		ND_PRINT(C_RESET, "%u%s%s%s%s%s%s",
 			GET_BE_U_2(np->id),
 			ns_ops[DNS_OPCODE(flags)],
 			ns_rcode(rcode),
@@ -1009,14 +1012,14 @@ domain_print(netdissect_options *ndo,
 			DNS_AD(flags)? "$" : "");
 
 		if (qdcount != 1)
-			ND_PRINT(" [%uq]", qdcount);
+			ND_PRINT(C_RESET, " [%uq]", qdcount);
 		/* Print QUESTION section on -vv */
 		cp = (const u_char *)(np + 1);
 		for (i = 0; i < qdcount; i++) {
 			if (i != 0)
-				ND_PRINT(",");
+				ND_PRINT(C_RESET, ",");
 			if (ndo->ndo_vflag > 1) {
-				ND_PRINT(" q:");
+				ND_PRINT(C_RESET, " q:");
 				if ((cp = ns_qprint(ndo, cp, bp, is_mdns)) == NULL)
 					goto trunc;
 			} else {
@@ -1025,13 +1028,13 @@ domain_print(netdissect_options *ndo,
 				cp += 4;	/* skip QTYPE and QCLASS */
 			}
 		}
-		ND_PRINT(" %u/%u/%u", ancount, nscount, arcount);
+		ND_PRINT(C_RESET, " %u/%u/%u", ancount, nscount, arcount);
 		if (ancount) {
 			if ((cp = ns_rprint(ndo, cp, bp, is_mdns)) == NULL)
 				goto trunc;
 			ancount--;
 			while (cp < ndo->ndo_snapend && ancount) {
-				ND_PRINT(",");
+				ND_PRINT(C_RESET, ",");
 				if ((cp = ns_rprint(ndo, cp, bp, is_mdns)) == NULL)
 					goto trunc;
 				ancount--;
@@ -1042,12 +1045,12 @@ domain_print(netdissect_options *ndo,
 		/* Print NS and AR sections on -vv */
 		if (ndo->ndo_vflag > 1) {
 			if (cp < ndo->ndo_snapend && nscount) {
-				ND_PRINT(" ns:");
+				ND_PRINT(C_RESET, " ns:");
 				if ((cp = ns_rprint(ndo, cp, bp, is_mdns)) == NULL)
 					goto trunc;
 				nscount--;
 				while (cp < ndo->ndo_snapend && nscount) {
-					ND_PRINT(",");
+					ND_PRINT(C_RESET, ",");
 					if ((cp = ns_rprint(ndo, cp, bp, is_mdns)) == NULL)
 						goto trunc;
 					nscount--;
@@ -1056,12 +1059,12 @@ domain_print(netdissect_options *ndo,
 			if (nscount)
 				goto trunc;
 			if (cp < ndo->ndo_snapend && arcount) {
-				ND_PRINT(" ar:");
+				ND_PRINT(C_RESET, " ar:");
 				if ((cp = ns_rprint(ndo, cp, bp, is_mdns)) == NULL)
 					goto trunc;
 				arcount--;
 				while (cp < ndo->ndo_snapend && arcount) {
-					ND_PRINT(",");
+					ND_PRINT(C_RESET, ",");
 					if ((cp = ns_rprint(ndo, cp, bp, is_mdns)) == NULL)
 						goto trunc;
 					arcount--;
@@ -1073,7 +1076,7 @@ domain_print(netdissect_options *ndo,
 	}
 	else {
 		/* this is a request */
-		ND_PRINT("%u%s%s%s", GET_BE_U_2(np->id),
+		ND_PRINT(C_RESET, "%u%s%s%s", GET_BE_U_2(np->id),
 			  ns_ops[DNS_OPCODE(flags)],
 			  DNS_RD(flags) ? "+" : "",
 			  DNS_CD(flags) ? "%" : "");
@@ -1081,24 +1084,24 @@ domain_print(netdissect_options *ndo,
 		/* any weirdness? */
 		b2 = GET_BE_U_2(((const u_short *)np) + 1);
 		if (b2 & 0x6cf)
-			ND_PRINT(" [b2&3=0x%x]", b2);
+			ND_PRINT(C_RESET, " [b2&3=0x%x]", b2);
 
 		if (DNS_OPCODE(flags) == IQUERY) {
 			if (qdcount)
-				ND_PRINT(" [%uq]", qdcount);
+				ND_PRINT(C_RESET, " [%uq]", qdcount);
 			if (ancount != 1)
-				ND_PRINT(" [%ua]", ancount);
+				ND_PRINT(C_RESET, " [%ua]", ancount);
 		}
 		else {
 			if (ancount)
-				ND_PRINT(" [%ua]", ancount);
+				ND_PRINT(C_RESET, " [%ua]", ancount);
 			if (qdcount != 1)
-				ND_PRINT(" [%uq]", qdcount);
+				ND_PRINT(C_RESET, " [%uq]", qdcount);
 		}
 		if (nscount)
-			ND_PRINT(" [%un]", nscount);
+			ND_PRINT(C_RESET, " [%un]", nscount);
 		if (arcount)
-			ND_PRINT(" [%uau]", arcount);
+			ND_PRINT(C_RESET, " [%uau]", arcount);
 
 		cp = (const u_char *)(np + 1);
 		if (qdcount) {
@@ -1125,7 +1128,7 @@ domain_print(netdissect_options *ndo,
 					goto trunc;
 				ancount--;
 				while (cp < ndo->ndo_snapend && ancount) {
-					ND_PRINT(",");
+					ND_PRINT(C_RESET, ",");
 					if ((cp = ns_rprint(ndo, cp, bp, is_mdns)) == NULL)
 						goto trunc;
 					ancount--;
@@ -1134,12 +1137,12 @@ domain_print(netdissect_options *ndo,
 			if (ancount)
 				goto trunc;
 			if (cp < ndo->ndo_snapend && nscount) {
-				ND_PRINT(" ns:");
+				ND_PRINT(C_RESET, " ns:");
 				if ((cp = ns_rprint(ndo, cp, bp, is_mdns)) == NULL)
 					goto trunc;
 				nscount--;
 				while (cp < ndo->ndo_snapend && nscount) {
-					ND_PRINT(",");
+					ND_PRINT(C_RESET, ",");
 					if ((cp = ns_rprint(ndo, cp, bp, is_mdns)) == NULL)
 						goto trunc;
 					nscount--;
@@ -1148,12 +1151,12 @@ domain_print(netdissect_options *ndo,
 			if (nscount > 0)
 				goto trunc;
 			if (cp < ndo->ndo_snapend && arcount) {
-				ND_PRINT(" ar:");
+				ND_PRINT(C_RESET, " ar:");
 				if ((cp = ns_rprint(ndo, cp, bp, is_mdns)) == NULL)
 					goto trunc;
 				arcount--;
 				while (cp < ndo->ndo_snapend && arcount) {
-					ND_PRINT(",");
+					ND_PRINT(C_RESET, ",");
 					if ((cp = ns_rprint(ndo, cp, bp, is_mdns)) == NULL)
 						goto trunc;
 					arcount--;
@@ -1163,7 +1166,7 @@ domain_print(netdissect_options *ndo,
 				goto trunc;
 		}
 	}
-	ND_PRINT(" (%u)", length);
+	ND_PRINT(C_RESET, " (%u)", length);
 	return;
 
   trunc:

--- a/print-dsa.c
+++ b/print-dsa.c
@@ -110,54 +110,54 @@ static void
 tag_common_print(netdissect_options *ndo, const u_char *p)
 {
 	if (ndo->ndo_eflag) {
-		ND_PRINT("mode %s, ", tok2str(dsa_mode_values, "unknown", DSA_MODE(p)));
+		ND_PRINT(C_RESET, C_RESET "mode %s, ", tok2str(dsa_mode_values, "unknown", DSA_MODE(p)));
 
 		switch (DSA_MODE(p)) {
 		case DSA_MODE_FORWARD:
-			ND_PRINT("dev %u, %s %u, ", DSA_DEV(p),
+			ND_PRINT(C_RESET, C_RESET "dev %u, %s %u, ", DSA_DEV(p),
 				 DSA_TRUNK(p) ? "trunk" : "port", DSA_PORT(p));
 			break;
 		case DSA_MODE_FROM_CPU:
-			ND_PRINT("target dev %u, port %u, ",
+			ND_PRINT(C_RESET, C_RESET "target dev %u, port %u, ",
 				 DSA_DEV(p), DSA_PORT(p));
 			break;
 		case DSA_MODE_TO_CPU:
-			ND_PRINT("source dev %u, port %u, ",
+			ND_PRINT(C_RESET, C_RESET "source dev %u, port %u, ",
 				 DSA_DEV(p), DSA_PORT(p));
-			ND_PRINT("code %s, ",
+			ND_PRINT(C_RESET, C_RESET "code %s, ",
 				 tok2str(dsa_code_values, "reserved", DSA_CODE(p)));
 			break;
 		case DSA_MODE_TO_SNIFFER:
-			ND_PRINT("source dev %u, port %u, ",
+			ND_PRINT(C_RESET, C_RESET "source dev %u, port %u, ",
 				 DSA_DEV(p), DSA_PORT(p));
-			ND_PRINT("%s sniff, ",
+			ND_PRINT(C_RESET, C_RESET "%s sniff, ",
 				 DSA_RX_SNIFF(p) ? "ingress" : "egress");
 			break;
 		default:
 			break;
 		}
 
-		ND_PRINT("%s, ", DSA_TAGGED(p) ? "tagged" : "untagged");
-		ND_PRINT("%s", DSA_CFI(p) ? "CFI, " : "");
-		ND_PRINT("VID %u, ", DSA_VID(p));
-		ND_PRINT("FPri %u, ", DSA_PRI(p));
+		ND_PRINT(C_RESET, C_RESET "%s, ", DSA_TAGGED(p) ? "tagged" : "untagged");
+		ND_PRINT(C_RESET, C_RESET "%s", DSA_CFI(p) ? "CFI, " : "");
+		ND_PRINT(C_RESET, C_RESET "VID %u, ", DSA_VID(p));
+		ND_PRINT(C_RESET, C_RESET "FPri %u, ", DSA_PRI(p));
 	} else {
 		switch (DSA_MODE(p)) {
 		case DSA_MODE_FORWARD:
-			ND_PRINT("Forward %s %u.%u, ",
+			ND_PRINT(C_RESET, C_RESET "Forward %s %u.%u, ",
 				 DSA_TRUNK(p) ? "trunk" : "port",
 				 DSA_DEV(p), DSA_PORT(p));
 			break;
 		case DSA_MODE_FROM_CPU:
-			ND_PRINT("CPU > port %u.%u, ",
+			ND_PRINT(C_RESET, C_RESET "CPU > port %u.%u, ",
 				 DSA_DEV(p), DSA_PORT(p));
 			break;
 		case DSA_MODE_TO_CPU:
-			ND_PRINT("port %u.%u > CPU, ",
+			ND_PRINT(C_RESET, C_RESET "port %u.%u > CPU, ",
 				 DSA_DEV(p), DSA_PORT(p));
 			break;
 		case DSA_MODE_TO_SNIFFER:
-			ND_PRINT("port %u.%u > %s Sniffer, ",
+			ND_PRINT(C_RESET, C_RESET "port %u.%u > %s Sniffer, ",
 				 DSA_DEV(p), DSA_PORT(p),
 				 DSA_RX_SNIFF(p) ? "Rx" : "Tx");
 			break;
@@ -165,7 +165,7 @@ tag_common_print(netdissect_options *ndo, const u_char *p)
 			break;
 		}
 
-		ND_PRINT("VLAN %u%c, ", DSA_VID(p), DSA_TAGGED(p) ? 't' : 'u');
+		ND_PRINT(C_RESET, C_RESET "VLAN %u%c, ", DSA_VID(p), DSA_TAGGED(p) ? 't' : 'u');
 	}
 }
 
@@ -173,9 +173,9 @@ static void
 dsa_tag_print(netdissect_options *ndo, const u_char *bp)
 {
 	if (ndo->ndo_eflag)
-		ND_PRINT("Marvell DSA ");
+		ND_PRINT(C_RESET, C_RESET "Marvell DSA ");
 	else
-		ND_PRINT("DSA ");
+		ND_PRINT(C_RESET, C_RESET "DSA ");
 	tag_common_print(ndo, bp);
 }
 
@@ -187,11 +187,11 @@ edsa_tag_print(netdissect_options *ndo, const u_char *bp)
 
 	edsa_etype = GET_BE_U_2(p);
 	if (ndo->ndo_eflag) {
-		ND_PRINT("Marvell EDSA ethertype 0x%04x (%s), ", edsa_etype,
+		ND_PRINT(C_RESET, C_RESET "Marvell EDSA ethertype 0x%04x (%s), ", edsa_etype,
 			 tok2str(ethertype_values, "Unknown", edsa_etype));
-		ND_PRINT("rsvd %u %u, ", GET_U_1(p + 2), GET_U_1(p + 3));
+		ND_PRINT(C_RESET, C_RESET "rsvd %u %u, ", GET_U_1(p + 2), GET_U_1(p + 3));
 	} else
-		ND_PRINT("EDSA 0x%04x, ", edsa_etype);
+		ND_PRINT(C_RESET, C_RESET "EDSA 0x%04x, ", edsa_etype);
 	p += 4;
 	tag_common_print(ndo, p);
 }

--- a/print-dsa.c
+++ b/print-dsa.c
@@ -110,54 +110,54 @@ static void
 tag_common_print(netdissect_options *ndo, const u_char *p)
 {
 	if (ndo->ndo_eflag) {
-		ND_PRINT(C_RESET, C_RESET "mode %s, ", tok2str(dsa_mode_values, "unknown", DSA_MODE(p)));
+		ND_PRINT(C_RESET, "mode %s, ", tok2str(dsa_mode_values, "unknown", DSA_MODE(p)));
 
 		switch (DSA_MODE(p)) {
 		case DSA_MODE_FORWARD:
-			ND_PRINT(C_RESET, C_RESET "dev %u, %s %u, ", DSA_DEV(p),
+			ND_PRINT(C_RESET, "dev %u, %s %u, ", DSA_DEV(p),
 				 DSA_TRUNK(p) ? "trunk" : "port", DSA_PORT(p));
 			break;
 		case DSA_MODE_FROM_CPU:
-			ND_PRINT(C_RESET, C_RESET "target dev %u, port %u, ",
+			ND_PRINT(C_RESET, "target dev %u, port %u, ",
 				 DSA_DEV(p), DSA_PORT(p));
 			break;
 		case DSA_MODE_TO_CPU:
-			ND_PRINT(C_RESET, C_RESET "source dev %u, port %u, ",
+			ND_PRINT(C_RESET, "source dev %u, port %u, ",
 				 DSA_DEV(p), DSA_PORT(p));
-			ND_PRINT(C_RESET, C_RESET "code %s, ",
+			ND_PRINT(C_RESET, "code %s, ",
 				 tok2str(dsa_code_values, "reserved", DSA_CODE(p)));
 			break;
 		case DSA_MODE_TO_SNIFFER:
-			ND_PRINT(C_RESET, C_RESET "source dev %u, port %u, ",
+			ND_PRINT(C_RESET, "source dev %u, port %u, ",
 				 DSA_DEV(p), DSA_PORT(p));
-			ND_PRINT(C_RESET, C_RESET "%s sniff, ",
+			ND_PRINT(C_RESET, "%s sniff, ",
 				 DSA_RX_SNIFF(p) ? "ingress" : "egress");
 			break;
 		default:
 			break;
 		}
 
-		ND_PRINT(C_RESET, C_RESET "%s, ", DSA_TAGGED(p) ? "tagged" : "untagged");
-		ND_PRINT(C_RESET, C_RESET "%s", DSA_CFI(p) ? "CFI, " : "");
-		ND_PRINT(C_RESET, C_RESET "VID %u, ", DSA_VID(p));
-		ND_PRINT(C_RESET, C_RESET "FPri %u, ", DSA_PRI(p));
+		ND_PRINT(C_RESET, "%s, ", DSA_TAGGED(p) ? "tagged" : "untagged");
+		ND_PRINT(C_RESET, "%s", DSA_CFI(p) ? "CFI, " : "");
+		ND_PRINT(C_RESET, "VID %u, ", DSA_VID(p));
+		ND_PRINT(C_RESET, "FPri %u, ", DSA_PRI(p));
 	} else {
 		switch (DSA_MODE(p)) {
 		case DSA_MODE_FORWARD:
-			ND_PRINT(C_RESET, C_RESET "Forward %s %u.%u, ",
+			ND_PRINT(C_RESET, "Forward %s %u.%u, ",
 				 DSA_TRUNK(p) ? "trunk" : "port",
 				 DSA_DEV(p), DSA_PORT(p));
 			break;
 		case DSA_MODE_FROM_CPU:
-			ND_PRINT(C_RESET, C_RESET "CPU > port %u.%u, ",
+			ND_PRINT(C_RESET, "CPU > port %u.%u, ",
 				 DSA_DEV(p), DSA_PORT(p));
 			break;
 		case DSA_MODE_TO_CPU:
-			ND_PRINT(C_RESET, C_RESET "port %u.%u > CPU, ",
+			ND_PRINT(C_RESET, "port %u.%u > CPU, ",
 				 DSA_DEV(p), DSA_PORT(p));
 			break;
 		case DSA_MODE_TO_SNIFFER:
-			ND_PRINT(C_RESET, C_RESET "port %u.%u > %s Sniffer, ",
+			ND_PRINT(C_RESET, "port %u.%u > %s Sniffer, ",
 				 DSA_DEV(p), DSA_PORT(p),
 				 DSA_RX_SNIFF(p) ? "Rx" : "Tx");
 			break;
@@ -165,7 +165,7 @@ tag_common_print(netdissect_options *ndo, const u_char *p)
 			break;
 		}
 
-		ND_PRINT(C_RESET, C_RESET "VLAN %u%c, ", DSA_VID(p), DSA_TAGGED(p) ? 't' : 'u');
+		ND_PRINT(C_RESET, "VLAN %u%c, ", DSA_VID(p), DSA_TAGGED(p) ? 't' : 'u');
 	}
 }
 
@@ -173,9 +173,9 @@ static void
 dsa_tag_print(netdissect_options *ndo, const u_char *bp)
 {
 	if (ndo->ndo_eflag)
-		ND_PRINT(C_RESET, C_RESET "Marvell DSA ");
+		ND_PRINT(C_RESET, "Marvell DSA ");
 	else
-		ND_PRINT(C_RESET, C_RESET "DSA ");
+		ND_PRINT(C_RESET, "DSA ");
 	tag_common_print(ndo, bp);
 }
 
@@ -187,11 +187,11 @@ edsa_tag_print(netdissect_options *ndo, const u_char *bp)
 
 	edsa_etype = GET_BE_U_2(p);
 	if (ndo->ndo_eflag) {
-		ND_PRINT(C_RESET, C_RESET "Marvell EDSA ethertype 0x%04x (%s), ", edsa_etype,
+		ND_PRINT(C_RESET, "Marvell EDSA ethertype 0x%04x (%s), ", edsa_etype,
 			 tok2str(ethertype_values, "Unknown", edsa_etype));
-		ND_PRINT(C_RESET, C_RESET "rsvd %u %u, ", GET_U_1(p + 2), GET_U_1(p + 3));
+		ND_PRINT(C_RESET, "rsvd %u %u, ", GET_U_1(p + 2), GET_U_1(p + 3));
 	} else
-		ND_PRINT(C_RESET, C_RESET "EDSA 0x%04x, ", edsa_etype);
+		ND_PRINT(C_RESET, "EDSA 0x%04x, ", edsa_etype);
 	p += 4;
 	tag_common_print(ndo, p);
 }

--- a/print-dtp.c
+++ b/print-dtp.c
@@ -48,11 +48,11 @@ dtp_print(netdissect_options *ndo, const u_char *tptr, u_int length)
 {
     ndo->ndo_protocol = "dtp";
     if (length < DTP_HEADER_LEN) {
-        ND_PRINT("[zero packet length]");
+        ND_PRINT(C_RESET, "[zero packet length]");
         goto invalid;
     }
 
-    ND_PRINT("DTPv%u, length %u",
+    ND_PRINT(C_RESET, "DTPv%u, length %u",
            GET_U_1(tptr),
            length);
 
@@ -70,7 +70,7 @@ dtp_print(netdissect_options *ndo, const u_char *tptr, u_int length)
         uint16_t type, len;
 
         if (length < 4) {
-            ND_PRINT("[%u bytes remaining]", length);
+            ND_PRINT(C_RESET, "[%u bytes remaining]", length);
             goto invalid;
         }
 	type = GET_BE_U_2(tptr);
@@ -78,19 +78,19 @@ dtp_print(netdissect_options *ndo, const u_char *tptr, u_int length)
        /* XXX: should not be but sometimes it is, see the test captures */
         if (type == 0)
             return;
-        ND_PRINT("\n\t%s (0x%04x) TLV, length %u",
+        ND_PRINT(C_RESET, "\n\t%s (0x%04x) TLV, length %u",
                tok2str(dtp_tlv_values, "Unknown", type),
                type, len);
 
         /* infinite loop check */
         if (len < 4 || len > length) {
-            ND_PRINT("[invalid TLV length %u]", len);
+            ND_PRINT(C_RESET, "[invalid TLV length %u]", len);
             goto invalid;
         }
 
         switch (type) {
 	case DTP_DOMAIN_TLV:
-		ND_PRINT(", ");
+		ND_PRINT(C_RESET, ", ");
 		nd_printjnp(ndo, tptr+4, len-4);
 		break;
 
@@ -98,13 +98,13 @@ dtp_print(netdissect_options *ndo, const u_char *tptr, u_int length)
 	case DTP_DTP_TYPE_TLV:
                 if (len != 5)
                     goto invalid;
-                ND_PRINT(", 0x%x", GET_U_1(tptr + 4));
+                ND_PRINT(C_RESET, ", 0x%x", GET_U_1(tptr + 4));
                 break;
 
 	case DTP_NEIGHBOR_TLV:
                 if (len != 10)
                     goto invalid;
-                ND_PRINT(", %s", GET_ETHERADDR_STRING(tptr+4));
+                ND_PRINT(C_RESET, ", %s", GET_ETHERADDR_STRING(tptr+4));
                 break;
 
         default:

--- a/print-dvmrp.c
+++ b/print-dvmrp.c
@@ -83,7 +83,7 @@ dvmrp_print(netdissect_options *ndo,
 
 	ndo->ndo_protocol = "dvmrp";
 	if (len < 8) {
-		ND_PRINT(" [length %u < 8]", len);
+		ND_PRINT(C_RESET, " [length %u < 8]", len);
 		goto invalid;
 	}
 
@@ -93,7 +93,7 @@ dvmrp_print(netdissect_options *ndo,
 	bp += 8;
 	len -= 8;
 
-	ND_PRINT(" %s", tok2str(dvmrp_msgtype_str, "[type %u]", type));
+	ND_PRINT(C_RESET, " %s", tok2str(dvmrp_msgtype_str, "[type %u]", type));
 	switch (type) {
 
 	case DVMRP_PROBE:
@@ -124,17 +124,17 @@ dvmrp_print(netdissect_options *ndo,
 		break;
 
 	case DVMRP_PRUNE:
-		ND_PRINT(" src %s grp %s", GET_IPADDR_STRING(bp), GET_IPADDR_STRING(bp + 4));
-		ND_PRINT(" timer ");
+		ND_PRINT(C_RESET, " src %s grp %s", GET_IPADDR_STRING(bp), GET_IPADDR_STRING(bp + 4));
+		ND_PRINT(C_RESET, " timer ");
 		unsigned_relts_print(ndo, GET_BE_U_4(bp + 8));
 		break;
 
 	case DVMRP_GRAFT:
-		ND_PRINT(" src %s grp %s", GET_IPADDR_STRING(bp), GET_IPADDR_STRING(bp + 4));
+		ND_PRINT(C_RESET, " src %s grp %s", GET_IPADDR_STRING(bp), GET_IPADDR_STRING(bp + 4));
 		break;
 
 	case DVMRP_GRAFT_ACK:
-		ND_PRINT(" src %s grp %s", GET_IPADDR_STRING(bp), GET_IPADDR_STRING(bp + 4));
+		ND_PRINT(C_RESET, " src %s grp %s", GET_IPADDR_STRING(bp), GET_IPADDR_STRING(bp + 4));
 		break;
 	}
 	return;
@@ -154,7 +154,7 @@ print_report(netdissect_options *ndo,
 
 	while (len > 0) {
 		if (len < 3) {
-			ND_PRINT(" [length %u < 3]", len);
+			ND_PRINT(C_RESET, " [length %u < 3]", len);
 			goto invalid;
 		}
 		mask = (uint32_t)0xff << 24 | GET_U_1(bp) << 16 |
@@ -167,12 +167,12 @@ print_report(netdissect_options *ndo,
 		if (GET_U_1(bp + 2))
 			width = 4;
 
-		ND_PRINT("\n\tMask %s", intoa(htonl(mask)));
+		ND_PRINT(C_RESET, "\n\tMask %s", intoa(htonl(mask)));
 		bp += 3;
 		len -= 3;
 		do {
 			if (len < width + 1) {
-				ND_PRINT("\n\t  [Truncated Report]");
+				ND_PRINT(C_RESET, "\n\t  [Truncated Report]");
 				goto invalid;
 			}
 			origin = 0;
@@ -187,7 +187,7 @@ print_report(netdissect_options *ndo,
 			bp++;
 			done = metric & 0x80;
 			metric &= 0x7f;
-			ND_PRINT("\n\t  %s metric %u", intoa(htonl(origin)),
+			ND_PRINT(C_RESET, "\n\t  %s metric %u", intoa(htonl(origin)),
 				metric);
 			len -= width + 1;
 		} while (!done);
@@ -204,11 +204,16 @@ print_probe(netdissect_options *ndo,
             u_int len)
 {
 	if (len < 4) {
-		ND_PRINT(" [full length %u < 4]", len);
+		ND_PRINT(C_RESET, " [full length %u < 4]", len);
 		goto invalid;
 	}
-	ND_PRINT(ndo->ndo_vflag > 1 ? "\n\t" : " ");
-	ND_PRINT("genid %u", GET_BE_U_4(bp));
+
+	if(ndo->ndo_vflag > 1)
+		ND_PRINT(C_RESET, "\n\t");
+	else
+		ND_PRINT(C_RESET, " ");
+
+	ND_PRINT(C_RESET, "genid %u", GET_BE_U_4(bp));
 	if (ndo->ndo_vflag < 2)
 		return;
 
@@ -216,10 +221,10 @@ print_probe(netdissect_options *ndo,
 	len -= 4;
 	while (len > 0) {
 		if (len < 4) {
-			ND_PRINT("[remaining length %u < 4]", len);
+			ND_PRINT(C_RESET, "[remaining length %u < 4]", len);
 			goto invalid;
 		}
-		ND_PRINT("\n\tneighbor %s", GET_IPADDR_STRING(bp));
+		ND_PRINT(C_RESET, "\n\tneighbor %s", GET_IPADDR_STRING(bp));
 		bp += 4; len -= 4;
 	}
 	return;
@@ -240,7 +245,7 @@ print_neighbors(netdissect_options *ndo,
 
 	while (len > 0) {
 		if (len < 7) {
-			ND_PRINT(" [length %u < 7]", len);
+			ND_PRINT(C_RESET, " [length %u < 7]", len);
 			goto invalid;
 		}
 		laddr = bp;
@@ -254,11 +259,11 @@ print_neighbors(netdissect_options *ndo,
 		len -= 7;
 		while (--ncount >= 0) {
 			if (len < 4) {
-				ND_PRINT(" [length %u < 4]", len);
+				ND_PRINT(C_RESET, " [length %u < 4]", len);
 				goto invalid;
 			}
-			ND_PRINT(" [%s ->", GET_IPADDR_STRING(laddr));
-			ND_PRINT(" %s, (%u/%u)]",
+			ND_PRINT(C_RESET, " [%s ->", GET_IPADDR_STRING(laddr));
+			ND_PRINT(C_RESET, " %s, (%u/%u)]",
 				   GET_IPADDR_STRING(bp), metric, thresh);
 			bp += 4;
 			len -= 4;
@@ -280,11 +285,11 @@ print_neighbors2(netdissect_options *ndo,
 	u_char metric, thresh, flags;
 	int ncount;
 
-	ND_PRINT(" (v %u.%u):", major_version, minor_version);
+	ND_PRINT(C_RESET, " (v %u.%u):", major_version, minor_version);
 
 	while (len > 0) {
 		if (len < 8) {
-			ND_PRINT(" [length %u < 8]", len);
+			ND_PRINT(C_RESET, " [length %u < 8]", len);
 			goto invalid;
 		}
 		laddr = bp;
@@ -300,28 +305,28 @@ print_neighbors2(netdissect_options *ndo,
 		len -= 8;
 		while (--ncount >= 0 && len > 0) {
 			if (len < 4) {
-				ND_PRINT(" [length %u < 4]", len);
+				ND_PRINT(C_RESET, " [length %u < 4]", len);
 				goto invalid;
 			}
-			ND_PRINT(" [%s -> ", GET_IPADDR_STRING(laddr));
-			ND_PRINT("%s (%u/%u", GET_IPADDR_STRING(bp),
+			ND_PRINT(C_RESET, " [%s -> ", GET_IPADDR_STRING(laddr));
+			ND_PRINT(C_RESET, "%s (%u/%u", GET_IPADDR_STRING(bp),
 				     metric, thresh);
 			if (flags & DVMRP_NF_TUNNEL)
-				ND_PRINT("/tunnel");
+				ND_PRINT(C_RESET, "/tunnel");
 			if (flags & DVMRP_NF_SRCRT)
-				ND_PRINT("/srcrt");
+				ND_PRINT(C_RESET, "/srcrt");
 			if (flags & DVMRP_NF_QUERIER)
-				ND_PRINT("/querier");
+				ND_PRINT(C_RESET, "/querier");
 			if (flags & DVMRP_NF_DISABLED)
-				ND_PRINT("/disabled");
+				ND_PRINT(C_RESET, "/disabled");
 			if (flags & DVMRP_NF_DOWN)
-				ND_PRINT("/down");
-			ND_PRINT(")]");
+				ND_PRINT(C_RESET, "/down");
+			ND_PRINT(C_RESET, ")]");
 			bp += 4;
 			len -= 4;
 		}
 		if (ncount != -1) {
-			ND_PRINT(" [invalid ncount]");
+			ND_PRINT(C_RESET, " [invalid ncount]");
 			goto invalid;
 		}
 	}

--- a/print-eap.c
+++ b/print-eap.c
@@ -164,16 +164,16 @@ eap_print(netdissect_options *ndo,
          * be done without that (e.g., fragmentation to make a message
          * fit in multiple TLVs in a RADIUS packet).
          */
-        ND_PRINT("EAP fragment?");
+        ND_PRINT(C_RESET, "EAP fragment?");
         return;
     }
-    ND_PRINT("%s (%u), id %u, len %u",
+    ND_PRINT(C_RESET, "%s (%u), id %u, len %u",
             tok2str(eap_code_values, "unknown", type),
             type,
             GET_U_1((cp + 1)),
             len);
     if (len < 4) {
-        ND_PRINT(" (too short for EAP header)");
+        ND_PRINT(C_RESET, " (too short for EAP header)");
         return;
     }
 
@@ -182,11 +182,11 @@ eap_print(netdissect_options *ndo,
     if (type == EAP_REQUEST || type == EAP_RESPONSE) {
         /* RFC 3748 Section 4.1 */
         if (len < 5) {
-            ND_PRINT(" (too short for EAP request/response)");
+            ND_PRINT(C_RESET, " (too short for EAP request/response)");
             return;
         }
         subtype = GET_U_1(cp + 4);
-        ND_PRINT("\n\t\t Type %s (%u)",
+        ND_PRINT(C_RESET, "\n\t\t Type %s (%u)",
                 tok2str(eap_type_values, "unknown", subtype),
                 subtype);
 
@@ -194,7 +194,7 @@ eap_print(netdissect_options *ndo,
             case EAP_TYPE_IDENTITY:
                 /* According to RFC 3748, the message is optional */
                 if (len > 5) {
-                    ND_PRINT(", Identity: ");
+                    ND_PRINT(C_RESET, ", Identity: ");
                     nd_printjnp(ndo, cp + 5, len - 5);
                 }
                 break;
@@ -202,10 +202,10 @@ eap_print(netdissect_options *ndo,
             case EAP_TYPE_NOTIFICATION:
                 /* According to RFC 3748, there must be at least one octet of message */
                 if (len < 6) {
-                    ND_PRINT(" (too short for EAP Notification request/response)");
+                    ND_PRINT(C_RESET, " (too short for EAP Notification request/response)");
                     return;
                 }
-                ND_PRINT(", Notification: ");
+                ND_PRINT(C_RESET, ", Notification: ");
                 nd_printjnp(ndo, cp + 5, len - 5);
                 break;
 
@@ -216,12 +216,12 @@ eap_print(netdissect_options *ndo,
                  * type one octet per type
                  */
                 if (len < 6) {
-                    ND_PRINT(" (too short for EAP Legacy NAK request/response)");
+                    ND_PRINT(C_RESET, " (too short for EAP Legacy NAK request/response)");
                     return;
                 }
                 sep = "";
                 for (count = 5; count < len; count++) {
-                    ND_PRINT("%s %s (%u)", sep,
+                    ND_PRINT(C_RESET, "%s %s (%u)", sep,
                            tok2str(eap_type_values, "unknown", GET_U_1((cp + count))),
                            GET_U_1(cp + count));
                     sep = ",";
@@ -231,42 +231,42 @@ eap_print(netdissect_options *ndo,
             case EAP_TYPE_TTLS:
             case EAP_TYPE_TLS:
                 if (len < 6) {
-                    ND_PRINT(" (too short for EAP TLS/TTLS request/response)");
+                    ND_PRINT(C_RESET, " (too short for EAP TLS/TTLS request/response)");
                     return;
                 }
                 if (subtype == EAP_TYPE_TTLS)
-                    ND_PRINT(" TTLSv%u",
+                    ND_PRINT(C_RESET, " TTLSv%u",
                            EAP_TTLS_VERSION(GET_U_1((cp + 5))));
-                ND_PRINT(" flags [%s] 0x%02x",
+                ND_PRINT(C_RESET, " flags [%s] 0x%02x",
                        bittok2str(eap_tls_flags_values, "none", GET_U_1((cp + 5))),
                        GET_U_1(cp + 5));
 
                 if (EAP_TLS_EXTRACT_BIT_L(GET_U_1(cp + 5))) {
                     if (len < 10) {
-                        ND_PRINT(" (too short for EAP TLS/TTLS request/response with length)");
+                        ND_PRINT(C_RESET, " (too short for EAP TLS/TTLS request/response with length)");
                         return;
                     }
-                    ND_PRINT(", len %u", GET_BE_U_4(cp + 6));
+                    ND_PRINT(C_RESET, ", len %u", GET_BE_U_4(cp + 6));
                 }
                 break;
 
             case EAP_TYPE_FAST:
                 if (len < 6) {
-                    ND_PRINT(" (too short for EAP FAST request/response)");
+                    ND_PRINT(C_RESET, " (too short for EAP FAST request/response)");
                     return;
                 }
-                ND_PRINT(" FASTv%u",
+                ND_PRINT(C_RESET, " FASTv%u",
                        EAP_TTLS_VERSION(GET_U_1((cp + 5))));
-                ND_PRINT(" flags [%s] 0x%02x",
+                ND_PRINT(C_RESET, " flags [%s] 0x%02x",
                        bittok2str(eap_tls_flags_values, "none", GET_U_1((cp + 5))),
                        GET_U_1(cp + 5));
 
                 if (EAP_TLS_EXTRACT_BIT_L(GET_U_1(cp + 5))) {
                     if (len < 10) {
-                        ND_PRINT(" (too short for EAP FAST request/response with length)");
+                        ND_PRINT(C_RESET, " (too short for EAP FAST request/response with length)");
                         return;
                     }
-                    ND_PRINT(", len %u", GET_BE_U_4(cp + 6));
+                    ND_PRINT(C_RESET, ", len %u", GET_BE_U_4(cp + 6));
                 }
 
                 /* FIXME - TLV attributes follow */
@@ -275,10 +275,10 @@ eap_print(netdissect_options *ndo,
             case EAP_TYPE_AKA:
             case EAP_TYPE_SIM:
                 if (len < 6) {
-                    ND_PRINT(" (too short for EAP SIM/AKA request/response)");
+                    ND_PRINT(C_RESET, " (too short for EAP SIM/AKA request/response)");
                     return;
                 }
-                ND_PRINT(" subtype [%s] 0x%02x",
+                ND_PRINT(C_RESET, " subtype [%s] 0x%02x",
                        tok2str(eap_aka_subtype_values, "unknown", GET_U_1((cp + 5))),
                        GET_U_1(cp + 5));
 
@@ -311,7 +311,7 @@ eapol_print(netdissect_options *ndo,
     ND_TCHECK_SIZE(eap);
     eap_type = GET_U_1(eap->type);
 
-    ND_PRINT("%s (%u) v%u, len %u",
+    ND_PRINT(C_RESET, "%s (%u) v%u, len %u",
            tok2str(eap_frame_type_values, "unknown", eap_type),
            eap_type,
            GET_U_1(eap->version),
@@ -326,7 +326,7 @@ eapol_print(netdissect_options *ndo,
     case EAP_FRAME_TYPE_PACKET:
         if (eap_len == 0)
             goto trunc;
-        ND_PRINT(", ");
+        ND_PRINT(C_RESET, ", ");
         eap_print(ndo, cp, eap_len);
         return;
     case EAP_FRAME_TYPE_LOGOFF:

--- a/print-egp.c
+++ b/print-egp.c
@@ -204,16 +204,16 @@ egpnr_print(netdissect_options *ndo,
 		distances = GET_U_1(cp);
 		cp++;
 		length--;
-		ND_PRINT(" %s %s ",
+		ND_PRINT(C_RESET, " %s %s ",
 		       gateways < intgw ? "int" : "ext",
 		       ipaddr_string(ndo, (const u_char *)&addr)); /* local buffer, not packet data; don't use GET_IPADDR_STRING() */
 
 		comma = "";
-		ND_PRINT("(");
+		ND_PRINT(C_RESET, "(");
 		while (distances != 0) {
 			if (length < 2)
 				goto invalid;
-			ND_PRINT("%sd%u:", comma, GET_U_1(cp));
+			ND_PRINT(C_RESET, "%sd%u:", comma, GET_U_1(cp));
 			cp++;
 			comma = ", ";
 			networks = GET_U_1(cp);
@@ -241,12 +241,12 @@ egpnr_print(netdissect_options *ndo,
 					cp++;
 					length -= 2;
 				}
-				ND_PRINT(" %s", ipaddr_string(ndo, (const u_char *)&addr)); /* local buffer, not packet data; don't use GET_IPADDR_STRING() */
+				ND_PRINT(C_RESET, " %s", ipaddr_string(ndo, (const u_char *)&addr)); /* local buffer, not packet data; don't use GET_IPADDR_STRING() */
 				networks--;
 			}
 			distances--;
 		}
-		ND_PRINT(")");
+		ND_PRINT(C_RESET, ")");
 	}
 	return;
 invalid:
@@ -270,30 +270,30 @@ egp_print(netdissect_options *ndo,
 
 	version = GET_U_1(egp->egp_version);
         if (!ndo->ndo_vflag) {
-            ND_PRINT("EGPv%u, AS %u, seq %u, length %u",
+            ND_PRINT(C_RESET, "EGPv%u, AS %u, seq %u, length %u",
                    version,
                    GET_BE_U_2(egp->egp_as),
                    GET_BE_U_2(egp->egp_sequence),
                    length);
             return;
         } else
-            ND_PRINT("EGPv%u, length %u",
+            ND_PRINT(C_RESET, "EGPv%u, length %u",
                    version,
                    length);
 
 	if (version != EGP_VERSION) {
-		ND_PRINT("[version %u]", version);
+		ND_PRINT(C_RESET, "[version %u]", version);
 		return;
 	}
 
 	type = GET_U_1(egp->egp_type);
-	ND_PRINT(" %s", tok2str(egp_type_str, "[type %u]", type));
+	ND_PRINT(C_RESET, " %s", tok2str(egp_type_str, "[type %u]", type));
 	code = GET_U_1(egp->egp_code);
 	status = GET_U_1(egp->egp_status);
 
 	switch (type) {
 	case EGPT_ACQUIRE:
-		ND_PRINT(" %s", tok2str(egp_acquire_codes_str, "[code %u]", code));
+		ND_PRINT(C_RESET, " %s", tok2str(egp_acquire_codes_str, "[code %u]", code));
 		switch (code) {
 		case EGPC_REQUEST:
 		case EGPC_CONFIRM:
@@ -301,14 +301,14 @@ egp_print(netdissect_options *ndo,
 			case EGPS_UNSPEC:
 			case EGPS_ACTIVE:
 			case EGPS_PASSIVE:
-				ND_PRINT(" %s", tok2str(egp_acquire_status_str, "%u", status));
+				ND_PRINT(C_RESET, " %s", tok2str(egp_acquire_status_str, "%u", status));
 				break;
 
 			default:
-				ND_PRINT(" [status %u]", status);
+				ND_PRINT(C_RESET, " [status %u]", status);
 				break;
 			}
-			ND_PRINT(" hello:%u poll:%u",
+			ND_PRINT(C_RESET, " hello:%u poll:%u",
 			       GET_BE_U_2(egp->egp_hello),
 			       GET_BE_U_2(egp->egp_poll));
 			break;
@@ -323,11 +323,11 @@ egp_print(netdissect_options *ndo,
 			case EGPS_GODOWN:
 			case EGPS_PARAM:
 			case EGPS_PROTO:
-				ND_PRINT(" %s", tok2str(egp_acquire_status_str, "%u", status));
+				ND_PRINT(C_RESET, " %s", tok2str(egp_acquire_status_str, "%u", status));
 				break;
 
 			default:
-				ND_PRINT("[status %u]", status);
+				ND_PRINT(C_RESET, "[status %u]", status);
 				break;
 			}
 			break;
@@ -335,27 +335,27 @@ egp_print(netdissect_options *ndo,
 		break;
 
 	case EGPT_REACH:
-		ND_PRINT(" %s", tok2str(egp_reach_codes_str, "[reach code %u]", code));
+		ND_PRINT(C_RESET, " %s", tok2str(egp_reach_codes_str, "[reach code %u]", code));
 		switch (code) {
 		case EGPC_HELLO:
 		case EGPC_HEARDU:
-			ND_PRINT(" state:%s", tok2str(egp_status_updown_str, "%u", status));
+			ND_PRINT(C_RESET, " state:%s", tok2str(egp_status_updown_str, "%u", status));
 			break;
 		}
 		break;
 
 	case EGPT_POLL:
-		ND_PRINT(" state:%s", tok2str(egp_status_updown_str, "%u", status));
-		ND_PRINT(" net:%s", GET_IPADDR_STRING(egp->egp_sourcenet));
+		ND_PRINT(C_RESET, " state:%s", tok2str(egp_status_updown_str, "%u", status));
+		ND_PRINT(C_RESET, " net:%s", GET_IPADDR_STRING(egp->egp_sourcenet));
 		break;
 
 	case EGPT_UPDATE:
 		if (status & EGPS_UNSOL) {
 			status &= ~EGPS_UNSOL;
-			ND_PRINT(" unsolicited");
+			ND_PRINT(C_RESET, " unsolicited");
 		}
-		ND_PRINT(" state:%s", tok2str(egp_status_updown_str, "%u", status));
-		ND_PRINT(" %s int %u ext %u",
+		ND_PRINT(C_RESET, " state:%s", tok2str(egp_status_updown_str, "%u", status));
+		ND_PRINT(C_RESET, " %s int %u ext %u",
 		       GET_IPADDR_STRING(egp->egp_sourcenet),
 		       GET_U_1(egp->egp_intgw),
 		       GET_U_1(egp->egp_extgw));
@@ -364,8 +364,8 @@ egp_print(netdissect_options *ndo,
 		break;
 
 	case EGPT_ERROR:
-		ND_PRINT(" state:%s", tok2str(egp_status_updown_str, "%u", status));
-		ND_PRINT(" %s", tok2str(egp_reasons_str, "[reason %u]", GET_BE_U_2(egp->egp_reason)));
+		ND_PRINT(C_RESET, " state:%s", tok2str(egp_status_updown_str, "%u", status));
+		ND_PRINT(C_RESET, " %s", tok2str(egp_reasons_str, "[reason %u]", GET_BE_U_2(egp->egp_reason)));
 		break;
 	}
 	return;

--- a/print-eigrp.c
+++ b/print-eigrp.c
@@ -240,20 +240,20 @@ eigrp_print(netdissect_options *ndo, const u_char *pptr, u_int len)
      * Sanity checking of the header.
      */
     if (len < sizeof(struct eigrp_common_header)) {
-        ND_PRINT("EIGRP %s, length: %u (too short, < %zu)",
+        ND_PRINT(C_RESET, "EIGRP %s, length: %u (too short, < %zu)",
                tok2str(eigrp_opcode_values, "unknown (%u)",GET_U_1(eigrp_com_header->opcode)),
                len, sizeof(struct eigrp_common_header));
         goto check_remainder;
     }
     if (GET_U_1(eigrp_com_header->version) != EIGRP_VERSION) {
-        ND_PRINT("EIGRP version %u packet not supported",
+        ND_PRINT(C_RESET, "EIGRP version %u packet not supported",
                  GET_U_1(eigrp_com_header->version));
         goto check_remainder;
     }
 
     /* in non-verbose mode just lets print the basic Message Type*/
     if (ndo->ndo_vflag < 1) {
-        ND_PRINT("EIGRP %s, length: %u",
+        ND_PRINT(C_RESET, "EIGRP %s, length: %u",
                tok2str(eigrp_opcode_values, "unknown (%u)",GET_U_1(eigrp_com_header->opcode)),
                len);
         goto check_remainder;
@@ -262,7 +262,7 @@ eigrp_print(netdissect_options *ndo, const u_char *pptr, u_int len)
     /* ok they seem to want to know everything - lets fully decode it */
     tlen -= sizeof(struct eigrp_common_header);
 
-    ND_PRINT("\n\tEIGRP v%u, opcode: %s (%u), chksum: 0x%04x, Flags: [%s]"
+    ND_PRINT(C_RESET, "\n\tEIGRP v%u, opcode: %s (%u), chksum: 0x%04x, Flags: [%s]"
              "\n\tseq: 0x%08x, ack: 0x%08x, VRID: %u, AS: %u, length: %u",
            GET_U_1(eigrp_com_header->version),
            tok2str(eigrp_opcode_values, "unknown, type: %u",GET_U_1(eigrp_com_header->opcode)),
@@ -281,14 +281,14 @@ eigrp_print(netdissect_options *ndo, const u_char *pptr, u_int len)
 
     while(tlen>0) {
         if (tlen < sizeof(struct eigrp_tlv_header)) {
-            ND_PRINT("\n\t  (only %u bytes of data)", tlen);
+            ND_PRINT(C_RESET, "\n\t  (only %u bytes of data)", tlen);
             goto invalid;
         }
         eigrp_tlv_header = (const struct eigrp_tlv_header *)tptr;
         eigrp_tlv_len=GET_BE_U_2(eigrp_tlv_header->length);
         eigrp_tlv_type=GET_BE_U_2(eigrp_tlv_header->type);
 
-        ND_PRINT("\n\t  %s TLV (0x%04x), length: %u",
+        ND_PRINT(C_RESET, "\n\t  %s TLV (0x%04x), length: %u",
                tok2str(eigrp_tlv_values,
                        "Unknown",
                        eigrp_tlv_type),
@@ -310,12 +310,12 @@ eigrp_print(netdissect_options *ndo, const u_char *pptr, u_int len)
         case EIGRP_TLV_GENERAL_PARM:
             tlv_ptr.eigrp_tlv_general_parm = (const struct eigrp_tlv_general_parm_t *)tlv_tptr;
             if (tlv_tlen < sizeof(*tlv_ptr.eigrp_tlv_general_parm)) {
-                ND_PRINT(" (too short, < %zu)",
+                ND_PRINT(C_RESET, " (too short, < %zu)",
         		 sizeof(struct eigrp_tlv_header) + sizeof(*tlv_ptr.eigrp_tlv_general_parm));
                 break;
             }
 
-            ND_PRINT("\n\t    holdtime: %us, k1 %u, k2 %u, k3 %u, k4 %u, k5 %u",
+            ND_PRINT(C_RESET, "\n\t    holdtime: %us, k1 %u, k2 %u, k3 %u, k4 %u, k5 %u",
                    GET_BE_U_2(tlv_ptr.eigrp_tlv_general_parm->holdtime),
                    GET_U_1(tlv_ptr.eigrp_tlv_general_parm->k1),
                    GET_U_1(tlv_ptr.eigrp_tlv_general_parm->k2),
@@ -327,12 +327,12 @@ eigrp_print(netdissect_options *ndo, const u_char *pptr, u_int len)
         case EIGRP_TLV_SW_VERSION:
             tlv_ptr.eigrp_tlv_sw_version = (const struct eigrp_tlv_sw_version_t *)tlv_tptr;
             if (tlv_tlen < sizeof(*tlv_ptr.eigrp_tlv_sw_version)) {
-                ND_PRINT(" (too short, < %zu)",
+                ND_PRINT(C_RESET, " (too short, < %zu)",
                          sizeof(struct eigrp_tlv_header) + sizeof(*tlv_ptr.eigrp_tlv_sw_version));
                 break;
             }
 
-            ND_PRINT("\n\t    IOS version: %u.%u, EIGRP version %u.%u",
+            ND_PRINT(C_RESET, "\n\t    IOS version: %u.%u, EIGRP version %u.%u",
                    GET_U_1(tlv_ptr.eigrp_tlv_sw_version->ios_major),
                    GET_U_1(tlv_ptr.eigrp_tlv_sw_version->ios_minor),
                    GET_U_1(tlv_ptr.eigrp_tlv_sw_version->eigrp_major),
@@ -342,30 +342,30 @@ eigrp_print(netdissect_options *ndo, const u_char *pptr, u_int len)
         case EIGRP_TLV_IP_INT:
             tlv_ptr.eigrp_tlv_ip_int = (const struct eigrp_tlv_ip_int_t *)tlv_tptr;
             if (tlv_tlen < sizeof(*tlv_ptr.eigrp_tlv_ip_int)) {
-                ND_PRINT(" (too short, < %zu)",
+                ND_PRINT(C_RESET, " (too short, < %zu)",
                          sizeof(struct eigrp_tlv_header) + sizeof(*tlv_ptr.eigrp_tlv_ip_int));
                 break;
             }
 
             bit_length = GET_U_1(tlv_ptr.eigrp_tlv_ip_int->plen);
             if (bit_length > 32) {
-                ND_PRINT("\n\t    illegal prefix length %u",bit_length);
+                ND_PRINT(C_RESET, "\n\t    illegal prefix length %u",bit_length);
                 break;
             }
             byte_length = (bit_length + 7) / 8; /* variable length encoding */
             memset(prefix, 0, 4);
             GET_CPY_BYTES(prefix, tlv_ptr.eigrp_tlv_ip_int->destination, byte_length);
 
-            ND_PRINT("\n\t    IPv4 prefix: %15s/%u, nexthop: ",
+            ND_PRINT(C_RESET, "\n\t    IPv4 prefix: %15s/%u, nexthop: ",
                    ipaddr_string(ndo, prefix),	/* local buffer, not packet data; don't use GET_IPADDR_STRING() */
                    bit_length);
             if (GET_BE_U_4(tlv_ptr.eigrp_tlv_ip_int->nexthop) == 0)
-                ND_PRINT("self");
+                ND_PRINT(C_RESET, "self");
             else
-                ND_PRINT("%s",
+                ND_PRINT(C_RESET, "%s",
                          GET_IPADDR_STRING(tlv_ptr.eigrp_tlv_ip_int->nexthop));
 
-            ND_PRINT("\n\t      delay %u ms, bandwidth %u Kbps, mtu %u, hop %u, reliability %u, load %u",
+            ND_PRINT(C_RESET, "\n\t      delay %u ms, bandwidth %u Kbps, mtu %u, hop %u, reliability %u, load %u",
                    (GET_BE_U_4(tlv_ptr.eigrp_tlv_ip_int->delay)/100),
                    GET_BE_U_4(tlv_ptr.eigrp_tlv_ip_int->bandwidth),
                    GET_BE_U_3(tlv_ptr.eigrp_tlv_ip_int->mtu),
@@ -377,30 +377,30 @@ eigrp_print(netdissect_options *ndo, const u_char *pptr, u_int len)
         case EIGRP_TLV_IP_EXT:
             tlv_ptr.eigrp_tlv_ip_ext = (const struct eigrp_tlv_ip_ext_t *)tlv_tptr;
             if (tlv_tlen < sizeof(*tlv_ptr.eigrp_tlv_ip_ext)) {
-                ND_PRINT(" (too short, < %zu)",
+                ND_PRINT(C_RESET, " (too short, < %zu)",
                          sizeof(struct eigrp_tlv_header) + sizeof(*tlv_ptr.eigrp_tlv_ip_ext));
                 break;
             }
 
             bit_length = GET_U_1(tlv_ptr.eigrp_tlv_ip_ext->plen);
             if (bit_length > 32) {
-                ND_PRINT("\n\t    illegal prefix length %u",bit_length);
+                ND_PRINT(C_RESET, "\n\t    illegal prefix length %u",bit_length);
                 break;
             }
             byte_length = (bit_length + 7) / 8; /* variable length encoding */
             memset(prefix, 0, 4);
             GET_CPY_BYTES(prefix, tlv_ptr.eigrp_tlv_ip_ext->destination, byte_length);
 
-            ND_PRINT("\n\t    IPv4 prefix: %15s/%u, nexthop: ",
+            ND_PRINT(C_RESET, "\n\t    IPv4 prefix: %15s/%u, nexthop: ",
                    ipaddr_string(ndo, prefix),	/* local buffer, not packet data; don't use GET_IPADDR_STRING() */
                    bit_length);
             if (GET_BE_U_4(tlv_ptr.eigrp_tlv_ip_ext->nexthop) == 0)
-                ND_PRINT("self");
+                ND_PRINT(C_RESET, "self");
             else
-                ND_PRINT("%s",
+                ND_PRINT(C_RESET, "%s",
                          GET_IPADDR_STRING(tlv_ptr.eigrp_tlv_ip_ext->nexthop));
 
-            ND_PRINT("\n\t      origin-router %s, origin-as %u, origin-proto %s, flags [0x%02x], tag 0x%08x, metric %u",
+            ND_PRINT(C_RESET, "\n\t      origin-router %s, origin-as %u, origin-proto %s, flags [0x%02x], tag 0x%08x, metric %u",
                    GET_IPADDR_STRING(tlv_ptr.eigrp_tlv_ip_ext->origin_router),
                    GET_BE_U_4(tlv_ptr.eigrp_tlv_ip_ext->origin_as),
                    tok2str(eigrp_ext_proto_id_values,"unknown",GET_U_1(tlv_ptr.eigrp_tlv_ip_ext->proto_id)),
@@ -408,7 +408,7 @@ eigrp_print(netdissect_options *ndo, const u_char *pptr, u_int len)
                    GET_BE_U_4(tlv_ptr.eigrp_tlv_ip_ext->tag),
                    GET_BE_U_4(tlv_ptr.eigrp_tlv_ip_ext->metric));
 
-            ND_PRINT("\n\t      delay %u ms, bandwidth %u Kbps, mtu %u, hop %u, reliability %u, load %u",
+            ND_PRINT(C_RESET, "\n\t      delay %u ms, bandwidth %u Kbps, mtu %u, hop %u, reliability %u, load %u",
                    (GET_BE_U_4(tlv_ptr.eigrp_tlv_ip_ext->delay)/100),
                    GET_BE_U_4(tlv_ptr.eigrp_tlv_ip_ext->bandwidth),
                    GET_BE_U_3(tlv_ptr.eigrp_tlv_ip_ext->mtu),
@@ -420,12 +420,12 @@ eigrp_print(netdissect_options *ndo, const u_char *pptr, u_int len)
         case EIGRP_TLV_AT_CABLE_SETUP:
             tlv_ptr.eigrp_tlv_at_cable_setup = (const struct eigrp_tlv_at_cable_setup_t *)tlv_tptr;
             if (tlv_tlen < sizeof(*tlv_ptr.eigrp_tlv_at_cable_setup)) {
-                ND_PRINT(" (too short, < %zu)",
+                ND_PRINT(C_RESET, " (too short, < %zu)",
                          sizeof(struct eigrp_tlv_header) + sizeof(*tlv_ptr.eigrp_tlv_at_cable_setup));
                 break;
             }
 
-            ND_PRINT("\n\t    Cable-range: %u-%u, Router-ID %u",
+            ND_PRINT(C_RESET, "\n\t    Cable-range: %u-%u, Router-ID %u",
                    GET_BE_U_2(tlv_ptr.eigrp_tlv_at_cable_setup->cable_start),
                    GET_BE_U_2(tlv_ptr.eigrp_tlv_at_cable_setup->cable_end),
                    GET_BE_U_4(tlv_ptr.eigrp_tlv_at_cable_setup->router_id));
@@ -434,23 +434,23 @@ eigrp_print(netdissect_options *ndo, const u_char *pptr, u_int len)
         case EIGRP_TLV_AT_INT:
             tlv_ptr.eigrp_tlv_at_int = (const struct eigrp_tlv_at_int_t *)tlv_tptr;
             if (tlv_tlen < sizeof(*tlv_ptr.eigrp_tlv_at_int)) {
-                ND_PRINT(" (too short, < %zu)",
+                ND_PRINT(C_RESET, " (too short, < %zu)",
                          sizeof(struct eigrp_tlv_header) + sizeof(*tlv_ptr.eigrp_tlv_at_int));
                 break;
             }
 
-            ND_PRINT("\n\t     Cable-Range: %u-%u, nexthop: ",
+            ND_PRINT(C_RESET, "\n\t     Cable-Range: %u-%u, nexthop: ",
                    GET_BE_U_2(tlv_ptr.eigrp_tlv_at_int->cable_start),
                    GET_BE_U_2(tlv_ptr.eigrp_tlv_at_int->cable_end));
 
             if (GET_BE_U_4(tlv_ptr.eigrp_tlv_at_int->nexthop) == 0)
-                ND_PRINT("self");
+                ND_PRINT(C_RESET, "self");
             else
-                ND_PRINT("%u.%u",
+                ND_PRINT(C_RESET, "%u.%u",
                        GET_BE_U_2(&tlv_ptr.eigrp_tlv_at_int->nexthop[0]),
                        GET_BE_U_2(&tlv_ptr.eigrp_tlv_at_int->nexthop[2]));
 
-            ND_PRINT("\n\t      delay %u ms, bandwidth %u Kbps, mtu %u, hop %u, reliability %u, load %u",
+            ND_PRINT(C_RESET, "\n\t      delay %u ms, bandwidth %u Kbps, mtu %u, hop %u, reliability %u, load %u",
                    (GET_BE_U_4(tlv_ptr.eigrp_tlv_at_int->delay)/100),
                    GET_BE_U_4(tlv_ptr.eigrp_tlv_at_int->bandwidth),
                    GET_BE_U_3(tlv_ptr.eigrp_tlv_at_int->mtu),
@@ -462,23 +462,23 @@ eigrp_print(netdissect_options *ndo, const u_char *pptr, u_int len)
         case EIGRP_TLV_AT_EXT:
             tlv_ptr.eigrp_tlv_at_ext = (const struct eigrp_tlv_at_ext_t *)tlv_tptr;
             if (tlv_tlen < sizeof(*tlv_ptr.eigrp_tlv_at_ext)) {
-                ND_PRINT(" (too short, < %zu)",
+                ND_PRINT(C_RESET, " (too short, < %zu)",
                          sizeof(struct eigrp_tlv_header) + sizeof(*tlv_ptr.eigrp_tlv_at_ext));
                 break;
             }
 
-            ND_PRINT("\n\t     Cable-Range: %u-%u, nexthop: ",
+            ND_PRINT(C_RESET, "\n\t     Cable-Range: %u-%u, nexthop: ",
                    GET_BE_U_2(tlv_ptr.eigrp_tlv_at_ext->cable_start),
                    GET_BE_U_2(tlv_ptr.eigrp_tlv_at_ext->cable_end));
 
             if (GET_BE_U_4(tlv_ptr.eigrp_tlv_at_ext->nexthop) == 0)
-                ND_PRINT("self");
+                ND_PRINT(C_RESET, "self");
             else
-                ND_PRINT("%u.%u",
+                ND_PRINT(C_RESET, "%u.%u",
                        GET_BE_U_2(&tlv_ptr.eigrp_tlv_at_ext->nexthop[0]),
                        GET_BE_U_2(&tlv_ptr.eigrp_tlv_at_ext->nexthop[2]));
 
-            ND_PRINT("\n\t      origin-router %u, origin-as %u, origin-proto %s, flags [0x%02x], tag 0x%08x, metric %u",
+            ND_PRINT(C_RESET, "\n\t      origin-router %u, origin-as %u, origin-proto %s, flags [0x%02x], tag 0x%08x, metric %u",
                    GET_BE_U_4(tlv_ptr.eigrp_tlv_at_ext->origin_router),
                    GET_BE_U_4(tlv_ptr.eigrp_tlv_at_ext->origin_as),
                    tok2str(eigrp_ext_proto_id_values,"unknown",GET_U_1(tlv_ptr.eigrp_tlv_at_ext->proto_id)),
@@ -486,7 +486,7 @@ eigrp_print(netdissect_options *ndo, const u_char *pptr, u_int len)
                    GET_BE_U_4(tlv_ptr.eigrp_tlv_at_ext->tag),
                    GET_BE_U_2(tlv_ptr.eigrp_tlv_at_ext->metric));
 
-            ND_PRINT("\n\t      delay %u ms, bandwidth %u Kbps, mtu %u, hop %u, reliability %u, load %u",
+            ND_PRINT(C_RESET, "\n\t      delay %u ms, bandwidth %u Kbps, mtu %u, hop %u, reliability %u, load %u",
                    (GET_BE_U_4(tlv_ptr.eigrp_tlv_at_ext->delay)/100),
                    GET_BE_U_4(tlv_ptr.eigrp_tlv_at_ext->bandwidth),
                    GET_BE_U_3(tlv_ptr.eigrp_tlv_at_ext->mtu),

--- a/print-enc.c
+++ b/print-enc.c
@@ -83,7 +83,7 @@ struct enchdr {
 
 #define ENC_PRINT_TYPE(wh, xf, name) \
 	if ((wh) & (xf)) { \
-		ND_PRINT("%s%s", name, (wh) == (xf) ? "): " : ","); \
+		ND_PRINT(C_RESET, "%s%s", name, (wh) == (xf) ? "): " : ","); \
 		(wh) &= ~(xf); \
 	}
 
@@ -134,13 +134,13 @@ enc_if_print(netdissect_options *ndo,
 	}
 
 	if (flags == 0)
-		ND_PRINT("(unprotected): ");
+		ND_PRINT(C_RESET, "(unprotected): ");
 	else
-		ND_PRINT("(");
+		ND_PRINT(C_RESET, "(");
 	ENC_PRINT_TYPE(flags, M_AUTH, "authentic");
 	ENC_PRINT_TYPE(flags, M_CONF, "confidential");
 	/* ENC_PRINT_TYPE(flags, M_TUNNEL, "tunnel"); */
-	ND_PRINT("SPI 0x%08x: ", GET_BE_U_4(hdr->spi));
+	ND_PRINT(C_RESET, "SPI 0x%08x: ", GET_BE_U_4(hdr->spi));
 
 	length -= ENC_HDRLEN;
 	p += ENC_HDRLEN;

--- a/print-esp.c
+++ b/print-esp.c
@@ -757,9 +757,9 @@ esp_print(netdissect_options *ndo,
 		nd_print_trunc(ndo);
 		return;
 	}
-	ND_PRINT("ESP(spi=0x%08x", GET_BE_U_4(esp->esp_spi));
-	ND_PRINT(",seq=0x%x)", GET_BE_U_4(esp->esp_seq));
-	ND_PRINT(", length %u", length);
+	ND_PRINT(C_RESET, "ESP(spi=0x%08x", GET_BE_U_4(esp->esp_spi));
+	ND_PRINT(C_RESET, ",seq=0x%x)", GET_BE_U_4(esp->esp_seq));
+	ND_PRINT(C_RESET, ", length %u", length);
 
 #ifdef HAVE_LIBCRYPTO
 	/* initialize SAs */
@@ -902,7 +902,7 @@ esp_print(netdissect_options *ndo,
 	/* Get the next header */
 	nh = GET_U_1(pt + payloadlen - 1);
 
-	ND_PRINT(": ");
+	ND_PRINT(C_RESET, ": ");
 
 	/*
 	 * Don't put padding + padding length(1 byte) + next header(1 byte)

--- a/print-ether.c
+++ b/print-ether.c
@@ -111,7 +111,7 @@ static void
 ether_addresses_print(netdissect_options *ndo, const u_char *src,
 		      const u_char *dst)
 {
-	ND_PRINT("%s > %s, ",
+	 ND_PRINT(C_RESET, "%s > %s, ",
 		 GET_ETHERADDR_STRING(src), GET_ETHERADDR_STRING(dst));
 }
 
@@ -119,10 +119,10 @@ static void
 ether_type_print(netdissect_options *ndo, uint16_t type)
 {
 	if (!ndo->ndo_qflag)
-		ND_PRINT("ethertype %s (0x%04x)",
+		 ND_PRINT(C_RESET, "ethertype %s (0x%04x)",
 			 tok2str(ethertype_values, "Unknown", type), type);
 	else
-		ND_PRINT("%s",
+		 ND_PRINT(C_RESET, "%s",
 			 tok2str(ethertype_values, "Unknown Ethertype (0x%04x)", type));
 }
 
@@ -151,7 +151,7 @@ ether_common_print(netdissect_options *ndo, const u_char *p, u_int length,
 	struct lladdr_info src, dst;
 
 	if (length < caplen) {
-		ND_PRINT("[length %u < caplen %u]", length, caplen);
+		 ND_PRINT(C_RESET, "[length %u < caplen %u]", length, caplen);
 		nd_print_invalid(ndo);
 		return length;
 	}
@@ -217,7 +217,7 @@ recurse:
 		 */
 		if (ndo->ndo_eflag) {
 			ether_type_print(ndo, length_type);
-			ND_PRINT(", length %u: ", orig_length);
+			 ND_PRINT(C_RESET, ", length %u: ", orig_length);
 			printed_length = 1;
 		}
 
@@ -273,11 +273,11 @@ recurse:
 
 			ether_type_print(ndo, length_type);
 			if (!printed_length) {
-				ND_PRINT(", length %u: ", orig_length);
+				 ND_PRINT(C_RESET, ", length %u: ", orig_length);
 				printed_length = 1;
 			} else
-				ND_PRINT(", ");
-			ND_PRINT("%s, ", ieee8021q_tci_string(tag));
+				 ND_PRINT(C_RESET, ", ");
+			 ND_PRINT(C_RESET, "%s, ", ieee8021q_tci_string(tag));
 		}
 
 		length_type = GET_BE_U_2(p + 2);
@@ -312,9 +312,9 @@ recurse:
 		}
 
 		if (ndo->ndo_eflag) {
-			ND_PRINT("802.3");
+			 ND_PRINT(C_RESET, "802.3");
 			if (!printed_length)
-				ND_PRINT(", length %u: ", length);
+				 ND_PRINT(C_RESET, ", length %u: ", length);
 		}
 
 		/*
@@ -351,15 +351,15 @@ recurse:
 		hdrlen += llc_hdrlen;
 	} else if (length_type == ETHERTYPE_ARISTA) {
 		if (caplen < 2) {
-			ND_PRINT("[|arista]");
+			 ND_PRINT(C_RESET, "[|arista]");
 			return hdrlen + caplen;
 		}
 		if (length < 2) {
-			ND_PRINT("[|arista]");
+			 ND_PRINT(C_RESET, "[|arista]");
 			return hdrlen + length;
 		}
 		ether_type_print(ndo, length_type);
-		ND_PRINT(", length %u: ", orig_length);
+		 ND_PRINT(C_RESET, ", length %u: ", orig_length);
 		int bytesConsumed = arista_ethertype_print(ndo, p, length);
 		if (bytesConsumed > 0) {
 			p += bytesConsumed;
@@ -372,7 +372,7 @@ recurse:
 			if (!ndo->ndo_eflag && length_type > MAX_ETHERNET_LENGTH_VAL) {
 				ether_addresses_print(ndo, src.addr, dst.addr);
 				ether_type_print(ndo, length_type);
-				ND_PRINT(", length %u: ", orig_length);
+				 ND_PRINT(C_RESET, ", length %u: ", orig_length);
 			}
 			 if (!ndo->ndo_suppress_default_print)
 				 ND_DEFAULTPRINT(p, caplen);
@@ -384,9 +384,9 @@ recurse:
 		if (ndo->ndo_eflag) {
 			ether_type_print(ndo, length_type);
 			if (!printed_length)
-				ND_PRINT(", length %u: ", orig_length);
+				 ND_PRINT(C_RESET, ", length %u: ", orig_length);
 			else
-				ND_PRINT(", ");
+				 ND_PRINT(C_RESET, ", ");
 		}
 		if (ethertype_print(ndo, length_type, p, length, caplen, &src, &dst) == 0) {
 			/* type not known, print raw packet */
@@ -400,7 +400,7 @@ recurse:
 				 */
 				ether_addresses_print(ndo, src.addr, dst.addr);
 				ether_type_print(ndo, length_type);
-				ND_PRINT(", length %u: ", orig_length);
+				 ND_PRINT(C_RESET, ", length %u: ", orig_length);
 			}
 
 			if (!ndo->ndo_suppress_default_print)
@@ -551,7 +551,7 @@ ethertype_print(netdissect_options *ndo,
 
 	case ETHERTYPE_ATALK:
 		if (ndo->ndo_vflag)
-			ND_PRINT("et1 ");
+			 ND_PRINT(C_RESET, "et1 ");
 		atalk_print(ndo, p, length);
 		return (1);
 
@@ -560,7 +560,7 @@ ethertype_print(netdissect_options *ndo,
 		return (1);
 
 	case ETHERTYPE_IPX:
-		ND_PRINT("(NOV-ETHII) ");
+		 ND_PRINT(C_RESET, "(NOV-ETHII) ");
 		ipx_print(ndo, p, length);
 		return (1);
 
@@ -593,7 +593,7 @@ ethertype_print(netdissect_options *ndo,
 
 	case ETHERTYPE_PPP:
 		if (length) {
-			ND_PRINT(": ");
+			 ND_PRINT(C_RESET, ": ");
 			ppp_print(ndo, p, length);
 		}
 		return (1);

--- a/print-fddi.c
+++ b/print-fddi.c
@@ -164,62 +164,62 @@ print_fddi_fc(netdissect_options *ndo, u_char fc)
 	switch (fc) {
 
 	case FDDIFC_VOID:                         /* Void frame */
-		ND_PRINT("void ");
+		ND_PRINT(C_RESET, "void ");
 		break;
 
 	case FDDIFC_NRT:                          /* Nonrestricted token */
-		ND_PRINT("nrt ");
+		ND_PRINT(C_RESET, "nrt ");
 		break;
 
 	case FDDIFC_RT:                           /* Restricted token */
-		ND_PRINT("rt ");
+		ND_PRINT(C_RESET, "rt ");
 		break;
 
 	case FDDIFC_SMT_INFO:                     /* SMT Info */
-		ND_PRINT("info ");
+		ND_PRINT(C_RESET, "info ");
 		break;
 
 	case FDDIFC_SMT_NSA:                      /* SMT Next station adrs */
-		ND_PRINT("nsa ");
+		ND_PRINT(C_RESET, "nsa ");
 		break;
 
 	case FDDIFC_MAC_BEACON:                   /* MAC Beacon frame */
-		ND_PRINT("beacon ");
+		ND_PRINT(C_RESET, "beacon ");
 		break;
 
 	case FDDIFC_MAC_CLAIM:                    /* MAC Claim frame */
-		ND_PRINT("claim ");
+		ND_PRINT(C_RESET, "claim ");
 		break;
 
 	default:
 		switch (fc & FDDIFC_CLFF) {
 
 		case FDDIFC_MAC:
-			ND_PRINT("mac%1x ", fc & FDDIFC_ZZZZ);
+			ND_PRINT(C_RESET, "mac%1x ", fc & FDDIFC_ZZZZ);
 			break;
 
 		case FDDIFC_SMT:
-			ND_PRINT("smt%1x ", fc & FDDIFC_ZZZZ);
+			ND_PRINT(C_RESET, "smt%1x ", fc & FDDIFC_ZZZZ);
 			break;
 
 		case FDDIFC_LLC_ASYNC:
-			ND_PRINT("async%1x ", fc & FDDIFC_ZZZZ);
+			ND_PRINT(C_RESET, "async%1x ", fc & FDDIFC_ZZZZ);
 			break;
 
 		case FDDIFC_LLC_SYNC:
-			ND_PRINT("sync%1x ", fc & FDDIFC_ZZZZ);
+			ND_PRINT(C_RESET, "sync%1x ", fc & FDDIFC_ZZZZ);
 			break;
 
 		case FDDIFC_IMP_ASYNC:
-			ND_PRINT("imp_async%1x ", fc & FDDIFC_ZZZZ);
+			ND_PRINT(C_RESET, "imp_async%1x ", fc & FDDIFC_ZZZZ);
 			break;
 
 		case FDDIFC_IMP_SYNC:
-			ND_PRINT("imp_sync%1x ", fc & FDDIFC_ZZZZ);
+			ND_PRINT(C_RESET, "imp_sync%1x ", fc & FDDIFC_ZZZZ);
 			break;
 
 		default:
-			ND_PRINT("%02x ", fc);
+			ND_PRINT(C_RESET, "%02x ", fc);
 			break;
 		}
 	}
@@ -262,7 +262,7 @@ fddi_hdr_print(netdissect_options *ndo,
 
 	if (!ndo->ndo_qflag)
 		print_fddi_fc(ndo, GET_U_1(fddip->fddi_fc));
-	ND_PRINT("%s > %s, length %u: ",
+	ND_PRINT(C_RESET, "%s > %s, length %u: ",
 	       srcname, dstname,
 	       length);
 }
@@ -270,7 +270,7 @@ fddi_hdr_print(netdissect_options *ndo,
 static void
 fddi_smt_print(netdissect_options *ndo, const u_char *p _U_, u_int length _U_)
 {
-	ND_PRINT("<SMT printer not yet implemented>");
+	ND_PRINT(C_RESET, "<SMT printer not yet implemented>");
 }
 
 u_int

--- a/print-forces.c
+++ b/print-forces.c
@@ -533,11 +533,11 @@ chk_op_type(netdissect_options *ndo,
 	if (type != F_TLV_PDAT) {
 		if (msk & B_KEYIN) {
 			if (type != F_TLV_KEYI) {
-				ND_PRINT("Based on flags expected KEYINFO TLV!\n");
+				ND_PRINT(C_RESET, "Based on flags expected KEYINFO TLV!\n");
 			}
 		} else {
 			if (!(msk & omsk)) {
-				ND_PRINT("Illegal DATA encoding for type 0x%x programmed %x got %x\n",
+				ND_PRINT(C_RESET, "Illegal DATA encoding for type 0x%x programmed %x got %x\n",
 				          type, omsk, msk);
 			}
 		}
@@ -672,20 +672,20 @@ prestlv_print(netdissect_options *ndo,
 	 */
 	dlen = len - TLV_HDRL;
 	if (dlen != RESLEN) {
-		ND_PRINT("illegal RESULT-TLV: %u bytes!\n", dlen);
+		ND_PRINT(C_RESET, "illegal RESULT-TLV: %u bytes!\n", dlen);
 		goto invalid;
 	}
 
 	ND_TCHECK_SIZE(r);
 	result = GET_U_1(r->result);
 	if (result >= 0x18 && result <= 0xFE) {
-		ND_PRINT("illegal reserved result code: 0x%x!\n", result);
+		ND_PRINT(C_RESET, "illegal reserved result code: 0x%x!\n", result);
 		goto invalid;
 	}
 
 	if (ndo->ndo_vflag >= 3) {
 		char *ib = indent_pr(indent, 0);
-		ND_PRINT("%s  Result: %s (code 0x%x)\n", ib,
+		ND_PRINT(C_RESET, "%s  Result: %s (code 0x%x)\n", ib,
 		       tok2str(ForCES_errs, NULL, result), result);
 	}
 	return 0;
@@ -712,15 +712,15 @@ fdatatlv_print(netdissect_options *ndo,
 	ND_TCHECK_SIZE(tlv);
 	type = GET_BE_U_2(tlv->type);
 	if (type != F_TLV_FULD) {
-		ND_PRINT("Error: expecting FULLDATA!\n");
+		ND_PRINT(C_RESET, "Error: expecting FULLDATA!\n");
 		goto invalid;
 	}
 
 	if (ndo->ndo_vflag >= 3) {
 		char *ib = indent_pr(indent + 2, 1);
-		ND_PRINT("%s[", ib + 1);
+		ND_PRINT(C_RESET, "%s[", ib + 1);
 		hex_print(ndo, ib, tdp, rlen);
-		ND_PRINT("\n%s]", ib + 1);
+		ND_PRINT(C_RESET, "\n%s]", ib + 1);
 	}
 	return 0;
 
@@ -738,7 +738,7 @@ sdatailv_print(netdissect_options *ndo,
 	int invilv;
 
 	if (len < ILV_HDRL) {
-		ND_PRINT("Error: BAD SPARSEDATA-TLV!\n");
+		ND_PRINT(C_RESET, "Error: BAD SPARSEDATA-TLV!\n");
 		goto invalid;
 	}
 	rlen = len;
@@ -748,13 +748,13 @@ sdatailv_print(netdissect_options *ndo,
 		const u_char *tdp = ILV_DATA(ilv);
 		invilv = ilv_valid(ndo, ilv, rlen);
 		if (invilv) {
-			ND_PRINT("Error: %s, rlen %u\n",
+			ND_PRINT(C_RESET, "Error: %s, rlen %u\n",
 			         tok2str(ForCES_TLV_err, NULL, invilv), rlen);
 			goto invalid;
 		}
 		if (ndo->ndo_vflag >= 3) {
 			u_int ilvl = GET_BE_U_4(ilv->length);
-			ND_PRINT("\n%s ILV: type %x length %u\n", ib + 1,
+			ND_PRINT(C_RESET, "\n%s ILV: type %x length %u\n", ib + 1,
 				  GET_BE_U_4(ilv->type), ilvl);
 			hex_print(ndo, "\t\t[", tdp, ilvl-ILV_HDRL);
 		}
@@ -785,7 +785,7 @@ sdatatlv_print(netdissect_options *ndo,
 	ND_TCHECK_SIZE(tlv);
 	type = GET_BE_U_2(tlv->type);
 	if (type != F_TLV_SPAD) {
-		ND_PRINT("Error: expecting SPARSEDATA!\n");
+		ND_PRINT(C_RESET, "Error: expecting SPARSEDATA!\n");
 		goto invalid;
 	}
 
@@ -810,13 +810,13 @@ pkeyitlv_print(netdissect_options *ndo,
 	u_int invtlv;
 
 	id = GET_BE_U_4(tdp);
-	ND_PRINT("%sKeyinfo: Key 0x%x\n", ib, id);
+	ND_PRINT(C_RESET, "%sKeyinfo: Key 0x%x\n", ib, id);
 	type = GET_BE_U_2(kdtlv->type);
 	tll = GET_BE_U_2(kdtlv->length);
 	invtlv = tlv_valid(tll, len);
 
 	if (invtlv) {
-		ND_PRINT("%s TLV type 0x%x len %u\n",
+		ND_PRINT(C_RESET, "%s TLV type 0x%x len %u\n",
 		       tok2str(ForCES_TLV_err, NULL, invtlv), type,
 		       tll);
 		goto invalid;
@@ -845,13 +845,13 @@ pdatacnt_print(netdissect_options *ndo,
 	char *ib = indent_pr(indent, 0);
 
 	if ((op_msk & B_APPND) && ndo->ndo_vflag >= 3) {
-		ND_PRINT("%sTABLE APPEND\n", ib);
+		ND_PRINT(C_RESET, "%sTABLE APPEND\n", ib);
 	}
 	for (i = 0; i < IDcnt; i++) {
 		ND_ICHECK_U(len, <, 4);
 		id = GET_BE_U_4(pptr);
 		if (ndo->ndo_vflag >= 3)
-			ND_PRINT("%sID#%02u: %u\n", ib, i + 1, id);
+			ND_PRINT(C_RESET, "%sID#%02u: %u\n", ib, i + 1, id);
 		len -= 4;
 		pptr += 4;
 	}
@@ -861,7 +861,7 @@ pdatacnt_print(netdissect_options *ndo,
 			uint32_t starti, endi;
 
 			if (len < PTH_DESC_SIZE) {
-				ND_PRINT("pathlength %u with key/range too short %u\n",
+				ND_PRINT(C_RESET, "pathlength %u with key/range too short %u\n",
 				       len, PTH_DESC_SIZE);
 				goto invalid;
 			}
@@ -878,7 +878,7 @@ pdatacnt_print(netdissect_options *ndo,
 			len -= 4;
 
 			if (ndo->ndo_vflag >= 3)
-				ND_PRINT("%sTable range: [%u,%u]\n", ib, starti, endi);
+				ND_PRINT(C_RESET, "%sTable range: [%u,%u]\n", ib, starti, endi);
 		}
 
 		if (op_msk & B_KEYIN) {
@@ -886,7 +886,7 @@ pdatacnt_print(netdissect_options *ndo,
 			uint16_t tll;
 
 			if (len < PTH_DESC_SIZE) {
-				ND_PRINT("pathlength %u with key/range too short %u\n",
+				ND_PRINT(C_RESET, "pathlength %u with key/range too short %u\n",
 				       len, PTH_DESC_SIZE);
 				goto invalid;
 			}
@@ -901,13 +901,13 @@ pdatacnt_print(netdissect_options *ndo,
 			/* skip key content */
 			tll = GET_BE_U_2(keytlv->length);
 			if (tll < TLV_HDRL) {
-				ND_PRINT("key content length %u < %u\n",
+				ND_PRINT(C_RESET, "key content length %u < %u\n",
 					tll, TLV_HDRL);
 				goto invalid;
 			}
 			tll -= TLV_HDRL;
 			if (len < tll) {
-				ND_PRINT("key content too short\n");
+				ND_PRINT(C_RESET, "key content too short\n");
 				goto invalid;
 			}
 			pptr += tll;
@@ -928,7 +928,7 @@ pdatacnt_print(netdissect_options *ndo,
 		tlvl = GET_BE_U_2(pdtlv->length);
 		invtlv = tlv_valid(tlvl, len);
 		if (invtlv) {
-			ND_PRINT("%s Outstanding bytes %u for TLV type 0x%x TLV len %u\n",
+			ND_PRINT(C_RESET, "%s Outstanding bytes %u for TLV type 0x%x TLV len %u\n",
 			          tok2str(ForCES_TLV_err, NULL, invtlv), len, type,
 			          tlvl);
 			goto pd_err;
@@ -942,7 +942,7 @@ pdatacnt_print(netdissect_options *ndo,
 		aln = F_ALN_LEN(tlvl);
 		if (aln > tlvl) {
 			if (aln > len) {
-				ND_PRINT("Invalid padded pathdata TLV type 0x%x len %u missing %u pad bytes\n",
+				ND_PRINT(C_RESET, "Invalid padded pathdata TLV type 0x%x len %u missing %u pad bytes\n",
 				          type, tlvl, aln - len);
 			} else {
 				pad = aln - tlvl;
@@ -953,10 +953,10 @@ pdatacnt_print(netdissect_options *ndo,
 
 			if (ndo->ndo_vflag >= 3 && ops->v != F_TLV_PDAT) {
 				if (pad)
-					ND_PRINT("%s  %s (Length %u DataLen %u pad %u Bytes)\n",
+					ND_PRINT(C_RESET, "%s  %s (Length %u DataLen %u pad %u Bytes)\n",
 					          ib, ops->s, tlvl, tll, pad);
 				else
-					ND_PRINT("%s  %s (Length %u DataLen %u Bytes)\n",
+					ND_PRINT(C_RESET, "%s  %s (Length %u DataLen %u Bytes)\n",
 					          ib, ops->s, tlvl, tll);
 			}
 
@@ -967,13 +967,13 @@ pdatacnt_print(netdissect_options *ndo,
 				    ==, -1);
 			len -= (TLV_HDRL + pad + tll);
 		} else {
-			ND_PRINT("Invalid path data content type 0x%x len %u\n",
+			ND_PRINT(C_RESET, "Invalid path data content type 0x%x len %u\n",
 			       type, tlvl);
 pd_err:
 			if (tlvl) {
                                 hex_print(ndo, "Bad Data val\n\t  [",
 					  pptr, len);
-				ND_PRINT("]\n");
+				ND_PRINT(C_RESET, "]\n");
 
 				goto invalid;
 			}
@@ -999,7 +999,7 @@ pdata_print(netdissect_options *ndo,
 	ND_TCHECK_SIZE(pdh);
 	ND_ICHECK_ZU(len, <, sizeof(struct pathdata_h));
 	if (ndo->ndo_vflag >= 3) {
-		ND_PRINT("\n%sPathdata: Flags 0x%x ID count %u\n",
+		ND_PRINT(C_RESET, "\n%sPathdata: Flags 0x%x ID count %u\n",
 		       ib, GET_BE_U_2(pdh->pflags),
 		       GET_BE_U_2(pdh->pIDcnt));
 	}
@@ -1022,15 +1022,15 @@ pdata_print(netdissect_options *ndo,
 	idcnt = GET_BE_U_2(pdh->pIDcnt);
 	minsize = idcnt * 4;
 	if (len < minsize) {
-		ND_PRINT("\t\t\ttruncated IDs expected %uB got %uB\n", minsize,
+		ND_PRINT(C_RESET, "\t\t\ttruncated IDs expected %uB got %uB\n", minsize,
 		       len);
 		hex_print(ndo, "\t\t\tID Data[", pptr, len);
-		ND_PRINT("]\n");
+		ND_PRINT(C_RESET, "]\n");
 		goto invalid;
 	}
 
 	if ((op_msk & B_TRNG) && (op_msk & B_KEYIN)) {
-		ND_PRINT("\t\t\tIllegal to have both Table ranges and keys\n");
+		ND_PRINT(C_RESET, "\t\t\tIllegal to have both Table ranges and keys\n");
 		goto invalid;
 	}
 
@@ -1062,10 +1062,10 @@ genoptlv_print(netdissect_options *ndo,
 	type = GET_BE_U_2(pdtlv->type);
 	tlvl = GET_BE_U_2(pdtlv->length);
 	invtlv = tlv_valid(tlvl, len);
-	ND_PRINT("genoptlvprint - %s TLV type 0x%x len %u\n",
+	ND_PRINT(C_RESET, "genoptlvprint - %s TLV type 0x%x len %u\n",
 	       tok2str(ForCES_TLV, NULL, type), type, tlvl);
 	if (invtlv) {
-		ND_PRINT("\t\t\tInvalid ForCES TLV type=%x", type);
+		ND_PRINT(C_RESET, "\t\t\tInvalid ForCES TLV type=%x", type);
 		goto invalid;
 	}
 	/*
@@ -1076,13 +1076,13 @@ genoptlv_print(netdissect_options *ndo,
 	const u_char *dp = TLV_DATA(pdtlv);
 
 	if (!ttlv_valid(type)) {
-		ND_PRINT("%s TLV type 0x%x len %u\n",
+		ND_PRINT(C_RESET, "%s TLV type 0x%x len %u\n",
 		       tok2str(ForCES_TLV_err, NULL, invtlv), type,
 		       tlvl);
 		goto invalid;
 	}
 	if (ndo->ndo_vflag >= 3)
-		ND_PRINT("%s%s, length %u (data length %u Bytes)",
+		ND_PRINT(C_RESET, "%s%s, length %u (data length %u Bytes)",
 		       ib, tok2str(ForCES_TLV, NULL, type),
 		       tlvl, tlvl - TLV_HDRL);
 
@@ -1120,7 +1120,7 @@ recpdoptlv_print(netdissect_options *ndo,
 		dp = TLV_DATA(pdtlv);
 
 		if (ndo->ndo_vflag >= 3)
-			ND_PRINT("%s%s, length %u (data encapsulated %u Bytes)",
+			ND_PRINT(C_RESET, "%s%s, length %u (data encapsulated %u Bytes)",
 			          ib, tok2str(ForCES_TLV, NULL, type),
 			          tlvl,
 			          tlvl - TLV_HDRL);
@@ -1131,7 +1131,7 @@ recpdoptlv_print(netdissect_options *ndo,
 	}
 
 	if (len) {
-		ND_PRINT("\n\t\tMessy PATHDATA TLV header, type (0x%x)\n\t\texcess of %u Bytes ",
+		ND_PRINT(C_RESET, "\n\t\tMessy PATHDATA TLV header, type (0x%x)\n\t\texcess of %u Bytes ",
 		          GET_BE_U_2(pdtlv->type),
 		          len - GET_BE_U_2(pdtlv->length));
 		goto invalid;
@@ -1150,9 +1150,9 @@ invoptlv_print(netdissect_options *ndo,
 	char *ib = indent_pr(indent, 1);
 
 	if (ndo->ndo_vflag >= 3) {
-		ND_PRINT("%sData[", ib + 1);
+		ND_PRINT(C_RESET, "%sData[", ib + 1);
 		hex_print(ndo, ib, pptr, len);
-		ND_PRINT("%s]\n", ib);
+		ND_PRINT(C_RESET, "%s]\n", ib);
 	}
 	return -1;
 }
@@ -1176,14 +1176,14 @@ otlv_print(netdissect_options *ndo,
 	tll = GET_BE_U_2(otlv->length) - TLV_HDRL;
 	ops = get_forces_optlv_h(type);
 	if (ndo->ndo_vflag >= 3) {
-		ND_PRINT("%sOper TLV %s(0x%x) length %u\n", ib, ops->s, type,
+		ND_PRINT(C_RESET, "%sOper TLV %s(0x%x) length %u\n", ib, ops->s, type,
 		       GET_BE_U_2(otlv->length));
 	}
 	/* rest of ops must at least have 12B {pathinfo} */
 	if (tll < OP_MIN_SIZ) {
-		ND_PRINT("\t\tOper TLV %s(0x%x) length %u\n", ops->s, type,
+		ND_PRINT(C_RESET, "\t\tOper TLV %s(0x%x) length %u\n", ops->s, type,
 		       GET_BE_U_2(otlv->length));
-		ND_PRINT("\t\tTruncated data size %u minimum required %u\n", tll,
+		ND_PRINT(C_RESET, "\t\tTruncated data size %u minimum required %u\n", tll,
 		       OP_MIN_SIZ);
 		return invoptlv_print(ndo, dp, tll, ops->op_msk, indent);
 
@@ -1213,19 +1213,19 @@ asttlv_print(netdissect_options *ndo,
 	 */
 	dlen = len - TLV_HDRL;
 	if (dlen != ASTDLN) {
-		ND_PRINT("illegal ASTresult-TLV: %u bytes!\n", dlen);
+		ND_PRINT(C_RESET, "illegal ASTresult-TLV: %u bytes!\n", dlen);
 		goto invalid;
 	}
 	rescode = GET_BE_U_4(pptr);
 	if (rescode > ASTMCD) {
-		ND_PRINT("illegal ASTresult result code: %u!\n", rescode);
+		ND_PRINT(C_RESET, "illegal ASTresult result code: %u!\n", rescode);
 		goto invalid;
 	}
 
 	if (ndo->ndo_vflag >= 3) {
-		ND_PRINT("Teardown reason:\n%s%s", ib,
+		ND_PRINT(C_RESET, "Teardown reason:\n%s%s", ib,
 		         tok2str(tdr_str, "unknown (%u)", rescode));
-		ND_PRINT("(%x)\n%s", rescode, ib);
+		ND_PRINT(C_RESET, "(%x)\n%s", rescode, ib);
 	}
 	return 0;
 invalid:
@@ -1249,33 +1249,33 @@ asrtlv_print(netdissect_options *ndo,
 	 */
 	dlen = len - TLV_HDRL;
 	if (dlen != ASRDLN) {	/* id, instance, oper tlv */
-		ND_PRINT("illegal ASRresult-TLV: %u bytes!\n", dlen);
+		ND_PRINT(C_RESET, "illegal ASRresult-TLV: %u bytes!\n", dlen);
 		goto invalid;
 	}
 	rescode = GET_BE_U_4(pptr);
 
 	if (rescode > ASRMCD) {
-		ND_PRINT("illegal ASRresult result code: %u!\n", rescode);
+		ND_PRINT(C_RESET, "illegal ASRresult result code: %u!\n", rescode);
 		goto invalid;
 	}
 
 	if (ndo->ndo_vflag >= 3) {
-		ND_PRINT("\n%s", ib);
+		ND_PRINT(C_RESET, "\n%s", ib);
 		switch (rescode) {
 		case 0:
-			ND_PRINT("Success ");
+			ND_PRINT(C_RESET, "Success ");
 			break;
 		case 1:
-			ND_PRINT("FE ID invalid ");
+			ND_PRINT(C_RESET, "FE ID invalid ");
 			break;
 		case 2:
-			ND_PRINT("permission denied ");
+			ND_PRINT(C_RESET, "permission denied ");
 			break;
 		default:
-			ND_PRINT("Unknown ");
+			ND_PRINT(C_RESET, "Unknown ");
 			break;
 		}
-		ND_PRINT("(%x)\n%s", rescode, ib);
+		ND_PRINT(C_RESET, "(%x)\n%s", rescode, ib);
 	}
 	return 0;
 invalid:
@@ -1294,7 +1294,7 @@ gentltlv_print(netdissect_options *ndo,
 	u_int dlen = len - TLV_HDRL;
 
 	if (dlen < 4) {		/* at least 32 bits must exist */
-		ND_PRINT("truncated TLV: %u bytes missing! ", 4 - dlen);
+		ND_PRINT(C_RESET, "truncated TLV: %u bytes missing! ", 4 - dlen);
 		return -1;
 	}
 	return 0;
@@ -1317,11 +1317,11 @@ print_metailv(netdissect_options *ndo,
 	 * ILV) >= ILV_HDRL.
 	 */
 	rlen = GET_BE_U_4(ilv->length) - ILV_HDRL;
-	ND_PRINT("%sMetaID 0x%x length %u\n", ib, GET_BE_U_4(ilv->type),
+	ND_PRINT(C_RESET, "%sMetaID 0x%x length %u\n", ib, GET_BE_U_4(ilv->type),
 		  GET_BE_U_4(ilv->length));
 	if (ndo->ndo_vflag >= 3) {
 		hex_print(ndo, "\t\t[", ILV_DATA(ilv), rlen);
-		ND_PRINT(" ]\n");
+		ND_PRINT(C_RESET, " ]\n");
 	}
 	return 0;
 }
@@ -1343,7 +1343,7 @@ print_metatlv(netdissect_options *ndo,
 	 */
 	dlen = len - TLV_HDRL;
 	rlen = dlen;
-	ND_PRINT("\n%s METADATA length %u\n", ib, rlen);
+	ND_PRINT(C_RESET, "\n%s METADATA length %u\n", ib, rlen);
 	while (rlen != 0) {
 		invilv = ilv_valid(ndo, ilv, rlen);
 		if (invilv) {
@@ -1374,12 +1374,12 @@ print_reddata(netdissect_options *ndo,
 
 	dlen = len - TLV_HDRL;
 	rlen = dlen;
-	ND_PRINT("\n%s Redirect Data length %u\n", ib, rlen);
+	ND_PRINT(C_RESET, "\n%s Redirect Data length %u\n", ib, rlen);
 
 	if (ndo->ndo_vflag >= 3) {
-		ND_PRINT("\t\t[");
+		ND_PRINT(C_RESET, "\t\t[");
 		hex_print(ndo, "\n\t\t", pptr, rlen);
-		ND_PRINT("\n\t\t]");
+		ND_PRINT(C_RESET, "\n\t\t]");
 	}
 
 	return 0;
@@ -1401,7 +1401,7 @@ redirect_print(netdissect_options *ndo,
 	 */
 	dlen = len - TLV_HDRL;
 	if (dlen <= RD_MIN) {
-		ND_PRINT("\n\t\ttruncated Redirect TLV: %u bytes missing! ",
+		ND_PRINT(C_RESET, "\n\t\ttruncated Redirect TLV: %u bytes missing! ",
 		       RD_MIN - dlen);
 		goto invalid;
 	}
@@ -1415,7 +1415,7 @@ redirect_print(netdissect_options *ndo,
 		tlvl = GET_BE_U_2(tlv->length);
 		invtlv = tlv_valid(tlvl, rlen);
 		if (invtlv) {
-			ND_PRINT("Bad Redirect data\n");
+			ND_PRINT(C_RESET, "Bad Redirect data\n");
 			break;
 		}
 
@@ -1433,7 +1433,7 @@ redirect_print(netdissect_options *ndo,
 				      tlvl, 0,
 				      indent);
 		} else {
-			ND_PRINT("Unknown REDIRECT TLV 0x%x len %u\n",
+			ND_PRINT(C_RESET, "Unknown REDIRECT TLV 0x%x len %u\n",
 			       type,
 			       tlvl);
 		}
@@ -1442,7 +1442,7 @@ redirect_print(netdissect_options *ndo,
 	}
 
 	if (rlen) {
-		ND_PRINT("\n\t\tMessy Redirect TLV header, type (0x%x)\n\t\texcess of %u Bytes ",
+		ND_PRINT(C_RESET, "\n\t\tMessy Redirect TLV header, type (0x%x)\n\t\texcess of %u Bytes ",
 		          GET_BE_U_2(tlv->type),
 		          rlen - GET_BE_U_2(tlv->length));
 		goto invalid;
@@ -1474,7 +1474,7 @@ lfbselect_print(netdissect_options *ndo,
 	 */
 	dlen = len - TLV_HDRL;
 	if (dlen <= OP_MIN) {	/* id, instance, oper tlv header .. */
-		ND_PRINT("\n\t\tundersized lfb selector: %u bytes missing! ",
+		ND_PRINT(C_RESET, "\n\t\tundersized lfb selector: %u bytes missing! ",
 		       OP_MIN - dlen);
 		goto invalid;
 	}
@@ -1488,7 +1488,7 @@ lfbselect_print(netdissect_options *ndo,
 	lfbs = (const struct forces_lfbsh *)pptr;
 	ND_TCHECK_SIZE(lfbs);
 	if (ndo->ndo_vflag >= 3) {
-		ND_PRINT("\n%s%s(Classid %x) instance %x\n",
+		ND_PRINT(C_RESET, "\n%s%s(Classid %x) instance %x\n",
 		       ib,
 		       tok2str(ForCES_LFBs, NULL, GET_BE_U_4(lfbs->class)),
 		       GET_BE_U_4(lfbs->class),
@@ -1516,8 +1516,8 @@ lfbselect_print(netdissect_options *ndo,
 			otlv_print(ndo, otlv, 0, indent);
 		} else {
 			if (ndo->ndo_vflag < 3)
-				ND_PRINT("\n");
-			ND_PRINT("\t\tINValid oper-TLV type 0x%x length %u for this ForCES message\n",
+				ND_PRINT(C_RESET, "\n");
+			ND_PRINT(C_RESET, "\t\tINValid oper-TLV type 0x%x length %u for this ForCES message\n",
 			          type, tlvl);
 			invoptlv_print(ndo, (const u_char *)otlv, rlen, 0, indent);
 		}
@@ -1525,7 +1525,7 @@ lfbselect_print(netdissect_options *ndo,
 	}
 
 	if (rlen) {
-		ND_PRINT("\n\t\tMessy oper TLV header, type (0x%x)\n\t\texcess of %u Bytes ",
+		ND_PRINT(C_RESET, "\n\t\tMessy oper TLV header, type (0x%x)\n\t\texcess of %u Bytes ",
 		          GET_BE_U_2(otlv->type),
 		          rlen - GET_BE_U_2(otlv->length));
 		goto invalid;
@@ -1556,14 +1556,14 @@ forces_type_print(netdissect_options *ndo,
 
 	if (rlen > TLV_HLN) {
 		if (tops->flags & ZERO_TTLV) {
-			ND_PRINT("<0x%x>Illegal Top level TLV!\n", tops->flags);
+			ND_PRINT(C_RESET, "<0x%x>Illegal Top level TLV!\n", tops->flags);
 			goto invalid;
 		}
 	} else {
 		if (tops->flags & ZERO_MORE_TTLV)
 			return 0;
 		if (tops->flags & ONE_MORE_TTLV) {
-			ND_PRINT("\tTop level TLV Data missing!\n");
+			ND_PRINT(C_RESET, "\tTop level TLV Data missing!\n");
 			goto invalid;
 		}
 	}
@@ -1592,13 +1592,13 @@ forces_type_print(netdissect_options *ndo,
 		 * go past the end of the packet).
 		 */
 		if (!ttlv_valid(type)) {
-			ND_PRINT("\n\tInvalid ForCES Top TLV type=0x%x",
+			ND_PRINT(C_RESET, "\n\tInvalid ForCES Top TLV type=0x%x",
 			       type);
 			goto invalid;
 		}
 
 		if (ndo->ndo_vflag >= 3)
-			ND_PRINT("\t%s, length %u (data length %u Bytes)",
+			ND_PRINT(C_RESET, "\t%s, length %u (data length %u Bytes)",
 			       tok2str(ForCES_TLV, NULL, type),
 			       tlvl,
 			       tlvl - TLV_HDRL);
@@ -1617,7 +1617,7 @@ forces_type_print(netdissect_options *ndo,
 	 * short, and didn't have *enough* TLVs in it?
 	 */
 	if (rlen) {
-		ND_PRINT("\tMess TopTLV header: min %u, total %u advertised %u ",
+		ND_PRINT(C_RESET, "\tMess TopTLV header: min %u, total %u advertised %u ",
 		       TLV_HDRL, rlen, GET_BE_U_2(tltlv->length));
 		goto invalid;
 	}
@@ -1643,7 +1643,7 @@ forces_print(netdissect_options *ndo,
 	ND_TCHECK_SIZE(fhdr);
 	tom = GET_U_1(fhdr->fm_tom);
 	if (!tom_valid(tom)) {
-		ND_PRINT("Invalid ForCES message type %u\n", tom);
+		ND_PRINT(C_RESET, "Invalid ForCES message type %u\n", tom);
 		goto invalid;
 	}
 
@@ -1651,29 +1651,29 @@ forces_print(netdissect_options *ndo,
 
 	tops = get_forces_tom(tom);
 	if (tops->v == TOM_RSVD) {
-		ND_PRINT("\n\tUnknown ForCES message type=0x%x", tom);
+		ND_PRINT(C_RESET, "\n\tUnknown ForCES message type=0x%x", tom);
 		goto invalid;
 	}
 
-	ND_PRINT("\n\tForCES %s ", tops->s);
+	ND_PRINT(C_RESET, "\n\tForCES %s ", tops->s);
 	if (!ForCES_HLN_VALID(mlen, len)) {
-		ND_PRINT("Illegal ForCES pkt len - min %u, total recvd %u, advertised %u ",
+		ND_PRINT(C_RESET, "Illegal ForCES pkt len - min %u, total recvd %u, advertised %u ",
 		          ForCES_HDRL, len, ForCES_BLN(fhdr));
 		goto invalid;
 	}
 
 	flg_raw = GET_BE_U_4(pptr + 20);
 	if (ndo->ndo_vflag >= 1) {
-		ND_PRINT("\n\tForCES Version %u len %uB flags 0x%08x ",
+		ND_PRINT(C_RESET, "\n\tForCES Version %u len %uB flags 0x%08x ",
 		       ForCES_V(fhdr), mlen, flg_raw);
-		ND_PRINT("\n\tSrcID 0x%x(%s) DstID 0x%x(%s) Correlator 0x%" PRIx64,
+		ND_PRINT(C_RESET, "\n\tSrcID 0x%x(%s) DstID 0x%x(%s) Correlator 0x%" PRIx64,
 		       ForCES_SID(fhdr), ForCES_node(ForCES_SID(fhdr)),
 		       ForCES_DID(fhdr), ForCES_node(ForCES_DID(fhdr)),
 		       GET_BE_U_8(fhdr->fm_cor));
 
 	}
 	if (ndo->ndo_vflag >= 2) {
-		ND_PRINT("\n\tForCES flags:\n\t  %s(0x%x), prio=%u, %s(0x%x),\n\t  %s(0x%x), %s(0x%x)\n",
+		ND_PRINT(C_RESET, "\n\tForCES flags:\n\t  %s(0x%x), prio=%u, %s(0x%x),\n\t  %s(0x%x), %s(0x%x)\n",
 		     tok2str(ForCES_ACKs, "ACKUnknown", ForCES_ACK(fhdr)),
 		     ForCES_ACK(fhdr),
 		     ForCES_PRI(fhdr),
@@ -1683,16 +1683,16 @@ forces_print(netdissect_options *ndo,
 		     ForCES_AT(fhdr),
 		     tok2str(ForCES_TPs, "TPUnknown", ForCES_TP(fhdr)),
 		     ForCES_TP(fhdr));
-		ND_PRINT("\t  Extra flags: rsv(b5-7) 0x%x rsv(b13-31) 0x%x\n",
+		ND_PRINT(C_RESET, "\t  Extra flags: rsv(b5-7) 0x%x rsv(b13-31) 0x%x\n",
 		     ForCES_RS1(fhdr), ForCES_RS2(fhdr));
 	}
 	rc = forces_type_print(ndo, pptr, fhdr, mlen, tops);
 	ND_ICHECK_U(rc, <, 0);
 
 	if (ndo->ndo_vflag >= 4) {
-		ND_PRINT("\n\t  Raw ForCES message\n\t [");
+		ND_PRINT(C_RESET, "\n\t  Raw ForCES message\n\t [");
 		hex_print(ndo, "\n\t ", pptr, len);
-		ND_PRINT("\n\t ]");
+		ND_PRINT(C_RESET, "\n\t ]");
 	}
 	return;
 invalid:

--- a/print-fr.c
+++ b/print-fr.c
@@ -197,12 +197,12 @@ fr_hdr_print(netdissect_options *ndo, int length, u_int addr_len,
 	     u_int dlci, uint32_t flags, uint16_t nlpid)
 {
     if (ndo->ndo_qflag) {
-        ND_PRINT("Q.922, DLCI %u, length %u: ",
+        ND_PRINT(C_RESET, "Q.922, DLCI %u, length %u: ",
                      dlci,
                      length);
     } else {
         if (nlpid <= 0xff) /* if its smaller than 256 then its a NLPID */
-            ND_PRINT("Q.922, hdr-len %u, DLCI %u, Flags [%s], NLPID %s (0x%02x), length %u: ",
+            ND_PRINT(C_RESET, "Q.922, hdr-len %u, DLCI %u, Flags [%s], NLPID %s (0x%02x), length %u: ",
                          addr_len,
                          dlci,
                          bittok2str(fr_header_flag_values, "none", flags),
@@ -210,7 +210,7 @@ fr_hdr_print(netdissect_options *ndo, int length, u_int addr_len,
                          nlpid,
                          length);
         else /* must be an ethertype */
-            ND_PRINT("Q.922, hdr-len %u, DLCI %u, Flags [%s], cisco-ethertype %s (0x%04x), length %u: ",
+            ND_PRINT(C_RESET, "Q.922, hdr-len %u, DLCI %u, Flags [%s], cisco-ethertype %s (0x%04x), length %u: ",
                          addr_len,
                          dlci,
                          bittok2str(fr_header_flag_values, "none", flags),
@@ -255,7 +255,7 @@ fr_print(netdissect_options *ndo,
 	if (ret == -1)
 		goto trunc;
 	if (ret == 0) {
-		ND_PRINT("Q.922, invalid address");
+		ND_PRINT(C_RESET, "Q.922, invalid address");
 		return 0;
 	}
 
@@ -271,7 +271,7 @@ fr_print(netdissect_options *ndo,
                  */
 		if (!ND_TTEST_2(p + addr_len) || length < addr_len + 2) {
                         /* no Ethertype */
-                        ND_PRINT("UI %02x! ", GET_U_1(p + addr_len));
+                        ND_PRINT(C_RESET, "UI %02x! ", GET_U_1(p + addr_len));
                 } else {
                         extracted_ethertype = GET_BE_U_2(p + addr_len);
 
@@ -285,7 +285,7 @@ fr_print(netdissect_options *ndo,
                                             ND_BYTES_AVAILABLE_AFTER(p)-addr_len-ETHERTYPE_LEN,
                                             NULL, NULL) == 0)
                                 /* ether_type not known, probably it wasn't one */
-                                ND_PRINT("UI %02x! ", GET_U_1(p + addr_len));
+                                ND_PRINT(C_RESET, "UI %02x! ", GET_U_1(p + addr_len));
                         else
                                 return addr_len + 2;
                 }
@@ -301,7 +301,7 @@ fr_print(netdissect_options *ndo,
 		 * A pad byte should only be used with 3-byte Q.922.
 		 */
 		if (addr_len != 3)
-			ND_PRINT("Pad! ");
+			ND_PRINT(C_RESET, "Pad! ");
 		hdr_len = addr_len + 1 /* UI */ + 1 /* pad */ + 1 /* NLPID */;
 	} else {
 		/*
@@ -309,7 +309,7 @@ fr_print(netdissect_options *ndo,
 		 * A pad byte should be used with 3-byte Q.922.
 		 */
 		if (addr_len == 3)
-			ND_PRINT("No pad! ");
+			ND_PRINT(C_RESET, "No pad! ");
 		hdr_len = addr_len + 1 /* UI */ + 1 /* NLPID */;
 	}
 
@@ -465,14 +465,14 @@ mfr_print(netdissect_options *ndo,
     ndo->ndo_protocol = "mfr";
 
     if (length < 4) {	/* minimum frame header length */
-        ND_PRINT("[length %u < 4]", length);
+        ND_PRINT(C_RESET, "[length %u < 4]", length);
         nd_print_invalid(ndo);
         return length;
     }
     ND_TCHECK_4(p);
 
     if ((GET_U_1(p) & MFR_BEC_MASK) == MFR_CTRL_FRAME && GET_U_1(p + 1) == 0) {
-        ND_PRINT("FRF.16 Control, Flags [%s], %s, length %u",
+        ND_PRINT(C_RESET, "FRF.16 Control, Flags [%s], %s, length %u",
                bittok2str(frf_flag_values,"none",(GET_U_1(p) & MFR_BEC_MASK)),
                tok2str(mfr_ctrl_msg_values,"Unknown Message (0x%02x)",GET_U_1(p + 2)),
                length);
@@ -488,7 +488,7 @@ mfr_print(netdissect_options *ndo,
             ie_type=GET_U_1(tptr);
             ie_len=GET_U_1(tptr + 1);
 
-            ND_PRINT("\n\tIE %s (%u), length %u: ",
+            ND_PRINT(C_RESET, "\n\tIE %s (%u), length %u: ",
                    tok2str(mfr_ctrl_ie_values,"Unknown",ie_type),
                    ie_type,
                    ie_len);
@@ -508,11 +508,11 @@ mfr_print(netdissect_options *ndo,
             case MFR_CTRL_IE_MAGIC_NUM:
                 /* FRF.16.1 Section 3.4.3 Magic Number Information Element */
                 if (ie_len != 4) {
-                    ND_PRINT("[IE data length %d != 4]", ie_len);
+                    ND_PRINT(C_RESET, "[IE data length %d != 4]", ie_len);
                     nd_print_invalid(ndo);
                     break;
                 }
-                ND_PRINT("0x%08x", GET_BE_U_4(tptr));
+                ND_PRINT(C_RESET, "0x%08x", GET_BE_U_4(tptr));
                 break;
 
             case MFR_CTRL_IE_BUNDLE_ID: /* same message format */
@@ -575,7 +575,7 @@ mfr_print(netdissect_options *ndo,
     /* whole packet or first fragment ? */
     if ((GET_U_1(p) & MFR_BEC_MASK) == MFR_FRAG_FRAME ||
         (GET_U_1(p) & MFR_BEC_MASK) == MFR_B_BIT) {
-        ND_PRINT("FRF.16 Frag, seq %u, Flags [%s], ",
+        ND_PRINT(C_RESET, "FRF.16 Frag, seq %u, Flags [%s], ",
                sequence_num,
                bittok2str(frf_flag_values,"none",(GET_U_1(p) & MFR_BEC_MASK)));
         hdr_len = 2;
@@ -584,7 +584,7 @@ mfr_print(netdissect_options *ndo,
     }
 
     /* must be a middle or the last fragment */
-    ND_PRINT("FRF.16 Frag, seq %u, Flags [%s]",
+    ND_PRINT(C_RESET, "FRF.16 Frag, seq %u, Flags [%s]",
            sequence_num,
            bittok2str(frf_flag_values,"none",(GET_U_1(p) & MFR_BEC_MASK)));
     print_unknown_data(ndo, p, "\n\t", length);
@@ -625,7 +625,7 @@ frf15_print(netdissect_options *ndo,
     flags = GET_U_1(p)&MFR_BEC_MASK;
     sequence_num = (GET_U_1(p)&0x1e)<<7 | GET_U_1(p + 1);
 
-    ND_PRINT("FRF.15, seq 0x%03x, Flags [%s],%s Fragmentation, length %u",
+    ND_PRINT(C_RESET, "FRF.15, seq 0x%03x, Flags [%s],%s Fragmentation, length %u",
            sequence_num,
            bittok2str(frf_flag_values,"none",flags),
            GET_U_1(p)&FR_FRF15_FRAGTYPE ? "Interface" : "End-to-End",
@@ -819,12 +819,12 @@ q933_print(netdissect_options *ndo,
 	u_int unshift_codeset;
 
 	ndo->ndo_protocol = "q.933";
-	ND_PRINT("%s", ndo->ndo_eflag ? "" : "Q.933");
+	ND_PRINT(C_RESET, "%s", ndo->ndo_eflag ? "" : "Q.933");
 
 	if (length == 0 || !ND_TTEST_1(p)) {
 		if (!ndo->ndo_eflag)
-			ND_PRINT(", ");
-		ND_PRINT("length %u", length);
+			ND_PRINT(C_RESET, ", ");
+		ND_PRINT(C_RESET, "length %u", length);
 		goto trunc;
 	}
 
@@ -842,8 +842,8 @@ q933_print(netdissect_options *ndo,
 	for (i = 0; i < call_ref_length; i++) {
 		if (length == 0 || !ND_TTEST_1(p)) {
 			if (!ndo->ndo_eflag)
-				ND_PRINT(", ");
-			ND_PRINT("length %u", olen);
+				ND_PRINT(C_RESET, ", ");
+			ND_PRINT(C_RESET, "length %u", olen);
 			goto trunc;
 		}
 		call_ref[i] = GET_U_1(p);
@@ -856,8 +856,8 @@ q933_print(netdissect_options *ndo,
 	 */
 	if (length == 0 || !ND_TTEST_1(p)) {
 		if (!ndo->ndo_eflag)
-			ND_PRINT(", ");
-		ND_PRINT("length %u", olen);
+			ND_PRINT(C_RESET, ", ");
+		ND_PRINT(C_RESET, "length %u", olen);
 		goto trunc;
 	}
 	msgtype = GET_U_1(p);
@@ -872,8 +872,8 @@ q933_print(netdissect_options *ndo,
 	if (length != 0) {
 		if (!ND_TTEST_1(p)) {
 			if (!ndo->ndo_eflag)
-				ND_PRINT(", ");
-			ND_PRINT("length %u", olen);
+				ND_PRINT(C_RESET, ", ");
+			ND_PRINT(C_RESET, "length %u", olen);
 			goto trunc;
 		}
 		iecode = GET_U_1(p);
@@ -922,27 +922,27 @@ q933_print(netdissect_options *ndo,
 
 	/* printing out header part */
 	if (!ndo->ndo_eflag)
-		ND_PRINT(", ");
-	ND_PRINT("%s, codeset %u", is_ansi ? "ANSI" : "CCITT", codeset);
+		ND_PRINT(C_RESET, ", ");
+	ND_PRINT(C_RESET, "%s, codeset %u", is_ansi ? "ANSI" : "CCITT", codeset);
 
 	if (call_ref_length != 0) {
 		if (call_ref_length > 1 || GET_U_1(p) != 0) {
 			/*
 			 * Not a dummy call reference.
 			 */
-			ND_PRINT(", Call Ref: 0x");
+			ND_PRINT(C_RESET, ", Call Ref: 0x");
 			for (i = 0; i < call_ref_length; i++)
-				ND_PRINT("%02x", call_ref[i]);
+				ND_PRINT(C_RESET, "%02x", call_ref[i]);
 		}
 	}
 	if (ndo->ndo_vflag) {
-		ND_PRINT(", %s (0x%02x), length %u",
+		ND_PRINT(C_RESET, ", %s (0x%02x), length %u",
 		   tok2str(fr_q933_msg_values,
 			"unknown message", msgtype),
 		   msgtype,
 		   olen);
 	} else {
-		ND_PRINT(", %s",
+		ND_PRINT(C_RESET, ", %s",
 		       tok2str(fr_q933_msg_values,
 			       "unknown message 0x%02x", msgtype));
 	}
@@ -972,7 +972,7 @@ q933_print(netdissect_options *ndo,
 		 */
 		if (!ND_TTEST_1(p)) {
 			if (!ndo->ndo_vflag) {
-				ND_PRINT(", length %u", olen);
+				ND_PRINT(C_RESET, ", length %u", olen);
 			}
 			goto trunc;
 		}
@@ -1015,7 +1015,7 @@ q933_print(netdissect_options *ndo,
 			 */
 			if (length == 0 || !ND_TTEST_1(p)) {
 				if (!ndo->ndo_vflag) {
-					ND_PRINT(", length %u", olen);
+					ND_PRINT(C_RESET, ", length %u", olen);
 				}
 				goto trunc;
 			}
@@ -1027,7 +1027,7 @@ q933_print(netdissect_options *ndo,
 			 * however some IEs (DLCI Status, Link Verify)
 			 * are also interesting in non-verbose mode */
 			if (ndo->ndo_vflag) {
-				ND_PRINT("\n\t%s IE (0x%02x), length %u: ",
+				ND_PRINT(C_RESET, "\n\t%s IE (0x%02x), length %u: ",
 				    tok2str(fr_q933_ie_codesets[codeset],
 					"unknown", iecode),
 				    iecode,
@@ -1040,7 +1040,7 @@ q933_print(netdissect_options *ndo,
 			}
 			if (length < ielength || !ND_TTEST_LEN(p, ielength)) {
 				if (!ndo->ndo_vflag) {
-					ND_PRINT(", length %u", olen);
+					ND_PRINT(C_RESET, ", length %u", olen);
 				}
 				goto trunc;
 			}
@@ -1074,7 +1074,7 @@ q933_print(netdissect_options *ndo,
 		}
 	}
 	if (!ndo->ndo_vflag) {
-	    ND_PRINT(", length %u", olen);
+	    ND_PRINT(C_RESET, ", length %u", olen);
 	}
 	return;
 
@@ -1094,13 +1094,13 @@ fr_q933_print_ie_codeset_0_5(netdissect_options *ndo, u_int iecode,
         case FR_LMI_CCITT_REPORT_TYPE_IE:
             if (ielength < 1) {
                 if (!ndo->ndo_vflag) {
-                    ND_PRINT(", ");
+                    ND_PRINT(C_RESET, ", ");
 	        }
-                ND_PRINT("Invalid REPORT TYPE IE");
+                ND_PRINT(C_RESET, "Invalid REPORT TYPE IE");
                 return 1;
             }
             if (ndo->ndo_vflag) {
-                ND_PRINT("%s (%u)",
+                ND_PRINT(C_RESET, "%s (%u)",
                        tok2str(fr_lmi_report_type_ie_values,"unknown",GET_U_1(p)),
                        GET_U_1(p));
 	    }
@@ -1110,19 +1110,19 @@ fr_q933_print_ie_codeset_0_5(netdissect_options *ndo, u_int iecode,
         case FR_LMI_CCITT_LINK_VERIFY_IE:
         case FR_LMI_ANSI_LINK_VERIFY_IE_91:
             if (!ndo->ndo_vflag) {
-                ND_PRINT(", ");
+                ND_PRINT(C_RESET, ", ");
 	    }
             if (ielength < 2) {
-                ND_PRINT("Invalid LINK VERIFY IE");
+                ND_PRINT(C_RESET, "Invalid LINK VERIFY IE");
                 return 1;
             }
-            ND_PRINT("TX Seq: %3d, RX Seq: %3d", GET_U_1(p), GET_U_1(p + 1));
+            ND_PRINT(C_RESET, "TX Seq: %3d, RX Seq: %3d", GET_U_1(p), GET_U_1(p + 1));
             return 1;
 
         case FR_LMI_ANSI_PVC_STATUS_IE: /* fall through */
         case FR_LMI_CCITT_PVC_STATUS_IE:
             if (!ndo->ndo_vflag) {
-                ND_PRINT(", ");
+                ND_PRINT(C_RESET, ", ");
 	    }
             /* now parse the DLCI information element. */
             if ((ielength < 3) ||
@@ -1135,7 +1135,7 @@ fr_q933_print_ie_codeset_0_5(netdissect_options *ndo, u_int iecode,
                    !(GET_U_1(p + 3) & 0x80))) ||
                 (ielength > 5) ||
                 !(GET_U_1(p + ielength - 1) & 0x80)) {
-                ND_PRINT("Invalid DLCI in PVC STATUS IE");
+                ND_PRINT(C_RESET, "Invalid DLCI in PVC STATUS IE");
                 return 1;
 	    }
 
@@ -1147,7 +1147,7 @@ fr_q933_print_ie_codeset_0_5(netdissect_options *ndo, u_int iecode,
                 dlci = (dlci << 13) | (GET_U_1(p + 2) & 0x7F) | ((GET_U_1(p + 3) & 0x7E) >> 1);
 	    }
 
-            ND_PRINT("DLCI %u: status %s%s", dlci,
+            ND_PRINT(C_RESET, "DLCI %u: status %s%s", dlci,
                     GET_U_1(p + ielength - 1) & 0x8 ? "New, " : "",
                     GET_U_1(p + ielength - 1) & 0x2 ? "Active" : "Inactive");
             return 1;

--- a/print-frag6.c
+++ b/print-frag6.c
@@ -43,13 +43,13 @@ frag6_print(netdissect_options *ndo, const u_char *bp, const u_char *bp2)
 	ip6 = (const struct ip6_hdr *)bp2;
 
 	if (ndo->ndo_vflag) {
-		ND_PRINT("frag (0x%08x:%u|%zu)",
+		ND_PRINT(C_RESET, "frag (0x%08x:%u|%zu)",
 			 GET_BE_U_4(dp->ip6f_ident),
 			 GET_BE_U_2(dp->ip6f_offlg) & IP6F_OFF_MASK,
 			 sizeof(struct ip6_hdr) + GET_BE_U_2(ip6->ip6_plen) -
 			        (bp - bp2) - sizeof(struct ip6_frag));
 	} else {
-		ND_PRINT("frag (%u|%zu)",
+		ND_PRINT(C_RESET, "frag (%u|%zu)",
 		         GET_BE_U_2(dp->ip6f_offlg) & IP6F_OFF_MASK,
 		         sizeof(struct ip6_hdr) + GET_BE_U_2(ip6->ip6_plen) -
 			         (bp - bp2) - sizeof(struct ip6_frag));
@@ -60,7 +60,7 @@ frag6_print(netdissect_options *ndo, const u_char *bp, const u_char *bp2)
 		return -1;
 	else
 	{
-		ND_PRINT(" ");
+		ND_PRINT(C_RESET, " ");
 		return sizeof(struct ip6_frag);
 	}
 }

--- a/print-geneve.c
+++ b/print-geneve.c
@@ -170,19 +170,19 @@ geneve_opts_print(netdissect_options *ndo, const u_char *bp, u_int len)
         uint8_t opt_len;
 
         ND_ICHECKMSG_U("remaining options length", len, <, 4);
-        ND_PRINT("%s", sep);
+        ND_PRINT(C_RESET, "%s", sep);
         sep = ", ";
 
         opt_class = GET_BE_U_2(bp);
         opt_type = GET_U_1(bp + 2);
         opt_len = 4 + ((GET_U_1(bp + 3) & OPT_LEN_MASK) * 4);
 
-        ND_PRINT("class %s (0x%x) type 0x%x%s len %u",
+        ND_PRINT(C_RESET, "class %s (0x%x) type 0x%x%s len %u",
                   format_opt_class(opt_class), opt_class, opt_type,
                   opt_type & OPT_TYPE_CRITICAL ? "(C)" : "", opt_len);
 
         if (opt_len > len) {
-            ND_PRINT(" [bad length]");
+            ND_PRINT(C_RESET, " [bad length]");
             goto invalid;
         }
 
@@ -190,10 +190,10 @@ geneve_opts_print(netdissect_options *ndo, const u_char *bp, u_int len)
             const uint32_t *data = (const uint32_t *)(bp + 4);
             int i;
 
-            ND_PRINT(" data");
+            ND_PRINT(C_RESET, " data");
 
             for (i = 4; i < opt_len; i += 4) {
-                ND_PRINT(" %08x", GET_BE_U_4(data));
+                ND_PRINT(C_RESET, " %08x", GET_BE_U_4(data));
                 data++;
             }
         }
@@ -219,7 +219,7 @@ geneve_print(netdissect_options *ndo, const u_char *bp, u_int len)
     u_int opts_len;
 
     ndo->ndo_protocol = "geneve";
-    ND_PRINT("Geneve");
+    ND_PRINT(C_RESET, "Geneve");
 
     ND_ICHECK_U(len, <, 8);
 
@@ -229,7 +229,7 @@ geneve_print(netdissect_options *ndo, const u_char *bp, u_int len)
 
     version = ver_opt >> VER_SHIFT;
     if (version != 0) {
-        ND_PRINT(" ERROR: unknown-version %u", version);
+        ND_PRINT(C_RESET, " ERROR: unknown-version %u", version);
         goto invalid;
     }
 
@@ -249,26 +249,26 @@ geneve_print(netdissect_options *ndo, const u_char *bp, u_int len)
     bp += 1;
     len -= 1;
 
-    ND_PRINT(", Flags [%s]",
+    ND_PRINT(C_RESET, ", Flags [%s]",
               bittok2str_nosep(geneve_flag_values, "none", flags));
-    ND_PRINT(", vni 0x%x", vni);
+    ND_PRINT(C_RESET, ", vni 0x%x", vni);
 
     if (reserved)
-        ND_PRINT(", rsvd 0x%x", reserved);
+        ND_PRINT(C_RESET, ", rsvd 0x%x", reserved);
 
     if (ndo->ndo_eflag)
-        ND_PRINT(", proto %s (0x%04x)",
+        ND_PRINT(C_RESET, ", proto %s (0x%04x)",
                   tok2str(ethertype_values, "unknown", prot), prot);
 
     opts_len = (ver_opt & HDR_OPTS_LEN_MASK) * 4;
 
     if (len < opts_len) {
-        ND_PRINT(" (opts_len %u > %u", opts_len, len);
+        ND_PRINT(C_RESET, " (opts_len %u > %u", opts_len, len);
         goto invalid;
     }
 
     if (opts_len > 0) {
-        ND_PRINT(", options [");
+        ND_PRINT(C_RESET, ", options [");
 
         if (ndo->ndo_vflag) {
             if (! geneve_opts_print(ndo, bp, opts_len))
@@ -276,25 +276,25 @@ geneve_print(netdissect_options *ndo, const u_char *bp, u_int len)
         }
         else {
             ND_TCHECK_LEN(bp, opts_len);
-            ND_PRINT("%u bytes", opts_len);
+            ND_PRINT(C_RESET, "%u bytes", opts_len);
         }
 
-        ND_PRINT("]");
+        ND_PRINT(C_RESET, "]");
     }
 
     bp += opts_len;
     len -= opts_len;
 
     if (ndo->ndo_vflag < 1)
-        ND_PRINT(": ");
+        ND_PRINT(C_RESET, ": ");
     else
-        ND_PRINT("\n\t");
+        ND_PRINT(C_RESET, "\n\t");
 
     if (ethertype_print(ndo, prot, bp, len, ND_BYTES_AVAILABLE_AFTER(bp), NULL, NULL) == 0) {
         if (prot == ETHERTYPE_TEB)
             ether_print(ndo, bp, len, ND_BYTES_AVAILABLE_AFTER(bp), NULL, NULL);
         else {
-            ND_PRINT("geneve-proto-0x%x", prot);
+            ND_PRINT(C_RESET, "geneve-proto-0x%x", prot);
             ND_TCHECK_LEN(bp, len);
         }
     }

--- a/print-geonet.c
+++ b/print-geonet.c
@@ -63,10 +63,10 @@ print_btp_body(netdissect_options *ndo,
 	u_int msg_type;
 
 	/* Assuming ItsPduHeader */
-	ND_PRINT("; ItsPduHeader v:%u", GET_U_1(bp));
+	ND_PRINT(C_RESET, "; ItsPduHeader v:%u", GET_U_1(bp));
 
 	msg_type = GET_U_1(bp + 1);
-	ND_PRINT(" t:%u-%s", msg_type,
+	ND_PRINT(C_RESET, " t:%u-%s", msg_type,
 	         tok2str(msg_type_values, "unknown (%u)", msg_type));
 }
 
@@ -75,17 +75,17 @@ static void
 print_btp(netdissect_options *ndo,
 	  const u_char *bp)
 {
-	ND_PRINT("; BTP Dst:%u", GET_BE_U_2(bp + 0));
-	ND_PRINT(" Src:%u", GET_BE_U_2(bp + 2));
+	ND_PRINT(C_RESET, "; BTP Dst:%u", GET_BE_U_2(bp + 0));
+	ND_PRINT(C_RESET, " Src:%u", GET_BE_U_2(bp + 2));
 }
 
 static void
 print_long_pos_vector(netdissect_options *ndo,
 		      const u_char *bp)
 {
-	ND_PRINT("GN_ADDR:%s ", GET_LINKADDR_STRING(bp, LINKADDR_OTHER, GEONET_ADDR_LEN));
-	ND_PRINT("lat:%u ", GET_BE_U_4(bp + 12));
-	ND_PRINT("lon:%u", GET_BE_U_4(bp + 16));
+	ND_PRINT(C_RESET, "GN_ADDR:%s ", GET_LINKADDR_STRING(bp, LINKADDR_OTHER, GEONET_ADDR_LEN));
+	ND_PRINT(C_RESET, "lat:%u ", GET_BE_U_4(bp + 12));
+	ND_PRINT(C_RESET, "lon:%u", GET_BE_U_4(bp + 16));
 }
 
 
@@ -108,14 +108,14 @@ geonet_print(netdissect_options *ndo, const u_char *bp, u_int length,
 	int hdr_size = -1;
 
 	ndo->ndo_protocol = "geonet";
-	ND_PRINT("GeoNet ");
+	ND_PRINT(C_RESET, "GeoNet ");
 	if (src != NULL)
-		ND_PRINT("src:%s", (src->addr_string)(ndo, src->addr));
-	ND_PRINT("; ");
+		ND_PRINT(C_RESET, "src:%s", (src->addr_string)(ndo, src->addr));
+	ND_PRINT(C_RESET, "; ");
 
 	/* Process Common Header */
 	if (length < 36) {
-		ND_PRINT(" (common header length %u < 36)", length);
+		ND_PRINT(C_RESET, " (common header length %u < 36)", length);
 		goto invalid;
 	}
 
@@ -161,11 +161,11 @@ geonet_print(netdissect_options *ndo, const u_char *bp, u_int length,
 			break;
 	}
 
-	ND_PRINT("v:%u ", version);
-	ND_PRINT("NH:%u-%s ", next_hdr, next_hdr_txt);
-	ND_PRINT("HT:%u-%u-%s ", hdr_type, hdr_subtype, hdr_type_txt);
-	ND_PRINT("HopLim:%u ", hop_limit);
-	ND_PRINT("Payload:%u ", payload_length);
+	ND_PRINT(C_RESET, "v:%u ", version);
+	ND_PRINT(C_RESET, "NH:%u-%s ", next_hdr, next_hdr_txt);
+	ND_PRINT(C_RESET, "HT:%u-%u-%s ", hdr_type, hdr_subtype, hdr_type_txt);
+	ND_PRINT(C_RESET, "HopLim:%u ", hop_limit);
+	ND_PRINT(C_RESET, "Payload:%u ", payload_length);
 	print_long_pos_vector(ndo, bp + 8);
 
 	/* Skip Common Header */
@@ -222,7 +222,7 @@ geonet_print(netdissect_options *ndo, const u_char *bp, u_int length,
 	/* Skip Extended headers */
 	if (hdr_size >= 0) {
 		if (length < (u_int)hdr_size) {
-			ND_PRINT(" (header size %d > %u)", hdr_size, length);
+			ND_PRINT(C_RESET, " (header size %d > %u)", hdr_size, length);
 			goto invalid;
 		}
 		ND_TCHECK_LEN(bp, hdr_size);
@@ -234,7 +234,7 @@ geonet_print(netdissect_options *ndo, const u_char *bp, u_int length,
 			case 1:
 			case 2: /* BTP A/B */
 				if (length < 4) {
-					ND_PRINT(" (BTP length %u < 4)", length);
+					ND_PRINT(C_RESET, " (BTP length %u < 4)", length);
 					goto invalid;
 				}
 				print_btp(ndo, bp);

--- a/print-gre.c
+++ b/print-gre.c
@@ -85,7 +85,7 @@ gre_print(netdissect_options *ndo, const u_char *bp, u_int length)
 	nd_print_protocol_caps(ndo);
 	ND_ICHECK_U(length, <, 2);
 	vers = GET_BE_U_2(bp) & GRE_VERS_MASK;
-	ND_PRINT(C_RESET, C_RESET "v%u",vers);
+	ND_PRINT(C_RESET, "v%u",vers);
 
 	switch(vers) {
 	case 0:
@@ -95,7 +95,7 @@ gre_print(netdissect_options *ndo, const u_char *bp, u_int length)
 		gre_print_1(ndo, bp, length);
 		break;
 	default:
-		ND_PRINT(C_RESET, C_RESET " ERROR: unknown-version");
+		ND_PRINT(C_RESET, " ERROR: unknown-version");
 		break;
 	}
 	return;
@@ -113,7 +113,7 @@ gre_print_0(netdissect_options *ndo, const u_char *bp, u_int length)
 	ND_ICHECK_U(len, <, 2);
 	flags = GET_BE_U_2(bp);
 	if (ndo->ndo_vflag)
-		ND_PRINT(C_RESET, C_RESET ", Flags [%s]",
+		ND_PRINT(C_RESET, ", Flags [%s]",
 			 bittok2str(gre_flag_values,"none",flags));
 
 	len -= 2;
@@ -130,26 +130,26 @@ gre_print_0(netdissect_options *ndo, const u_char *bp, u_int length)
 		ND_ICHECK_U(len, <, 2);
 		sum =  GET_BE_U_2(bp);
 		if (ndo->ndo_vflag)
-			ND_PRINT(C_RESET, C_RESET ", sum 0x%x", sum);
+			ND_PRINT(C_RESET, ", sum 0x%x", sum);
 		bp += 2;
 		len -= 2;
 
 		ND_ICHECK_U(len, <, 2);
-		ND_PRINT(C_RESET, C_RESET ", off 0x%x", GET_BE_U_2(bp));
+		ND_PRINT(C_RESET, ", off 0x%x", GET_BE_U_2(bp));
 		bp += 2;
 		len -= 2;
 	}
 
 	if (flags & GRE_KP) {
 		ND_ICHECK_U(len, <, 4);
-		ND_PRINT(C_RESET, C_RESET ", key=0x%x", GET_BE_U_4(bp));
+		ND_PRINT(C_RESET, ", key=0x%x", GET_BE_U_4(bp));
 		bp += 4;
 		len -= 4;
 	}
 
 	if (flags & GRE_SP) {
 		ND_ICHECK_U(len, <, 4);
-		ND_PRINT(C_RESET, C_RESET ", seq %u", GET_BE_U_4(bp));
+		ND_PRINT(C_RESET, ", seq %u", GET_BE_U_4(bp));
 		bp += 4;
 		len -= 4;
 	}
@@ -180,15 +180,15 @@ gre_print_0(netdissect_options *ndo, const u_char *bp, u_int length)
 	}
 
 	if (ndo->ndo_eflag)
-		ND_PRINT(C_RESET, C_RESET ", proto %s (0x%04x)",
+		ND_PRINT(C_RESET, ", proto %s (0x%04x)",
 			 tok2str(ethertype_values,"unknown",prot), prot);
 
-	ND_PRINT(C_RESET, C_RESET ", length %u",length);
+	ND_PRINT(C_RESET, ", length %u",length);
 
 	if (ndo->ndo_vflag < 1)
-		ND_PRINT(C_RESET, C_RESET ": "); /* put in a colon as protocol demarc */
+		ND_PRINT(C_RESET, ": "); /* put in a colon as protocol demarc */
 	else
-		ND_PRINT(C_RESET, C_RESET "\n\t"); /* if verbose go multiline */
+		ND_PRINT(C_RESET, "\n\t"); /* if verbose go multiline */
 
 	switch (prot) {
 	case ETHERTYPE_IP:
@@ -213,7 +213,7 @@ gre_print_0(netdissect_options *ndo, const u_char *bp, u_int length)
 		ether_print(ndo, bp, len, ND_BYTES_AVAILABLE_AFTER(bp), NULL, NULL);
 		break;
 	default:
-		ND_PRINT(C_RESET, C_RESET "gre-proto-0x%x", prot);
+		ND_PRINT(C_RESET, "gre-proto-0x%x", prot);
 	}
 	return;
 
@@ -233,7 +233,7 @@ gre_print_1(netdissect_options *ndo, const u_char *bp, u_int length)
 	bp += 2;
 
 	if (ndo->ndo_vflag)
-		ND_PRINT(C_RESET, C_RESET ", Flags [%s]",
+		ND_PRINT(C_RESET, ", Flags [%s]",
 			 bittok2str(gre_flag_values,"none",flags));
 
 	ND_ICHECK_U(len, <, 2);
@@ -247,48 +247,48 @@ gre_print_1(netdissect_options *ndo, const u_char *bp, u_int length)
 
 		ND_ICHECK_U(len, <, 4);
 		k = GET_BE_U_4(bp);
-		ND_PRINT(C_RESET, C_RESET ", call %u", k & 0xffff);
+		ND_PRINT(C_RESET, ", call %u", k & 0xffff);
 		len -= 4;
 		bp += 4;
 	}
 
 	if (flags & GRE_SP) {
 		ND_ICHECK_U(len, <, 4);
-		ND_PRINT(C_RESET, C_RESET ", seq %u", GET_BE_U_4(bp));
+		ND_PRINT(C_RESET, ", seq %u", GET_BE_U_4(bp));
 		bp += 4;
 		len -= 4;
 	}
 
 	if (flags & GRE_AP) {
 		ND_ICHECK_U(len, <, 4);
-		ND_PRINT(C_RESET, C_RESET ", ack %u", GET_BE_U_4(bp));
+		ND_PRINT(C_RESET, ", ack %u", GET_BE_U_4(bp));
 		bp += 4;
 		len -= 4;
 	}
 
 	if ((flags & GRE_SP) == 0)
-		ND_PRINT(C_RESET, C_RESET ", no-payload");
+		ND_PRINT(C_RESET, ", no-payload");
 
 	if (ndo->ndo_eflag)
-		ND_PRINT(C_RESET, C_RESET ", proto %s (0x%04x)",
+		ND_PRINT(C_RESET, ", proto %s (0x%04x)",
 			 tok2str(ethertype_values,"unknown",prot), prot);
 
-	ND_PRINT(C_RESET, C_RESET ", length %u",length);
+	ND_PRINT(C_RESET, ", length %u",length);
 
 	if ((flags & GRE_SP) == 0)
 		return;
 
 	if (ndo->ndo_vflag < 1)
-		ND_PRINT(C_RESET, C_RESET ": "); /* put in a colon as protocol demarc */
+		ND_PRINT(C_RESET, ": "); /* put in a colon as protocol demarc */
 	else
-		ND_PRINT(C_RESET, C_RESET "\n\t"); /* if verbose go multiline */
+		ND_PRINT(C_RESET, "\n\t"); /* if verbose go multiline */
 
 	switch (prot) {
 	case ETHERTYPE_PPP:
 		ppp_print(ndo, bp, len);
 		break;
 	default:
-		ND_PRINT(C_RESET, C_RESET "gre-proto-0x%x", prot);
+		ND_PRINT(C_RESET, "gre-proto-0x%x", prot);
 		break;
 	}
 	return;
@@ -305,17 +305,17 @@ gre_sre_print(netdissect_options *ndo, uint16_t af, uint8_t sreoff,
 
 	switch (af) {
 	case GRESRE_IP:
-		ND_PRINT(C_RESET, C_RESET ", (rtaf=ip");
+		ND_PRINT(C_RESET, ", (rtaf=ip");
 		ret = gre_sre_ip_print(ndo, sreoff, srelen, bp, len);
-		ND_PRINT(C_RESET, C_RESET ")");
+		ND_PRINT(C_RESET, ")");
 		break;
 	case GRESRE_ASN:
-		ND_PRINT(C_RESET, C_RESET ", (rtaf=asn");
+		ND_PRINT(C_RESET, ", (rtaf=asn");
 		ret = gre_sre_asn_print(ndo, sreoff, srelen, bp, len);
-		ND_PRINT(C_RESET, C_RESET ")");
+		ND_PRINT(C_RESET, ")");
 		break;
 	default:
-		ND_PRINT(C_RESET, C_RESET ", (rtaf=0x%x)", af);
+		ND_PRINT(C_RESET, ", (rtaf=0x%x)", af);
 		ret = 1;
 	}
 	return (ret);
@@ -329,15 +329,15 @@ gre_sre_ip_print(netdissect_options *ndo, uint8_t sreoff, uint8_t srelen,
 	char buf[INET_ADDRSTRLEN];
 
 	if (sreoff & 3) {
-		ND_PRINT(C_RESET, C_RESET ", badoffset=%u", sreoff);
+		ND_PRINT(C_RESET, ", badoffset=%u", sreoff);
 		goto invalid;
 	}
 	if (srelen & 3) {
-		ND_PRINT(C_RESET, C_RESET ", badlength=%u", srelen);
+		ND_PRINT(C_RESET, ", badlength=%u", srelen);
 		goto invalid;
 	}
 	if (sreoff >= srelen) {
-		ND_PRINT(C_RESET, C_RESET ", badoff/len=%u/%u", sreoff, srelen);
+		ND_PRINT(C_RESET, ", badoff/len=%u/%u", sreoff, srelen);
 		goto invalid;
 	}
 
@@ -346,7 +346,7 @@ gre_sre_ip_print(netdissect_options *ndo, uint8_t sreoff, uint8_t srelen,
 
 		ND_TCHECK_LEN(bp, sizeof(nd_ipv4));
 		addrtostr(bp, buf, sizeof(buf));
-		ND_PRINT(C_RESET, C_RESET " %s%s",
+		ND_PRINT(C_RESET, " %s%s",
 			 ((bp - up) == sreoff) ? "*" : "", buf);
 
 		bp += 4;
@@ -366,22 +366,22 @@ gre_sre_asn_print(netdissect_options *ndo, uint8_t sreoff, uint8_t srelen,
 	const u_char *up = bp;
 
 	if (sreoff & 1) {
-		ND_PRINT(C_RESET, C_RESET ", badoffset=%u", sreoff);
+		ND_PRINT(C_RESET, ", badoffset=%u", sreoff);
 		goto invalid;
 	}
 	if (srelen & 1) {
-		ND_PRINT(C_RESET, C_RESET ", badlength=%u", srelen);
+		ND_PRINT(C_RESET, ", badlength=%u", srelen);
 		goto invalid;
 	}
 	if (sreoff >= srelen) {
-		ND_PRINT(C_RESET, C_RESET ", badoff/len=%u/%u", sreoff, srelen);
+		ND_PRINT(C_RESET, ", badoff/len=%u/%u", sreoff, srelen);
 		goto invalid;
 	}
 
 	while (srelen != 0) {
 		ND_ICHECK_U(len, <, 2);
 
-		ND_PRINT(C_RESET, C_RESET " %s%x",
+		ND_PRINT(C_RESET, " %s%x",
 			 ((bp - up) == sreoff) ? "*" : "", GET_BE_U_2(bp));
 
 		bp += 2;

--- a/print-gre.c
+++ b/print-gre.c
@@ -85,7 +85,7 @@ gre_print(netdissect_options *ndo, const u_char *bp, u_int length)
 	nd_print_protocol_caps(ndo);
 	ND_ICHECK_U(length, <, 2);
 	vers = GET_BE_U_2(bp) & GRE_VERS_MASK;
-	ND_PRINT("v%u",vers);
+	ND_PRINT(C_RESET, C_RESET "v%u",vers);
 
 	switch(vers) {
 	case 0:
@@ -95,7 +95,7 @@ gre_print(netdissect_options *ndo, const u_char *bp, u_int length)
 		gre_print_1(ndo, bp, length);
 		break;
 	default:
-		ND_PRINT(" ERROR: unknown-version");
+		ND_PRINT(C_RESET, C_RESET " ERROR: unknown-version");
 		break;
 	}
 	return;
@@ -113,7 +113,7 @@ gre_print_0(netdissect_options *ndo, const u_char *bp, u_int length)
 	ND_ICHECK_U(len, <, 2);
 	flags = GET_BE_U_2(bp);
 	if (ndo->ndo_vflag)
-		ND_PRINT(", Flags [%s]",
+		ND_PRINT(C_RESET, C_RESET ", Flags [%s]",
 			 bittok2str(gre_flag_values,"none",flags));
 
 	len -= 2;
@@ -130,26 +130,26 @@ gre_print_0(netdissect_options *ndo, const u_char *bp, u_int length)
 		ND_ICHECK_U(len, <, 2);
 		sum =  GET_BE_U_2(bp);
 		if (ndo->ndo_vflag)
-			ND_PRINT(", sum 0x%x", sum);
+			ND_PRINT(C_RESET, C_RESET ", sum 0x%x", sum);
 		bp += 2;
 		len -= 2;
 
 		ND_ICHECK_U(len, <, 2);
-		ND_PRINT(", off 0x%x", GET_BE_U_2(bp));
+		ND_PRINT(C_RESET, C_RESET ", off 0x%x", GET_BE_U_2(bp));
 		bp += 2;
 		len -= 2;
 	}
 
 	if (flags & GRE_KP) {
 		ND_ICHECK_U(len, <, 4);
-		ND_PRINT(", key=0x%x", GET_BE_U_4(bp));
+		ND_PRINT(C_RESET, C_RESET ", key=0x%x", GET_BE_U_4(bp));
 		bp += 4;
 		len -= 4;
 	}
 
 	if (flags & GRE_SP) {
 		ND_ICHECK_U(len, <, 4);
-		ND_PRINT(", seq %u", GET_BE_U_4(bp));
+		ND_PRINT(C_RESET, C_RESET ", seq %u", GET_BE_U_4(bp));
 		bp += 4;
 		len -= 4;
 	}
@@ -180,15 +180,15 @@ gre_print_0(netdissect_options *ndo, const u_char *bp, u_int length)
 	}
 
 	if (ndo->ndo_eflag)
-		ND_PRINT(", proto %s (0x%04x)",
+		ND_PRINT(C_RESET, C_RESET ", proto %s (0x%04x)",
 			 tok2str(ethertype_values,"unknown",prot), prot);
 
-	ND_PRINT(", length %u",length);
+	ND_PRINT(C_RESET, C_RESET ", length %u",length);
 
 	if (ndo->ndo_vflag < 1)
-		ND_PRINT(": "); /* put in a colon as protocol demarc */
+		ND_PRINT(C_RESET, C_RESET ": "); /* put in a colon as protocol demarc */
 	else
-		ND_PRINT("\n\t"); /* if verbose go multiline */
+		ND_PRINT(C_RESET, C_RESET "\n\t"); /* if verbose go multiline */
 
 	switch (prot) {
 	case ETHERTYPE_IP:
@@ -213,7 +213,7 @@ gre_print_0(netdissect_options *ndo, const u_char *bp, u_int length)
 		ether_print(ndo, bp, len, ND_BYTES_AVAILABLE_AFTER(bp), NULL, NULL);
 		break;
 	default:
-		ND_PRINT("gre-proto-0x%x", prot);
+		ND_PRINT(C_RESET, C_RESET "gre-proto-0x%x", prot);
 	}
 	return;
 
@@ -233,7 +233,7 @@ gre_print_1(netdissect_options *ndo, const u_char *bp, u_int length)
 	bp += 2;
 
 	if (ndo->ndo_vflag)
-		ND_PRINT(", Flags [%s]",
+		ND_PRINT(C_RESET, C_RESET ", Flags [%s]",
 			 bittok2str(gre_flag_values,"none",flags));
 
 	ND_ICHECK_U(len, <, 2);
@@ -247,48 +247,48 @@ gre_print_1(netdissect_options *ndo, const u_char *bp, u_int length)
 
 		ND_ICHECK_U(len, <, 4);
 		k = GET_BE_U_4(bp);
-		ND_PRINT(", call %u", k & 0xffff);
+		ND_PRINT(C_RESET, C_RESET ", call %u", k & 0xffff);
 		len -= 4;
 		bp += 4;
 	}
 
 	if (flags & GRE_SP) {
 		ND_ICHECK_U(len, <, 4);
-		ND_PRINT(", seq %u", GET_BE_U_4(bp));
+		ND_PRINT(C_RESET, C_RESET ", seq %u", GET_BE_U_4(bp));
 		bp += 4;
 		len -= 4;
 	}
 
 	if (flags & GRE_AP) {
 		ND_ICHECK_U(len, <, 4);
-		ND_PRINT(", ack %u", GET_BE_U_4(bp));
+		ND_PRINT(C_RESET, C_RESET ", ack %u", GET_BE_U_4(bp));
 		bp += 4;
 		len -= 4;
 	}
 
 	if ((flags & GRE_SP) == 0)
-		ND_PRINT(", no-payload");
+		ND_PRINT(C_RESET, C_RESET ", no-payload");
 
 	if (ndo->ndo_eflag)
-		ND_PRINT(", proto %s (0x%04x)",
+		ND_PRINT(C_RESET, C_RESET ", proto %s (0x%04x)",
 			 tok2str(ethertype_values,"unknown",prot), prot);
 
-	ND_PRINT(", length %u",length);
+	ND_PRINT(C_RESET, C_RESET ", length %u",length);
 
 	if ((flags & GRE_SP) == 0)
 		return;
 
 	if (ndo->ndo_vflag < 1)
-		ND_PRINT(": "); /* put in a colon as protocol demarc */
+		ND_PRINT(C_RESET, C_RESET ": "); /* put in a colon as protocol demarc */
 	else
-		ND_PRINT("\n\t"); /* if verbose go multiline */
+		ND_PRINT(C_RESET, C_RESET "\n\t"); /* if verbose go multiline */
 
 	switch (prot) {
 	case ETHERTYPE_PPP:
 		ppp_print(ndo, bp, len);
 		break;
 	default:
-		ND_PRINT("gre-proto-0x%x", prot);
+		ND_PRINT(C_RESET, C_RESET "gre-proto-0x%x", prot);
 		break;
 	}
 	return;
@@ -305,17 +305,17 @@ gre_sre_print(netdissect_options *ndo, uint16_t af, uint8_t sreoff,
 
 	switch (af) {
 	case GRESRE_IP:
-		ND_PRINT(", (rtaf=ip");
+		ND_PRINT(C_RESET, C_RESET ", (rtaf=ip");
 		ret = gre_sre_ip_print(ndo, sreoff, srelen, bp, len);
-		ND_PRINT(")");
+		ND_PRINT(C_RESET, C_RESET ")");
 		break;
 	case GRESRE_ASN:
-		ND_PRINT(", (rtaf=asn");
+		ND_PRINT(C_RESET, C_RESET ", (rtaf=asn");
 		ret = gre_sre_asn_print(ndo, sreoff, srelen, bp, len);
-		ND_PRINT(")");
+		ND_PRINT(C_RESET, C_RESET ")");
 		break;
 	default:
-		ND_PRINT(", (rtaf=0x%x)", af);
+		ND_PRINT(C_RESET, C_RESET ", (rtaf=0x%x)", af);
 		ret = 1;
 	}
 	return (ret);
@@ -329,15 +329,15 @@ gre_sre_ip_print(netdissect_options *ndo, uint8_t sreoff, uint8_t srelen,
 	char buf[INET_ADDRSTRLEN];
 
 	if (sreoff & 3) {
-		ND_PRINT(", badoffset=%u", sreoff);
+		ND_PRINT(C_RESET, C_RESET ", badoffset=%u", sreoff);
 		goto invalid;
 	}
 	if (srelen & 3) {
-		ND_PRINT(", badlength=%u", srelen);
+		ND_PRINT(C_RESET, C_RESET ", badlength=%u", srelen);
 		goto invalid;
 	}
 	if (sreoff >= srelen) {
-		ND_PRINT(", badoff/len=%u/%u", sreoff, srelen);
+		ND_PRINT(C_RESET, C_RESET ", badoff/len=%u/%u", sreoff, srelen);
 		goto invalid;
 	}
 
@@ -346,7 +346,7 @@ gre_sre_ip_print(netdissect_options *ndo, uint8_t sreoff, uint8_t srelen,
 
 		ND_TCHECK_LEN(bp, sizeof(nd_ipv4));
 		addrtostr(bp, buf, sizeof(buf));
-		ND_PRINT(" %s%s",
+		ND_PRINT(C_RESET, C_RESET " %s%s",
 			 ((bp - up) == sreoff) ? "*" : "", buf);
 
 		bp += 4;
@@ -366,22 +366,22 @@ gre_sre_asn_print(netdissect_options *ndo, uint8_t sreoff, uint8_t srelen,
 	const u_char *up = bp;
 
 	if (sreoff & 1) {
-		ND_PRINT(", badoffset=%u", sreoff);
+		ND_PRINT(C_RESET, C_RESET ", badoffset=%u", sreoff);
 		goto invalid;
 	}
 	if (srelen & 1) {
-		ND_PRINT(", badlength=%u", srelen);
+		ND_PRINT(C_RESET, C_RESET ", badlength=%u", srelen);
 		goto invalid;
 	}
 	if (sreoff >= srelen) {
-		ND_PRINT(", badoff/len=%u/%u", sreoff, srelen);
+		ND_PRINT(C_RESET, C_RESET ", badoff/len=%u/%u", sreoff, srelen);
 		goto invalid;
 	}
 
 	while (srelen != 0) {
 		ND_ICHECK_U(len, <, 2);
 
-		ND_PRINT(" %s%x",
+		ND_PRINT(C_RESET, C_RESET " %s%x",
 			 ((bp - up) == sreoff) ? "*" : "", GET_BE_U_2(bp));
 
 		bp += 2;

--- a/print-hncp.c
+++ b/print-hncp.c
@@ -49,7 +49,7 @@ hncp_print(netdissect_options *ndo,
            const u_char *cp, u_int length)
 {
     ndo->ndo_protocol = "hncp";
-    ND_PRINT("hncp (%u)", length);
+    ND_PRINT(C_RESET, "hncp (%u)", length);
     hncp_print_rec(ndo, cp, length, 1);
 }
 
@@ -234,7 +234,7 @@ print_prefix(netdissect_options *ndo, const u_char *prefix, u_int max_length)
             return plenbytes;
     }
 
-    ND_PRINT("%s", buf);
+    ND_PRINT(C_RESET, "%s", buf);
     return plenbytes;
 }
 
@@ -249,7 +249,7 @@ print_dns_label(netdissect_options *ndo,
         if (lab_length == 0)
             return (int)length;
         if (length > 1 && print)
-            ND_PRINT(".");
+            ND_PRINT(C_RESET, ".");
         if (length+lab_length > max_length) {
             if (print)
                 nd_printjnp(ndo, cp+length, max_length-length);
@@ -260,7 +260,7 @@ print_dns_label(netdissect_options *ndo,
         length += lab_length;
     }
     if (print)
-        ND_PRINT("[|DNS]");
+        ND_PRINT(C_RESET, "[|DNS]");
     return -1;
 }
 
@@ -281,12 +281,12 @@ dhcpv4_print(netdissect_options *ndo,
         optlen = GET_U_1(tlv + 1);
         value = tlv + 2;
 
-        ND_PRINT("\n");
+        ND_PRINT(C_RESET, "\n");
         for (t = indent; t > 0; t--)
-            ND_PRINT("\t");
+            ND_PRINT(C_RESET, "\t");
 
-        ND_PRINT("%s", tok2str(dh4opt_str, "Unknown", type));
-        ND_PRINT(" (%u)", optlen + 2 );
+        ND_PRINT(C_RESET, "%s", tok2str(dh4opt_str, "Unknown", type));
+        ND_PRINT(C_RESET, " (%u)", optlen + 2 );
         if (i + 2 + optlen > length)
             return -1;
 
@@ -297,13 +297,13 @@ dhcpv4_print(netdissect_options *ndo,
                 return -1;
             }
             for (t = 0; t < optlen; t += 4)
-                ND_PRINT(" %s", GET_IPADDR_STRING(value + t));
+                ND_PRINT(C_RESET, " %s", GET_IPADDR_STRING(value + t));
         }
             break;
         case DH4OPT_DOMAIN_SEARCH: {
             const u_char *tp = value;
             while (tp < value + optlen) {
-                ND_PRINT(" ");
+                ND_PRINT(C_RESET, " ");
                 if ((tp = fqdn_print(ndo, tp, value + optlen)) == NULL)
                     return -1;
             }
@@ -333,12 +333,12 @@ dhcpv6_print(netdissect_options *ndo,
         optlen = GET_BE_U_2(tlv + 2);
         value = tlv + 4;
 
-        ND_PRINT("\n");
+        ND_PRINT(C_RESET, "\n");
         for (t = indent; t > 0; t--)
-            ND_PRINT("\t");
+            ND_PRINT(C_RESET, "\t");
 
-        ND_PRINT("%s", tok2str(dh6opt_str, "Unknown", type));
-        ND_PRINT(" (%u)", optlen + 4 );
+        ND_PRINT(C_RESET, "%s", tok2str(dh6opt_str, "Unknown", type));
+        ND_PRINT(C_RESET, " (%u)", optlen + 4 );
         if (i + 4 + optlen > length)
             return -1;
 
@@ -350,13 +350,13 @@ dhcpv6_print(netdissect_options *ndo,
                     return -1;
                 }
                 for (t = 0; t < optlen; t += 16)
-                    ND_PRINT(" %s", GET_IP6ADDR_STRING(value + t));
+                    ND_PRINT(C_RESET, " %s", GET_IP6ADDR_STRING(value + t));
             }
                 break;
             case DH6OPT_DOMAIN_LIST: {
                 const u_char *tp = value;
                 while (tp < value + optlen) {
-                    ND_PRINT(" ");
+                    ND_PRINT(C_RESET, " ");
                     if ((tp = fqdn_print(ndo, tp, value + optlen)) == NULL)
                         return -1;
                 }
@@ -385,18 +385,18 @@ print_type_in_line(netdissect_options *ndo,
             *first_one = 0;
             if (indent > 1) {
                 u_int t;
-                ND_PRINT("\n");
+                ND_PRINT(C_RESET, "\n");
                 for (t = indent; t > 0; t--)
-                    ND_PRINT("\t");
+                    ND_PRINT(C_RESET, "\t");
             } else {
-                ND_PRINT(" ");
+                ND_PRINT(C_RESET, " ");
             }
         } else {
-            ND_PRINT(", ");
+            ND_PRINT(C_RESET, ", ");
         }
-        ND_PRINT("%s", tok2str(type_values, "Easter Egg", type));
+        ND_PRINT(C_RESET, "%s", tok2str(type_values, "Easter Egg", type));
         if (count > 1)
-            ND_PRINT(" (x%d)", count);
+            ND_PRINT(C_RESET, " (x%d)", count);
     }
 }
 
@@ -421,9 +421,9 @@ hncp_print_rec(netdissect_options *ndo,
         tlv = cp + i;
 
         if (!in_line) {
-            ND_PRINT("\n");
+            ND_PRINT(C_RESET, "\n");
             for (t = indent; t > 0; t--)
-                ND_PRINT("\t");
+                ND_PRINT(C_RESET, "\t");
         }
 
         ND_TCHECK_4(tlv);
@@ -471,10 +471,10 @@ hncp_print_rec(netdissect_options *ndo,
             goto skip_multiline;
         }
 
-        ND_PRINT("%s", tok2str(type_values, "Easter Egg (42)", type_mask) );
+        ND_PRINT(C_RESET, "%s", tok2str(type_values, "Easter Egg (42)", type_mask) );
         if (type_mask > 0xffff)
-            ND_PRINT(": type=%u", type );
-        ND_PRINT(" (%u)", bodylen + 4 );
+            ND_PRINT(C_RESET, ": type=%u", type );
+        ND_PRINT(C_RESET, " (%u)", bodylen + 4 );
 
         switch (type_mask) {
 
@@ -491,7 +491,7 @@ hncp_print_rec(netdissect_options *ndo,
                 break;
             }
             node_identifier = format_nid(ndo, value);
-            ND_PRINT(" NID: %s", node_identifier);
+            ND_PRINT(C_RESET, " NID: %s", node_identifier);
         }
             break;
 
@@ -504,7 +504,7 @@ hncp_print_rec(netdissect_options *ndo,
             }
             node_identifier = format_nid(ndo, value);
             endpoint_identifier = GET_BE_U_4(value + 4);
-            ND_PRINT(" NID: %s EPID: %08x",
+            ND_PRINT(C_RESET, " NID: %s EPID: %08x",
                 node_identifier,
                 endpoint_identifier
             );
@@ -518,7 +518,7 @@ hncp_print_rec(netdissect_options *ndo,
                 break;
             }
             hash = GET_BE_U_8(value);
-            ND_PRINT(" hash: %016" PRIx64, hash);
+            ND_PRINT(C_RESET, " hash: %016" PRIx64, hash);
         }
             break;
 
@@ -534,7 +534,7 @@ hncp_print_rec(netdissect_options *ndo,
             sequence_number = GET_BE_U_4(value + 4);
             interval = format_interval(GET_BE_U_4(value + 8));
             hash = GET_BE_U_8(value + 12);
-            ND_PRINT(" NID: %s seqno: %u %s hash: %016" PRIx64,
+            ND_PRINT(C_RESET, " NID: %s seqno: %u %s hash: %016" PRIx64,
                 node_identifier,
                 sequence_number,
                 interval,
@@ -554,7 +554,7 @@ hncp_print_rec(netdissect_options *ndo,
             peer_node_identifier = format_nid(ndo, value);
             peer_endpoint_identifier = GET_BE_U_4(value + 4);
             endpoint_identifier = GET_BE_U_4(value + 8);
-            ND_PRINT(" Peer-NID: %s Peer-EPID: %08x Local-EPID: %08x",
+            ND_PRINT(C_RESET, " Peer-NID: %s Peer-EPID: %08x Local-EPID: %08x",
                 peer_node_identifier,
                 peer_endpoint_identifier,
                 endpoint_identifier
@@ -571,7 +571,7 @@ hncp_print_rec(netdissect_options *ndo,
             }
             endpoint_identifier = GET_BE_U_4(value);
             interval = format_interval(GET_BE_U_4(value + 4));
-            ND_PRINT(" EPID: %08x Interval: %s",
+            ND_PRINT(C_RESET, " EPID: %08x Interval: %s",
                 endpoint_identifier,
                 interval
             );
@@ -583,7 +583,7 @@ hncp_print_rec(netdissect_options *ndo,
                 nd_print_invalid(ndo);
                 break;
             }
-            ND_PRINT(" Verdict: %u Fingerprint: %s Common Name: ",
+            ND_PRINT(C_RESET, " Verdict: %u Fingerprint: %s Common Name: ",
                 GET_U_1(value),
                 format_256(ndo, value + 4));
             nd_printjnp(ndo, value + 36, bodylen - 36);
@@ -602,7 +602,7 @@ hncp_print_rec(netdissect_options *ndo,
             P = (uint8_t)((capabilities >> 8) & 0xf);
             H = (uint8_t)((capabilities >> 4) & 0xf);
             L = (uint8_t)(capabilities & 0xf);
-            ND_PRINT(" M: %u P: %u H: %u L: %u User-agent: ",
+            ND_PRINT(C_RESET, " M: %u P: %u H: %u L: %u User-agent: ",
                 M, P, H, L
             );
             nd_printjnp(ndo, value + 4, bodylen - 4);
@@ -621,13 +621,13 @@ hncp_print_rec(netdissect_options *ndo,
                 nd_print_invalid(ndo);
                 break;
             }
-            ND_PRINT(" VLSO: %s PLSO: %s Prefix: ",
+            ND_PRINT(C_RESET, " VLSO: %s PLSO: %s Prefix: ",
                 format_interval(GET_BE_U_4(value)),
                 format_interval(GET_BE_U_4(value + 4))
             );
             l = print_prefix(ndo, value + 8, bodylen - 8);
             if (l == -1) {
-                ND_PRINT("(length is invalid)");
+                ND_PRINT(C_RESET, "(length is invalid)");
                 break;
             }
             if (l < 0) {
@@ -658,18 +658,18 @@ hncp_print_rec(netdissect_options *ndo,
                 break;
             }
             policy = GET_U_1(value);
-            ND_PRINT(" type: ");
+            ND_PRINT(C_RESET, " type: ");
             if (policy == 0) {
                 if (bodylen != 1) {
                     nd_print_invalid(ndo);
                     break;
                 }
-                ND_PRINT("Internet connectivity");
+                ND_PRINT(C_RESET, "Internet connectivity");
             } else if (policy >= 1 && policy <= 128) {
-                ND_PRINT("Dest-Prefix: ");
+                ND_PRINT(C_RESET, "Dest-Prefix: ");
                 l = print_prefix(ndo, value, bodylen);
                 if (l == -1) {
-                    ND_PRINT("(length is invalid)");
+                    ND_PRINT(C_RESET, "(length is invalid)");
                     break;
                 }
                 if (l < 0) {
@@ -686,19 +686,19 @@ hncp_print_rec(netdissect_options *ndo,
                     break;
                 }
             } else if (policy == 129) {
-                ND_PRINT("DNS domain: ");
+                ND_PRINT(C_RESET, "DNS domain: ");
                 print_dns_label(ndo, value+1, bodylen-1, 1);
             } else if (policy == 130) {
-                ND_PRINT("Opaque UTF-8: ");
+                ND_PRINT(C_RESET, "Opaque UTF-8: ");
                 nd_printjnp(ndo, value + 1, bodylen - 1);
             } else if (policy == 131) {
                 if (bodylen != 1) {
                     nd_print_invalid(ndo);
                     break;
                 }
-                ND_PRINT("Restrictive assignment");
+                ND_PRINT(C_RESET, "Restrictive assignment");
             } else if (policy >= 132) {
-                ND_PRINT("Unknown (%u)", policy); /* Reserved for future additions */
+                ND_PRINT(C_RESET, "Unknown (%u)", policy); /* Reserved for future additions */
             }
         }
             break;
@@ -733,11 +733,11 @@ hncp_print_rec(netdissect_options *ndo,
                 break;
             }
             prty = GET_U_1(value + 4) & 0xf;
-            ND_PRINT(" EPID: %08x Prty: %u",
+            ND_PRINT(C_RESET, " EPID: %08x Prty: %u",
                 GET_BE_U_4(value),
                 prty
             );
-            ND_PRINT(" Prefix: ");
+            ND_PRINT(C_RESET, " Prefix: ");
             if ((l = print_prefix(ndo, value + 5, bodylen - 5)) < 0) {
                 nd_print_invalid(ndo);
                 break;
@@ -759,7 +759,7 @@ hncp_print_rec(netdissect_options *ndo,
             }
             endpoint_identifier = GET_BE_U_4(value);
             ip_address = format_ip6addr(ndo, value + 4);
-            ND_PRINT(" EPID: %08x IP Address: %s",
+            ND_PRINT(C_RESET, " EPID: %08x IP Address: %s",
                 endpoint_identifier,
                 ip_address
             );
@@ -776,7 +776,7 @@ hncp_print_rec(netdissect_options *ndo,
                 break;
             }
             ip_address = format_ip6addr(ndo, value);
-            ND_PRINT(" IP-Address: %s %c%c%c ",
+            ND_PRINT(C_RESET, " IP-Address: %s %c%c%c ",
                 ip_address,
                 (GET_U_1(value + 16) & 4) ? 'l' : '-',
                 (GET_U_1(value + 16) & 2) ? 'b' : '-',
@@ -799,7 +799,7 @@ hncp_print_rec(netdissect_options *ndo,
                 nd_print_invalid(ndo);
                 break;
             }
-            ND_PRINT(" Domain: ");
+            ND_PRINT(C_RESET, " Domain: ");
             print_dns_label(ndo, value, bodylen, 1);
         }
             break;
@@ -815,13 +815,13 @@ hncp_print_rec(netdissect_options *ndo,
                 nd_print_invalid(ndo);
                 break;
             }
-            ND_PRINT(" IP-Address: %s Name: ",
+            ND_PRINT(C_RESET, " IP-Address: %s Name: ",
                 format_ip6addr(ndo, value)
             );
             if (l < 64) {
-                ND_PRINT("\"");
+                ND_PRINT(C_RESET, "\"");
                 nd_printjnp(ndo, value + 17, l);
-                ND_PRINT("\"");
+                ND_PRINT(C_RESET, "\"");
             } else {
                 nd_print_invalid(ndo);
             }
@@ -837,7 +837,7 @@ hncp_print_rec(netdissect_options *ndo,
                 nd_print_invalid(ndo);
                 break;
             }
-            ND_PRINT(" PSK: %s", format_256(ndo, value));
+            ND_PRINT(C_RESET, " PSK: %s", format_256(ndo, value));
             hncp_print_rec(ndo, value + 32, bodylen - 32, indent+1);
         }
             break;

--- a/print-hsrp.c
+++ b/print-hsrp.c
@@ -101,33 +101,33 @@ hsrp_print(netdissect_options *ndo, const u_char *bp, u_int len)
 
 	ndo->ndo_protocol = "hsrp";
 	version = GET_U_1(hp->hsrp_version);
-	ND_PRINT("HSRPv%u", version);
+	ND_PRINT(C_RESET, C_RESET "HSRPv%u", version);
 	if (version != 0)
 		return;
-	ND_PRINT("-");
-	ND_PRINT("%s ",
+	ND_PRINT(C_RESET, C_RESET "-");
+	ND_PRINT(C_RESET, C_RESET "%s ",
 		 tok2strary(op_code_str, "unknown (%u)", GET_U_1(hp->hsrp_op_code)));
-	ND_PRINT("%u: ", len);
-	ND_PRINT("state=%s ",
+	ND_PRINT(C_RESET, C_RESET "%u: ", len);
+	ND_PRINT(C_RESET, C_RESET "state=%s ",
 		 tok2str(states, "Unknown (%u)", GET_U_1(hp->hsrp_state)));
-	ND_PRINT("group=%u ", GET_U_1(hp->hsrp_group));
+	ND_PRINT(C_RESET, C_RESET "group=%u ", GET_U_1(hp->hsrp_group));
 	if (GET_U_1(hp->hsrp_reserved) != 0) {
-		ND_PRINT("[reserved=%u!] ", GET_U_1(hp->hsrp_reserved));
+		ND_PRINT(C_RESET, C_RESET "[reserved=%u!] ", GET_U_1(hp->hsrp_reserved));
 	}
-	ND_PRINT("addr=%s", GET_IPADDR_STRING(hp->hsrp_virtaddr));
+	ND_PRINT(C_RESET, C_RESET "addr=%s", GET_IPADDR_STRING(hp->hsrp_virtaddr));
 	if (ndo->ndo_vflag) {
-		ND_PRINT(" hellotime=");
+		ND_PRINT(C_RESET, C_RESET " hellotime=");
 		unsigned_relts_print(ndo, GET_U_1(hp->hsrp_hellotime));
-		ND_PRINT(" holdtime=");
+		ND_PRINT(C_RESET, C_RESET " holdtime=");
 		unsigned_relts_print(ndo, GET_U_1(hp->hsrp_holdtime));
-		ND_PRINT(" priority=%u", GET_U_1(hp->hsrp_priority));
-		ND_PRINT(" auth=\"");
+		ND_PRINT(C_RESET, C_RESET " priority=%u", GET_U_1(hp->hsrp_priority));
+		ND_PRINT(C_RESET, C_RESET " auth=\"");
 		/*
 		 * RFC 2281 Section 5.1 does not specify the encoding of
 		 * Authentication Data explicitly, but zero padding can be
 		 * inferred from the "recommended default value".
 		 */
 		nd_printjnp(ndo, hp->hsrp_authdata, HSRP_AUTH_SIZE);
-		ND_PRINT("\"");
+		ND_PRINT(C_RESET, C_RESET "\"");
 	}
 }

--- a/print-hsrp.c
+++ b/print-hsrp.c
@@ -101,33 +101,33 @@ hsrp_print(netdissect_options *ndo, const u_char *bp, u_int len)
 
 	ndo->ndo_protocol = "hsrp";
 	version = GET_U_1(hp->hsrp_version);
-	ND_PRINT(C_RESET, C_RESET "HSRPv%u", version);
+	ND_PRINT(C_RESET, "HSRPv%u", version);
 	if (version != 0)
 		return;
-	ND_PRINT(C_RESET, C_RESET "-");
-	ND_PRINT(C_RESET, C_RESET "%s ",
+	ND_PRINT(C_RESET, "-");
+	ND_PRINT(C_RESET, "%s ",
 		 tok2strary(op_code_str, "unknown (%u)", GET_U_1(hp->hsrp_op_code)));
-	ND_PRINT(C_RESET, C_RESET "%u: ", len);
-	ND_PRINT(C_RESET, C_RESET "state=%s ",
+	ND_PRINT(C_RESET, "%u: ", len);
+	ND_PRINT(C_RESET, "state=%s ",
 		 tok2str(states, "Unknown (%u)", GET_U_1(hp->hsrp_state)));
-	ND_PRINT(C_RESET, C_RESET "group=%u ", GET_U_1(hp->hsrp_group));
+	ND_PRINT(C_RESET, "group=%u ", GET_U_1(hp->hsrp_group));
 	if (GET_U_1(hp->hsrp_reserved) != 0) {
-		ND_PRINT(C_RESET, C_RESET "[reserved=%u!] ", GET_U_1(hp->hsrp_reserved));
+		ND_PRINT(C_RESET, "[reserved=%u!] ", GET_U_1(hp->hsrp_reserved));
 	}
-	ND_PRINT(C_RESET, C_RESET "addr=%s", GET_IPADDR_STRING(hp->hsrp_virtaddr));
+	ND_PRINT(C_RESET, "addr=%s", GET_IPADDR_STRING(hp->hsrp_virtaddr));
 	if (ndo->ndo_vflag) {
-		ND_PRINT(C_RESET, C_RESET " hellotime=");
+		ND_PRINT(C_RESET, " hellotime=");
 		unsigned_relts_print(ndo, GET_U_1(hp->hsrp_hellotime));
-		ND_PRINT(C_RESET, C_RESET " holdtime=");
+		ND_PRINT(C_RESET, " holdtime=");
 		unsigned_relts_print(ndo, GET_U_1(hp->hsrp_holdtime));
-		ND_PRINT(C_RESET, C_RESET " priority=%u", GET_U_1(hp->hsrp_priority));
-		ND_PRINT(C_RESET, C_RESET " auth=\"");
+		ND_PRINT(C_RESET, " priority=%u", GET_U_1(hp->hsrp_priority));
+		ND_PRINT(C_RESET, " auth=\"");
 		/*
 		 * RFC 2281 Section 5.1 does not specify the encoding of
 		 * Authentication Data explicitly, but zero padding can be
 		 * inferred from the "recommended default value".
 		 */
 		nd_printjnp(ndo, hp->hsrp_authdata, HSRP_AUTH_SIZE);
-		ND_PRINT(C_RESET, C_RESET "\"");
+		ND_PRINT(C_RESET, "\"");
 	}
 }

--- a/print-icmp.c
+++ b/print-icmp.c
@@ -695,7 +695,7 @@ icmp_print(netdissect_options *ndo, const u_char *bp, u_int plen, const u_char *
 		str = tok2str(icmp2str, "type-#%u", icmp_type);
 		break;
 	}
-	ND_PRINT("ICMP %s, length %u", str, plen);
+	ND_PRINT(C_RESET, "ICMP %s, length %u", str, plen);
 	if (ndo->ndo_vflag && !fragmented) { /* don't attempt checksumming if this is a frag */
 		if (ND_TTEST_LEN(bp, plen)) {
 			uint16_t sum;
@@ -705,7 +705,7 @@ icmp_print(netdissect_options *ndo, const u_char *bp, u_int plen, const u_char *
 			sum = in_cksum(vec, 1);
 			if (sum != 0) {
 				uint16_t icmp_sum = GET_BE_U_2(dp->icmp_cksum);
-				ND_PRINT(" (wrong icmp cksum %x (->%x)!)",
+				ND_PRINT(C_RESET, " (wrong icmp cksum %x (->%x)!)",
 					     icmp_sum,
 					     in_cksum_shouldbe(icmp_sum, sum));
 			}
@@ -720,7 +720,7 @@ icmp_print(netdissect_options *ndo, const u_char *bp, u_int plen, const u_char *
 		const u_char *snapend_save;
 
 		bp += 8;
-		ND_PRINT("\n\t");
+		ND_PRINT(C_RESET, "\n\t");
 		ip = (const struct ip *)bp;
 		snapend_save = ndo->ndo_snapend;
 		/*
@@ -763,7 +763,7 @@ icmp_print(netdissect_options *ndo, const u_char *bp, u_int plen, const u_char *
                 }
             }
 
-            ND_PRINT("\n\tICMP Multi-Part extension v%u",
+            ND_PRINT(C_RESET, "\n\tICMP Multi-Part extension v%u",
                    ICMP_EXT_EXTRACT_VERSION(*(ext_dp->icmp_ext_version_res)));
 
             /*
@@ -771,7 +771,7 @@ icmp_print(netdissect_options *ndo, const u_char *bp, u_int plen, const u_char *
              */
             if (ICMP_EXT_EXTRACT_VERSION(*(ext_dp->icmp_ext_version_res)) !=
                 ICMP_EXT_VERSION) {
-                ND_PRINT(" packet not supported");
+                ND_PRINT(C_RESET, " packet not supported");
                 return;
             }
 
@@ -779,7 +779,7 @@ icmp_print(netdissect_options *ndo, const u_char *bp, u_int plen, const u_char *
             if (ND_TTEST_LEN(ext_dp->icmp_ext_version_res, hlen)) {
                 vec[0].ptr = (const uint8_t *)(const void *)&ext_dp->icmp_ext_version_res;
                 vec[0].len = hlen;
-                ND_PRINT(", checksum 0x%04x (%scorrect), length %u",
+                ND_PRINT(C_RESET, ", checksum 0x%04x (%scorrect), length %u",
                        GET_BE_U_2(ext_dp->icmp_ext_checksum),
                        in_cksum(vec, 1) ? "in" : "",
                        hlen);
@@ -797,7 +797,7 @@ icmp_print(netdissect_options *ndo, const u_char *bp, u_int plen, const u_char *
                 obj_ctype = GET_U_1(icmp_multipart_ext_object_header->ctype);
                 obj_tptr += sizeof(struct icmp_multipart_ext_object_header_t);
 
-                ND_PRINT("\n\t  %s Object (%u), Class-Type: %u, length %u",
+                ND_PRINT(C_RESET, "\n\t  %s Object (%u), Class-Type: %u, length %u",
                        tok2str(icmp_multipart_ext_obj_values,"unknown",obj_class_num),
                        obj_class_num,
                        obj_ctype,
@@ -817,10 +817,10 @@ icmp_print(netdissect_options *ndo, const u_char *bp, u_int plen, const u_char *
                     switch(obj_ctype) {
                     case 1:
                         raw_label = GET_BE_U_4(obj_tptr);
-                        ND_PRINT("\n\t    label %u, tc %u", MPLS_LABEL(raw_label), MPLS_TC(raw_label));
+                        ND_PRINT(C_RESET, "\n\t    label %u, tc %u", MPLS_LABEL(raw_label), MPLS_TC(raw_label));
                         if (MPLS_STACK(raw_label))
-                            ND_PRINT(", [S]");
-                        ND_PRINT(", ttl %u", MPLS_TTL(raw_label));
+                            ND_PRINT(C_RESET, ", [S]");
+                        ND_PRINT(C_RESET, ", ttl %u", MPLS_TTL(raw_label));
                         break;
                     default:
                         print_unknown_data(ndo, obj_tptr, "\n\t    ", obj_tlen);
@@ -842,30 +842,30 @@ icmp_print(netdissect_options *ndo, const u_char *bp, u_int plen, const u_char *
                     name_flag      = (obj_ctype & 0x2) >> 1;
                     mtu_flag       = (obj_ctype & 0x1);
 
-                    ND_PRINT("\n\t\t This object describes %s",
+                    ND_PRINT(C_RESET, "\n\t\t This object describes %s",
                              tok2str(icmp_interface_identification_role_values,
                              "an unknown interface role",interface_role));
 
                     offset = obj_tptr;
 
                     if (if_index_flag) {
-                        ND_PRINT("\n\t\t Interface Index: %u", GET_BE_U_4(offset));
+                        ND_PRINT(C_RESET, "\n\t\t Interface Index: %u", GET_BE_U_4(offset));
                         offset += 4;
                     }
                     if (ipaddr_flag) {
-                        ND_PRINT("\n\t\t IP Address sub-object: ");
+                        ND_PRINT(C_RESET, "\n\t\t IP Address sub-object: ");
                         ipaddr_subobj = (const struct icmp_interface_identification_ipaddr_subobject_t *) offset;
                         switch (GET_BE_U_2(ipaddr_subobj->afi)) {
                             case 1:
-                                ND_PRINT("%s", GET_IPADDR_STRING(ipaddr_subobj->ip_addr));
+                                ND_PRINT(C_RESET, "%s", GET_IPADDR_STRING(ipaddr_subobj->ip_addr));
                                 offset += 4;
                                 break;
                             case 2:
-                                ND_PRINT("%s", GET_IP6ADDR_STRING(ipaddr_subobj->ip_addr));
+                                ND_PRINT(C_RESET, "%s", GET_IP6ADDR_STRING(ipaddr_subobj->ip_addr));
                                 offset += 16;
                                 break;
                             default:
-                                ND_PRINT("Unknown Address Family Identifier");
+                                ND_PRINT(C_RESET, "Unknown Address Family Identifier");
                                 return;
                         }
                         offset += 4;
@@ -875,26 +875,26 @@ icmp_print(netdissect_options *ndo, const u_char *bp, u_int plen, const u_char *
 
                         ifname_subobj = (const struct icmp_interface_identification_ifname_subobject_t *) offset;
                         inft_name_length_field = GET_U_1(ifname_subobj->length);
-                        ND_PRINT("\n\t\t Interface Name");
+                        ND_PRINT(C_RESET, "\n\t\t Interface Name");
                         if (inft_name_length_field % 4 != 0) {
-                            ND_PRINT(" [length %u != N x 4]", inft_name_length_field);
+                            ND_PRINT(C_RESET, " [length %u != N x 4]", inft_name_length_field);
                             nd_print_invalid(ndo);
                             offset += inft_name_length_field;
                             break;
                         }
                         if (inft_name_length_field > 64) {
-                            ND_PRINT(" [length %u > 64]", inft_name_length_field);
+                            ND_PRINT(C_RESET, " [length %u > 64]", inft_name_length_field);
                             nd_print_invalid(ndo);
                             offset += inft_name_length_field;
                             break;
                         }
-                        ND_PRINT(", length %u: ", inft_name_length_field);
+                        ND_PRINT(C_RESET, ", length %u: ", inft_name_length_field);
                         nd_printjnp(ndo, ifname_subobj->if_name,
                                     inft_name_length_field - 1);
                         offset += inft_name_length_field;
                     }
                     if (mtu_flag) {
-                        ND_PRINT("\n\t\t MTU: %u", GET_BE_U_4(offset));
+                        ND_PRINT(C_RESET, "\n\t\t MTU: %u", GET_BE_U_4(offset));
                         offset += 4;
                     }
                     break;

--- a/print-icmp6.c
+++ b/print-icmp6.c
@@ -762,8 +762,8 @@ print_lladdr(netdissect_options *ndo, const uint8_t *p, size_t l)
 	ep = p + l;
 	while (l > 0 && q < ep) {
 		if (q > p)
-                        ND_PRINT(":");
-		ND_PRINT("%02x", GET_U_1(q));
+                        ND_PRINT(C_RESET, ":");
+		ND_PRINT(C_RESET, "%02x", GET_U_1(q));
 		q++;
 		l--;
 	}
@@ -809,12 +809,12 @@ rpl_printopts(netdissect_options *ndo, const uint8_t *opts, u_int length)
 		dio_type = GET_U_1(opt->rpl_dio_type);
 		if (dio_type == RPL_OPT_PAD1) {
                         optlen = 1;
-                        ND_PRINT(" opt:pad1");
+                        ND_PRINT(C_RESET, " opt:pad1");
                 } else {
                 	if (length < RPL_GENOPTION_LEN)
                 		goto trunc;
 	                optlen = GET_U_1(opt->rpl_dio_len)+RPL_GENOPTION_LEN;
-                        ND_PRINT(" opt:%s len:%u ",
+                        ND_PRINT(C_RESET, " opt:%s len:%u ",
                                   tok2str(rpl_subopt_values, "subopt:%u", dio_type),
                                   optlen);
                         ND_TCHECK_LEN(opt, optlen);
@@ -842,7 +842,7 @@ rpl_dio_print(netdissect_options *ndo,
         const struct nd_rpl_dio *dio = (const struct nd_rpl_dio *)bp;
 
         ND_ICHECK_ZU(length, <, sizeof(struct nd_rpl_dio));
-        ND_PRINT(" [dagid:%s,seq:%u,instance:%u,rank:%u,%smop:%s,prf:%u]",
+        ND_PRINT(C_RESET, " [dagid:%s,seq:%u,instance:%u,rank:%u,%smop:%s,prf:%u]",
                   GET_IP6ADDR_STRING(dio->rpl_dagid),
                   GET_U_1(dio->rpl_dtsn),
                   GET_U_1(dio->rpl_instanceid),
@@ -881,7 +881,7 @@ rpl_dao_print(netdissect_options *ndo,
                 length -= DAGID_LEN;
         }
 
-        ND_PRINT(" [dagid:%s,seq:%u,instance:%u%s%s,flags:%02x]",
+        ND_PRINT(C_RESET, " [dagid:%s,seq:%u,instance:%u%s%s,flags:%02x]",
                   dagid_str,
                   GET_U_1(dao->rpl_daoseq),
                   GET_U_1(dao->rpl_instanceid),
@@ -915,7 +915,7 @@ rpl_daoack_print(netdissect_options *ndo,
                 length -= DAGID_LEN;
         }
 
-        ND_PRINT(" [dagid:%s,seq:%u,instance:%u,status:%u]",
+        ND_PRINT(C_RESET, " [dagid:%s,seq:%u,instance:%u,status:%u]",
                   dagid_str,
                   GET_U_1(daoack->rpl_daoseq),
                   GET_U_1(daoack->rpl_instanceid),
@@ -939,42 +939,42 @@ rpl_print(netdissect_options *ndo,
         int basecode= icmp6_code & 0x7f;
 
         if(secured) {
-                ND_PRINT(", (SEC) [worktodo]");
+                ND_PRINT(C_RESET, ", (SEC) [worktodo]");
                 /* XXX
                  * the next header pointer needs to move forward to
                  * skip the secure part.
                  */
                 return;
         } else {
-                ND_PRINT(", (CLR)");
+                ND_PRINT(C_RESET, ", (CLR)");
         }
 
         switch(basecode) {
         case ND_RPL_DAG_IS:
-                ND_PRINT("DODAG Information Solicitation");
+                ND_PRINT(C_RESET, "DODAG Information Solicitation");
                 if(ndo->ndo_vflag) {
                 }
                 break;
         case ND_RPL_DAG_IO:
-                ND_PRINT("DODAG Information Object");
+                ND_PRINT(C_RESET, "DODAG Information Object");
                 if(ndo->ndo_vflag) {
                         rpl_dio_print(ndo, bp, length);
                 }
                 break;
         case ND_RPL_DAO:
-                ND_PRINT("Destination Advertisement Object");
+                ND_PRINT(C_RESET, "Destination Advertisement Object");
                 if(ndo->ndo_vflag) {
                         rpl_dao_print(ndo, bp, length);
                 }
                 break;
         case ND_RPL_DAO_ACK:
-                ND_PRINT("Destination Advertisement Object Ack");
+                ND_PRINT(C_RESET, "Destination Advertisement Object Ack");
                 if(ndo->ndo_vflag) {
                         rpl_daoack_print(ndo, bp, length);
                 }
                 break;
         default:
-                ND_PRINT("RPL message, unknown code %u",icmp6_code);
+                ND_PRINT(C_RESET, "RPL message, unknown code %u",icmp6_code);
                 break;
         }
 	return;
@@ -1007,7 +1007,7 @@ icmp6_print(netdissect_options *ndo,
 	/* 'ep' points to the end of available data. */
 	ep = ndo->ndo_snapend;
 	if (length == 0) {
-		ND_PRINT("ICMP6, length 0");
+		ND_PRINT(C_RESET, "ICMP6, length 0");
 		nd_print_invalid(ndo);
 		return;
 	}
@@ -1019,16 +1019,16 @@ icmp6_print(netdissect_options *ndo,
 			udp_sum = GET_BE_U_2(dp->icmp6_cksum);
 			sum = icmp6_cksum(ndo, ip, dp, length);
 			if (sum != 0)
-				ND_PRINT("[bad icmp6 cksum 0x%04x -> 0x%04x!] ",
+				ND_PRINT(C_RESET, "[bad icmp6 cksum 0x%04x -> 0x%04x!] ",
                                                 udp_sum,
                                                 in_cksum_shouldbe(udp_sum, sum));
 			else
-				ND_PRINT("[icmp6 sum ok] ");
+				ND_PRINT(C_RESET, "[icmp6 sum ok] ");
 		}
 	}
 
 	icmp6_type = GET_U_1(dp->icmp6_type);
-	ND_PRINT("ICMP6, %s", tok2str(icmp6_type_values,"unknown icmp6 type (%u)",icmp6_type));
+	ND_PRINT(C_RESET, "ICMP6, %s", tok2str(icmp6_type_values,"unknown icmp6 type (%u)",icmp6_type));
 
         /* display cosmetics: print the packet length for printer that use the vflag now */
         if (ndo->ndo_vflag && (icmp6_type == ND_ROUTER_SOLICIT ||
@@ -1038,22 +1038,22 @@ icmp6_print(netdissect_options *ndo,
                       icmp6_type == ND_REDIRECT ||
                       icmp6_type == ICMP6_HADISCOV_REPLY ||
                       icmp6_type == ICMP6_MOBILEPREFIX_ADVERT ))
-                ND_PRINT(", length %u", length);
+                ND_PRINT(C_RESET, ", length %u", length);
 
 	icmp6_code = GET_U_1(dp->icmp6_code);
 
 	switch (icmp6_type) {
 	case ICMP6_DST_UNREACH:
-                ND_PRINT(", %s", tok2str(icmp6_dst_unreach_code_values,"unknown unreach code (%u)",icmp6_code));
+                ND_PRINT(C_RESET, ", %s", tok2str(icmp6_dst_unreach_code_values,"unknown unreach code (%u)",icmp6_code));
 		switch (icmp6_code) {
 
 		case ICMP6_DST_UNREACH_NOROUTE: /* fall through */
 		case ICMP6_DST_UNREACH_ADMIN:
 		case ICMP6_DST_UNREACH_ADDR:
-                        ND_PRINT(" %s",GET_IP6ADDR_STRING(oip->ip6_dst));
+                        ND_PRINT(C_RESET, " %s",GET_IP6ADDR_STRING(oip->ip6_dst));
                         break;
 		case ICMP6_DST_UNREACH_BEYONDSCOPE:
-			ND_PRINT(" %s, source address %s",
+			ND_PRINT(C_RESET, " %s, source address %s",
 			       GET_IP6ADDR_STRING(oip->ip6_dst),
                                   GET_IP6ADDR_STRING(oip->ip6_src));
 			break;
@@ -1065,17 +1065,17 @@ icmp6_print(netdissect_options *ndo,
 			dport = GET_BE_U_2(ouh->uh_dport);
 			switch (prot) {
 			case IPPROTO_TCP:
-				ND_PRINT(", %s tcp port %s",
+				ND_PRINT(C_RESET, ", %s tcp port %s",
 					GET_IP6ADDR_STRING(oip->ip6_dst),
                                           tcpport_string(ndo, dport));
 				break;
 			case IPPROTO_UDP:
-				ND_PRINT(", %s udp port %s",
+				ND_PRINT(C_RESET, ", %s udp port %s",
 					GET_IP6ADDR_STRING(oip->ip6_dst),
                                           udpport_string(ndo, dport));
 				break;
 			default:
-				ND_PRINT(", %s protocol %u port %u unreachable",
+				ND_PRINT(C_RESET, ", %s protocol %u port %u unreachable",
 					GET_IP6ADDR_STRING(oip->ip6_dst),
                                           prot, dport);
 				break;
@@ -1090,19 +1090,19 @@ icmp6_print(netdissect_options *ndo,
 		}
 		break;
 	case ICMP6_PACKET_TOO_BIG:
-		ND_PRINT(", mtu %u", GET_BE_U_4(dp->icmp6_mtu));
+		ND_PRINT(C_RESET, ", mtu %u", GET_BE_U_4(dp->icmp6_mtu));
 		break;
 	case ICMP6_TIME_EXCEEDED:
 		switch (icmp6_code) {
 		case ICMP6_TIME_EXCEED_TRANSIT:
-			ND_PRINT(" for %s",
+			ND_PRINT(C_RESET, " for %s",
                                   GET_IP6ADDR_STRING(oip->ip6_dst));
 			break;
 		case ICMP6_TIME_EXCEED_REASSEMBLY:
-			ND_PRINT(" (reassembly)");
+			ND_PRINT(C_RESET, " (reassembly)");
 			break;
 		default:
-                        ND_PRINT(", unknown code (%u)", icmp6_code);
+                        ND_PRINT(C_RESET, ", unknown code (%u)", icmp6_code);
 			break;
 		}
 		break;
@@ -1110,40 +1110,40 @@ icmp6_print(netdissect_options *ndo,
 		ND_TCHECK_16(oip->ip6_dst);
 		switch (icmp6_code) {
 		case ICMP6_PARAMPROB_HEADER:
-                        ND_PRINT(", erroneous - octet %u",
+                        ND_PRINT(C_RESET, ", erroneous - octet %u",
 				 GET_BE_U_4(dp->icmp6_pptr));
                         break;
 		case ICMP6_PARAMPROB_NEXTHEADER:
-                        ND_PRINT(", next header - octet %u",
+                        ND_PRINT(C_RESET, ", next header - octet %u",
 				 GET_BE_U_4(dp->icmp6_pptr));
                         break;
 		case ICMP6_PARAMPROB_OPTION:
-                        ND_PRINT(", option - octet %u",
+                        ND_PRINT(C_RESET, ", option - octet %u",
 				 GET_BE_U_4(dp->icmp6_pptr));
                         break;
 		case ICMP6_PARAMPROB_FRAGHDRCHAIN:
-                        ND_PRINT(", incomplete header chain - octet %u",
+                        ND_PRINT(C_RESET, ", incomplete header chain - octet %u",
 				 GET_BE_U_4(dp->icmp6_pptr));
                         break;
 		default:
-                        ND_PRINT(", code-#%u",
+                        ND_PRINT(C_RESET, ", code-#%u",
                                   icmp6_code);
                         break;
 		}
 		break;
 	case ICMP6_ECHO_REQUEST:
 	case ICMP6_ECHO_REPLY:
-                ND_PRINT(", id %u, seq %u", GET_BE_U_2(dp->icmp6_id),
+                ND_PRINT(C_RESET, ", id %u, seq %u", GET_BE_U_2(dp->icmp6_id),
 			 GET_BE_U_2(dp->icmp6_seq));
 		break;
 	case ICMP6_MEMBERSHIP_QUERY:
 		if (length == MLD_MINLEN) {
 			mld6_print(ndo, (const u_char *)dp);
 		} else if (length >= MLDV2_MINLEN) {
-			ND_PRINT(" v2");
+			ND_PRINT(C_RESET, " v2");
 			mldv2_query_print(ndo, (const u_char *)dp, length);
 		} else {
-                        ND_PRINT(" unknown-version (len %u) ", length);
+                        ND_PRINT(C_RESET, " unknown-version (len %u) ", length);
 		}
 		break;
 	case ICMP6_MEMBERSHIP_REPORT:
@@ -1166,7 +1166,7 @@ icmp6_print(netdissect_options *ndo,
 			const struct nd_router_advert *p;
 
 			p = (const struct nd_router_advert *)dp;
-			ND_PRINT("\n\thop limit %u, Flags [%s]"
+			ND_PRINT(C_RESET, "\n\thop limit %u, Flags [%s]"
                                   ", pref %s, router lifetime %us, reachable time %ums, retrans timer %ums",
                                   GET_U_1(p->nd_ra_curhoplimit),
                                   bittok2str(icmp6_opt_ra_flag_values,"none",GET_U_1(p->nd_ra_flags_reserved)),
@@ -1184,7 +1184,7 @@ icmp6_print(netdissect_options *ndo,
 	    {
 		const struct nd_neighbor_solicit *p;
 		p = (const struct nd_neighbor_solicit *)dp;
-		ND_PRINT(", who has %s", GET_IP6ADDR_STRING(p->nd_ns_target));
+		ND_PRINT(C_RESET, ", who has %s", GET_IP6ADDR_STRING(p->nd_ns_target));
 		if (ndo->ndo_vflag) {
 #define NDSOLLEN 24
 			if (icmp6_opt_print(ndo, (const u_char *)dp + NDSOLLEN,
@@ -1198,10 +1198,10 @@ icmp6_print(netdissect_options *ndo,
 		const struct nd_neighbor_advert *p;
 
 		p = (const struct nd_neighbor_advert *)dp;
-		ND_PRINT(", tgt is %s",
+		ND_PRINT(C_RESET, ", tgt is %s",
                           GET_IP6ADDR_STRING(p->nd_na_target));
 		if (ndo->ndo_vflag) {
-                        ND_PRINT(", Flags [%s]",
+                        ND_PRINT(C_RESET, ", Flags [%s]",
                                   bittok2str(icmp6_nd_na_flag_values,
                                              "none",
                                              GET_BE_U_4(p->nd_na_flags_reserved)));
@@ -1218,8 +1218,8 @@ icmp6_print(netdissect_options *ndo,
 		const struct nd_redirect *p;
 
 		p = (const struct nd_redirect *)dp;
-		ND_PRINT(", %s", GET_IP6ADDR_STRING(p->nd_rd_dst));
-		ND_PRINT(" to %s", GET_IP6ADDR_STRING(p->nd_rd_target));
+		ND_PRINT(C_RESET, ", %s", GET_IP6ADDR_STRING(p->nd_rd_dst));
+		ND_PRINT(C_RESET, " to %s", GET_IP6ADDR_STRING(p->nd_rd_target));
 #define REDIRECTLEN 40
 		if (ndo->ndo_vflag) {
 			if (icmp6_opt_print(ndo, (const u_char *)dp + REDIRECTLEN,
@@ -1244,19 +1244,19 @@ icmp6_print(netdissect_options *ndo,
 		break;
 	case ICMP6_MOBILEPREFIX_SOLICIT: /* fall through */
 	case ICMP6_HADISCOV_REQUEST:
-                ND_PRINT(", id 0x%04x", GET_BE_U_2(dp->icmp6_data16[0]));
+                ND_PRINT(C_RESET, ", id 0x%04x", GET_BE_U_2(dp->icmp6_data16[0]));
                 break;
 	case ICMP6_HADISCOV_REPLY:
 		if (ndo->ndo_vflag) {
 			const u_char *cp;
 			const u_char *p;
 
-			ND_PRINT(", id 0x%04x",
+			ND_PRINT(C_RESET, ", id 0x%04x",
 				 GET_BE_U_2(dp->icmp6_data16[0]));
 			cp = (const u_char *)dp + length;
 			p = (const u_char *)(dp + 1);
 			while (p < cp) {
-				ND_PRINT(", %s", GET_IP6ADDR_STRING(p));
+				ND_PRINT(C_RESET, ", %s", GET_IP6ADDR_STRING(p));
 				p += 16;
 			}
 		}
@@ -1265,15 +1265,15 @@ icmp6_print(netdissect_options *ndo,
 		if (ndo->ndo_vflag) {
 			uint16_t flags;
 
-			ND_PRINT(", id 0x%04x",
+			ND_PRINT(C_RESET, ", id 0x%04x",
 				 GET_BE_U_2(dp->icmp6_data16[0]));
 			flags = GET_BE_U_2(dp->icmp6_data16[1]);
 			if (flags & 0xc000)
-				ND_PRINT(" ");
+				ND_PRINT(C_RESET, " ");
 			if (flags & 0x8000)
-				ND_PRINT("M");
+				ND_PRINT(C_RESET, "M");
 			if (flags & 0x4000)
-				ND_PRINT("O");
+				ND_PRINT(C_RESET, "O");
 #define MPADVLEN 8
 			if (icmp6_opt_print(ndo, (const u_char *)dp + MPADVLEN,
 					    length - MPADVLEN) == -1)
@@ -1285,13 +1285,13 @@ icmp6_print(netdissect_options *ndo,
                 rpl_print(ndo, icmp6_code, dp->icmp6_data, length-sizeof(struct icmp6_hdr)+4);
                 break;
 	default:
-                ND_PRINT(", length %u", length);
+                ND_PRINT(C_RESET, ", length %u", length);
                 if (ndo->ndo_vflag <= 1)
                         print_unknown_data(ndo, bp,"\n\t", length);
                 return;
         }
         if (!ndo->ndo_vflag)
-                ND_PRINT(", length %u", length);
+                ND_PRINT(C_RESET, ", length %u", length);
 	return;
 trunc:
 	nd_print_trunc(ndo);
@@ -1406,7 +1406,7 @@ icmp6_opt_print(netdissect_options *ndo, const u_char *bp, int resid)
 		if (cp + (opt_len << 3) > ep)
 			goto trunc;
 
-                ND_PRINT("\n\t  %s option (%u), length %u (%u): ",
+                ND_PRINT(C_RESET, "\n\t  %s option (%u), length %u (%u): ",
                           tok2str(icmp6_opt_values, "unknown", opt_type),
                           opt_type,
                           opt_len << 3,
@@ -1423,13 +1423,13 @@ icmp6_opt_print(netdissect_options *ndo, const u_char *bp, int resid)
 			break;
 		case ND_OPT_PREFIX_INFORMATION:
 			opp = (const struct nd_opt_prefix_info *)op;
-                        ND_PRINT("%s/%u%s, Flags [%s], valid time %s",
+                        ND_PRINT(C_RESET, "%s/%u%s, Flags [%s], valid time %s",
                                   GET_IP6ADDR_STRING(opp->nd_opt_pi_prefix),
                                   GET_U_1(opp->nd_opt_pi_prefix_len),
                                   (opt_len != 4) ? "badlen" : "",
                                   bittok2str(icmp6_opt_pi_flag_values, "none", GET_U_1(opp->nd_opt_pi_flags_reserved)),
                                   get_lifetime(GET_BE_U_4(opp->nd_opt_pi_valid_time)));
-                        ND_PRINT(", pref. time %s",
+                        ND_PRINT(C_RESET, ", pref. time %s",
 				 get_lifetime(GET_BE_U_4(opp->nd_opt_pi_preferred_time)));
 			break;
 		case ND_OPT_REDIRECTED_HEADER:
@@ -1438,40 +1438,40 @@ icmp6_opt_print(netdissect_options *ndo, const u_char *bp, int resid)
 			break;
 		case ND_OPT_MTU:
 			opm = (const struct nd_opt_mtu *)op;
-			ND_PRINT(" %u%s",
+			ND_PRINT(C_RESET, " %u%s",
                                GET_BE_U_4(opm->nd_opt_mtu_mtu),
                                (opt_len != 1) ? "bad option length" : "" );
                         break;
 		case ND_OPT_RDNSS:
 			oprd = (const struct nd_opt_rdnss *)op;
 			l = (opt_len - 1) / 2;
-			ND_PRINT(" lifetime %us,",
+			ND_PRINT(C_RESET, " lifetime %us,",
                                   GET_BE_U_4(oprd->nd_opt_rdnss_lifetime));
 			for (i = 0; i < l; i++) {
-				ND_PRINT(" addr: %s",
+				ND_PRINT(C_RESET, " addr: %s",
                                           GET_IP6ADDR_STRING(oprd->nd_opt_rdnss_addr[i]));
 			}
 			break;
 		case ND_OPT_DNSSL:
 			opds = (const struct nd_opt_dnssl *)op;
-			ND_PRINT(" lifetime %us, domain(s):",
+			ND_PRINT(C_RESET, " lifetime %us, domain(s):",
                                   GET_BE_U_4(opds->nd_opt_dnssl_lifetime));
 			domp = cp + 8; /* domain names, variable-sized, RFC1035-encoded */
 			while (domp < cp + (opt_len << 3) && GET_U_1(domp) != '\0')
 			{
-				ND_PRINT(" ");
+				ND_PRINT(C_RESET, " ");
 				if ((domp = fqdn_print(ndo, domp, bp)) == NULL)
 					goto trunc;
 			}
 			break;
 		case ND_OPT_ADVINTERVAL:
 			opa = (const struct nd_opt_advinterval *)op;
-			ND_PRINT(" %ums",
+			ND_PRINT(C_RESET, " %ums",
 				 GET_BE_U_4(opa->nd_opt_adv_interval));
 			break;
                 case ND_OPT_HOMEAGENT_INFO:
 			oph = (const struct nd_opt_homeagent_info *)op;
-			ND_PRINT(" preference %u, lifetime %u",
+			ND_PRINT(C_RESET, " preference %u, lifetime %u",
                                   GET_BE_U_2(oph->nd_opt_hai_preference),
                                   GET_BE_U_2(oph->nd_opt_hai_lifetime));
 			break;
@@ -1491,11 +1491,11 @@ icmp6_opt_print(netdissect_options *ndo, const u_char *bp, int resid)
 			default:
 				goto trunc;
 			}
-			ND_PRINT(" %s/%u", ip6addr_string(ndo, (const u_char *)&in6), /* local buffer, not packet data; don't use GET_IP6ADDR_STRING() */
+			ND_PRINT(C_RESET, " %s/%u", ip6addr_string(ndo, (const u_char *)&in6), /* local buffer, not packet data; don't use GET_IP6ADDR_STRING() */
                                   GET_U_1(opri->nd_opt_rti_prefixlen));
-			ND_PRINT(", pref=%s",
+			ND_PRINT(C_RESET, ", pref=%s",
 				 get_rtpref(GET_U_1(opri->nd_opt_rti_flags)));
-			ND_PRINT(", lifetime=%s",
+			ND_PRINT(C_RESET, ", lifetime=%s",
                                   get_lifetime(GET_BE_U_4(opri->nd_opt_rti_lifetime)));
 			break;
 		default:
@@ -1530,8 +1530,8 @@ mld6_print(netdissect_options *ndo, const u_char *bp)
 	if ((const u_char *)mp + sizeof(*mp) > ep)
 		return;
 
-	ND_PRINT("max resp delay: %u ", GET_BE_U_2(mp->mld6_maxdelay));
-	ND_PRINT("addr: %s", GET_IP6ADDR_STRING(mp->mld6_addr));
+	ND_PRINT(C_RESET, "max resp delay: %u ", GET_BE_U_2(mp->mld6_maxdelay));
+	ND_PRINT(C_RESET, "addr: %s", GET_IP6ADDR_STRING(mp->mld6_addr));
 }
 
 static void
@@ -1543,43 +1543,43 @@ mldv2_report_print(netdissect_options *ndo, const u_char *bp, u_int len)
 
     /* Minimum len is 8 */
     if (len < 8) {
-            ND_PRINT(" [invalid len %u]", len);
+            ND_PRINT(C_RESET, " [invalid len %u]", len);
             return;
     }
 
     ngroups = GET_BE_U_2(icp->icmp6_data16[1]);
-    ND_PRINT(", %u group record(s)", ngroups);
+    ND_PRINT(C_RESET, ", %u group record(s)", ngroups);
     if (ndo->ndo_vflag > 0) {
 	/* Print the group records */
 	group = 8;
         for (i = 0; i < ngroups; i++) {
 	    /* type(1) + auxlen(1) + numsrc(2) + grp(16) */
 	    if (len < group + 20) {
-                    ND_PRINT(" [invalid number of groups]");
+                    ND_PRINT(C_RESET, " [invalid number of groups]");
                     return;
 	    }
-            ND_PRINT(" [gaddr %s", GET_IP6ADDR_STRING(bp + group + 4));
-	    ND_PRINT(" %s", tok2str(mldv2report2str, " [v2-report-#%u]",
+            ND_PRINT(C_RESET, " [gaddr %s", GET_IP6ADDR_STRING(bp + group + 4));
+	    ND_PRINT(C_RESET, " %s", tok2str(mldv2report2str, " [v2-report-#%u]",
                                          GET_U_1(bp + group)));
             nsrcs = GET_BE_U_2(bp + group + 2);
 	    /* Check the number of sources and print them */
 	    if (len < group + 20 + (nsrcs * sizeof(nd_ipv6))) {
-                    ND_PRINT(" [invalid number of sources %u]", nsrcs);
+                    ND_PRINT(C_RESET, " [invalid number of sources %u]", nsrcs);
                     return;
 	    }
             if (ndo->ndo_vflag == 1)
-                    ND_PRINT(", %u source(s)", nsrcs);
+                    ND_PRINT(C_RESET, ", %u source(s)", nsrcs);
             else {
 		/* Print the sources */
-                    ND_PRINT(" {");
+                    ND_PRINT(C_RESET, " {");
                 for (j = 0; j < nsrcs; j++) {
-		    ND_PRINT(" %s", GET_IP6ADDR_STRING(bp + group + 20 + (j * sizeof(nd_ipv6))));
+		    ND_PRINT(C_RESET, " %s", GET_IP6ADDR_STRING(bp + group + 20 + (j * sizeof(nd_ipv6))));
 		}
-                ND_PRINT(" }");
+                ND_PRINT(C_RESET, " }");
             }
 	    /* Next group record */
             group += 20 + nsrcs * sizeof(nd_ipv6);
-	    ND_PRINT("]");
+	    ND_PRINT(C_RESET, "]");
         }
     }
 }
@@ -1595,7 +1595,7 @@ mldv2_query_print(netdissect_options *ndo, const u_char *bp, u_int len)
 
     /* Minimum len is 28 */
     if (len < 28) {
-        ND_PRINT(" [invalid len %u]", len);
+        ND_PRINT(C_RESET, " [invalid len %u]", len);
 	return;
     }
     mrc = GET_BE_U_2(icp->icmp6_data16[0]);
@@ -1605,16 +1605,16 @@ mldv2_query_print(netdissect_options *ndo, const u_char *bp, u_int len)
         mrt = ((mrc & 0x0fff) | 0x1000) << (((mrc & 0x7000) >> 12) + 3);
     }
     if (ndo->ndo_vflag) {
-            ND_PRINT(" [max resp delay=%u]", mrt);
+            ND_PRINT(C_RESET, " [max resp delay=%u]", mrt);
     }
-    ND_PRINT(" [gaddr %s", GET_IP6ADDR_STRING(bp + 8));
+    ND_PRINT(C_RESET, " [gaddr %s", GET_IP6ADDR_STRING(bp + 8));
 
     if (ndo->ndo_vflag) {
 	if (GET_U_1(bp + 24) & 0x08) {
-		ND_PRINT(" sflag");
+		ND_PRINT(C_RESET, " sflag");
 	}
 	if (GET_U_1(bp + 24) & 0x07) {
-		ND_PRINT(" robustness=%u", GET_U_1(bp + 24) & 0x07);
+		ND_PRINT(C_RESET, " robustness=%u", GET_U_1(bp + 24) & 0x07);
 	}
 	if (GET_U_1(bp + 25) < 128) {
 		qqi = GET_U_1(bp + 25);
@@ -1622,23 +1622,23 @@ mldv2_query_print(netdissect_options *ndo, const u_char *bp, u_int len)
 		qqi = ((GET_U_1(bp + 25) & 0x0f) | 0x10) <<
 		       (((GET_U_1(bp + 25) & 0x70) >> 4) + 3);
 	}
-	ND_PRINT(" qqi=%u", qqi);
+	ND_PRINT(C_RESET, " qqi=%u", qqi);
     }
 
     nsrcs = GET_BE_U_2(bp + 26);
     if (nsrcs > 0) {
 	if (len < 28 + nsrcs * sizeof(nd_ipv6))
-	    ND_PRINT(" [invalid number of sources]");
+	    ND_PRINT(C_RESET, " [invalid number of sources]");
 	else if (ndo->ndo_vflag > 1) {
-	    ND_PRINT(" {");
+	    ND_PRINT(C_RESET, " {");
 	    for (i = 0; i < nsrcs; i++) {
-		ND_PRINT(" %s", GET_IP6ADDR_STRING(bp + 28 + (i * sizeof(nd_ipv6))));
+		ND_PRINT(C_RESET, " %s", GET_IP6ADDR_STRING(bp + 28 + (i * sizeof(nd_ipv6))));
 	    }
-	    ND_PRINT(" }");
+	    ND_PRINT(C_RESET, " }");
 	} else
-                ND_PRINT(", %u source(s)", nsrcs);
+                ND_PRINT(C_RESET, ", %u source(s)", nsrcs);
     }
-    ND_PRINT("]");
+    ND_PRINT(C_RESET, "]");
 }
 
 static void
@@ -1647,13 +1647,13 @@ dnsname_print(netdissect_options *ndo, const u_char *cp, const u_char *ep)
 	int i;
 
 	/* DNS name decoding - no decompression */
-	ND_PRINT(", \"");
+	ND_PRINT(C_RESET, ", \"");
 	while (cp < ep) {
 		i = GET_U_1(cp);
 		cp++;
 		if (i) {
 			if (i > ep - cp) {
-				ND_PRINT("???");
+				ND_PRINT(C_RESET, "???");
 				break;
 			}
 			while (i-- && cp < ep) {
@@ -1661,21 +1661,21 @@ dnsname_print(netdissect_options *ndo, const u_char *cp, const u_char *ep)
 				cp++;
 			}
 			if (cp + 1 < ep && GET_U_1(cp))
-				ND_PRINT(".");
+				ND_PRINT(C_RESET, ".");
 		} else {
 			if (cp == ep) {
 				/* FQDN */
-				ND_PRINT(".");
+				ND_PRINT(C_RESET, ".");
 			} else if (cp + 1 == ep && GET_U_1(cp) == '\0') {
 				/* truncated */
 			} else {
 				/* invalid */
-				ND_PRINT("???");
+				ND_PRINT(C_RESET, "???");
 			}
 			break;
 		}
 	}
-	ND_PRINT("\"");
+	ND_PRINT(C_RESET, "\"");
 }
 
 static void
@@ -1697,34 +1697,34 @@ icmp6_nodeinfo_print(netdissect_options *ndo, u_int icmp6len, const u_char *bp, 
 	case ICMP6_NI_QUERY:
 		if (siz == sizeof(*dp) + 4) {
 			/* KAME who-are-you */
-			ND_PRINT(" who-are-you request");
+			ND_PRINT(C_RESET, " who-are-you request");
 			break;
 		}
-		ND_PRINT(" node information query");
+		ND_PRINT(C_RESET, " node information query");
 
 		ND_TCHECK_LEN(dp, sizeof(*ni6));
 		ni6 = (const struct icmp6_nodeinfo *)dp;
-		ND_PRINT(" (");	/*)*/
+		ND_PRINT(C_RESET, " (");	/*)*/
 		switch (GET_BE_U_2(ni6->ni_qtype)) {
 		case NI_QTYPE_NOOP:
-			ND_PRINT("noop");
+			ND_PRINT(C_RESET, "noop");
 			break;
 		case NI_QTYPE_SUPTYPES:
-			ND_PRINT("supported qtypes");
+			ND_PRINT(C_RESET, "supported qtypes");
 			i = GET_BE_U_2(ni6->ni_flags);
 			if (i)
-				ND_PRINT(" [%s]", (i & 0x01) ? "C" : "");
+				ND_PRINT(C_RESET, " [%s]", (i & 0x01) ? "C" : "");
 			break;
 		case NI_QTYPE_FQDN:
-			ND_PRINT("DNS name");
+			ND_PRINT(C_RESET, "DNS name");
 			break;
 		case NI_QTYPE_NODEADDR:
-			ND_PRINT("node addresses");
+			ND_PRINT(C_RESET, "node addresses");
 			i = GET_BE_U_2(ni6->ni_flags);
 			if (!i)
 				break;
 			/* NI_NODEADDR_FLAG_TRUNCATE undefined for query */
-			ND_PRINT(" [%s%s%s%s%s%s]",
+			ND_PRINT(C_RESET, " [%s%s%s%s%s%s]",
 			    (i & NI_NODEADDR_FLAG_ANYCAST) ? "a" : "",
 			    (i & NI_NODEADDR_FLAG_GLOBAL) ? "G" : "",
 			    (i & NI_NODEADDR_FLAG_SITELOCAL) ? "S" : "",
@@ -1733,7 +1733,7 @@ icmp6_nodeinfo_print(netdissect_options *ndo, u_int icmp6len, const u_char *bp, 
 			    (i & NI_NODEADDR_FLAG_ALL) ? "A" : "");
 			break;
 		default:
-			ND_PRINT("unknown");
+			ND_PRINT(C_RESET, "unknown");
 			break;
 		}
 
@@ -1741,17 +1741,17 @@ icmp6_nodeinfo_print(netdissect_options *ndo, u_int icmp6len, const u_char *bp, 
 		    GET_BE_U_2(ni6->ni_qtype) == NI_QTYPE_SUPTYPES) {
 			if (siz != sizeof(*ni6))
 				if (ndo->ndo_vflag)
-					ND_PRINT(", invalid len");
+					ND_PRINT(C_RESET, ", invalid len");
 			/*(*/
-			ND_PRINT(")");
+			ND_PRINT(C_RESET, ")");
 			break;
 		}
 
 		/* XXX backward compat, icmp-name-lookup-03 */
 		if (siz == sizeof(*ni6)) {
-			ND_PRINT(", 03 draft");
+			ND_PRINT(C_RESET, ", 03 draft");
 			/*(*/
-			ND_PRINT(")");
+			ND_PRINT(C_RESET, ")");
 			break;
 		}
 
@@ -1762,25 +1762,25 @@ icmp6_nodeinfo_print(netdissect_options *ndo, u_int icmp6len, const u_char *bp, 
 				break;
 			if (siz != sizeof(*ni6) + sizeof(nd_ipv6)) {
 				if (ndo->ndo_vflag)
-					ND_PRINT(", invalid subject len");
+					ND_PRINT(C_RESET, ", invalid subject len");
 				break;
 			}
-			ND_PRINT(", subject=%s",
+			ND_PRINT(C_RESET, ", subject=%s",
                                   GET_IP6ADDR_STRING(cp));
 			break;
 		case ICMP6_NI_SUBJ_FQDN:
-			ND_PRINT(", subject=DNS name");
+			ND_PRINT(C_RESET, ", subject=DNS name");
 			if (GET_U_1(cp) == ep - cp - 1) {
 				/* icmp-name-lookup-03, pascal string */
 				if (ndo->ndo_vflag)
-					ND_PRINT(", 03 draft");
+					ND_PRINT(C_RESET, ", 03 draft");
 				cp++;
-				ND_PRINT(", \"");
+				ND_PRINT(C_RESET, ", \"");
 				while (cp < ep) {
 					fn_print_char(ndo, GET_U_1(cp));
 					cp++;
 				}
-				ND_PRINT("\"");
+				ND_PRINT(C_RESET, "\"");
 			} else
 				dnsname_print(ndo, cp, ep);
 			break;
@@ -1789,19 +1789,19 @@ icmp6_nodeinfo_print(netdissect_options *ndo, u_int icmp6len, const u_char *bp, 
 				break;
 			if (siz != sizeof(*ni6) + sizeof(nd_ipv4)) {
 				if (ndo->ndo_vflag)
-					ND_PRINT(", invalid subject len");
+					ND_PRINT(C_RESET, ", invalid subject len");
 				break;
 			}
-			ND_PRINT(", subject=%s",
+			ND_PRINT(C_RESET, ", subject=%s",
                                   GET_IPADDR_STRING(cp));
 			break;
 		default:
-			ND_PRINT(", unknown subject");
+			ND_PRINT(C_RESET, ", unknown subject");
 			break;
 		}
 
 		/*(*/
-		ND_PRINT(")");
+		ND_PRINT(C_RESET, ")");
 		break;
 
 	case ICMP6_NI_REPLY:
@@ -1812,84 +1812,84 @@ icmp6_nodeinfo_print(netdissect_options *ndo, u_int icmp6len, const u_char *bp, 
 
 		ND_TCHECK_LEN(dp, sizeof(*ni6));
 		ni6 = (const struct icmp6_nodeinfo *)dp;
-		ND_PRINT(" node information reply");
-		ND_PRINT(" (");	/*)*/
+		ND_PRINT(C_RESET, " node information reply");
+		ND_PRINT(C_RESET, " (");	/*)*/
 		switch (GET_U_1(ni6->ni_code)) {
 		case ICMP6_NI_SUCCESS:
 			if (ndo->ndo_vflag) {
-				ND_PRINT("success");
+				ND_PRINT(C_RESET, "success");
 				needcomma++;
 			}
 			break;
 		case ICMP6_NI_REFUSED:
-			ND_PRINT("refused");
+			ND_PRINT(C_RESET, "refused");
 			needcomma++;
 			if (siz != sizeof(*ni6))
 				if (ndo->ndo_vflag)
-					ND_PRINT(", invalid length");
+					ND_PRINT(C_RESET, ", invalid length");
 			break;
 		case ICMP6_NI_UNKNOWN:
-			ND_PRINT("unknown");
+			ND_PRINT(C_RESET, "unknown");
 			needcomma++;
 			if (siz != sizeof(*ni6))
 				if (ndo->ndo_vflag)
-					ND_PRINT(", invalid length");
+					ND_PRINT(C_RESET, ", invalid length");
 			break;
 		}
 
 		if (GET_U_1(ni6->ni_code) != ICMP6_NI_SUCCESS) {
 			/*(*/
-			ND_PRINT(")");
+			ND_PRINT(C_RESET, ")");
 			break;
 		}
 
 		switch (GET_BE_U_2(ni6->ni_qtype)) {
 		case NI_QTYPE_NOOP:
 			if (needcomma)
-				ND_PRINT(", ");
-			ND_PRINT("noop");
+				ND_PRINT(C_RESET, ", ");
+			ND_PRINT(C_RESET, "noop");
 			if (siz != sizeof(*ni6))
 				if (ndo->ndo_vflag)
-					ND_PRINT(", invalid length");
+					ND_PRINT(C_RESET, ", invalid length");
 			break;
 		case NI_QTYPE_SUPTYPES:
 			if (needcomma)
-				ND_PRINT(", ");
-			ND_PRINT("supported qtypes");
+				ND_PRINT(C_RESET, ", ");
+			ND_PRINT(C_RESET, "supported qtypes");
 			i = GET_BE_U_2(ni6->ni_flags);
 			if (i)
-				ND_PRINT(" [%s]", (i & 0x01) ? "C" : "");
+				ND_PRINT(C_RESET, " [%s]", (i & 0x01) ? "C" : "");
 			break;
 		case NI_QTYPE_FQDN:
 			if (needcomma)
-				ND_PRINT(", ");
-			ND_PRINT("DNS name");
+				ND_PRINT(C_RESET, ", ");
+			ND_PRINT(C_RESET, "DNS name");
 			cp = (const u_char *)(ni6 + 1) + 4;
 			if (GET_U_1(cp) == ep - cp - 1) {
 				/* icmp-name-lookup-03, pascal string */
 				if (ndo->ndo_vflag)
-					ND_PRINT(", 03 draft");
+					ND_PRINT(C_RESET, ", 03 draft");
 				cp++;
-				ND_PRINT(", \"");
+				ND_PRINT(C_RESET, ", \"");
 				while (cp < ep) {
 					fn_print_char(ndo, GET_U_1(cp));
 					cp++;
 				}
-				ND_PRINT("\"");
+				ND_PRINT(C_RESET, "\"");
 			} else
 				dnsname_print(ndo, cp, ep);
 			if ((GET_BE_U_2(ni6->ni_flags) & 0x01) != 0)
-				ND_PRINT(" [TTL=%u]", GET_BE_U_4(ni6 + 1));
+				ND_PRINT(C_RESET, " [TTL=%u]", GET_BE_U_4(ni6 + 1));
 			break;
 		case NI_QTYPE_NODEADDR:
 			if (needcomma)
-				ND_PRINT(", ");
-			ND_PRINT("node addresses");
+				ND_PRINT(C_RESET, ", ");
+			ND_PRINT(C_RESET, "node addresses");
 			i = sizeof(*ni6);
 			while (i < siz) {
 				if (i + sizeof(uint32_t) + sizeof(nd_ipv6) > siz)
 					break;
-				ND_PRINT(" %s(%u)",
+				ND_PRINT(C_RESET, " %s(%u)",
 				    GET_IP6ADDR_STRING(bp + i + sizeof(uint32_t)),
 				    GET_BE_U_4(bp + i));
 				i += sizeof(uint32_t) + sizeof(nd_ipv6);
@@ -1897,7 +1897,7 @@ icmp6_nodeinfo_print(netdissect_options *ndo, u_int icmp6len, const u_char *bp, 
 			i = GET_BE_U_2(ni6->ni_flags);
 			if (!i)
 				break;
-			ND_PRINT(" [%s%s%s%s%s%s%s]",
+			ND_PRINT(C_RESET, " [%s%s%s%s%s%s%s]",
                                   (i & NI_NODEADDR_FLAG_ANYCAST) ? "a" : "",
                                   (i & NI_NODEADDR_FLAG_GLOBAL) ? "G" : "",
                                   (i & NI_NODEADDR_FLAG_SITELOCAL) ? "S" : "",
@@ -1908,13 +1908,13 @@ icmp6_nodeinfo_print(netdissect_options *ndo, u_int icmp6len, const u_char *bp, 
 			break;
 		default:
 			if (needcomma)
-				ND_PRINT(", ");
-			ND_PRINT("unknown");
+				ND_PRINT(C_RESET, ", ");
+			ND_PRINT(C_RESET, "unknown");
 			break;
 		}
 
 		/*(*/
-		ND_PRINT(")");
+		ND_PRINT(C_RESET, ")");
 		break;
 	}
 	return;
@@ -1941,38 +1941,38 @@ icmp6_rrenum_print(netdissect_options *ndo, const u_char *bp, const u_char *ep)
 	ND_TCHECK_4(rr6->rr_reserved);
 	switch (GET_U_1(rr6->rr_code)) {
 	case ICMP6_ROUTER_RENUMBERING_COMMAND:
-		ND_PRINT(", command");
+		ND_PRINT(C_RESET, ", command");
 		break;
 	case ICMP6_ROUTER_RENUMBERING_RESULT:
-		ND_PRINT(", result");
+		ND_PRINT(C_RESET, ", result");
 		break;
 	case ICMP6_ROUTER_RENUMBERING_SEQNUM_RESET:
-		ND_PRINT(", sequence number reset");
+		ND_PRINT(C_RESET, ", sequence number reset");
 		break;
 	default:
-		ND_PRINT(", code-#%u", GET_U_1(rr6->rr_code));
+		ND_PRINT(C_RESET, ", code-#%u", GET_U_1(rr6->rr_code));
 		break;
 	}
 
-        ND_PRINT(", seq=%u", GET_BE_U_4(rr6->rr_seqnum));
+        ND_PRINT(C_RESET, ", seq=%u", GET_BE_U_4(rr6->rr_seqnum));
 
 	if (ndo->ndo_vflag) {
 		uint8_t rr_flags = GET_U_1(rr6->rr_flags);
 #define F(x, y)	(rr_flags & (x) ? (y) : "")
-		ND_PRINT("[");	/*]*/
+		ND_PRINT(C_RESET, "[");	/*]*/
 		if (rr_flags) {
-			ND_PRINT("%s%s%s%s%s,", F(ICMP6_RR_FLAGS_TEST, "T"),
+			ND_PRINT(C_RESET, "%s%s%s%s%s,", F(ICMP6_RR_FLAGS_TEST, "T"),
                                   F(ICMP6_RR_FLAGS_REQRESULT, "R"),
                                   F(ICMP6_RR_FLAGS_FORCEAPPLY, "A"),
                                   F(ICMP6_RR_FLAGS_SPECSITE, "S"),
                                   F(ICMP6_RR_FLAGS_PREVDONE, "P"));
 		}
-                ND_PRINT("seg=%u,", GET_U_1(rr6->rr_segnum));
-                ND_PRINT("maxdelay=%u", GET_BE_U_2(rr6->rr_maxdelay));
+                ND_PRINT(C_RESET, "seg=%u,", GET_U_1(rr6->rr_segnum));
+                ND_PRINT(C_RESET, "maxdelay=%u", GET_BE_U_2(rr6->rr_maxdelay));
 		if (GET_BE_U_4(rr6->rr_reserved))
-			ND_PRINT("rsvd=0x%x", GET_BE_U_4(rr6->rr_reserved));
+			ND_PRINT(C_RESET, "rsvd=0x%x", GET_BE_U_4(rr6->rr_reserved));
 		/*[*/
-		ND_PRINT("]");
+		ND_PRINT(C_RESET, "]");
 #undef F
 	}
 
@@ -1983,29 +1983,29 @@ icmp6_rrenum_print(netdissect_options *ndo, const u_char *bp, const u_char *ep)
 		ND_TCHECK_16(match->rpm_prefix);
 
 		if (ndo->ndo_vflag > 1)
-			ND_PRINT("\n\t");
+			ND_PRINT(C_RESET, "\n\t");
 		else
-			ND_PRINT(" ");
-		ND_PRINT("match(");	/*)*/
+			ND_PRINT(C_RESET, " ");
+		ND_PRINT(C_RESET, "match(");	/*)*/
 		switch (GET_U_1(match->rpm_code)) {
-		case RPM_PCO_ADD:	ND_PRINT("add"); break;
-		case RPM_PCO_CHANGE:	ND_PRINT("change"); break;
-		case RPM_PCO_SETGLOBAL:	ND_PRINT("setglobal"); break;
-		default:		ND_PRINT("#%u",
+		case RPM_PCO_ADD:	ND_PRINT(C_RESET, "add"); break;
+		case RPM_PCO_CHANGE:	ND_PRINT(C_RESET, "change"); break;
+		case RPM_PCO_SETGLOBAL:	ND_PRINT(C_RESET, "setglobal"); break;
+		default:		ND_PRINT(C_RESET, "#%u",
 						 GET_U_1(match->rpm_code)); break;
 		}
 
 		if (ndo->ndo_vflag) {
-			ND_PRINT(",ord=%u", GET_U_1(match->rpm_ordinal));
-			ND_PRINT(",min=%u", GET_U_1(match->rpm_minlen));
-			ND_PRINT(",max=%u", GET_U_1(match->rpm_maxlen));
+			ND_PRINT(C_RESET, ",ord=%u", GET_U_1(match->rpm_ordinal));
+			ND_PRINT(C_RESET, ",min=%u", GET_U_1(match->rpm_minlen));
+			ND_PRINT(C_RESET, ",max=%u", GET_U_1(match->rpm_maxlen));
 		}
 		if (addrtostr6(match->rpm_prefix, hbuf, sizeof(hbuf)))
-			ND_PRINT(",%s/%u", hbuf, GET_U_1(match->rpm_matchlen));
+			ND_PRINT(C_RESET, ",%s/%u", hbuf, GET_U_1(match->rpm_matchlen));
 		else
-			ND_PRINT(",?/%u", GET_U_1(match->rpm_matchlen));
+			ND_PRINT(C_RESET, ",?/%u", GET_U_1(match->rpm_matchlen));
 		/*(*/
-		ND_PRINT(")");
+		ND_PRINT(C_RESET, ")");
 
 		n = GET_U_1(match->rpm_len) - 3;
 		if (n % 4)
@@ -2018,42 +2018,42 @@ icmp6_rrenum_print(netdissect_options *ndo, const u_char *bp, const u_char *ep)
 			ND_TCHECK_16(use->rpu_prefix);
 
 			if (ndo->ndo_vflag > 1)
-				ND_PRINT("\n\t");
+				ND_PRINT(C_RESET, "\n\t");
 			else
-				ND_PRINT(" ");
-			ND_PRINT("use(");	/*)*/
+				ND_PRINT(C_RESET, " ");
+			ND_PRINT(C_RESET, "use(");	/*)*/
 			if (GET_U_1(use->rpu_flags)) {
 #define F(x, y)	(GET_U_1(use->rpu_flags) & (x) ? (y) : "")
-				ND_PRINT("%s%s,",
+				ND_PRINT(C_RESET, "%s%s,",
                                           F(ICMP6_RR_PCOUSE_FLAGS_DECRVLTIME, "V"),
                                           F(ICMP6_RR_PCOUSE_FLAGS_DECRPLTIME, "P"));
 #undef F
 			}
 			if (ndo->ndo_vflag) {
-				ND_PRINT("mask=0x%x,",
+				ND_PRINT(C_RESET, "mask=0x%x,",
 					 GET_U_1(use->rpu_ramask));
-				ND_PRINT("raflags=0x%x,",
+				ND_PRINT(C_RESET, "raflags=0x%x,",
 					 GET_U_1(use->rpu_raflags));
 				if (GET_BE_U_4(use->rpu_vltime) == 0xffffffff)
-					ND_PRINT("vltime=infty,");
+					ND_PRINT(C_RESET, "vltime=infty,");
 				else
-					ND_PRINT("vltime=%u,",
+					ND_PRINT(C_RESET, "vltime=%u,",
                                                   GET_BE_U_4(use->rpu_vltime));
 				if (GET_BE_U_4(use->rpu_pltime) == 0xffffffff)
-					ND_PRINT("pltime=infty,");
+					ND_PRINT(C_RESET, "pltime=infty,");
 				else
-					ND_PRINT("pltime=%u,",
+					ND_PRINT(C_RESET, "pltime=%u,",
                                                   GET_BE_U_4(use->rpu_pltime));
 			}
 			if (addrtostr6(use->rpu_prefix, hbuf, sizeof(hbuf)))
-				ND_PRINT("%s/%u/%u", hbuf,
+				ND_PRINT(C_RESET, "%s/%u/%u", hbuf,
                                           GET_U_1(use->rpu_uselen),
                                           GET_U_1(use->rpu_keeplen));
 			else
-				ND_PRINT("?/%u/%u", GET_U_1(use->rpu_uselen),
+				ND_PRINT(C_RESET, "?/%u/%u", GET_U_1(use->rpu_uselen),
                                           GET_U_1(use->rpu_keeplen));
 			/*(*/
-                        ND_PRINT(")");
+                        ND_PRINT(C_RESET, ")");
 		}
 	}
 

--- a/print-igmp.c
+++ b/print-igmp.c
@@ -115,16 +115,16 @@ print_mtrace(netdissect_options *ndo,
     const struct tr_query *tr = (const struct tr_query *)(bp + 8);
 
     if (len < 8 + sizeof (struct tr_query)) {
-	ND_PRINT(" [invalid len %u]", len);
+	ND_PRINT(C_RESET, " [invalid len %u]", len);
 	return;
     }
-    ND_PRINT("%s %u: %s to %s reply-to %s",
+    ND_PRINT(C_RESET, "%s %u: %s to %s reply-to %s",
         typename,
         GET_BE_U_3(tr->tr_qid),
         GET_IPADDR_STRING(tr->tr_src), GET_IPADDR_STRING(tr->tr_dst),
         GET_IPADDR_STRING(tr->tr_raddr));
     if (IN_CLASSD(GET_BE_U_4(tr->tr_raddr)))
-        ND_PRINT(" with-ttl %u", GET_U_1(tr->tr_rttl));
+        ND_PRINT(C_RESET, " with-ttl %u", GET_U_1(tr->tr_rttl));
 }
 
 static void
@@ -136,41 +136,41 @@ print_igmpv3_report(netdissect_options *ndo,
 
     /* Minimum len is 16, and should be a multiple of 4 */
     if (len < 16 || len & 0x03) {
-	ND_PRINT(" [invalid len %u]", len);
+	ND_PRINT(C_RESET, " [invalid len %u]", len);
 	return;
     }
     ngroups = GET_BE_U_2(bp + 6);
-    ND_PRINT(", %u group record(s)", ngroups);
+    ND_PRINT(C_RESET, ", %u group record(s)", ngroups);
     if (ndo->ndo_vflag > 0) {
 	/* Print the group records */
 	group = 8;
         for (i=0; i<ngroups; i++) {
 	    if (len < group+8) {
-		ND_PRINT(" [invalid number of groups]");
+		ND_PRINT(C_RESET, " [invalid number of groups]");
 		return;
 	    }
-            ND_PRINT(" [gaddr %s", GET_IPADDR_STRING(bp + group + 4));
-	    ND_PRINT(" %s", tok2str(igmpv3report2str, " [v3-report-#%u]",
+            ND_PRINT(C_RESET, " [gaddr %s", GET_IPADDR_STRING(bp + group + 4));
+	    ND_PRINT(C_RESET, " %s", tok2str(igmpv3report2str, " [v3-report-#%u]",
 								GET_U_1(bp + group)));
             nsrcs = GET_BE_U_2(bp + group + 2);
 	    /* Check the number of sources and print them */
 	    if (len < group+8+(nsrcs<<2)) {
-		ND_PRINT(" [invalid number of sources %u]", nsrcs);
+		ND_PRINT(C_RESET, " [invalid number of sources %u]", nsrcs);
 		return;
 	    }
             if (ndo->ndo_vflag == 1)
-                ND_PRINT(", %u source(s)", nsrcs);
+                ND_PRINT(C_RESET, ", %u source(s)", nsrcs);
             else {
 		/* Print the sources */
-                ND_PRINT(" {");
+                ND_PRINT(C_RESET, " {");
                 for (j=0; j<nsrcs; j++) {
-		    ND_PRINT(" %s", GET_IPADDR_STRING(bp + group + 8 + (j << 2)));
+		    ND_PRINT(C_RESET, " %s", GET_IPADDR_STRING(bp + group + 8 + (j << 2)));
 		}
-                ND_PRINT(" }");
+                ND_PRINT(C_RESET, " }");
             }
 	    /* Next group record */
             group += 8 + (nsrcs << 2);
-	    ND_PRINT("]");
+	    ND_PRINT(C_RESET, "]");
         }
     }
 }
@@ -184,10 +184,10 @@ print_igmpv3_query(netdissect_options *ndo,
     u_int nsrcs;
     u_int i;
 
-    ND_PRINT(" v3");
+    ND_PRINT(C_RESET, " v3");
     /* Minimum len is 12, and should be a multiple of 4 */
     if (len < 12 || len & 0x03) {
-	ND_PRINT(" [invalid len %u]", len);
+	ND_PRINT(C_RESET, " [invalid len %u]", len);
 	return;
     }
     mrc = GET_U_1(bp + 1);
@@ -197,31 +197,31 @@ print_igmpv3_query(netdissect_options *ndo,
         mrt = ((mrc & 0x0f) | 0x10) << (((mrc & 0x70) >> 4) + 3);
     }
     if (mrc != 100) {
-	ND_PRINT(" [max resp time ");
+	ND_PRINT(C_RESET, " [max resp time ");
         if (mrt < 600) {
-            ND_PRINT("%.1fs", mrt * 0.1);
+            ND_PRINT(C_RESET, "%.1fs", mrt * 0.1);
         } else {
             unsigned_relts_print(ndo, mrt / 10);
         }
-	ND_PRINT("]");
+	ND_PRINT(C_RESET, "]");
     }
     if (GET_BE_U_4(bp + 4) == 0)
 	return;
-    ND_PRINT(" [gaddr %s", GET_IPADDR_STRING(bp + 4));
+    ND_PRINT(C_RESET, " [gaddr %s", GET_IPADDR_STRING(bp + 4));
     nsrcs = GET_BE_U_2(bp + 10);
     if (nsrcs > 0) {
 	if (len < 12 + (nsrcs << 2))
-	    ND_PRINT(" [invalid number of sources]");
+	    ND_PRINT(C_RESET, " [invalid number of sources]");
 	else if (ndo->ndo_vflag > 1) {
-	    ND_PRINT(" {");
+	    ND_PRINT(C_RESET, " {");
 	    for (i=0; i<nsrcs; i++) {
-		ND_PRINT(" %s", GET_IPADDR_STRING(bp + 12 + (i << 2)));
+		ND_PRINT(C_RESET, " %s", GET_IPADDR_STRING(bp + 12 + (i << 2)));
 	    }
-	    ND_PRINT(" }");
+	    ND_PRINT(C_RESET, " }");
 	} else
-	    ND_PRINT(", %u source(s)", nsrcs);
+	    ND_PRINT(C_RESET, ", %u source(s)", nsrcs);
     }
-    ND_PRINT("]");
+    ND_PRINT(C_RESET, "]");
 }
 
 void
@@ -232,52 +232,52 @@ igmp_print(netdissect_options *ndo,
 
     ndo->ndo_protocol = "igmp";
     if (ndo->ndo_qflag) {
-        ND_PRINT("igmp");
+        ND_PRINT(C_RESET, "igmp");
         return;
     }
 
     switch (GET_U_1(bp)) {
     case 0x11:
-        ND_PRINT("igmp query");
+        ND_PRINT(C_RESET, "igmp query");
 	if (len >= 12)
 	    print_igmpv3_query(ndo, bp, len);
 	else {
 	    if (GET_U_1(bp + 1)) {
-		ND_PRINT(" v2");
+		ND_PRINT(C_RESET, " v2");
 		if (GET_U_1(bp + 1) != 100)
-		    ND_PRINT(" [max resp time %u]", GET_U_1(bp + 1));
+		    ND_PRINT(C_RESET, " [max resp time %u]", GET_U_1(bp + 1));
 	    } else
-		ND_PRINT(" v1");
+		ND_PRINT(C_RESET, " v1");
 	    if (GET_BE_U_4(bp + 4))
-                ND_PRINT(" [gaddr %s]", GET_IPADDR_STRING(bp + 4));
+                ND_PRINT(C_RESET, " [gaddr %s]", GET_IPADDR_STRING(bp + 4));
             if (len != 8)
-                ND_PRINT(" [len %u]", len);
+                ND_PRINT(C_RESET, " [len %u]", len);
 	}
         break;
     case 0x12:
-        ND_PRINT("igmp v1 report %s", GET_IPADDR_STRING(bp + 4));
+        ND_PRINT(C_RESET, "igmp v1 report %s", GET_IPADDR_STRING(bp + 4));
         if (len != 8)
-            ND_PRINT(" [len %u]", len);
+            ND_PRINT(C_RESET, " [len %u]", len);
         break;
     case 0x16:
-        ND_PRINT("igmp v2 report %s", GET_IPADDR_STRING(bp + 4));
+        ND_PRINT(C_RESET, "igmp v2 report %s", GET_IPADDR_STRING(bp + 4));
         break;
     case 0x22:
-        ND_PRINT("igmp v3 report");
+        ND_PRINT(C_RESET, "igmp v3 report");
 	print_igmpv3_report(ndo, bp, len);
         break;
     case 0x17:
-        ND_PRINT("igmp leave %s", GET_IPADDR_STRING(bp + 4));
+        ND_PRINT(C_RESET, "igmp leave %s", GET_IPADDR_STRING(bp + 4));
         break;
     case 0x13:
-        ND_PRINT("igmp dvmrp");
+        ND_PRINT(C_RESET, "igmp dvmrp");
         if (len < 8)
-            ND_PRINT(" [len %u]", len);
+            ND_PRINT(C_RESET, " [len %u]", len);
         else
             dvmrp_print(ndo, bp, len);
         break;
     case 0x14:
-        ND_PRINT("igmp pimv1");
+        ND_PRINT(C_RESET, "igmp pimv1");
         pimv1_print(ndo, bp, len);
         break;
     case 0x1e:
@@ -287,7 +287,7 @@ igmp_print(netdissect_options *ndo,
         print_mtrace(ndo, "mtrace", bp, len);
         break;
     default:
-        ND_PRINT("igmp-%u", GET_U_1(bp));
+        ND_PRINT(C_RESET, "igmp-%u", GET_U_1(bp));
         break;
     }
 
@@ -296,6 +296,6 @@ igmp_print(netdissect_options *ndo,
         vec[0].ptr = bp;
         vec[0].len = len;
         if (in_cksum(vec, 1))
-            ND_PRINT(" bad igmp cksum %x!", GET_BE_U_2(bp + 2));
+            ND_PRINT(C_RESET, " bad igmp cksum %x!", GET_BE_U_2(bp + 2));
     }
 }

--- a/print-igrp.c
+++ b/print-igrp.c
@@ -76,7 +76,7 @@ igrp_entry_print(netdissect_options *ndo, const struct igrprte *igr)
 	metric = ND_MIN(bandwidth + delay, 0xffffff);
 	mtu = GET_BE_U_2(igr->igr_mtu);
 
-	ND_PRINT(" d=%u b=%u r=%u l=%u M=%u mtu=%u in %u hops",
+	ND_PRINT(C_RESET, " d=%u b=%u r=%u l=%u M=%u mtu=%u in %u hops",
 	    10 * delay, bandwidth == 0 ? 0 : 10000000 / bandwidth,
 	    GET_U_1(igr->igr_rel), GET_U_1(igr->igr_ld), metric,
 	    mtu, GET_U_1(igr->igr_hct));
@@ -99,14 +99,14 @@ igrp_print(netdissect_options *ndo, const u_char *bp, u_int length)
 	ndo->ndo_protocol = "igrp";
 	hdr = (const struct igrphdr *)bp;
 	cp = (const u_char *)(hdr + 1);
-	ND_PRINT("igrp:");
+	ND_PRINT(C_RESET, "igrp:");
 
 	/* Header */
 	nint = GET_BE_U_2(hdr->ig_ni);
 	nsys = GET_BE_U_2(hdr->ig_ns);
 	next = GET_BE_U_2(hdr->ig_nx);
 
-	ND_PRINT(" %s V%u edit=%u AS=%u (%u/%u/%u)",
+	ND_PRINT(C_RESET, " %s V%u edit=%u AS=%u (%u/%u/%u)",
 	    tok2str(op2str, "op-#%u", IGRP_OP(GET_U_1(hdr->ig_vop))),
 	    IGRP_V(GET_U_1(hdr->ig_vop)),
 	    GET_U_1(hdr->ig_ed),
@@ -116,7 +116,7 @@ igrp_print(netdissect_options *ndo, const u_char *bp, u_int length)
 	    next);
 	cksum = GET_BE_U_2(hdr->ig_sum);
 	if (ndo->ndo_vflag)
-		ND_PRINT(" checksum=0x%04x", cksum);
+		ND_PRINT(C_RESET, " checksum=0x%04x", cksum);
 
 	length -= sizeof(*hdr);
 	while (length >= IGRP_RTE_SIZE) {
@@ -126,19 +126,19 @@ igrp_print(netdissect_options *ndo, const u_char *bp, u_int length)
 		uint8_t net2 = GET_U_1(&igr->igr_net[2]);
 
 		if (nint > 0) {
-			ND_PRINT(" *.%u.%u.%u", net0, net1, net2);
+			ND_PRINT(C_RESET, " *.%u.%u.%u", net0, net1, net2);
 			igrp_entry_print(ndo, igr);
 			--nint;
 		} else if (nsys > 0) {
-			ND_PRINT(" %u.%u.%u.0", net0, net1, net2);
+			ND_PRINT(C_RESET, " %u.%u.%u.0", net0, net1, net2);
 			igrp_entry_print(ndo, igr);
 			--nsys;
 		} else if (next > 0) {
-			ND_PRINT(" X%u.%u.%u.0", net0, net1, net2);
+			ND_PRINT(C_RESET, " X%u.%u.%u.0", net0, net1, net2);
 			igrp_entry_print(ndo, igr);
 			--next;
 		} else {
-			ND_PRINT(" [extra bytes %u]", length);
+			ND_PRINT(C_RESET, " [extra bytes %u]", length);
 			break;
 		}
 		cp += IGRP_RTE_SIZE;

--- a/print-ip-demux.c
+++ b/print-ip-demux.c
@@ -106,7 +106,7 @@ again:
 		if (ver == 4)
 			icmp_print(ndo, bp, length, iph, fragmented);
 		else {
-			ND_PRINT("[%s requires IPv4]",
+			ND_PRINT(C_RESET, "[%s requires IPv4]",
 				 tok2str(ipproto_values,"unknown",nh));
 			nd_print_invalid(ndo);
 		}
@@ -116,7 +116,7 @@ again:
 		if (ver == 6)
 			icmp6_print(ndo, bp, length, iph, fragmented);
 		else {
-			ND_PRINT("[%s requires IPv6]",
+			ND_PRINT(C_RESET, "[%s requires IPv6]",
 				 tok2str(ipproto_values,"unknown",nh));
 			nd_print_invalid(ndo);
 		}
@@ -144,7 +144,7 @@ again:
 		break;
 
 	case IPPROTO_ND:
-		ND_PRINT(" nd %u", length);
+		ND_PRINT(C_RESET, " nd %u", length);
 		break;
 
 	case IPPROTO_EGP:
@@ -162,7 +162,7 @@ again:
 		if (ver == 4)
 			igmp_print(ndo, bp, length);
 		else {
-			ND_PRINT("[%s requires IPv4]",
+			ND_PRINT(C_RESET, "[%s requires IPv4]",
 				 tok2str(ipproto_values,"unknown",nh));
 			nd_print_invalid(ndo);
 		}
@@ -210,22 +210,22 @@ again:
 		if (ver == 6)
 			ether_print(ndo, bp, length, ND_BYTES_AVAILABLE_AFTER(bp), NULL, NULL);
 		else {
-			ND_PRINT("[%s requires IPv6]",
+			ND_PRINT(C_RESET, "[%s requires IPv6]",
 				 tok2str(ipproto_values,"unknown",nh));
 			nd_print_invalid(ndo);
 		}
 		break;
 
 	case IPPROTO_NONE:
-		ND_PRINT("no next header");
+		ND_PRINT(C_RESET, "no next header");
 		break;
 
 	default:
 		if (ndo->ndo_nflag==0 && (p_name = netdb_protoname(nh)) != NULL)
-			ND_PRINT(" %s", p_name);
+			ND_PRINT(C_RESET, " %s", p_name);
 		else
-			ND_PRINT(" ip-proto-%u", nh);
-		ND_PRINT(" %u", length);
+			ND_PRINT(C_RESET, " ip-proto-%u", nh);
+		ND_PRINT(C_RESET, " %u", length);
 		break;
 	}
 }

--- a/print-ip.c
+++ b/print-ip.c
@@ -59,20 +59,20 @@ ip_printroute(netdissect_options *ndo,
 	u_int len;
 
 	if (length < 3) {
-		ND_PRINT(" [bad length %u]", length);
+		ND_PRINT(C_RESET, " [bad length %u]", length);
 		return (0);
 	}
 	if ((length + 1) & 3)
-		ND_PRINT(" [bad length %u]", length);
+		ND_PRINT(C_RESET, " [bad length %u]", length);
 	ptr = GET_U_1(cp + 2) - 1;
 	if (ptr < 3 || ((ptr + 1) & 3) || ptr > length + 1)
-		ND_PRINT(" [bad ptr %u]", GET_U_1(cp + 2));
+		ND_PRINT(C_RESET, " [bad ptr %u]", GET_U_1(cp + 2));
 
 	for (len = 3; len < length; len += 4) {
 		ND_TCHECK_4(cp + len);	/* Needed to print the IP addresses */
-		ND_PRINT(" %s", GET_IPADDR_STRING(cp + len));
+		ND_PRINT(C_RESET, " %s", GET_IPADDR_STRING(cp + len));
 		if (ptr > len)
-			ND_PRINT(",");
+			ND_PRINT(C_RESET, ",");
 	}
 	return (0);
 
@@ -174,29 +174,29 @@ ip_printts(netdissect_options *ndo,
 	const char *type;
 
 	if (length < 4) {
-		ND_PRINT("[bad length %u]", length);
+		ND_PRINT(C_RESET, "[bad length %u]", length);
 		return (0);
 	}
-	ND_PRINT(" TS{");
+	ND_PRINT(C_RESET, " TS{");
 	hoplen = ((GET_U_1(cp + 3) & 0xF) != IPOPT_TS_TSONLY) ? 8 : 4;
 	if ((length - 4) & (hoplen-1))
-		ND_PRINT("[bad length %u]", length);
+		ND_PRINT(C_RESET, "[bad length %u]", length);
 	ptr = GET_U_1(cp + 2) - 1;
 	len = 0;
 	if (ptr < 4 || ((ptr - 4) & (hoplen-1)) || ptr > length + 1)
-		ND_PRINT("[bad ptr %u]", GET_U_1(cp + 2));
+		ND_PRINT(C_RESET, "[bad ptr %u]", GET_U_1(cp + 2));
 	switch (GET_U_1(cp + 3)&0xF) {
 	case IPOPT_TS_TSONLY:
-		ND_PRINT("TSONLY");
+		ND_PRINT(C_RESET, "TSONLY");
 		break;
 	case IPOPT_TS_TSANDADDR:
-		ND_PRINT("TS+ADDR");
+		ND_PRINT(C_RESET, "TS+ADDR");
 		break;
 	case IPOPT_TS_PRESPEC:
-		ND_PRINT("PRESPEC");
+		ND_PRINT(C_RESET, "PRESPEC");
 		break;
 	default:
-		ND_PRINT("[bad ts type %u]", GET_U_1(cp + 3)&0xF);
+		ND_PRINT(C_RESET, "[bad ts type %u]", GET_U_1(cp + 3)&0xF);
 		goto done;
 	}
 
@@ -205,18 +205,18 @@ ip_printts(netdissect_options *ndo,
 		if (ptr == len)
 			type = " ^ ";
 		ND_TCHECK_LEN(cp + len, hoplen);
-		ND_PRINT("%s%u@%s", type, GET_BE_U_4(cp + len + hoplen - 4),
+		ND_PRINT(C_RESET, "%s%u@%s", type, GET_BE_U_4(cp + len + hoplen - 4),
 			  hoplen!=8 ? "" : GET_IPADDR_STRING(cp + len));
 		type = " ";
 	}
 
 done:
-	ND_PRINT("%s", ptr == len ? " ^ " : "");
+	ND_PRINT(C_RESET, "%s", ptr == len ? " ^ " : "");
 
 	if (GET_U_1(cp + 3) >> 4)
-		ND_PRINT(" [%u hops not recorded]} ", GET_U_1(cp + 3)>>4);
+		ND_PRINT(C_RESET, " [%u hops not recorded]} ", GET_U_1(cp + 3)>>4);
 	else
-		ND_PRINT("}");
+		ND_PRINT(C_RESET, "}");
 	return (0);
 
 trunc:
@@ -237,12 +237,12 @@ ip_optprint(netdissect_options *ndo,
 	for (; length > 0; cp += option_len, length -= option_len) {
 		u_int option_code;
 
-		ND_PRINT("%s", sep);
+		ND_PRINT(C_RESET, "%s", sep);
 		sep = ",";
 
 		option_code = GET_U_1(cp);
 
-		ND_PRINT("%s",
+		ND_PRINT(C_RESET, "%s",
 		          tok2str(ip_option_values,"unknown %u",option_code));
 
 		if (option_code == IPOPT_NOP ||
@@ -252,13 +252,13 @@ ip_optprint(netdissect_options *ndo,
 		else {
 			option_len = GET_U_1(cp + 1);
 			if (option_len < 2) {
-				ND_PRINT(" [bad length %u]", option_len);
+				ND_PRINT(C_RESET, " [bad length %u]", option_len);
 				return 0;
 			}
 		}
 
 		if (option_len > length) {
-			ND_PRINT(" [bad length %u]", option_len);
+			ND_PRINT(C_RESET, " [bad length %u]", option_len);
 			return 0;
 		}
 
@@ -282,12 +282,12 @@ ip_optprint(netdissect_options *ndo,
 
 		case IPOPT_RA:
 			if (option_len < 4) {
-				ND_PRINT(" [bad length %u]", option_len);
+				ND_PRINT(C_RESET, " [bad length %u]", option_len);
 				break;
 			}
 			ND_TCHECK_1(cp + 3);
 			if (GET_BE_U_2(cp + 2) != 0)
-				ND_PRINT(" value %u", GET_BE_U_2(cp + 2));
+				ND_PRINT(C_RESET, " value %u", GET_BE_U_2(cp + 2));
 			break;
 
 		case IPOPT_NOP:       /* nothing to print - fall through */
@@ -334,34 +334,34 @@ ip_print(netdissect_options *ndo,
 	ip = (const struct ip *)bp;
 	if (IP_V(ip) != 4) { /* print version and fail if != 4 */
 	    if (IP_V(ip) == 6)
-	      ND_PRINT("IP6, wrong link-layer encapsulation");
+	      ND_PRINT(C_RESET, "IP6, wrong link-layer encapsulation");
 	    else
-	      ND_PRINT("IP%u", IP_V(ip));
+	      ND_PRINT(C_RESET, "IP%u", IP_V(ip));
 	    nd_print_invalid(ndo);
 	    return;
 	}
 	if (!ndo->ndo_eflag)
-		ND_PRINT("IP ");
+		ND_PRINT(C_RESET, "IP ");
 
 	ND_TCHECK_SIZE(ip);
 	if (length < sizeof (struct ip)) {
-		ND_PRINT("truncated-ip %u", length);
+		ND_PRINT(C_RESET, "truncated-ip %u", length);
 		return;
 	}
 	hlen = IP_HL(ip) * 4;
 	if (hlen < sizeof (struct ip)) {
-		ND_PRINT("bad-hlen %u", hlen);
+		ND_PRINT(C_RESET, "bad-hlen %u", hlen);
 		return;
 	}
 
 	len = GET_BE_U_2(ip->ip_len);
 	if (length < len)
-		ND_PRINT("truncated-ip - %u bytes missing! ",
+		ND_PRINT(C_RESET, "truncated-ip - %u bytes missing! ",
 			len - length);
 	if (len < hlen) {
 #ifdef GUESS_TSO
             if (len) {
-                ND_PRINT("bad-len %u", len);
+                ND_PRINT(C_RESET, "bad-len %u", len);
                 return;
             }
             else {
@@ -369,7 +369,7 @@ ip_print(netdissect_options *ndo,
                 len = length;
             }
 #else
-            ND_PRINT("bad-len %u", len);
+            ND_PRINT(C_RESET, "bad-len %u", len);
             return;
 #endif /* GUESS_TSO */
 	}
@@ -390,7 +390,7 @@ ip_print(netdissect_options *ndo,
 
         if (ndo->ndo_vflag) {
             ip_tos = GET_U_1(ip->ip_tos);
-            ND_PRINT("(tos 0x%x", ip_tos);
+            ND_PRINT(C_RESET, "(tos 0x%x", ip_tos);
             /* ECN bits */
             switch (ip_tos & 0x03) {
 
@@ -398,44 +398,44 @@ ip_print(netdissect_options *ndo,
                 break;
 
             case 1:
-                ND_PRINT(",ECT(1)");
+                ND_PRINT(C_RESET, ",ECT(1)");
                 break;
 
             case 2:
-                ND_PRINT(",ECT(0)");
+                ND_PRINT(C_RESET, ",ECT(0)");
                 break;
 
             case 3:
-                ND_PRINT(",CE");
+                ND_PRINT(C_RESET, ",CE");
                 break;
             }
 
             ip_ttl = GET_U_1(ip->ip_ttl);
             if (ip_ttl >= 1)
-                ND_PRINT(", ttl %u", ip_ttl);
+                ND_PRINT(C_RESET, ", ttl %u", ip_ttl);
 
 	    /*
 	     * for the firewall guys, print id, offset.
              * On all but the last stick a "+" in the flags portion.
 	     * For unfragmented datagrams, note the don't fragment flag.
 	     */
-	    ND_PRINT(", id %u, offset %u, flags [%s], proto %s (%u)",
+	    ND_PRINT(C_RESET, ", id %u, offset %u, flags [%s], proto %s (%u)",
                          GET_BE_U_2(ip->ip_id),
                          (off & IP_OFFMASK) * 8,
                          bittok2str(ip_frag_values, "none", off & (IP_RES|IP_DF|IP_MF)),
                          tok2str(ipproto_values, "unknown", ip_proto),
                          ip_proto);
 
-            ND_PRINT(", length %u", GET_BE_U_2(ip->ip_len));
+            ND_PRINT(C_RESET, ", length %u", GET_BE_U_2(ip->ip_len));
 
             if ((hlen - sizeof(struct ip)) > 0) {
-                ND_PRINT(", options (");
+                ND_PRINT(C_RESET, ", options (");
                 if (ip_optprint(ndo, (const u_char *)(ip + 1),
                     hlen - sizeof(struct ip)) == -1) {
-                        ND_PRINT(" [truncated-option]");
+                        ND_PRINT(C_RESET, " [truncated-option]");
 			truncated = 1;
                 }
-                ND_PRINT(")");
+                ND_PRINT(C_RESET, ")");
             }
 
 	    if (!ndo->ndo_Kflag && (const u_char *)ip + hlen <= ndo->ndo_snapend) {
@@ -444,14 +444,14 @@ ip_print(netdissect_options *ndo,
 	        sum = in_cksum(vec, 1);
 		if (sum != 0) {
 		    ip_sum = GET_BE_U_2(ip->ip_sum);
-		    ND_PRINT(", bad cksum %x (->%x)!", ip_sum,
+		    ND_PRINT(C_RESET, ", bad cksum %x (->%x)!", ip_sum,
 			     in_cksum_shouldbe(ip_sum, sum));
 		}
 	    }
 
-	    ND_PRINT(")\n    ");
+	    ND_PRINT(C_RESET, ")\n    ");
 	    if (truncated) {
-		ND_PRINT("%s > %s: ",
+		ND_PRINT(C_RESET, "%s > %s: ",
 			 GET_IPADDR_STRING(ip->ip_src),
 			 GET_IPADDR_STRING(ip->ip_dst));
 		nd_print_trunc(ndo);
@@ -470,7 +470,7 @@ ip_print(netdissect_options *ndo,
 
 		if (nh != IPPROTO_TCP && nh != IPPROTO_UDP &&
 		    nh != IPPROTO_SCTP && nh != IPPROTO_DCCP) {
-			ND_PRINT("%s > %s: ",
+			ND_PRINT(C_RESET, "%s > %s: ",
 				     GET_IPADDR_STRING(ip->ip_src),
 				     GET_IPADDR_STRING(ip->ip_dst));
 		}
@@ -479,7 +479,7 @@ ip_print(netdissect_options *ndo,
 		 * At least the header data is required.
 		 */
 		if (!ND_TTEST_LEN((const u_char *)ip, hlen)) {
-			ND_PRINT(" [remaining caplen(%u) < header length(%u)]",
+			ND_PRINT(C_RESET, " [remaining caplen(%u) < header length(%u)]",
 				 ND_BYTES_AVAILABLE_AFTER((const u_char *)ip),
 				 hlen);
 			nd_trunc_longjmp(ndo);
@@ -501,12 +501,12 @@ ip_print(netdissect_options *ndo,
 		 * next level protocol header.  print the ip addr
 		 * and the protocol.
 		 */
-		ND_PRINT("%s > %s:", GET_IPADDR_STRING(ip->ip_src),
+		ND_PRINT(C_RESET, "%s > %s:", GET_IPADDR_STRING(ip->ip_src),
 		          GET_IPADDR_STRING(ip->ip_dst));
 		if (!ndo->ndo_nflag && (p_name = netdb_protoname(ip_proto)) != NULL)
-			ND_PRINT(" %s", p_name);
+			ND_PRINT(C_RESET, " %s", p_name);
 		else
-			ND_PRINT(" ip-proto-%u", ip_proto);
+			ND_PRINT(C_RESET, " ip-proto-%u", ip_proto);
 	}
 	nd_pop_packet_info(ndo);
 	return;
@@ -520,7 +520,7 @@ ipN_print(netdissect_options *ndo, const u_char *bp, u_int length)
 {
 	ndo->ndo_protocol = "ipn";
 	if (length < 1) {
-		ND_PRINT("truncated-ip %u", length);
+		ND_PRINT(C_RESET, "truncated-ip %u", length);
 		return;
 	}
 
@@ -532,7 +532,7 @@ ipN_print(netdissect_options *ndo, const u_char *bp, u_int length)
 		ip6_print(ndo, bp, length);
 		break;
 	default:
-		ND_PRINT("unknown ip %u", (GET_U_1(bp) & 0xF0) >> 4);
+		ND_PRINT(C_RESET, "unknown ip %u", (GET_U_1(bp) & 0xF0) >> 4);
 		break;
 	}
 }

--- a/print-ip6.c
+++ b/print-ip6.c
@@ -243,15 +243,15 @@ ip6_print(netdissect_options *ndo, const u_char *bp, u_int length)
 
 	ND_TCHECK_SIZE(ip6);
 	if (length < sizeof (struct ip6_hdr)) {
-		ND_PRINT(C_RESET, C_RESET "truncated-ip6 %u", length);
+		ND_PRINT(C_RESET, "truncated-ip6 %u", length);
 		return;
 	}
 
 	if (!ndo->ndo_eflag)
-	    ND_PRINT(C_RESET, C_RESET "IP6 ");
+	    ND_PRINT(C_RESET, "IP6 ");
 
 	if (IP6_VERSION(ip6) != 6) {
-	  ND_PRINT(C_RESET, C_RESET "version error: %u != 6", IP6_VERSION(ip6));
+	  ND_PRINT(C_RESET, "version error: %u != 6", IP6_VERSION(ip6));
 	  return;
 	}
 
@@ -281,7 +281,7 @@ ip6_print(netdissect_options *ndo, const u_char *bp, u_int length)
 	if (payload_len != 0) {
 		len = payload_len + sizeof(struct ip6_hdr);
 		if (length < len)
-			ND_PRINT(C_RESET, C_RESET "truncated-ip6 - %u bytes missing!",
+			ND_PRINT(C_RESET, "truncated-ip6 - %u bytes missing!",
 				len - length);
 	} else
 		len = length + sizeof(struct ip6_hdr);
@@ -290,14 +290,14 @@ ip6_print(netdissect_options *ndo, const u_char *bp, u_int length)
 	nh = GET_U_1(ip6->ip6_nxt);
 	if (ndo->ndo_vflag) {
 	    flow = GET_BE_U_4(ip6->ip6_flow);
-	    ND_PRINT(C_RESET, C_RESET "(");
+	    ND_PRINT(C_RESET, "(");
 	    /* RFC 2460 */
 	    if (flow & 0x0ff00000)
-	        ND_PRINT(C_RESET, C_RESET "class 0x%02x, ", (flow & 0x0ff00000) >> 20);
+	        ND_PRINT(C_RESET, "class 0x%02x, ", (flow & 0x0ff00000) >> 20);
 	    if (flow & 0x000fffff)
-	        ND_PRINT(C_RESET, C_RESET "flowlabel 0x%05x, ", flow & 0x000fffff);
+	        ND_PRINT(C_RESET, "flowlabel 0x%05x, ", flow & 0x000fffff);
 
-	    ND_PRINT(C_RESET, C_RESET "hlim %u, next-header %s (%u) payload length: %u) ",
+	    ND_PRINT(C_RESET, "hlim %u, next-header %s (%u) payload length: %u) ",
 	                 GET_U_1(ip6->ip6_hlim),
 	                 tok2str(ipproto_values,"unknown",nh),
 	                 nh,
@@ -329,7 +329,7 @@ ip6_print(netdissect_options *ndo, const u_char *bp, u_int length)
 		if (cp == (const u_char *)(ip6 + 1) &&
 		    nh != IPPROTO_TCP && nh != IPPROTO_UDP &&
 		    nh != IPPROTO_DCCP && nh != IPPROTO_SCTP) {
-			ND_PRINT(C_RESET, C_RESET "%s > %s: ", GET_IP6ADDR_STRING(ip6->ip6_src),
+			ND_PRINT(C_RESET, "%s > %s: ", GET_IP6ADDR_STRING(ip6->ip6_src),
 				     GET_IP6ADDR_STRING(ip6->ip6_dst));
 		}
 
@@ -341,18 +341,18 @@ ip6_print(netdissect_options *ndo, const u_char *bp, u_int length)
 			 * must immediately follow the IPv6 header (RFC 8200)
 			 */
 			if (found_hbh == 1) {
-				ND_PRINT(C_RESET, C_RESET "[The Hop-by-Hop Options header was already found]");
+				ND_PRINT(C_RESET, "[The Hop-by-Hop Options header was already found]");
 				nd_print_invalid(ndo);
 				return;
 			}
 			if (ph != 255) {
-				ND_PRINT(C_RESET, C_RESET "[The Hop-by-Hop Options header don't follow the IPv6 header]");
+				ND_PRINT(C_RESET, "[The Hop-by-Hop Options header don't follow the IPv6 header]");
 				nd_print_invalid(ndo);
 				return;
 			}
 			advance = hbhopt_process(ndo, cp, &found_jumbo, &payload_len);
 			if (payload_len == 0 && found_jumbo == 0) {
-				ND_PRINT(C_RESET, C_RESET "[No valid Jumbo Payload Hop-by-Hop option found]");
+				ND_PRINT(C_RESET, "[No valid Jumbo Payload Hop-by-Hop option found]");
 				nd_print_invalid(ndo);
 				return;
 			}
@@ -437,7 +437,7 @@ ip6_print(netdissect_options *ndo, const u_char *bp, u_int length)
 				if (len < total_advance)
 					goto trunc;
 				if (length < len)
-					ND_PRINT(C_RESET, C_RESET "truncated-ip6 - %u bytes missing!",
+					ND_PRINT(C_RESET, "truncated-ip6 - %u bytes missing!",
 						len - length);
 				nd_change_snaplen(ndo, bp, len);
 

--- a/print-ip6.c
+++ b/print-ip6.c
@@ -243,15 +243,15 @@ ip6_print(netdissect_options *ndo, const u_char *bp, u_int length)
 
 	ND_TCHECK_SIZE(ip6);
 	if (length < sizeof (struct ip6_hdr)) {
-		ND_PRINT("truncated-ip6 %u", length);
+		ND_PRINT(C_RESET, C_RESET "truncated-ip6 %u", length);
 		return;
 	}
 
 	if (!ndo->ndo_eflag)
-	    ND_PRINT("IP6 ");
+	    ND_PRINT(C_RESET, C_RESET "IP6 ");
 
 	if (IP6_VERSION(ip6) != 6) {
-	  ND_PRINT("version error: %u != 6", IP6_VERSION(ip6));
+	  ND_PRINT(C_RESET, C_RESET "version error: %u != 6", IP6_VERSION(ip6));
 	  return;
 	}
 
@@ -281,7 +281,7 @@ ip6_print(netdissect_options *ndo, const u_char *bp, u_int length)
 	if (payload_len != 0) {
 		len = payload_len + sizeof(struct ip6_hdr);
 		if (length < len)
-			ND_PRINT("truncated-ip6 - %u bytes missing!",
+			ND_PRINT(C_RESET, C_RESET "truncated-ip6 - %u bytes missing!",
 				len - length);
 	} else
 		len = length + sizeof(struct ip6_hdr);
@@ -290,14 +290,14 @@ ip6_print(netdissect_options *ndo, const u_char *bp, u_int length)
 	nh = GET_U_1(ip6->ip6_nxt);
 	if (ndo->ndo_vflag) {
 	    flow = GET_BE_U_4(ip6->ip6_flow);
-	    ND_PRINT("(");
+	    ND_PRINT(C_RESET, C_RESET "(");
 	    /* RFC 2460 */
 	    if (flow & 0x0ff00000)
-	        ND_PRINT("class 0x%02x, ", (flow & 0x0ff00000) >> 20);
+	        ND_PRINT(C_RESET, C_RESET "class 0x%02x, ", (flow & 0x0ff00000) >> 20);
 	    if (flow & 0x000fffff)
-	        ND_PRINT("flowlabel 0x%05x, ", flow & 0x000fffff);
+	        ND_PRINT(C_RESET, C_RESET "flowlabel 0x%05x, ", flow & 0x000fffff);
 
-	    ND_PRINT("hlim %u, next-header %s (%u) payload length: %u) ",
+	    ND_PRINT(C_RESET, C_RESET "hlim %u, next-header %s (%u) payload length: %u) ",
 	                 GET_U_1(ip6->ip6_hlim),
 	                 tok2str(ipproto_values,"unknown",nh),
 	                 nh,
@@ -329,7 +329,7 @@ ip6_print(netdissect_options *ndo, const u_char *bp, u_int length)
 		if (cp == (const u_char *)(ip6 + 1) &&
 		    nh != IPPROTO_TCP && nh != IPPROTO_UDP &&
 		    nh != IPPROTO_DCCP && nh != IPPROTO_SCTP) {
-			ND_PRINT("%s > %s: ", GET_IP6ADDR_STRING(ip6->ip6_src),
+			ND_PRINT(C_RESET, C_RESET "%s > %s: ", GET_IP6ADDR_STRING(ip6->ip6_src),
 				     GET_IP6ADDR_STRING(ip6->ip6_dst));
 		}
 
@@ -341,18 +341,18 @@ ip6_print(netdissect_options *ndo, const u_char *bp, u_int length)
 			 * must immediately follow the IPv6 header (RFC 8200)
 			 */
 			if (found_hbh == 1) {
-				ND_PRINT("[The Hop-by-Hop Options header was already found]");
+				ND_PRINT(C_RESET, C_RESET "[The Hop-by-Hop Options header was already found]");
 				nd_print_invalid(ndo);
 				return;
 			}
 			if (ph != 255) {
-				ND_PRINT("[The Hop-by-Hop Options header don't follow the IPv6 header]");
+				ND_PRINT(C_RESET, C_RESET "[The Hop-by-Hop Options header don't follow the IPv6 header]");
 				nd_print_invalid(ndo);
 				return;
 			}
 			advance = hbhopt_process(ndo, cp, &found_jumbo, &payload_len);
 			if (payload_len == 0 && found_jumbo == 0) {
-				ND_PRINT("[No valid Jumbo Payload Hop-by-Hop option found]");
+				ND_PRINT(C_RESET, C_RESET "[No valid Jumbo Payload Hop-by-Hop option found]");
 				nd_print_invalid(ndo);
 				return;
 			}
@@ -437,7 +437,7 @@ ip6_print(netdissect_options *ndo, const u_char *bp, u_int length)
 				if (len < total_advance)
 					goto trunc;
 				if (length < len)
-					ND_PRINT("truncated-ip6 - %u bytes missing!",
+					ND_PRINT(C_RESET, C_RESET "truncated-ip6 - %u bytes missing!",
 						len - length);
 				nd_change_snaplen(ndo, bp, len);
 

--- a/print-ip6opts.c
+++ b/print-ip6opts.c
@@ -61,21 +61,21 @@ ip6_sopt_print(netdissect_options *ndo, const u_char *bp, int len)
 
 	switch (GET_U_1(bp + i)) {
 	case IP6OPT_PAD1:
-            ND_PRINT(", pad1");
+            ND_PRINT(C_RESET, ", pad1");
 	    break;
 	case IP6OPT_PADN:
 	    if (len - i < IP6OPT_MINLEN) {
-		ND_PRINT(", padn: trunc");
+		ND_PRINT(C_RESET, ", padn: trunc");
 		goto trunc;
 	    }
-            ND_PRINT(", padn");
+            ND_PRINT(C_RESET, ", padn");
 	    break;
 	default:
 	    if (len - i < IP6OPT_MINLEN) {
-		ND_PRINT(", sopt_type %u: trunc)", GET_U_1(bp + i));
+		ND_PRINT(C_RESET, ", sopt_type %u: trunc)", GET_U_1(bp + i));
 		goto trunc;
 	    }
-	    ND_PRINT(", sopt_type 0x%02x: len=%u", GET_U_1(bp + i),
+	    ND_PRINT(C_RESET, ", sopt_type 0x%02x: len=%u", GET_U_1(bp + i),
                      GET_U_1(bp + i + 1));
 	    break;
 	}
@@ -112,52 +112,52 @@ ip6_opt_process(netdissect_options *ndo, const u_char *bp, int len,
 	switch (GET_U_1(bp + i)) {
 	case IP6OPT_PAD1:
 	    if (ndo->ndo_vflag)
-                ND_PRINT("(pad1)");
+                ND_PRINT(C_RESET, "(pad1)");
 	    break;
 	case IP6OPT_PADN:
 	    if (len - i < IP6OPT_MINLEN) {
-		ND_PRINT("(padn: trunc)");
+		ND_PRINT(C_RESET, "(padn: trunc)");
 		goto trunc;
 	    }
 	    if (ndo->ndo_vflag)
-                ND_PRINT("(padn)");
+                ND_PRINT(C_RESET, "(padn)");
 	    break;
 	case IP6OPT_ROUTER_ALERT:
 	    if (len - i < IP6OPT_RTALERT_LEN) {
-		ND_PRINT("(rtalert: trunc)");
+		ND_PRINT(C_RESET, "(rtalert: trunc)");
 		goto trunc;
 	    }
 	    if (GET_U_1(bp + i + 1) != IP6OPT_RTALERT_LEN - 2) {
-		ND_PRINT("(rtalert: invalid len %u)", GET_U_1(bp + i + 1));
+		ND_PRINT(C_RESET, "(rtalert: invalid len %u)", GET_U_1(bp + i + 1));
 		goto trunc;
 	    }
 	    if (ndo->ndo_vflag)
-		ND_PRINT("(rtalert: 0x%04x) ", GET_BE_U_2(bp + i + 2));
+		ND_PRINT(C_RESET, "(rtalert: 0x%04x) ", GET_BE_U_2(bp + i + 2));
 	    break;
 	case IP6OPT_JUMBO:
 	    if (len - i < IP6OPT_JUMBO_LEN) {
-		ND_PRINT("(jumbo: trunc)");
+		ND_PRINT(C_RESET, "(jumbo: trunc)");
 		goto trunc;
 	    }
 	    if (GET_U_1(bp + i + 1) != IP6OPT_JUMBO_LEN - 2) {
-		ND_PRINT("(jumbo: invalid len %u)", GET_U_1(bp + i + 1));
+		ND_PRINT(C_RESET, "(jumbo: invalid len %u)", GET_U_1(bp + i + 1));
 		goto trunc;
 	    }
 	    jumbolen = GET_BE_U_4(bp + i + 2);
 	    if (found_jumbo) {
 		/* More than one Jumbo Payload option */
 		if (ndo->ndo_vflag)
-		    ND_PRINT("(jumbo: %u - already seen) ", jumbolen);
+		    ND_PRINT(C_RESET, "(jumbo: %u - already seen) ", jumbolen);
 	    } else {
 		found_jumbo = 1;
 		if (payload_len == NULL) {
 		    /* Not a hop-by-hop option - not valid */
 		    if (ndo->ndo_vflag)
-			ND_PRINT("(jumbo: %u - not a hop-by-hop option) ", jumbolen);
+			ND_PRINT(C_RESET, "(jumbo: %u - not a hop-by-hop option) ", jumbolen);
 		} else if (*payload_len != 0) {
 		    /* Payload length was non-zero - not valid */
 		    if (ndo->ndo_vflag)
-			ND_PRINT("(jumbo: %u - payload len != 0) ", jumbolen);
+			ND_PRINT(C_RESET, "(jumbo: %u - payload len != 0) ", jumbolen);
 		} else {
 		    /*
 		     * This is a hop-by-hop option, and Payload length
@@ -166,49 +166,49 @@ ip6_opt_process(netdissect_options *ndo, const u_char *bp, int len,
 		    if (jumbolen < 65536) {
 			/* Too short */
 			if (ndo->ndo_vflag)
-			    ND_PRINT("(jumbo: %u - < 65536) ", jumbolen);
+			    ND_PRINT(C_RESET, "(jumbo: %u - < 65536) ", jumbolen);
 		    } else {
 			/* OK, this is valid */
 			*found_jumbop = 1;
 			*payload_len = jumbolen;
 			if (ndo->ndo_vflag)
-			    ND_PRINT("(jumbo: %u) ", jumbolen);
+			    ND_PRINT(C_RESET, "(jumbo: %u) ", jumbolen);
 		    }
 		}
 	    }
 	    break;
         case IP6OPT_HOME_ADDRESS:
 	    if (len - i < IP6OPT_HOMEADDR_MINLEN) {
-		ND_PRINT("(homeaddr: trunc)");
+		ND_PRINT(C_RESET, "(homeaddr: trunc)");
 		goto trunc;
 	    }
 	    if (GET_U_1(bp + i + 1) < IP6OPT_HOMEADDR_MINLEN - 2) {
-		ND_PRINT("(homeaddr: invalid len %u)", GET_U_1(bp + i + 1));
+		ND_PRINT(C_RESET, "(homeaddr: invalid len %u)", GET_U_1(bp + i + 1));
 		goto trunc;
 	    }
 	    if (ndo->ndo_vflag) {
-		ND_PRINT("(homeaddr: %s", GET_IP6ADDR_STRING(bp + i + 2));
+		ND_PRINT(C_RESET, "(homeaddr: %s", GET_IP6ADDR_STRING(bp + i + 2));
 		if (GET_U_1(bp + i + 1) > IP6OPT_HOMEADDR_MINLEN - 2) {
 		    if (ip6_sopt_print(ndo, bp + i + IP6OPT_HOMEADDR_MINLEN,
 				       (optlen - IP6OPT_HOMEADDR_MINLEN)) == -1)
 			goto trunc;
 		}
-		ND_PRINT(")");
+		ND_PRINT(C_RESET, ")");
 	    }
 	    break;
 	default:
 	    if (len - i < IP6OPT_MINLEN) {
-		ND_PRINT("(type %u: trunc)", GET_U_1(bp + i));
+		ND_PRINT(C_RESET, "(type %u: trunc)", GET_U_1(bp + i));
 		goto trunc;
 	    }
 	    if (ndo->ndo_vflag)
-		ND_PRINT("(opt_type 0x%02x: len=%u)", GET_U_1(bp + i),
+		ND_PRINT(C_RESET, "(opt_type 0x%02x: len=%u)", GET_U_1(bp + i),
 			 GET_U_1(bp + i + 1));
 	    break;
 	}
     }
     if (ndo->ndo_vflag)
-        ND_PRINT(" ");
+        ND_PRINT(C_RESET, " ");
     return 0;
 
 trunc:
@@ -225,7 +225,7 @@ hbhopt_process(netdissect_options *ndo, const u_char *bp, int *found_jumbo,
     ndo->ndo_protocol = "hbhopt";
     hbhlen = (GET_U_1(dp->ip6h_len) + 1) << 3;
     ND_TCHECK_LEN(dp, hbhlen);
-    ND_PRINT("HBH ");
+    ND_PRINT(C_RESET, "HBH ");
     if (ip6_opt_process(ndo, (const u_char *)dp + sizeof(*dp),
 			hbhlen - sizeof(*dp), found_jumbo, jumbolen) == -1)
 	goto trunc;
@@ -245,7 +245,7 @@ dstopt_process(netdissect_options *ndo, const u_char *bp)
     ndo->ndo_protocol = "dstopt";
     dstoptlen = (GET_U_1(dp->ip6d_len) + 1) << 3;
     ND_TCHECK_LEN(dp, dstoptlen);
-    ND_PRINT("DSTOPT ");
+    ND_PRINT(C_RESET, "DSTOPT ");
     if (ndo->ndo_vflag) {
 	/*
 	 * The Jumbo Payload option is a hop-by-hop option; we don't

--- a/print-ipcomp.c
+++ b/print-ipcomp.c
@@ -46,7 +46,7 @@ ipcomp_print(netdissect_options *ndo, const u_char *bp)
 	ipcomp = (const struct ipcomp *)bp;
 	cpi = GET_BE_U_2(ipcomp->comp_cpi);
 
-	ND_PRINT("IPComp(cpi=0x%04x)", cpi);
+	ND_PRINT(C_RESET, "IPComp(cpi=0x%04x)", cpi);
 
 	/*
 	 * XXX - based on the CPI, we could decompress the packet here.

--- a/print-ipfc.c
+++ b/print-ipfc.c
@@ -84,7 +84,7 @@ ipfc_hdr_print(netdissect_options *ndo,
 	 * so, for captures following this specification, the upper 16
 	 * bits should be 0x1000, followed by a MAC address.
 	 */
-	ND_PRINT("%s > %s, length %u: ", srcname, dstname, length);
+	ND_PRINT(C_RESET, "%s > %s, length %u: ", srcname, dstname, length);
 }
 
 static u_int

--- a/print-ipnet.c
+++ b/print-ipnet.c
@@ -39,22 +39,22 @@ ipnet_hdr_print(netdissect_options *ndo, const u_char *bp, u_int length)
 	const ipnet_hdr_t *hdr;
 	hdr = (const ipnet_hdr_t *)bp;
 
-	ND_PRINT("%u > %u", GET_BE_U_4(hdr->iph_zsrc),
+	ND_PRINT(C_RESET, "%u > %u", GET_BE_U_4(hdr->iph_zsrc),
 		  GET_BE_U_4(hdr->iph_zdst));
 
 	if (!ndo->ndo_qflag) {
-		ND_PRINT(", family %s (%u)",
+		ND_PRINT(C_RESET, ", family %s (%u)",
                           tok2str(ipnet_values, "Unknown",
                                   GET_U_1(hdr->iph_family)),
                           GET_U_1(hdr->iph_family));
         } else {
-		ND_PRINT(", %s",
+		ND_PRINT(C_RESET, ", %s",
                           tok2str(ipnet_values,
                                   "Unknown Ethertype (0x%04x)",
 				  GET_U_1(hdr->iph_family)));
         }
 
-	ND_PRINT(", length %u: ", length);
+	ND_PRINT(C_RESET, ", length %u: ", length);
 }
 
 static void

--- a/print-ipoib.c
+++ b/print-ipoib.c
@@ -47,15 +47,15 @@ ipoib_hdr_print(netdissect_options *ndo, const u_char *bp, u_int length)
 
 	ether_type = GET_BE_U_2(bp + 40);
 	if (!ndo->ndo_qflag) {
-		ND_PRINT(", ethertype %s (0x%04x)",
+		ND_PRINT(C_RESET, ", ethertype %s (0x%04x)",
 			     tok2str(ethertype_values,"Unknown", ether_type),
 			     ether_type);
 	} else {
-		ND_PRINT(", ethertype %s",
+		ND_PRINT(C_RESET, ", ethertype %s",
 			     tok2str(ethertype_values,"Unknown", ether_type));
 	}
 
-	ND_PRINT(", length %u: ", length);
+	ND_PRINT(C_RESET, ", length %u: ", length);
 }
 
 /*

--- a/print-ipx.c
+++ b/print-ipx.c
@@ -76,13 +76,13 @@ ipx_print(netdissect_options *ndo, const u_char *p, u_int length)
 
 	ndo->ndo_protocol = "ipx";
 	if (!ndo->ndo_eflag)
-		ND_PRINT("IPX ");
+		ND_PRINT(C_RESET, "IPX ");
 
-	ND_PRINT("%s.%04x > ",
+	ND_PRINT(C_RESET, "%s.%04x > ",
 		     ipxaddr_string(ndo, GET_BE_U_4(ipx->srcNet), ipx->srcNode),
 		     GET_BE_U_2(ipx->srcSkt));
 
-	ND_PRINT("%s.%04x: ",
+	ND_PRINT(C_RESET, "%s.%04x: ",
 		     ipxaddr_string(ndo, GET_BE_U_4(ipx->dstNet), ipx->dstNode),
 		     GET_BE_U_2(ipx->dstSkt));
 
@@ -90,7 +90,7 @@ ipx_print(netdissect_options *ndo, const u_char *p, u_int length)
 	length = GET_BE_U_2(ipx->length);
 
 	if (length < ipxSize) {
-		ND_PRINT("[length %u < %u]", length, ipxSize);
+		ND_PRINT(C_RESET, "[length %u < %u]", length, ipxSize);
 		nd_print_invalid(ndo);
 		return;
 	}
@@ -118,7 +118,7 @@ ipx_decode(netdissect_options *ndo, const struct ipxHdr *ipx, const u_char *data
     dstSkt = GET_BE_U_2(ipx->dstSkt);
     switch (dstSkt) {
       case IPX_SKT_NCP:
-	ND_PRINT("ipx-ncp %u", length);
+	ND_PRINT(C_RESET, "ipx-ncp %u", length);
 	break;
       case IPX_SKT_SAP:
 	ipx_sap_print(ndo, datap, length);
@@ -127,16 +127,16 @@ ipx_decode(netdissect_options *ndo, const struct ipxHdr *ipx, const u_char *data
 	ipx_rip_print(ndo, datap, length);
 	break;
       case IPX_SKT_NETBIOS:
-	ND_PRINT("ipx-netbios %u", length);
+	ND_PRINT(C_RESET, "ipx-netbios %u", length);
 #ifdef ENABLE_SMB
 	ipx_netbios_print(ndo, datap, length);
 #endif
 	break;
       case IPX_SKT_DIAGNOSTICS:
-	ND_PRINT("ipx-diags %u", length);
+	ND_PRINT(C_RESET, "ipx-diags %u", length);
 	break;
       case IPX_SKT_NWLINK_DGM:
-	ND_PRINT("ipx-nwlink-dgm %u", length);
+	ND_PRINT(C_RESET, "ipx-nwlink-dgm %u", length);
 #ifdef ENABLE_SMB
 	ipx_netbios_print(ndo, datap, length);
 #endif
@@ -145,7 +145,7 @@ ipx_decode(netdissect_options *ndo, const struct ipxHdr *ipx, const u_char *data
 	eigrp_print(ndo, datap, length);
 	break;
       default:
-	ND_PRINT("ipx-#%x %u", dstSkt, length);
+	ND_PRINT(C_RESET, "ipx-#%x %u", dstSkt, length);
 	break;
     }
 }
@@ -164,38 +164,38 @@ ipx_sap_print(netdissect_options *ndo, const u_char *ipx, u_int length)
       case 1:
       case 3:
 	if (command == 1)
-	    ND_PRINT("ipx-sap-req");
+	    ND_PRINT(C_RESET, "ipx-sap-req");
 	else
-	    ND_PRINT("ipx-sap-nearest-req");
+	    ND_PRINT(C_RESET, "ipx-sap-nearest-req");
 
-	ND_PRINT(" %s", ipxsap_string(ndo, htons(GET_BE_U_2(ipx))));
+	ND_PRINT(C_RESET, " %s", ipxsap_string(ndo, htons(GET_BE_U_2(ipx))));
 	break;
 
       case 2:
       case 4:
 	if (command == 2)
-	    ND_PRINT("ipx-sap-resp");
+	    ND_PRINT(C_RESET, "ipx-sap-resp");
 	else
-	    ND_PRINT("ipx-sap-nearest-resp");
+	    ND_PRINT(C_RESET, "ipx-sap-nearest-resp");
 
 	for (i = 0; i < 8 && length != 0; i++) {
 	    ND_ICHECK_U(length, <, 2);
-	    ND_PRINT(" %s '", ipxsap_string(ndo, htons(GET_BE_U_2(ipx))));
+	    ND_PRINT(C_RESET, " %s '", ipxsap_string(ndo, htons(GET_BE_U_2(ipx))));
 	    ipx += 2;
 	    length -= 2;
 	    if (length < 48) {
-		ND_PRINT("'");
+		ND_PRINT(C_RESET, "'");
 		goto invalid;
 	    }
 	    nd_printjnp(ndo, ipx, 48);
-	    ND_PRINT("'");
+	    ND_PRINT(C_RESET, "'");
 	    ipx += 48;
 	    length -= 48;
 	    /*
 	     * 10 bytes of IPX address.
 	     */
 	    ND_ICHECK_U(length, <, 10);
-	    ND_PRINT(" addr %s",
+	    ND_PRINT(C_RESET, " addr %s",
 		ipxaddr_string(ndo, GET_BE_U_4(ipx), ipx + 4));
 	    ipx += 10;
 	    length -= 10;
@@ -210,7 +210,7 @@ ipx_sap_print(netdissect_options *ndo, const u_char *ipx, u_int length)
 	}
 	break;
       default:
-	ND_PRINT("ipx-sap-?%x", command);
+	ND_PRINT(C_RESET, "ipx-sap-?%x", command);
 	break;
     }
     return;
@@ -231,18 +231,18 @@ ipx_rip_print(netdissect_options *ndo, const u_char *ipx, u_int length)
 
     switch (command) {
       case 1:
-	ND_PRINT("ipx-rip-req");
+	ND_PRINT(C_RESET, "ipx-rip-req");
 	if (length != 0) {
 	    ND_ICHECK_U(length, <, 8);
-	    ND_PRINT(" %08x/%u.%u", GET_BE_U_4(ipx),
+	    ND_PRINT(C_RESET, " %08x/%u.%u", GET_BE_U_4(ipx),
 			 GET_BE_U_2(ipx + 4), GET_BE_U_2(ipx + 6));
 	}
 	break;
       case 2:
-	ND_PRINT("ipx-rip-resp");
+	ND_PRINT(C_RESET, "ipx-rip-resp");
 	for (i = 0; i < 50 && length != 0; i++) {
 	    ND_ICHECK_U(length, <, 8);
-	    ND_PRINT(" %08x/%u.%u", GET_BE_U_4(ipx),
+	    ND_PRINT(C_RESET, " %08x/%u.%u", GET_BE_U_4(ipx),
 			 GET_BE_U_2(ipx + 4), GET_BE_U_2(ipx + 6));
 
 	    ipx += 8;
@@ -250,7 +250,7 @@ ipx_rip_print(netdissect_options *ndo, const u_char *ipx, u_int length)
 	}
 	break;
       default:
-	ND_PRINT("ipx-rip-?%x", command);
+	ND_PRINT(C_RESET, "ipx-rip-?%x", command);
 	break;
     }
     return;

--- a/print-isakmp.c
+++ b/print-isakmp.c
@@ -731,7 +731,7 @@ static const char *etypestr[] = {
 
 #define CHECKLEN(p, np)							\
 		if (ep < (const u_char *)(p)) {				\
-			ND_PRINT(" [|%s]", NPSTR(np));		\
+			ND_PRINT(C_RESET, " [|%s]", NPSTR(np));		\
 			goto done;					\
 		}
 
@@ -852,7 +852,7 @@ hexprint(netdissect_options *ndo, const uint8_t *loc, size_t len)
 
 	p = loc;
 	for (i = 0; i < len; i++)
-		ND_PRINT("%02x", p[i] & 0xff);
+		ND_PRINT(C_RESET, "%02x", p[i] & 0xff);
 }
 
 static int
@@ -887,13 +887,13 @@ static int ike_show_somedata(netdissect_options *ndo,
 		elen = ep - end;
 	}
 
-	ND_PRINT(" data=(");
+	ND_PRINT(C_RESET, " data=(");
 	if(!rawprint(ndo, (const uint8_t *)(cp), len)) goto trunc;
-	ND_PRINT("...");
+	ND_PRINT(C_RESET, "...");
 	if(elen) {
 		if(!rawprint(ndo, (const uint8_t *)(end), elen)) goto trunc;
 	}
-	ND_PRINT(")");
+	ND_PRINT(C_RESET, ")");
 	return 1;
 
 trunc:
@@ -920,35 +920,35 @@ ikev1_attrmap_print(netdissect_options *ndo,
 		totlen = 4 + GET_BE_U_2(p + 2);
 	}
 	if (ep2 < p + totlen) {
-		ND_PRINT("[|attr]");
+		ND_PRINT(C_RESET, "[|attr]");
 		return ep2 + 1;
 	}
 
-	ND_PRINT("(");
+	ND_PRINT(C_RESET, "(");
 	t = GET_BE_U_2(p) & 0x7fff;
 	if (map && t < nmap && map[t].type)
-		ND_PRINT("type=%s ", map[t].type);
+		ND_PRINT(C_RESET, "type=%s ", map[t].type);
 	else
-		ND_PRINT("type=#%u ", t);
+		ND_PRINT(C_RESET, "type=#%u ", t);
 	if (GET_U_1(p) & 0x80) {
-		ND_PRINT("value=");
+		ND_PRINT(C_RESET, "value=");
 		v = GET_BE_U_2(p + 2);
 		if (map && t < nmap && v < map[t].nvalue && map[t].value[v])
-			ND_PRINT("%s", map[t].value[v]);
+			ND_PRINT(C_RESET, "%s", map[t].value[v]);
 		else {
 			if (!rawprint(ndo, (const uint8_t *)(p + 2), 2)) {
-				ND_PRINT(")");
+				ND_PRINT(C_RESET, ")");
 				goto trunc;
 			}
 		}
 	} else {
-		ND_PRINT("len=%u value=", totlen - 4);
+		ND_PRINT(C_RESET, "len=%u value=", totlen - 4);
 		if (!rawprint(ndo, (const uint8_t *)(p + 4), totlen - 4)) {
-			ND_PRINT(")");
+			ND_PRINT(C_RESET, ")");
 			goto trunc;
 		}
 	}
-	ND_PRINT(")");
+	ND_PRINT(C_RESET, ")");
 	return p + totlen;
 
 trunc:
@@ -967,28 +967,28 @@ ikev1_attr_print(netdissect_options *ndo, const u_char *p, const u_char *ep2)
 		totlen = 4 + GET_BE_U_2(p + 2);
 	}
 	if (ep2 < p + totlen) {
-		ND_PRINT("[|attr]");
+		ND_PRINT(C_RESET, "[|attr]");
 		return ep2 + 1;
 	}
 
-	ND_PRINT("(");
+	ND_PRINT(C_RESET, "(");
 	t = GET_BE_U_2(p) & 0x7fff;
-	ND_PRINT("type=#%u ", t);
+	ND_PRINT(C_RESET, "type=#%u ", t);
 	if (GET_U_1(p) & 0x80) {
-		ND_PRINT("value=");
+		ND_PRINT(C_RESET, "value=");
 		t = GET_U_1(p + 2);
 		if (!rawprint(ndo, (const uint8_t *)(p + 2), 2)) {
-			ND_PRINT(")");
+			ND_PRINT(C_RESET, ")");
 			goto trunc;
 		}
 	} else {
-		ND_PRINT("len=%u value=", totlen - 4);
+		ND_PRINT(C_RESET, "len=%u value=", totlen - 4);
 		if (!rawprint(ndo, (const uint8_t *)(p + 4), totlen - 4)) {
-			ND_PRINT(")");
+			ND_PRINT(C_RESET, ")");
 			goto trunc;
 		}
 	}
-	ND_PRINT(")");
+	ND_PRINT(C_RESET, ")");
 	return p + totlen;
 
 trunc:
@@ -1007,36 +1007,36 @@ ikev1_sa_print(netdissect_options *ndo, u_char tpay _U_,
 	const u_char *cp, *np;
 	int t;
 
-	ND_PRINT("%s:", NPSTR(ISAKMP_NPTYPE_SA));
+	ND_PRINT(C_RESET, "%s:", NPSTR(ISAKMP_NPTYPE_SA));
 
 	p = (const struct ikev1_pl_sa *)ext;
 	ND_TCHECK_SIZE(p);
 	doi = GET_BE_U_4(p->doi);
 	sit = GET_BE_U_4(p->sit);
 	if (doi != 1) {
-		ND_PRINT(" doi=%u", doi);
-		ND_PRINT(" situation=%u", sit);
+		ND_PRINT(C_RESET, " doi=%u", doi);
+		ND_PRINT(C_RESET, " situation=%u", sit);
 		return (const u_char *)(p + 1);
 	}
 
-	ND_PRINT(" doi=ipsec");
-	ND_PRINT(" situation=");
+	ND_PRINT(C_RESET, " doi=ipsec");
+	ND_PRINT(C_RESET, " situation=");
 	t = 0;
 	if (sit & 0x01) {
-		ND_PRINT("identity");
+		ND_PRINT(C_RESET, "identity");
 		t++;
 	}
 	if (sit & 0x02) {
-		ND_PRINT("%ssecrecy", t ? "+" : "");
+		ND_PRINT(C_RESET, "%ssecrecy", t ? "+" : "");
 		t++;
 	}
 	if (sit & 0x04)
-		ND_PRINT("%sintegrity", t ? "+" : "");
+		ND_PRINT(C_RESET, "%sintegrity", t ? "+" : "");
 
 	np = (const u_char *)ext + sizeof(struct ikev1_pl_sa);
 	if (sit != 0x01) {
 		ident = GET_BE_U_4(ext + 1);
-		ND_PRINT(" ident=%u", ident);
+		ND_PRINT(C_RESET, " ident=%u", ident);
 		np += sizeof(ident);
 	}
 
@@ -1048,7 +1048,7 @@ ikev1_sa_print(netdissect_options *ndo, u_char tpay _U_,
 
 	return cp;
 trunc:
-	ND_PRINT(" [|%s]", NPSTR(ISAKMP_NPTYPE_SA));
+	ND_PRINT(C_RESET, " [|%s]", NPSTR(ISAKMP_NPTYPE_SA));
 	return NULL;
 }
 
@@ -1062,16 +1062,16 @@ ikev1_p_print(netdissect_options *ndo, u_char tpay _U_,
 	const u_char *cp;
 	uint8_t spi_size;
 
-	ND_PRINT("%s:", NPSTR(ISAKMP_NPTYPE_P));
+	ND_PRINT(C_RESET, "%s:", NPSTR(ISAKMP_NPTYPE_P));
 
 	p = (const struct ikev1_pl_p *)ext;
 	ND_TCHECK_SIZE(p);
-	ND_PRINT(" #%u protoid=%s transform=%u",
+	ND_PRINT(C_RESET, " #%u protoid=%s transform=%u",
 		  GET_U_1(p->p_no), PROTOIDSTR(GET_U_1(p->prot_id)),
 		  GET_U_1(p->num_t));
 	spi_size = GET_U_1(p->spi_size);
 	if (spi_size) {
-		ND_PRINT(" spi=");
+		ND_PRINT(C_RESET, " spi=");
 		if (!rawprint(ndo, (const uint8_t *)(p + 1), spi_size))
 			goto trunc;
 	}
@@ -1084,7 +1084,7 @@ ikev1_p_print(netdissect_options *ndo, u_char tpay _U_,
 
 	return cp;
 trunc:
-	ND_PRINT(" [|%s]", NPSTR(ISAKMP_NPTYPE_P));
+	ND_PRINT(C_RESET, " [|%s]", NPSTR(ISAKMP_NPTYPE_P));
 	return NULL;
 }
 
@@ -1229,7 +1229,7 @@ ikev1_t_print(netdissect_options *ndo, u_char tpay _U_,
 	size_t nmap;
 	const u_char *ep2;
 
-	ND_PRINT("%s:", NPSTR(ISAKMP_NPTYPE_T));
+	ND_PRINT(C_RESET, "%s:", NPSTR(ISAKMP_NPTYPE_T));
 
 	p = (const struct ikev1_pl_t *)ext;
 	ND_TCHECK_SIZE(p);
@@ -1263,9 +1263,9 @@ ikev1_t_print(netdissect_options *ndo, u_char tpay _U_,
 	}
 
 	if (idstr)
-		ND_PRINT(" #%u id=%s ", GET_U_1(p->t_no), idstr);
+		ND_PRINT(C_RESET, " #%u id=%s ", GET_U_1(p->t_no), idstr);
 	else
-		ND_PRINT(" #%u id=%u ", GET_U_1(p->t_no), GET_U_1(p->t_id));
+		ND_PRINT(C_RESET, " #%u id=%u ", GET_U_1(p->t_no), GET_U_1(p->t_id));
 	cp = (const u_char *)(p + 1);
 	ep2 = (const u_char *)p + item_len;
 	while (cp < ep && cp < ep2) {
@@ -1277,10 +1277,10 @@ ikev1_t_print(netdissect_options *ndo, u_char tpay _U_,
 			goto trunc;
 	}
 	if (ep < ep2)
-		ND_PRINT("...");
+		ND_PRINT(C_RESET, "...");
 	return cp;
 trunc:
-	ND_PRINT(" [|%s]", NPSTR(ISAKMP_NPTYPE_T));
+	ND_PRINT(C_RESET, " [|%s]", NPSTR(ISAKMP_NPTYPE_T));
 	return NULL;
 }
 
@@ -1290,22 +1290,22 @@ ikev1_ke_print(netdissect_options *ndo, u_char tpay _U_,
 	       const u_char *ep _U_, uint32_t phase _U_, uint32_t doi _U_,
 	       uint32_t proto _U_, int depth _U_)
 {
-	ND_PRINT("%s:", NPSTR(ISAKMP_NPTYPE_KE));
+	ND_PRINT(C_RESET, "%s:", NPSTR(ISAKMP_NPTYPE_KE));
 
 	ND_TCHECK_SIZE(ext);
 	/*
 	 * Our caller has ensured that the length is >= 4.
 	 */
-	ND_PRINT(" key len=%u", item_len - 4);
+	ND_PRINT(C_RESET, " key len=%u", item_len - 4);
 	if (2 < ndo->ndo_vflag && item_len > 4) {
 		/* Print the entire payload in hex */
-		ND_PRINT(" ");
+		ND_PRINT(C_RESET, " ");
 		if (!rawprint(ndo, (const uint8_t *)(ext + 1), item_len - 4))
 			goto trunc;
 	}
 	return (const u_char *)ext + item_len;
 trunc:
-	ND_PRINT(" [|%s]", NPSTR(ISAKMP_NPTYPE_KE));
+	ND_PRINT(C_RESET, " [|%s]", NPSTR(ISAKMP_NPTYPE_KE));
 	return NULL;
 }
 
@@ -1328,7 +1328,7 @@ ikev1_id_print(netdissect_options *ndo, u_char tpay _U_,
 	u_int len;
 	const u_char *data;
 
-	ND_PRINT("%s:", NPSTR(ISAKMP_NPTYPE_ID));
+	ND_PRINT(C_RESET, "%s:", NPSTR(ISAKMP_NPTYPE_ID));
 
 	p = (const struct ikev1_pl_id *)ext;
 	ND_TCHECK_SIZE(p);
@@ -1341,16 +1341,16 @@ ikev1_id_print(netdissect_options *ndo, u_char tpay _U_,
 	}
 
 #if 0 /*debug*/
-	ND_PRINT(" [phase=%u doi=%u proto=%u]", phase, doi, proto);
+	ND_PRINT(C_RESET, " [phase=%u doi=%u proto=%u]", phase, doi, proto);
 #endif
 	switch (phase) {
 #ifndef USE_IPSECDOI_IN_PHASE1
 	case 1:
 #endif
 	default:
-		ND_PRINT(" idtype=%s",
+		ND_PRINT(C_RESET, " idtype=%s",
 			 STR_OR_ID(GET_U_1(p->d.id_type), idtypestr));
-		ND_PRINT(" doi_data=%u",
+		ND_PRINT(C_RESET, " doi_data=%u",
 			  GET_BE_U_4(p->d.doi_data) & 0xffffff);
 		break;
 
@@ -1366,14 +1366,14 @@ ikev1_id_print(netdissect_options *ndo, u_char tpay _U_,
 		doi_p = (const struct ipsecdoi_id *)ext;
 		ND_TCHECK_SIZE(doi_p);
 		type = GET_U_1(doi_p->type);
-		ND_PRINT(" idtype=%s", STR_OR_ID(type, ipsecidtypestr));
+		ND_PRINT(C_RESET, " idtype=%s", STR_OR_ID(type, ipsecidtypestr));
 		/* A protocol ID of 0 DOES NOT mean IPPROTO_IP! */
 		proto_id = GET_U_1(doi_p->proto_id);
 		if (!ndo->ndo_nflag && proto_id && (p_name = netdb_protoname(proto_id)) != NULL)
-			ND_PRINT(" protoid=%s", p_name);
+			ND_PRINT(C_RESET, " protoid=%s", p_name);
 		else
-			ND_PRINT(" protoid=%u", proto_id);
-		ND_PRINT(" port=%u", GET_BE_U_2(doi_p->port));
+			ND_PRINT(C_RESET, " protoid=%u", proto_id);
+		ND_PRINT(C_RESET, " port=%u", GET_BE_U_2(doi_p->port));
 		if (!len)
 			break;
 		if (data == NULL)
@@ -1382,16 +1382,16 @@ ikev1_id_print(netdissect_options *ndo, u_char tpay _U_,
 		switch (type) {
 		case IPSECDOI_ID_IPV4_ADDR:
 			if (len < 4)
-				ND_PRINT(" len=%u [bad: < 4]", len);
+				ND_PRINT(C_RESET, " len=%u [bad: < 4]", len);
 			else
-				ND_PRINT(" len=%u %s", len, GET_IPADDR_STRING(data));
+				ND_PRINT(C_RESET, " len=%u %s", len, GET_IPADDR_STRING(data));
 			len = 0;
 			break;
 		case IPSECDOI_ID_FQDN:
 		case IPSECDOI_ID_USER_FQDN:
 		    {
 			u_int i;
-			ND_PRINT(" len=%u ", len);
+			ND_PRINT(C_RESET, " len=%u ", len);
 			for (i = 0; i < len; i++)
 				fn_print_char(ndo, GET_U_1(data + i));
 			len = 0;
@@ -1401,10 +1401,10 @@ ikev1_id_print(netdissect_options *ndo, u_char tpay _U_,
 		    {
 			const u_char *mask;
 			if (len < 8)
-				ND_PRINT(" len=%u [bad: < 8]", len);
+				ND_PRINT(C_RESET, " len=%u [bad: < 8]", len);
 			else {
 				mask = data + sizeof(nd_ipv4);
-				ND_PRINT(" len=%u %s/%u.%u.%u.%u", len,
+				ND_PRINT(C_RESET, " len=%u %s/%u.%u.%u.%u", len,
 					  GET_IPADDR_STRING(data),
 					  GET_U_1(mask), GET_U_1(mask + 1),
 					  GET_U_1(mask + 2),
@@ -1415,20 +1415,20 @@ ikev1_id_print(netdissect_options *ndo, u_char tpay _U_,
 		    }
 		case IPSECDOI_ID_IPV6_ADDR:
 			if (len < 16)
-				ND_PRINT(" len=%u [bad: < 16]", len);
+				ND_PRINT(C_RESET, " len=%u [bad: < 16]", len);
 			else
-				ND_PRINT(" len=%u %s", len, GET_IP6ADDR_STRING(data));
+				ND_PRINT(C_RESET, " len=%u %s", len, GET_IP6ADDR_STRING(data));
 			len = 0;
 			break;
 		case IPSECDOI_ID_IPV6_ADDR_SUBNET:
 		    {
 			const u_char *mask;
 			if (len < 32)
-				ND_PRINT(" len=%u [bad: < 32]", len);
+				ND_PRINT(C_RESET, " len=%u [bad: < 32]", len);
 			else {
 				mask = (const u_char *)(data + sizeof(nd_ipv6));
 				/*XXX*/
-				ND_PRINT(" len=%u %s/0x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x", len,
+				ND_PRINT(C_RESET, " len=%u %s/0x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x", len,
 					  GET_IP6ADDR_STRING(data),
 					  GET_U_1(mask), GET_U_1(mask + 1),
 					  GET_U_1(mask + 2),
@@ -1451,9 +1451,9 @@ ikev1_id_print(netdissect_options *ndo, u_char tpay _U_,
 		    }
 		case IPSECDOI_ID_IPV4_ADDR_RANGE:
 			if (len < 8)
-				ND_PRINT(" len=%u [bad: < 8]", len);
+				ND_PRINT(C_RESET, " len=%u [bad: < 8]", len);
 			else {
-				ND_PRINT(" len=%u %s-%s", len,
+				ND_PRINT(C_RESET, " len=%u %s-%s", len,
 					  GET_IPADDR_STRING(data),
 					  GET_IPADDR_STRING(data + sizeof(nd_ipv4)));
 			}
@@ -1461,9 +1461,9 @@ ikev1_id_print(netdissect_options *ndo, u_char tpay _U_,
 			break;
 		case IPSECDOI_ID_IPV6_ADDR_RANGE:
 			if (len < 32)
-				ND_PRINT(" len=%u [bad: < 32]", len);
+				ND_PRINT(C_RESET, " len=%u [bad: < 32]", len);
 			else {
-				ND_PRINT(" len=%u %s-%s", len,
+				ND_PRINT(C_RESET, " len=%u %s-%s", len,
 					  GET_IP6ADDR_STRING(data),
 					  GET_IP6ADDR_STRING(data + sizeof(nd_ipv6)));
 			}
@@ -1478,16 +1478,16 @@ ikev1_id_print(netdissect_options *ndo, u_char tpay _U_,
 	    }
 	}
 	if (data && len) {
-		ND_PRINT(" len=%u", len);
+		ND_PRINT(C_RESET, " len=%u", len);
 		if (2 < ndo->ndo_vflag) {
-			ND_PRINT(" ");
+			ND_PRINT(C_RESET, " ");
 			if (!rawprint(ndo, (const uint8_t *)data, len))
 				goto trunc;
 		}
 	}
 	return (const u_char *)ext + item_len;
 trunc:
-	ND_PRINT(" [|%s]", NPSTR(ISAKMP_NPTYPE_ID));
+	ND_PRINT(C_RESET, " [|%s]", NPSTR(ISAKMP_NPTYPE_ID));
 	return NULL;
 }
 
@@ -1505,24 +1505,24 @@ ikev1_cert_print(netdissect_options *ndo, u_char tpay _U_,
 		"arl", "spki", "x509attr",
 	};
 
-	ND_PRINT("%s:", NPSTR(ISAKMP_NPTYPE_CERT));
+	ND_PRINT(C_RESET, "%s:", NPSTR(ISAKMP_NPTYPE_CERT));
 
 	p = (const struct ikev1_pl_cert *)ext;
 	ND_TCHECK_SIZE(p);
 	/*
 	 * Our caller has ensured that the length is >= 4.
 	 */
-	ND_PRINT(" len=%u", item_len - 4);
-	ND_PRINT(" type=%s", STR_OR_ID(GET_U_1(p->encode), certstr));
+	ND_PRINT(C_RESET, " len=%u", item_len - 4);
+	ND_PRINT(C_RESET, " type=%s", STR_OR_ID(GET_U_1(p->encode), certstr));
 	if (2 < ndo->ndo_vflag && 4 < item_len) {
 		/* Print the entire payload in hex */
-		ND_PRINT(" ");
+		ND_PRINT(C_RESET, " ");
 		if (!rawprint(ndo, (const uint8_t *)(ext + 1), item_len - 4))
 			goto trunc;
 	}
 	return (const u_char *)ext + item_len;
 trunc:
-	ND_PRINT(" [|%s]", NPSTR(ISAKMP_NPTYPE_CERT));
+	ND_PRINT(C_RESET, " [|%s]", NPSTR(ISAKMP_NPTYPE_CERT));
 	return NULL;
 }
 
@@ -1539,24 +1539,24 @@ ikev1_cr_print(netdissect_options *ndo, u_char tpay _U_,
 		"arl", "spki", "x509attr",
 	};
 
-	ND_PRINT("%s:", NPSTR(ISAKMP_NPTYPE_CR));
+	ND_PRINT(C_RESET, "%s:", NPSTR(ISAKMP_NPTYPE_CR));
 
 	p = (const struct ikev1_pl_cert *)ext;
 	ND_TCHECK_SIZE(p);
 	/*
 	 * Our caller has ensured that the length is >= 4.
 	 */
-	ND_PRINT(" len=%u", item_len - 4);
-	ND_PRINT(" type=%s", STR_OR_ID(GET_U_1(p->encode), certstr));
+	ND_PRINT(C_RESET, " len=%u", item_len - 4);
+	ND_PRINT(C_RESET, " type=%s", STR_OR_ID(GET_U_1(p->encode), certstr));
 	if (2 < ndo->ndo_vflag && 4 < item_len) {
 		/* Print the entire payload in hex */
-		ND_PRINT(" ");
+		ND_PRINT(C_RESET, " ");
 		if (!rawprint(ndo, (const uint8_t *)(ext + 1), item_len - 4))
 			goto trunc;
 	}
 	return (const u_char *)ext + item_len;
 trunc:
-	ND_PRINT(" [|%s]", NPSTR(ISAKMP_NPTYPE_CR));
+	ND_PRINT(C_RESET, " [|%s]", NPSTR(ISAKMP_NPTYPE_CR));
 	return NULL;
 }
 
@@ -1566,22 +1566,22 @@ ikev1_hash_print(netdissect_options *ndo, u_char tpay _U_,
 		 const u_char *ep _U_, uint32_t phase _U_, uint32_t doi _U_,
 		 uint32_t proto _U_, int depth _U_)
 {
-	ND_PRINT("%s:", NPSTR(ISAKMP_NPTYPE_HASH));
+	ND_PRINT(C_RESET, "%s:", NPSTR(ISAKMP_NPTYPE_HASH));
 
 	ND_TCHECK_SIZE(ext);
 	/*
 	 * Our caller has ensured that the length is >= 4.
 	 */
-	ND_PRINT(" len=%u", item_len - 4);
+	ND_PRINT(C_RESET, " len=%u", item_len - 4);
 	if (2 < ndo->ndo_vflag && 4 < item_len) {
 		/* Print the entire payload in hex */
-		ND_PRINT(" ");
+		ND_PRINT(C_RESET, " ");
 		if (!rawprint(ndo, (const uint8_t *)(ext + 1), item_len - 4))
 			goto trunc;
 	}
 	return (const u_char *)ext + item_len;
 trunc:
-	ND_PRINT(" [|%s]", NPSTR(ISAKMP_NPTYPE_HASH));
+	ND_PRINT(C_RESET, " [|%s]", NPSTR(ISAKMP_NPTYPE_HASH));
 	return NULL;
 }
 
@@ -1591,22 +1591,22 @@ ikev1_sig_print(netdissect_options *ndo, u_char tpay _U_,
 		const u_char *ep _U_, uint32_t phase _U_, uint32_t doi _U_,
 		uint32_t proto _U_, int depth _U_)
 {
-	ND_PRINT("%s:", NPSTR(ISAKMP_NPTYPE_SIG));
+	ND_PRINT(C_RESET, "%s:", NPSTR(ISAKMP_NPTYPE_SIG));
 
 	ND_TCHECK_SIZE(ext);
 	/*
 	 * Our caller has ensured that the length is >= 4.
 	 */
-	ND_PRINT(" len=%u", item_len - 4);
+	ND_PRINT(C_RESET, " len=%u", item_len - 4);
 	if (2 < ndo->ndo_vflag && 4 < item_len) {
 		/* Print the entire payload in hex */
-		ND_PRINT(" ");
+		ND_PRINT(C_RESET, " ");
 		if (!rawprint(ndo, (const uint8_t *)(ext + 1), item_len - 4))
 			goto trunc;
 	}
 	return (const u_char *)ext + item_len;
 trunc:
-	ND_PRINT(" [|%s]", NPSTR(ISAKMP_NPTYPE_SIG));
+	ND_PRINT(C_RESET, " [|%s]", NPSTR(ISAKMP_NPTYPE_SIG));
 	return NULL;
 }
 
@@ -1618,27 +1618,27 @@ ikev1_nonce_print(netdissect_options *ndo, u_char tpay _U_,
 		  uint32_t phase _U_, uint32_t doi _U_,
 		  uint32_t proto _U_, int depth _U_)
 {
-	ND_PRINT("%s:", NPSTR(ISAKMP_NPTYPE_NONCE));
+	ND_PRINT(C_RESET, "%s:", NPSTR(ISAKMP_NPTYPE_NONCE));
 
 	ND_TCHECK_SIZE(ext);
 	/*
 	 * Our caller has ensured that the length is >= 4.
 	 */
-	ND_PRINT(" n len=%u", item_len - 4);
+	ND_PRINT(C_RESET, " n len=%u", item_len - 4);
 	if (item_len > 4) {
 		if (ndo->ndo_vflag > 2) {
-			ND_PRINT(" ");
+			ND_PRINT(C_RESET, " ");
 			if (!rawprint(ndo, (const uint8_t *)(ext + 1), item_len - 4))
 				goto trunc;
 		} else if (ndo->ndo_vflag > 1) {
-			ND_PRINT(" ");
+			ND_PRINT(C_RESET, " ");
 			if (!ike_show_somedata(ndo, (const u_char *)(ext + 1), ep))
 				goto trunc;
 		}
 	}
 	return (const u_char *)ext + item_len;
 trunc:
-	ND_PRINT(" [|%s]", NPSTR(ISAKMP_NPTYPE_NONCE));
+	ND_PRINT(C_RESET, " [|%s]", NPSTR(ISAKMP_NPTYPE_NONCE));
 	return NULL;
 }
 
@@ -1701,49 +1701,49 @@ ikev1_n_print(netdissect_options *ndo, u_char tpay _U_,
 #define IPSEC_NOTIFY_STATUS_STR(x) \
 	STR_OR_ID((u_int)((x) - 24576), ipsec_notify_status_str)
 
-	ND_PRINT("%s:", NPSTR(ISAKMP_NPTYPE_N));
+	ND_PRINT(C_RESET, "%s:", NPSTR(ISAKMP_NPTYPE_N));
 
 	p = (const struct ikev1_pl_n *)ext;
 	ND_TCHECK_SIZE(p);
 	doi = GET_BE_U_4(p->doi);
 	proto = GET_U_1(p->prot_id);
 	if (doi != 1) {
-		ND_PRINT(" doi=%u", doi);
-		ND_PRINT(" proto=%u", proto);
+		ND_PRINT(C_RESET, " doi=%u", doi);
+		ND_PRINT(C_RESET, " proto=%u", proto);
 		type = GET_BE_U_2(p->type);
 		if (type < 8192)
-			ND_PRINT(" type=%s", NOTIFY_ERROR_STR(type));
+			ND_PRINT(C_RESET, " type=%s", NOTIFY_ERROR_STR(type));
 		else if (type < 16384)
-			ND_PRINT(" type=%s", numstr(type));
+			ND_PRINT(C_RESET, " type=%s", numstr(type));
 		else if (type < 24576)
-			ND_PRINT(" type=%s", NOTIFY_STATUS_STR(type));
+			ND_PRINT(C_RESET, " type=%s", NOTIFY_STATUS_STR(type));
 		else
-			ND_PRINT(" type=%s", numstr(type));
+			ND_PRINT(C_RESET, " type=%s", numstr(type));
 		spi_size = GET_U_1(p->spi_size);
 		if (spi_size) {
-			ND_PRINT(" spi=");
+			ND_PRINT(C_RESET, " spi=");
 			if (!rawprint(ndo, (const uint8_t *)(p + 1), spi_size))
 				goto trunc;
 		}
 		return (const u_char *)(p + 1) + spi_size;
 	}
 
-	ND_PRINT(" doi=ipsec");
-	ND_PRINT(" proto=%s", PROTOIDSTR(proto));
+	ND_PRINT(C_RESET, " doi=ipsec");
+	ND_PRINT(C_RESET, " proto=%s", PROTOIDSTR(proto));
 	type = GET_BE_U_2(p->type);
 	if (type < 8192)
-		ND_PRINT(" type=%s", NOTIFY_ERROR_STR(type));
+		ND_PRINT(C_RESET, " type=%s", NOTIFY_ERROR_STR(type));
 	else if (type < 16384)
-		ND_PRINT(" type=%s", IPSEC_NOTIFY_ERROR_STR(type));
+		ND_PRINT(C_RESET, " type=%s", IPSEC_NOTIFY_ERROR_STR(type));
 	else if (type < 24576)
-		ND_PRINT(" type=%s", NOTIFY_STATUS_STR(type));
+		ND_PRINT(C_RESET, " type=%s", NOTIFY_STATUS_STR(type));
 	else if (type < 32768)
-		ND_PRINT(" type=%s", IPSEC_NOTIFY_STATUS_STR(type));
+		ND_PRINT(C_RESET, " type=%s", IPSEC_NOTIFY_STATUS_STR(type));
 	else
-		ND_PRINT(" type=%s", numstr(type));
+		ND_PRINT(C_RESET, " type=%s", numstr(type));
 	spi_size = GET_U_1(p->spi_size);
 	if (spi_size) {
-		ND_PRINT(" spi=");
+		ND_PRINT(C_RESET, " spi=");
 		if (!rawprint(ndo, (const uint8_t *)(p + 1), spi_size))
 			goto trunc;
 	}
@@ -1757,22 +1757,22 @@ ikev1_n_print(netdissect_options *ndo, u_char tpay _U_,
 		    {
 			const struct attrmap *map = oakley_t_map;
 			size_t nmap = sizeof(oakley_t_map)/sizeof(oakley_t_map[0]);
-			ND_PRINT(" attrs=(");
+			ND_PRINT(C_RESET, " attrs=(");
 			while (cp < ep && cp < ep2) {
 				cp = ikev1_attrmap_print(ndo, cp, ep2, map, nmap);
 				if (cp == NULL) {
-					ND_PRINT(")");
+					ND_PRINT(C_RESET, ")");
 					goto trunc;
 				}
 			}
-			ND_PRINT(")");
+			ND_PRINT(C_RESET, ")");
 			break;
 		    }
 		case IPSECDOI_NTYPE_REPLAY_STATUS:
-			ND_PRINT(" status=(");
-			ND_PRINT("replay detection %sabled",
+			ND_PRINT(C_RESET, " status=(");
+			ND_PRINT(C_RESET, "replay detection %sabled",
 				  GET_BE_U_4(cp) ? "en" : "dis");
-			ND_PRINT(")");
+			ND_PRINT(C_RESET, ")");
 			break;
 		default:
 			/*
@@ -1780,10 +1780,10 @@ ikev1_n_print(netdissect_options *ndo, u_char tpay _U_,
 			 * draft-ietf-ipsec-notifymsg-04.
 			 */
 			if (ndo->ndo_vflag > 3) {
-				ND_PRINT(" data=(");
+				ND_PRINT(C_RESET, " data=(");
 				if (!rawprint(ndo, (const uint8_t *)(cp), ep - cp))
 					goto trunc;
-				ND_PRINT(")");
+				ND_PRINT(C_RESET, ")");
 			} else {
 				if (!ike_show_somedata(ndo, cp, ep))
 					goto trunc;
@@ -1793,7 +1793,7 @@ ikev1_n_print(netdissect_options *ndo, u_char tpay _U_,
 	}
 	return (const u_char *)ext + item_len;
 trunc:
-	ND_PRINT(" [|%s]", NPSTR(ISAKMP_NPTYPE_N));
+	ND_PRINT(C_RESET, " [|%s]", NPSTR(ISAKMP_NPTYPE_N));
 	return NULL;
 }
 
@@ -1811,35 +1811,35 @@ ikev1_d_print(netdissect_options *ndo, u_char tpay _U_,
 	uint16_t num_spi;
 	u_int i;
 
-	ND_PRINT("%s:", NPSTR(ISAKMP_NPTYPE_D));
+	ND_PRINT(C_RESET, "%s:", NPSTR(ISAKMP_NPTYPE_D));
 
 	p = (const struct ikev1_pl_d *)ext;
 	ND_TCHECK_SIZE(p);
 	doi = GET_BE_U_4(p->doi);
 	proto = GET_U_1(p->prot_id);
 	if (doi != 1) {
-		ND_PRINT(" doi=%u", doi);
-		ND_PRINT(" proto=%u", proto);
+		ND_PRINT(C_RESET, " doi=%u", doi);
+		ND_PRINT(C_RESET, " proto=%u", proto);
 	} else {
-		ND_PRINT(" doi=ipsec");
-		ND_PRINT(" proto=%s", PROTOIDSTR(proto));
+		ND_PRINT(C_RESET, " doi=ipsec");
+		ND_PRINT(C_RESET, " proto=%s", PROTOIDSTR(proto));
 	}
 	spi_size = GET_U_1(p->spi_size);
-	ND_PRINT(" spilen=%u", spi_size);
+	ND_PRINT(C_RESET, " spilen=%u", spi_size);
 	num_spi = GET_BE_U_2(p->num_spi);
-	ND_PRINT(" nspi=%u", num_spi);
-	ND_PRINT(" spi=");
+	ND_PRINT(C_RESET, " nspi=%u", num_spi);
+	ND_PRINT(C_RESET, " spi=");
 	q = (const uint8_t *)(p + 1);
 	for (i = 0; i < num_spi; i++) {
 		if (i != 0)
-			ND_PRINT(",");
+			ND_PRINT(C_RESET, ",");
 		if (!rawprint(ndo, (const uint8_t *)q, spi_size))
 			goto trunc;
 		q += spi_size;
 	}
 	return q;
 trunc:
-	ND_PRINT(" [|%s]", NPSTR(ISAKMP_NPTYPE_D));
+	ND_PRINT(C_RESET, " [|%s]", NPSTR(ISAKMP_NPTYPE_D));
 	return NULL;
 }
 
@@ -1850,22 +1850,22 @@ ikev1_vid_print(netdissect_options *ndo, u_char tpay _U_,
 		uint32_t phase _U_, uint32_t doi _U_,
 		uint32_t proto _U_, int depth _U_)
 {
-	ND_PRINT("%s:", NPSTR(ISAKMP_NPTYPE_VID));
+	ND_PRINT(C_RESET, "%s:", NPSTR(ISAKMP_NPTYPE_VID));
 
 	ND_TCHECK_SIZE(ext);
 	/*
 	 * Our caller has ensured that the length is >= 4.
 	 */
-	ND_PRINT(" len=%u", item_len - 4);
+	ND_PRINT(C_RESET, " len=%u", item_len - 4);
 	if (2 < ndo->ndo_vflag && 4 < item_len) {
 		/* Print the entire payload in hex */
-		ND_PRINT(" ");
+		ND_PRINT(C_RESET, " ");
 		if (!rawprint(ndo, (const uint8_t *)(ext + 1), item_len - 4))
 			goto trunc;
 	}
 	return (const u_char *)ext + item_len;
 trunc:
-	ND_PRINT(" [|%s]", NPSTR(ISAKMP_NPTYPE_VID));
+	ND_PRINT(C_RESET, " [|%s]", NPSTR(ISAKMP_NPTYPE_VID));
 	return NULL;
 }
 
@@ -1878,7 +1878,7 @@ trunc:
 static void
 ikev2_pay_print(netdissect_options *ndo, const char *payname, uint8_t critical)
 {
-	ND_PRINT("%s%s:", payname, critical&0x80 ? "[C]" : "");
+	ND_PRINT(C_RESET, "%s%s:", payname, critical&0x80 ? "[C]" : "");
 }
 
 static const u_char *
@@ -1893,16 +1893,16 @@ ikev2_gen_print(netdissect_options *ndo, u_char tpay,
 	/*
 	 * Our caller has ensured that the length is >= 4.
 	 */
-	ND_PRINT(" len=%u", item_len - 4);
+	ND_PRINT(C_RESET, " len=%u", item_len - 4);
 	if (2 < ndo->ndo_vflag && 4 < item_len) {
 		/* Print the entire payload in hex */
-		ND_PRINT(" ");
+		ND_PRINT(C_RESET, " ");
 		if (!rawprint(ndo, (const uint8_t *)(ext + 1), item_len - 4))
 			goto trunc;
 	}
 	return (const u_char *)ext + item_len;
 trunc:
-	ND_PRINT(" [|%s]", NPSTR(tpay));
+	ND_PRINT(C_RESET, " [|%s]", NPSTR(tpay));
 	return NULL;
 }
 
@@ -1959,11 +1959,11 @@ ikev2_t_print(netdissect_options *ndo, int tcount,
 	}
 
 	if (idstr)
-		ND_PRINT(" #%u type=%s id=%s ", tcount,
+		ND_PRINT(C_RESET, " #%u type=%s id=%s ", tcount,
 			  STR_OR_ID(t_type, ikev2_t_type_map),
 			  idstr);
 	else
-		ND_PRINT(" #%u type=%s id=%u ", tcount,
+		ND_PRINT(C_RESET, " #%u type=%s id=%u ", tcount,
 			  STR_OR_ID(t_type, ikev2_t_type_map),
 			  t_id);
 	cp = (const u_char *)(p + 1);
@@ -1977,10 +1977,10 @@ ikev2_t_print(netdissect_options *ndo, int tcount,
 			goto trunc;
 	}
 	if (ep < ep2)
-		ND_PRINT("...");
+		ND_PRINT(C_RESET, "...");
 	return cp;
 trunc:
-	ND_PRINT(" [|%s]", NPSTR(ISAKMP_NPTYPE_T));
+	ND_PRINT(C_RESET, " [|%s]", NPSTR(ISAKMP_NPTYPE_T));
 	return NULL;
 }
 
@@ -2007,7 +2007,7 @@ ikev2_p_print(netdissect_options *ndo, u_char tpay _U_, int pcount _U_,
 	 * ikev2_sa_print() guarantees that this is >= 4.
 	 */
 	prop_length = oprop_length - 4;
-	ND_PRINT(" #%u protoid=%s transform=%u len=%u",
+	ND_PRINT(C_RESET, " #%u protoid=%s transform=%u len=%u",
 		  GET_U_1(p->p_no),  PROTOIDSTR(GET_U_1(p->prot_id)),
 		  GET_U_1(p->num_t), oprop_length);
 	cp = (const u_char *)(p + 1);
@@ -2016,7 +2016,7 @@ ikev2_p_print(netdissect_options *ndo, u_char tpay _U_, int pcount _U_,
 	if (spi_size) {
 		if (prop_length < spi_size)
 			goto toolong;
-		ND_PRINT(" spi=");
+		ND_PRINT(C_RESET, " spi=");
 		if (!rawprint(ndo, (const uint8_t *)cp, spi_size))
 			goto trunc;
 		cp += spi_size;
@@ -2049,10 +2049,10 @@ ikev2_p_print(netdissect_options *ndo, u_char tpay _U_, int pcount _U_,
 		ND_TCHECK_LEN(cp, item_len);
 
 		depth++;
-		ND_PRINT("\n");
+		ND_PRINT(C_RESET, "\n");
 		for (i = 0; i < depth; i++)
-			ND_PRINT("    ");
-		ND_PRINT("(");
+			ND_PRINT(C_RESET, "    ");
+		ND_PRINT(C_RESET, "(");
 		if (np == ISAKMP_NPTYPE_T) {
 			cp = ikev2_t_print(ndo, tcount, ext, item_len, ep);
 			if (cp == NULL) {
@@ -2060,10 +2060,10 @@ ikev2_p_print(netdissect_options *ndo, u_char tpay _U_, int pcount _U_,
 				return NULL;
 			}
 		} else {
-			ND_PRINT("%s", NPSTR(np));
+			ND_PRINT(C_RESET, "%s", NPSTR(np));
 			cp += item_len;
 		}
-		ND_PRINT(")");
+		ND_PRINT(C_RESET, ")");
 		depth--;
 		prop_length -= item_len;
 	}
@@ -2073,10 +2073,10 @@ toolong:
 	 * Skip the rest of the proposal.
 	 */
 	cp += prop_length;
-	ND_PRINT(" [|%s]", NPSTR(ISAKMP_NPTYPE_P));
+	ND_PRINT(C_RESET, " [|%s]", NPSTR(ISAKMP_NPTYPE_P));
 	return cp;
 trunc:
-	ND_PRINT(" [|%s]", NPSTR(ISAKMP_NPTYPE_P));
+	ND_PRINT(C_RESET, " [|%s]", NPSTR(ISAKMP_NPTYPE_P));
 	return NULL;
 }
 
@@ -2103,7 +2103,7 @@ ikev2_sa_print(netdissect_options *ndo, u_char tpay,
 	 */
 	osa_length= GET_BE_U_2(ext1->len);
 	sa_length = osa_length - 4;
-	ND_PRINT(" len=%u", sa_length);
+	ND_PRINT(C_RESET, " len=%u", sa_length);
 
 	/*
 	 * Print the payloads.
@@ -2132,10 +2132,10 @@ ikev2_sa_print(netdissect_options *ndo, u_char tpay,
 		ND_TCHECK_LEN(cp, item_len);
 
 		depth++;
-		ND_PRINT("\n");
+		ND_PRINT(C_RESET, "\n");
 		for (i = 0; i < depth; i++)
-			ND_PRINT("    ");
-		ND_PRINT("(");
+			ND_PRINT(C_RESET, "    ");
+		ND_PRINT(C_RESET, "(");
 		if (np == ISAKMP_NPTYPE_P) {
 			cp = ikev2_p_print(ndo, np, pcount, ext, item_len,
 					   ep, depth);
@@ -2144,10 +2144,10 @@ ikev2_sa_print(netdissect_options *ndo, u_char tpay,
 				return NULL;
 			}
 		} else {
-			ND_PRINT("%s", NPSTR(np));
+			ND_PRINT(C_RESET, "%s", NPSTR(np));
 			cp += item_len;
 		}
-		ND_PRINT(")");
+		ND_PRINT(C_RESET, ")");
 		depth--;
 		sa_length -= item_len;
 	}
@@ -2157,10 +2157,10 @@ toolong:
 	 * Skip the rest of the SA.
 	 */
 	cp += sa_length;
-	ND_PRINT(" [|%s]", NPSTR(tpay));
+	ND_PRINT(C_RESET, " [|%s]", NPSTR(tpay));
 	return cp;
 trunc:
-	ND_PRINT(" [|%s]", NPSTR(tpay));
+	ND_PRINT(C_RESET, " [|%s]", NPSTR(tpay));
 	return NULL;
 }
 
@@ -2178,20 +2178,20 @@ ikev2_ke_print(netdissect_options *ndo, u_char tpay,
 	ikev2_pay_print(ndo, NPSTR(tpay), GET_U_1(k->h.critical));
 
 	if (item_len < 8) {
-		ND_PRINT(" len=%u < 8", item_len);
+		ND_PRINT(C_RESET, " len=%u < 8", item_len);
 		return (const u_char *)ext + item_len;
 	}
-	ND_PRINT(" len=%u group=%s", item_len - 8,
+	ND_PRINT(C_RESET, " len=%u group=%s", item_len - 8,
 		  STR_OR_ID(GET_BE_U_2(k->ke_group), dh_p_map));
 
 	if (2 < ndo->ndo_vflag && 8 < item_len) {
-		ND_PRINT(" ");
+		ND_PRINT(C_RESET, " ");
 		if (!rawprint(ndo, (const uint8_t *)(k + 1), item_len - 8))
 			goto trunc;
 	}
 	return (const u_char *)ext + item_len;
 trunc:
-	ND_PRINT(" [|%s]", NPSTR(tpay));
+	ND_PRINT(C_RESET, " [|%s]", NPSTR(tpay));
 	return NULL;
 }
 
@@ -2214,10 +2214,10 @@ ikev2_ID_print(netdissect_options *ndo, u_char tpay,
 	/*
 	 * Our caller has ensured that the length is >= 4.
 	 */
-	ND_PRINT(" len=%u", item_len - 4);
+	ND_PRINT(C_RESET, " len=%u", item_len - 4);
 	if (2 < ndo->ndo_vflag && 4 < item_len) {
 		/* Print the entire payload in hex */
-		ND_PRINT(" ");
+		ND_PRINT(C_RESET, " ");
 		if (!rawprint(ndo, (const uint8_t *)(ext + 1), item_len - 4))
 			goto trunc;
 	}
@@ -2229,31 +2229,31 @@ ikev2_ID_print(netdissect_options *ndo, u_char tpay,
 
 	switch(GET_U_1(idp->type)) {
 	case ID_IPV4_ADDR:
-		ND_PRINT(" ipv4:");
+		ND_PRINT(C_RESET, " ipv4:");
 		dumphex=1;
 		break;
 	case ID_FQDN:
-		ND_PRINT(" fqdn:");
+		ND_PRINT(C_RESET, " fqdn:");
 		dumpascii=1;
 		break;
 	case ID_RFC822_ADDR:
-		ND_PRINT(" rfc822:");
+		ND_PRINT(C_RESET, " rfc822:");
 		dumpascii=1;
 		break;
 	case ID_IPV6_ADDR:
-		ND_PRINT(" ipv6:");
+		ND_PRINT(C_RESET, " ipv6:");
 		dumphex=1;
 		break;
 	case ID_DER_ASN1_DN:
-		ND_PRINT(" dn:");
+		ND_PRINT(C_RESET, " dn:");
 		dumphex=1;
 		break;
 	case ID_DER_ASN1_GN:
-		ND_PRINT(" gn:");
+		ND_PRINT(C_RESET, " gn:");
 		dumphex=1;
 		break;
 	case ID_KEY_ID:
-		ND_PRINT(" keyid:");
+		ND_PRINT(C_RESET, " keyid:");
 		dumphex=1;
 		break;
 	}
@@ -2262,9 +2262,9 @@ ikev2_ID_print(netdissect_options *ndo, u_char tpay,
 		ND_TCHECK_LEN(typedata, idtype_len);
 		for(i=0; i<idtype_len; i++) {
 			if(ND_ASCII_ISPRINT(GET_U_1(typedata + i))) {
-				ND_PRINT("%c", GET_U_1(typedata + i));
+				ND_PRINT(C_RESET, "%c", GET_U_1(typedata + i));
 			} else {
-				ND_PRINT(".");
+				ND_PRINT(C_RESET, ".");
 			}
 		}
 	}
@@ -2275,7 +2275,7 @@ ikev2_ID_print(netdissect_options *ndo, u_char tpay,
 
 	return (const u_char *)ext + item_len;
 trunc:
-	ND_PRINT(" [|%s]", NPSTR(tpay));
+	ND_PRINT(C_RESET, " [|%s]", NPSTR(tpay));
 	return NULL;
 }
 
@@ -2318,14 +2318,14 @@ ikev2_auth_print(netdissect_options *ndo, u_char tpay,
 	/*
 	 * Our caller has ensured that the length is >= 4.
 	 */
-	ND_PRINT(" len=%u method=%s", item_len-4,
+	ND_PRINT(C_RESET, " len=%u method=%s", item_len-4,
 		  STR_OR_ID(GET_U_1(p->auth_method), v2_auth));
 	if (item_len > 4) {
 		if (ndo->ndo_vflag > 1) {
-			ND_PRINT(" authdata=(");
+			ND_PRINT(C_RESET, " authdata=(");
 			if (!rawprint(ndo, (const uint8_t *)authdata, item_len - sizeof(struct ikev2_auth)))
 				goto trunc;
-			ND_PRINT(") ");
+			ND_PRINT(C_RESET, ") ");
 		} else if (ndo->ndo_vflag) {
 			if (!ike_show_somedata(ndo, authdata, ep))
 				goto trunc;
@@ -2334,7 +2334,7 @@ ikev2_auth_print(netdissect_options *ndo, u_char tpay,
 
 	return (const u_char *)ext + item_len;
 trunc:
-	ND_PRINT(" [|%s]", NPSTR(tpay));
+	ND_PRINT(C_RESET, " [|%s]", NPSTR(tpay));
 	return NULL;
 }
 
@@ -2351,19 +2351,19 @@ ikev2_nonce_print(netdissect_options *ndo, u_char tpay,
 	/*
 	 * Our caller has ensured that the length is >= 4.
 	 */
-	ND_PRINT(" len=%u", item_len - 4);
+	ND_PRINT(C_RESET, " len=%u", item_len - 4);
 	if (1 < ndo->ndo_vflag && 4 < item_len) {
-		ND_PRINT(" nonce=(");
+		ND_PRINT(C_RESET, " nonce=(");
 		if (!rawprint(ndo, (const uint8_t *)(ext + 1), item_len - 4))
 			goto trunc;
-		ND_PRINT(") ");
+		ND_PRINT(C_RESET, ") ");
 	} else if(ndo->ndo_vflag && 4 < item_len) {
 		if(!ike_show_somedata(ndo, (const u_char *)(ext+1), ep)) goto trunc;
 	}
 
 	return (const u_char *)ext + item_len;
 trunc:
-	ND_PRINT(" [|%s]", NPSTR(tpay));
+	ND_PRINT(C_RESET, " [|%s]", NPSTR(tpay));
 	return NULL;
 }
 
@@ -2390,7 +2390,7 @@ ikev2_n_print(netdissect_options *ndo, u_char tpay _U_,
 	showsomedata=0;
 	notify_name=NULL;
 
-	ND_PRINT(" prot_id=%s", PROTOIDSTR(GET_U_1(p->prot_id)));
+	ND_PRINT(C_RESET, " prot_id=%s", PROTOIDSTR(GET_U_1(p->prot_id)));
 
 	type = GET_BE_U_2(p->type);
 
@@ -2540,13 +2540,13 @@ ikev2_n_print(netdissect_options *ndo, u_char tpay _U_,
 	}
 
 	if(notify_name) {
-		ND_PRINT(" type=%u(%s)", type, notify_name);
+		ND_PRINT(C_RESET, " type=%u(%s)", type, notify_name);
 	}
 
 
 	spi_size = GET_U_1(p->spi_size);
 	if (showspi && spi_size) {
-		ND_PRINT(" spi=");
+		ND_PRINT(C_RESET, " spi=");
 		if (!rawprint(ndo, (const uint8_t *)(p + 1), spi_size))
 			goto trunc;
 	}
@@ -2555,11 +2555,11 @@ ikev2_n_print(netdissect_options *ndo, u_char tpay _U_,
 
 	if (cp < ep) {
 		if (ndo->ndo_vflag > 3 || (showsomedata && ep-cp < 30)) {
-			ND_PRINT(" data=(");
+			ND_PRINT(C_RESET, " data=(");
 			if (!rawprint(ndo, (const uint8_t *)(cp), ep - cp))
 				goto trunc;
 
-			ND_PRINT(")");
+			ND_PRINT(C_RESET, ")");
 		} else if (showsomedata) {
 			if (!ike_show_somedata(ndo, cp, ep))
 				goto trunc;
@@ -2568,7 +2568,7 @@ ikev2_n_print(netdissect_options *ndo, u_char tpay _U_,
 
 	return (const u_char *)ext + item_len;
 trunc:
-	ND_PRINT(" [|%s]", NPSTR(ISAKMP_NPTYPE_N));
+	ND_PRINT(C_RESET, " [|%s]", NPSTR(ISAKMP_NPTYPE_N));
 	return NULL;
 }
 
@@ -2598,25 +2598,25 @@ ikev2_vid_print(netdissect_options *ndo, u_char tpay,
 	/*
 	 * Our caller has ensured that the length is >= 4.
 	 */
-	ND_PRINT(" len=%u vid=", item_len - 4);
+	ND_PRINT(C_RESET, " len=%u vid=", item_len - 4);
 
 	vid = (const u_char *)(ext+1);
 	len = item_len - 4;
 	ND_TCHECK_LEN(vid, len);
 	for(i=0; i<len; i++) {
 		if(ND_ASCII_ISPRINT(GET_U_1(vid + i)))
-			ND_PRINT("%c", GET_U_1(vid + i));
-		else ND_PRINT(".");
+			ND_PRINT(C_RESET, "%c", GET_U_1(vid + i));
+		else ND_PRINT(C_RESET, ".");
 	}
 	if (2 < ndo->ndo_vflag && 4 < len) {
 		/* Print the entire payload in hex */
-		ND_PRINT(" ");
+		ND_PRINT(C_RESET, " ");
 		if (!rawprint(ndo, (const uint8_t *)(ext + 1), item_len - 4))
 			goto trunc;
 	}
 	return (const u_char *)ext + item_len;
 trunc:
-	ND_PRINT(" [|%s]", NPSTR(tpay));
+	ND_PRINT(C_RESET, " [|%s]", NPSTR(tpay));
 	return NULL;
 }
 
@@ -2667,9 +2667,9 @@ ikev2_e_print(netdissect_options *ndo,
 
 	dlen = item_len-4;
 
-	ND_PRINT(" len=%u", dlen);
+	ND_PRINT(C_RESET, " len=%u", dlen);
 	if (2 < ndo->ndo_vflag && 4 < dlen) {
-		ND_PRINT(" ");
+		ND_PRINT(C_RESET, " ");
 		if (!rawprint(ndo, (const uint8_t *)(ext + 1), dlen))
 			goto trunc;
 	}
@@ -2707,7 +2707,7 @@ ikev2_e_print(netdissect_options *ndo,
 	 */
 	return NULL;
 trunc:
-	ND_PRINT(" [|%s]", NPSTR(tpay));
+	ND_PRINT(C_RESET, " [|%s]", NPSTR(tpay));
 	return NULL;
 }
 
@@ -2760,7 +2760,7 @@ ike_sub0_print(netdissect_options *ndo,
 		 */
 		cp = (*npfunc[np])(ndo, np, ext, item_len, ep, phase, doi, proto, depth);
 	} else {
-		ND_PRINT("%s", NPSTR(np));
+		ND_PRINT(C_RESET, "%s", NPSTR(np));
 		cp += item_len;
 	}
 
@@ -2788,12 +2788,12 @@ ikev1_sub_print(netdissect_options *ndo,
 		ND_TCHECK_LEN(ext, item_len);
 
 		depth++;
-		ND_PRINT("\n");
+		ND_PRINT(C_RESET, "\n");
 		for (i = 0; i < depth; i++)
-			ND_PRINT("    ");
-		ND_PRINT("(");
+			ND_PRINT(C_RESET, "    ");
+		ND_PRINT(C_RESET, "(");
 		cp = ike_sub0_print(ndo, np, ext, ep, phase, doi, proto, depth);
-		ND_PRINT(")");
+		ND_PRINT(C_RESET, ")");
 		depth--;
 
 		if (cp == NULL) {
@@ -2806,7 +2806,7 @@ ikev1_sub_print(netdissect_options *ndo,
 	}
 	return cp;
 trunc:
-	ND_PRINT(" [|%s]", NPSTR(np));
+	ND_PRINT(C_RESET, " [|%s]", NPSTR(np));
 	return NULL;
 }
 
@@ -2835,39 +2835,39 @@ ikev1_print(netdissect_options *ndo,
 
 	phase = (GET_BE_U_4(base->msgid) == 0) ? 1 : 2;
 	if (phase == 1)
-		ND_PRINT(" phase %u", phase);
+		ND_PRINT(C_RESET, " phase %u", phase);
 	else
-		ND_PRINT(" phase %u/others", phase);
+		ND_PRINT(C_RESET, " phase %u/others", phase);
 
 	i = cookie_find(&base->i_ck);
 	if (i < 0) {
 		if (iszero(ndo, base->r_ck, sizeof(base->r_ck))) {
 			/* the first packet */
-			ND_PRINT(" I");
+			ND_PRINT(C_RESET, " I");
 			if (bp2)
 				cookie_record(ndo, &base->i_ck, bp2);
 		} else
-			ND_PRINT(" ?");
+			ND_PRINT(C_RESET, " ?");
 	} else {
 		if (bp2 && cookie_isinitiator(ndo, i, bp2))
-			ND_PRINT(" I");
+			ND_PRINT(C_RESET, " I");
 		else if (bp2 && cookie_isresponder(ndo, i, bp2))
-			ND_PRINT(" R");
+			ND_PRINT(C_RESET, " R");
 		else
-			ND_PRINT(" ?");
+			ND_PRINT(C_RESET, " ?");
 	}
 
-	ND_PRINT(" %s", ETYPESTR(GET_U_1(base->etype)));
+	ND_PRINT(C_RESET, " %s", ETYPESTR(GET_U_1(base->etype)));
 	flags = GET_U_1(base->flags);
 	if (flags) {
-		ND_PRINT("[%s%s]", flags & ISAKMP_FLAG_E ? "E" : "",
+		ND_PRINT(C_RESET, "[%s%s]", flags & ISAKMP_FLAG_E ? "E" : "",
 			  flags & ISAKMP_FLAG_C ? "C" : "");
 	}
 
 	if (ndo->ndo_vflag) {
 		const struct isakmp_gen *ext;
 
-		ND_PRINT(":");
+		ND_PRINT(C_RESET, ":");
 
 		np = GET_U_1(base->np);
 
@@ -2877,7 +2877,7 @@ ikev1_print(netdissect_options *ndo,
 			 * encrypted, nothing we can do right now.
 			 * we hope to decrypt the packet in the future...
 			 */
-			ND_PRINT(" [encrypted %s]", NPSTR(np));
+			ND_PRINT(C_RESET, " [encrypted %s]", NPSTR(np));
 			goto done;
 		}
 
@@ -2889,7 +2889,7 @@ ikev1_print(netdissect_options *ndo,
 done:
 	if (ndo->ndo_vflag) {
 		if (GET_BE_U_4(base->len) != length) {
-			ND_PRINT(" (len mismatch: isakmp %u/ip %u)",
+			ND_PRINT(C_RESET, " (len mismatch: isakmp %u/ip %u)",
 				  GET_BE_U_4(base->len), length);
 		}
 	}
@@ -2928,7 +2928,7 @@ ikev2_sub0_print(netdissect_options *ndo, const struct isakmp *base,
 		cp = (*npfunc[np])(ndo, np, ext, item_len,
 				   ep, phase, doi, proto, depth);
 	} else {
-		ND_PRINT("%s", NPSTR(np));
+		ND_PRINT(C_RESET, "%s", NPSTR(np));
 		cp += item_len;
 	}
 
@@ -2954,13 +2954,13 @@ ikev2_sub_print(netdissect_options *ndo,
 		ND_TCHECK_LEN(ext, GET_BE_U_2(ext->len));
 
 		depth++;
-		ND_PRINT("\n");
+		ND_PRINT(C_RESET, "\n");
 		for (i = 0; i < depth; i++)
-			ND_PRINT("    ");
-		ND_PRINT("(");
+			ND_PRINT(C_RESET, "    ");
+		ND_PRINT(C_RESET, "(");
 		cp = ikev2_sub0_print(ndo, base, np,
 				      ext, ep, phase, doi, proto, depth);
-		ND_PRINT(")");
+		ND_PRINT(C_RESET, ")");
 		depth--;
 
 		if (cp == NULL) {
@@ -2973,7 +2973,7 @@ ikev2_sub_print(netdissect_options *ndo,
 	}
 	return cp;
 trunc:
-	ND_PRINT(" [|%s]", NPSTR(np));
+	ND_PRINT(C_RESET, " [|%s]", NPSTR(np));
 	return NULL;
 }
 
@@ -2993,14 +2993,14 @@ ikev2_print(netdissect_options *ndo,
 
 	phase = (GET_BE_U_4(base->msgid) == 0) ? 1 : 2;
 	if (phase == 1)
-		ND_PRINT(" parent_sa");
+		ND_PRINT(C_RESET, " parent_sa");
 	else
-		ND_PRINT(" child_sa ");
+		ND_PRINT(C_RESET, " child_sa ");
 
-	ND_PRINT(" %s", ETYPESTR(GET_U_1(base->etype)));
+	ND_PRINT(C_RESET, " %s", ETYPESTR(GET_U_1(base->etype)));
 	flags = GET_U_1(base->flags);
 	if (flags) {
-		ND_PRINT("[%s%s%s]",
+		ND_PRINT(C_RESET, "[%s%s%s]",
 			  flags & ISAKMP_FLAG_I ? "I" : "",
 			  flags & ISAKMP_FLAG_V ? "V" : "",
 			  flags & ISAKMP_FLAG_R ? "R" : "");
@@ -3009,7 +3009,7 @@ ikev2_print(netdissect_options *ndo,
 	if (ndo->ndo_vflag) {
 		const struct isakmp_gen *ext;
 
-		ND_PRINT(":");
+		ND_PRINT(C_RESET, ":");
 
 		np = GET_U_1(base->np);
 
@@ -3019,7 +3019,7 @@ ikev2_print(netdissect_options *ndo,
 			 * encrypted, nothing we can do right now.
 			 * we hope to decrypt the packet in the future...
 			 */
-			ND_PRINT(" [encrypted %s]", NPSTR(np));
+			ND_PRINT(C_RESET, " [encrypted %s]", NPSTR(np));
 			goto done;
 		}
 
@@ -3031,7 +3031,7 @@ ikev2_print(netdissect_options *ndo,
 done:
 	if (ndo->ndo_vflag) {
 		if (GET_BE_U_4(base->len) != length) {
-			ND_PRINT(" (len mismatch: isakmp %u/ip %u)",
+			ND_PRINT(C_RESET, " (len mismatch: isakmp %u/ip %u)",
 				  GET_BE_U_4(base->len), length);
 		}
 	}
@@ -3063,28 +3063,28 @@ isakmp_print(netdissect_options *ndo,
 		return;
 	}
 
-	ND_PRINT("isakmp");
+	ND_PRINT(C_RESET, "isakmp");
 	major = (GET_U_1(p->vers) & ISAKMP_VERS_MAJOR)
 		>> ISAKMP_VERS_MAJOR_SHIFT;
 	minor = (GET_U_1(p->vers) & ISAKMP_VERS_MINOR)
 		>> ISAKMP_VERS_MINOR_SHIFT;
 
 	if (ndo->ndo_vflag) {
-		ND_PRINT(" %u.%u", major, minor);
+		ND_PRINT(C_RESET, " %u.%u", major, minor);
 	}
 
 	if (ndo->ndo_vflag) {
-		ND_PRINT(" msgid ");
+		ND_PRINT(C_RESET, " msgid ");
 		hexprint(ndo, p->msgid, sizeof(p->msgid));
 	}
 
 	if (1 < ndo->ndo_vflag) {
-		ND_PRINT(" cookie ");
+		ND_PRINT(C_RESET, " cookie ");
 		hexprint(ndo, p->i_ck, sizeof(p->i_ck));
-		ND_PRINT("->");
+		ND_PRINT(C_RESET, "->");
 		hexprint(ndo, p->r_ck, sizeof(p->r_ck));
 	}
-	ND_PRINT(":");
+	ND_PRINT(C_RESET, ":");
 
 	switch(major) {
 	case IKEv1_MAJOR_VERSION:
@@ -3104,7 +3104,7 @@ isakmp_rfc3948_print(netdissect_options *ndo,
 {
 	ndo->ndo_protocol = "isakmp_rfc3948";
 	if(length == 1 && GET_U_1(bp)==0xff) {
-		ND_PRINT("isakmp-nat-keep-alive");
+		ND_PRINT(C_RESET, "isakmp-nat-keep-alive");
 		return;
 	}
 
@@ -3116,14 +3116,14 @@ isakmp_rfc3948_print(netdissect_options *ndo,
 	 * see if this is an IKE packet
 	 */
 	if (GET_BE_U_4(bp) == 0) {
-		ND_PRINT("NONESP-encap: ");
+		ND_PRINT(C_RESET, "NONESP-encap: ");
 		isakmp_print(ndo, bp+4, length-4, bp2);
 		return;
 	}
 
 	/* must be an ESP packet */
 	{
-		ND_PRINT("UDP-encap: ");
+		ND_PRINT(C_RESET, "UDP-encap: ");
 
 		esp_print(ndo, bp, length, bp2, ver, fragmented, ttl_hl);
 

--- a/print-isoclns.c
+++ b/print-isoclns.c
@@ -737,7 +737,7 @@ isoclns_print(netdissect_options *ndo, const u_char *p, u_int length)
 	ndo->ndo_protocol = "isoclns";
 
 	if (ndo->ndo_eflag)
-		ND_PRINT("OSI NLPID %s (0x%02x): ",
+		ND_PRINT(C_RESET, "OSI NLPID %s (0x%02x): ",
 			 tok2str(nlpid_values, "Unknown", GET_U_1(p)),
 			 GET_U_1(p));
 
@@ -758,7 +758,7 @@ isoclns_print(netdissect_options *ndo, const u_char *p, u_int length)
 		break;
 
 	case NLPID_NULLNS:
-		ND_PRINT("%slength: %u", ndo->ndo_eflag ? "" : ", ", length);
+		ND_PRINT(C_RESET, "%slength: %u", ndo->ndo_eflag ? "" : ", ", length);
 		break;
 
 	case NLPID_Q933:
@@ -779,8 +779,8 @@ isoclns_print(netdissect_options *ndo, const u_char *p, u_int length)
 
 	default:
 		if (!ndo->ndo_eflag)
-			ND_PRINT("OSI NLPID 0x%02x unknown", GET_U_1(p));
-		ND_PRINT("%slength: %u", ndo->ndo_eflag ? "" : ", ", length);
+			ND_PRINT(C_RESET, "OSI NLPID 0x%02x unknown", GET_U_1(p));
+		ND_PRINT(C_RESET, "%slength: %u", ndo->ndo_eflag ? "" : ", ", length);
 		if (length > 1)
 			print_unknown_data(ndo, p, "\n\t", length);
 		break;
@@ -849,20 +849,20 @@ clnp_print(netdissect_options *ndo,
          */
 
         if (GET_U_1(clnp_header->version) != CLNP_VERSION) {
-            ND_PRINT("version %u packet not supported",
+            ND_PRINT(C_RESET, "version %u packet not supported",
                      GET_U_1(clnp_header->version));
             return (0);
         }
 
 	if (li > length) {
-            ND_PRINT(" length indicator(%u) > PDU size (%u)!", li, length);
+            ND_PRINT(C_RESET, " length indicator(%u) > PDU size (%u)!", li, length);
             return (0);
 	}
 
         if (li < sizeof(struct clnp_header_t)) {
-            ND_PRINT(" length indicator %u < min PDU size:", li);
+            ND_PRINT(C_RESET, " length indicator %u < min PDU size:", li);
             while (pptr < ndo->ndo_snapend) {
-                ND_PRINT("%02X", GET_U_1(pptr));
+                ND_PRINT(C_RESET, "%02X", GET_U_1(pptr));
                 pptr++;
             }
             return (0);
@@ -877,14 +877,14 @@ clnp_print(netdissect_options *ndo,
         li_remaining -= sizeof(struct clnp_header_t);
 
         if (li_remaining < 1) {
-            ND_PRINT("li < size of fixed part of CLNP header and addresses");
+            ND_PRINT(C_RESET, "li < size of fixed part of CLNP header and addresses");
             return (0);
         }
         dest_address_length = GET_U_1(pptr);
         pptr += 1;
         li_remaining -= 1;
         if (li_remaining < dest_address_length) {
-            ND_PRINT("li < size of fixed part of CLNP header and addresses");
+            ND_PRINT(C_RESET, "li < size of fixed part of CLNP header and addresses");
             return (0);
         }
         ND_TCHECK_LEN(pptr, dest_address_length);
@@ -893,14 +893,14 @@ clnp_print(netdissect_options *ndo,
         li_remaining -= dest_address_length;
 
         if (li_remaining < 1) {
-            ND_PRINT("li < size of fixed part of CLNP header and addresses");
+            ND_PRINT(C_RESET, "li < size of fixed part of CLNP header and addresses");
             return (0);
         }
         source_address_length = GET_U_1(pptr);
         pptr += 1;
         li_remaining -= 1;
         if (li_remaining < source_address_length) {
-            ND_PRINT("li < size of fixed part of CLNP header and addresses");
+            ND_PRINT(C_RESET, "li < size of fixed part of CLNP header and addresses");
             return (0);
         }
         ND_TCHECK_LEN(pptr, source_address_length);
@@ -909,7 +909,7 @@ clnp_print(netdissect_options *ndo,
         li_remaining -= source_address_length;
 
         if (ndo->ndo_vflag < 1) {
-            ND_PRINT("%s%s > %s, %s, length %u",
+            ND_PRINT(C_RESET, "%s%s > %s, %s, length %u",
                    ndo->ndo_eflag ? "" : ", ",
                    GET_ISONSAP_STRING(source_address, source_address_length),
                    GET_ISONSAP_STRING(dest_address, dest_address_length),
@@ -917,9 +917,9 @@ clnp_print(netdissect_options *ndo,
                    length);
             return (1);
         }
-        ND_PRINT("%slength %u", ndo->ndo_eflag ? "" : ", ", length);
+        ND_PRINT(C_RESET, "%slength %u", ndo->ndo_eflag ? "" : ", ", length);
 
-        ND_PRINT("\n\t%s PDU, hlen: %u, v: %u, lifetime: %u.%us, Segment PDU length: %u, checksum: 0x%04x",
+        ND_PRINT(C_RESET, "\n\t%s PDU, hlen: %u, v: %u, lifetime: %u.%us, Segment PDU length: %u, checksum: 0x%04x",
                tok2str(clnp_pdu_values, "unknown (%u)",clnp_pdu_type),
                GET_U_1(clnp_header->length_indicator),
                GET_U_1(clnp_header->version),
@@ -931,10 +931,10 @@ clnp_print(netdissect_options *ndo,
         osi_print_cksum(ndo, optr, GET_BE_U_2(clnp_header->cksum), 7,
                         GET_U_1(clnp_header->length_indicator));
 
-        ND_PRINT("\n\tFlags [%s]",
+        ND_PRINT(C_RESET, "\n\tFlags [%s]",
                bittok2str(clnp_flag_values, "none", clnp_flags));
 
-        ND_PRINT("\n\tsource address (length %u): %s\n\tdest   address (length %u): %s",
+        ND_PRINT(C_RESET, "\n\tsource address (length %u): %s\n\tdest   address (length %u): %s",
                source_address_length,
                GET_ISONSAP_STRING(source_address, source_address_length),
                dest_address_length,
@@ -942,12 +942,12 @@ clnp_print(netdissect_options *ndo,
 
         if (clnp_flags & CLNP_SEGMENT_PART) {
                 if (li_remaining < sizeof(struct clnp_segment_header_t)) {
-                    ND_PRINT("li < size of fixed part of CLNP header, addresses, and segment part");
+                    ND_PRINT(C_RESET, "li < size of fixed part of CLNP header, addresses, and segment part");
                     return (0);
                 }
 		clnp_segment_header = (const struct clnp_segment_header_t *) pptr;
                 ND_TCHECK_SIZE(clnp_segment_header);
-                ND_PRINT("\n\tData Unit ID: 0x%04x, Segment Offset: %u, Total PDU Length: %u",
+                ND_PRINT(C_RESET, "\n\tData Unit ID: 0x%04x, Segment Offset: %u, Total PDU Length: %u",
                        GET_BE_U_2(clnp_segment_header->data_unit_id),
                        GET_BE_U_2(clnp_segment_header->segment_offset),
                        GET_BE_U_2(clnp_segment_header->total_length));
@@ -961,7 +961,7 @@ clnp_print(netdissect_options *ndo,
             const uint8_t *tptr;
 
             if (li_remaining < 2) {
-                ND_PRINT(", bad opts/li");
+                ND_PRINT(C_RESET, ", bad opts/li");
                 return (0);
             }
             op = GET_U_1(pptr);
@@ -969,7 +969,7 @@ clnp_print(netdissect_options *ndo,
             pptr += 2;
             li_remaining -= 2;
             if (opli > li_remaining) {
-                ND_PRINT(", opt (%u) too long", op);
+                ND_PRINT(C_RESET, ", opt (%u) too long", op);
                 return (0);
             }
             ND_TCHECK_LEN(pptr, opli);
@@ -977,7 +977,7 @@ clnp_print(netdissect_options *ndo,
             tptr = pptr;
             tlen = opli;
 
-            ND_PRINT("\n\t  %s Option #%u, length %u, value: ",
+            ND_PRINT(C_RESET, "\n\t  %s Option #%u, length %u, value: ",
                    tok2str(clnp_option_values,"Unknown",op),
                    op,
                    opli);
@@ -996,20 +996,20 @@ clnp_print(netdissect_options *ndo,
             case CLNP_OPTION_ROUTE_RECORDING: /* those two options share the format */
             case CLNP_OPTION_SOURCE_ROUTING:
                     if (tlen < 2) {
-                            ND_PRINT(", bad opt len");
+                            ND_PRINT(C_RESET, ", bad opt len");
                             return (0);
                     }
-                    ND_PRINT("%s %s",
+                    ND_PRINT(C_RESET, "%s %s",
                            tok2str(clnp_option_sr_rr_values,"Unknown",GET_U_1(tptr)),
                            tok2str(clnp_option_sr_rr_string_values, "Unknown Option %u", op));
                     nsap_offset=GET_U_1(tptr + 1);
                     if (nsap_offset == 0) {
-                            ND_PRINT(" Bad NSAP offset (0)");
+                            ND_PRINT(C_RESET, " Bad NSAP offset (0)");
                             break;
                     }
                     nsap_offset-=1; /* offset to nsap list */
                     if (nsap_offset > tlen) {
-                            ND_PRINT(" Bad NSAP offset (past end of option)");
+                            ND_PRINT(C_RESET, " Bad NSAP offset (past end of option)");
                             break;
                     }
                     tptr+=nsap_offset;
@@ -1017,12 +1017,12 @@ clnp_print(netdissect_options *ndo,
                     while (tlen > 0) {
                             source_address_length=GET_U_1(tptr);
                             if (tlen < source_address_length+1) {
-                                    ND_PRINT("\n\t    NSAP address goes past end of option");
+                                    ND_PRINT(C_RESET, "\n\t    NSAP address goes past end of option");
                                     break;
                             }
                             if (source_address_length > 0) {
                                     source_address=(tptr+1);
-                                    ND_PRINT("\n\t    NSAP address (length %u): %s",
+                                    ND_PRINT(C_RESET, "\n\t    NSAP address (length %u): %s",
                                            source_address_length,
                                            GET_ISONSAP_STRING(source_address, source_address_length));
                             }
@@ -1032,22 +1032,22 @@ clnp_print(netdissect_options *ndo,
 
             case CLNP_OPTION_PRIORITY:
                     if (tlen < 1) {
-                            ND_PRINT(", bad opt len");
+                            ND_PRINT(C_RESET, ", bad opt len");
                             return (0);
                     }
-                    ND_PRINT("0x%1x", GET_U_1(tptr)&0x0f);
+                    ND_PRINT(C_RESET, "0x%1x", GET_U_1(tptr)&0x0f);
                     break;
 
             case CLNP_OPTION_QOS_MAINTENANCE:
                     if (tlen < 1) {
-                            ND_PRINT(", bad opt len");
+                            ND_PRINT(C_RESET, ", bad opt len");
                             return (0);
                     }
-                    ND_PRINT("\n\t    Format Code: %s",
+                    ND_PRINT(C_RESET, "\n\t    Format Code: %s",
                            tok2str(clnp_option_scope_values, "Reserved", GET_U_1(tptr) & CLNP_OPTION_SCOPE_MASK));
 
                     if ((GET_U_1(tptr)&CLNP_OPTION_SCOPE_MASK) == CLNP_OPTION_SCOPE_GLOBAL)
-                            ND_PRINT("\n\t    QoS Flags [%s]",
+                            ND_PRINT(C_RESET, "\n\t    QoS Flags [%s]",
                                    bittok2str(clnp_option_qos_global_values,
                                               "none",
                                               GET_U_1(tptr)&CLNP_OPTION_OPTION_QOS_MASK));
@@ -1055,23 +1055,23 @@ clnp_print(netdissect_options *ndo,
 
             case CLNP_OPTION_SECURITY:
                     if (tlen < 2) {
-                            ND_PRINT(", bad opt len");
+                            ND_PRINT(C_RESET, ", bad opt len");
                             return (0);
                     }
-                    ND_PRINT("\n\t    Format Code: %s, Security-Level %u",
+                    ND_PRINT(C_RESET, "\n\t    Format Code: %s, Security-Level %u",
                            tok2str(clnp_option_scope_values,"Reserved",GET_U_1(tptr)&CLNP_OPTION_SCOPE_MASK),
                            GET_U_1(tptr + 1));
                     break;
 
             case CLNP_OPTION_DISCARD_REASON:
                 if (tlen < 1) {
-                        ND_PRINT(", bad opt len");
+                        ND_PRINT(C_RESET, ", bad opt len");
                         return (0);
                 }
                 rfd_error = GET_U_1(tptr);
                 rfd_error_major = (rfd_error&0xf0) >> 4;
                 rfd_error_minor = rfd_error&0x0f;
-                ND_PRINT("\n\t    Class: %s Error (0x%01x), %s (0x%01x)",
+                ND_PRINT(C_RESET, "\n\t    Class: %s Error (0x%01x), %s (0x%01x)",
                        tok2str(clnp_option_rfd_class_values,"Unknown",rfd_error_major),
                        rfd_error_major,
                        tok2str(clnp_option_rfd_error_class[rfd_error_major],"Unknown",rfd_error_minor),
@@ -1079,7 +1079,7 @@ clnp_print(netdissect_options *ndo,
                 break;
 
             case CLNP_OPTION_PADDING:
-                    ND_PRINT("padding data");
+                    ND_PRINT(C_RESET, "padding data");
                 break;
 
                 /*
@@ -1101,7 +1101,7 @@ clnp_print(netdissect_options *ndo,
         case    CLNP_PDU_ER: /* fall through */
         case	CLNP_PDU_ERP:
             if (GET_U_1(pptr) == NLPID_CLNP) {
-                ND_PRINT("\n\t-----original packet-----\n\t");
+                ND_PRINT(C_RESET, "\n\t-----original packet-----\n\t");
                 /* FIXME recursion protection */
                 clnp_print(ndo, pptr, length - li);
                 break;
@@ -1126,7 +1126,7 @@ clnp_print(netdissect_options *ndo,
         default:
             /* dump the PDU specific data */
             if (length > ND_BYTES_BETWEEN(pptr, optr)) {
-                ND_PRINT("\n\t  undecoded non-header data, length %u", length-li);
+                ND_PRINT(C_RESET, "\n\t  undecoded non-header data, length %u", length-li);
                 print_unknown_data(ndo, pptr, "\n\t  ", length - ND_BYTES_BETWEEN(pptr, optr));
             }
         }
@@ -1171,10 +1171,14 @@ esis_print(netdissect_options *ndo,
 
 	ndo->ndo_protocol = "esis";
 	if (!ndo->ndo_eflag)
-		ND_PRINT("ES-IS");
+		ND_PRINT(C_RESET, "ES-IS");
 
 	if (length <= 2) {
-		ND_PRINT(ndo->ndo_qflag ? "bad pkt!" : "no header at all!");
+        if(ndo->ndo_qflag)
+            ND_PRINT(C_RESET, "bad pkt!");
+        else
+            ND_PRINT(C_RESET, "no header at all!");
+
 		return;
 	}
 
@@ -1188,26 +1192,26 @@ esis_print(netdissect_options *ndo,
          */
 
         if (GET_U_1(esis_header->nlpid) != NLPID_ESIS) {
-            ND_PRINT(" nlpid 0x%02x packet not supported",
+            ND_PRINT(C_RESET, " nlpid 0x%02x packet not supported",
 		     GET_U_1(esis_header->nlpid));
             return;
         }
 
         version = GET_U_1(esis_header->version);
         if (version != ESIS_VERSION) {
-            ND_PRINT(" version %u packet not supported", version);
+            ND_PRINT(C_RESET, " version %u packet not supported", version);
             return;
         }
 
 	if (li > length) {
-            ND_PRINT(" length indicator(%u) > PDU size (%u)!", li, length);
+            ND_PRINT(C_RESET, " length indicator(%u) > PDU size (%u)!", li, length);
             return;
 	}
 
 	if (li < sizeof(struct esis_header_t) + 2) {
-            ND_PRINT(" length indicator %u < min PDU size:", li);
+            ND_PRINT(C_RESET, " length indicator %u < min PDU size:", li);
             while (pptr < ndo->ndo_snapend) {
-                ND_PRINT("%02X", GET_U_1(pptr));
+                ND_PRINT(C_RESET, "%02X", GET_U_1(pptr));
                 pptr++;
             }
             return;
@@ -1216,25 +1220,25 @@ esis_print(netdissect_options *ndo,
         esis_pdu_type = GET_U_1(esis_header->type) & ESIS_PDU_TYPE_MASK;
 
         if (ndo->ndo_vflag < 1) {
-            ND_PRINT("%s%s, length %u",
+            ND_PRINT(C_RESET, "%s%s, length %u",
                    ndo->ndo_eflag ? "" : ", ",
                    tok2str(esis_pdu_values,"unknown type (%u)",esis_pdu_type),
                    length);
             return;
         } else
-            ND_PRINT("%slength %u\n\t%s (%u)",
+            ND_PRINT(C_RESET, "%slength %u\n\t%s (%u)",
                    ndo->ndo_eflag ? "" : ", ",
                    length,
                    tok2str(esis_pdu_values,"unknown type: %u", esis_pdu_type),
                    esis_pdu_type);
 
-        ND_PRINT(", v: %u%s", version, version == ESIS_VERSION ? "" : "unsupported" );
-        ND_PRINT(", checksum: 0x%04x", GET_BE_U_2(esis_header->cksum));
+        ND_PRINT(C_RESET, ", v: %u%s", version, version == ESIS_VERSION ? "" : "unsupported" );
+        ND_PRINT(C_RESET, ", checksum: 0x%04x", GET_BE_U_2(esis_header->cksum));
 
         osi_print_cksum(ndo, pptr, GET_BE_U_2(esis_header->cksum), 7,
                         li);
 
-        ND_PRINT(", holding time: %us, length indicator: %u",
+        ND_PRINT(C_RESET, ", holding time: %us, length indicator: %u",
                   GET_BE_U_2(esis_header->holdtime), li);
 
         if (ndo->ndo_vflag > 1)
@@ -1250,7 +1254,7 @@ esis_print(netdissect_options *ndo,
 
 		ND_TCHECK_1(pptr);
 		if (li < 1) {
-			ND_PRINT(", bad redirect/li");
+			ND_PRINT(C_RESET, ", bad redirect/li");
 			return;
 		}
 		dstl = GET_U_1(pptr);
@@ -1258,17 +1262,17 @@ esis_print(netdissect_options *ndo,
 		li--;
 		ND_TCHECK_LEN(pptr, dstl);
 		if (li < dstl) {
-			ND_PRINT(", bad redirect/li");
+			ND_PRINT(C_RESET, ", bad redirect/li");
 			return;
 		}
 		dst = pptr;
 		pptr += dstl;
                 li -= dstl;
-		ND_PRINT("\n\t  %s", GET_ISONSAP_STRING(dst, dstl));
+		ND_PRINT(C_RESET, "\n\t  %s", GET_ISONSAP_STRING(dst, dstl));
 
 		ND_TCHECK_1(pptr);
 		if (li < 1) {
-			ND_PRINT(", bad redirect/li");
+			ND_PRINT(C_RESET, ", bad redirect/li");
 			return;
 		}
 		snpal = GET_U_1(pptr);
@@ -1276,7 +1280,7 @@ esis_print(netdissect_options *ndo,
 		li--;
 		ND_TCHECK_LEN(pptr, snpal);
 		if (li < snpal) {
-			ND_PRINT(", bad redirect/li");
+			ND_PRINT(C_RESET, ", bad redirect/li");
 			return;
 		}
 		snpa = pptr;
@@ -1284,14 +1288,14 @@ esis_print(netdissect_options *ndo,
                 li -= snpal;
 		ND_TCHECK_1(pptr);
 		if (li < 1) {
-			ND_PRINT(", bad redirect/li");
+			ND_PRINT(C_RESET, ", bad redirect/li");
 			return;
 		}
 		netal = GET_U_1(pptr);
 		pptr++;
 		ND_TCHECK_LEN(pptr, netal);
 		if (li < netal) {
-			ND_PRINT(", bad redirect/li");
+			ND_PRINT(C_RESET, ", bad redirect/li");
 			return;
 		}
 		neta = pptr;
@@ -1299,15 +1303,15 @@ esis_print(netdissect_options *ndo,
                 li -= netal;
 
 		if (snpal == MAC_ADDR_LEN)
-			ND_PRINT("\n\t  SNPA (length: %u): %s",
+			ND_PRINT(C_RESET, "\n\t  SNPA (length: %u): %s",
 			       snpal,
 			       GET_ETHERADDR_STRING(snpa));
 		else
-			ND_PRINT("\n\t  SNPA (length: %u): %s",
+			ND_PRINT(C_RESET, "\n\t  SNPA (length: %u): %s",
 			       snpal,
 			       GET_LINKADDR_STRING(snpa, LINKADDR_OTHER, snpal));
 		if (netal != 0)
-			ND_PRINT("\n\t  NET (length: %u) %s",
+			ND_PRINT(C_RESET, "\n\t  NET (length: %u) %s",
 			       netal,
 			       GET_ISONSAP_STRING(neta, netal));
 		break;
@@ -1316,19 +1320,19 @@ esis_print(netdissect_options *ndo,
 	case ESIS_PDU_ESH:
             ND_TCHECK_1(pptr);
             if (li < 1) {
-                ND_PRINT(", bad esh/li");
+                ND_PRINT(C_RESET, ", bad esh/li");
                 return;
             }
             source_address_number = GET_U_1(pptr);
             pptr++;
             li--;
 
-            ND_PRINT("\n\t  Number of Source Addresses: %u", source_address_number);
+            ND_PRINT(C_RESET, "\n\t  Number of Source Addresses: %u", source_address_number);
 
             while (source_address_number > 0) {
                 ND_TCHECK_1(pptr);
 		if (li < 1) {
-                    ND_PRINT(", bad esh/li");
+                    ND_PRINT(C_RESET, ", bad esh/li");
 		    return;
 		}
                 source_address_length = GET_U_1(pptr);
@@ -1337,10 +1341,10 @@ esis_print(netdissect_options *ndo,
 
                 ND_TCHECK_LEN(pptr, source_address_length);
 		if (li < source_address_length) {
-                    ND_PRINT(", bad esh/li");
+                    ND_PRINT(C_RESET, ", bad esh/li");
 		    return;
 		}
-                ND_PRINT("\n\t  NET (length: %u): %s",
+                ND_PRINT(C_RESET, "\n\t  NET (length: %u): %s",
                        source_address_length,
                        GET_ISONSAP_STRING(pptr, source_address_length));
                 pptr += source_address_length;
@@ -1353,7 +1357,7 @@ esis_print(netdissect_options *ndo,
 	case ESIS_PDU_ISH: {
             ND_TCHECK_1(pptr);
             if (li < 1) {
-                ND_PRINT(", bad ish/li");
+                ND_PRINT(C_RESET, ", bad ish/li");
                 return;
             }
             source_address_length = GET_U_1(pptr);
@@ -1361,10 +1365,10 @@ esis_print(netdissect_options *ndo,
             li--;
             ND_TCHECK_LEN(pptr, source_address_length);
             if (li < source_address_length) {
-                ND_PRINT(", bad ish/li");
+                ND_PRINT(C_RESET, ", bad ish/li");
                 return;
             }
-            ND_PRINT("\n\t  NET (length: %u): %s", source_address_length, GET_ISONSAP_STRING(pptr, source_address_length));
+            ND_PRINT(C_RESET, "\n\t  NET (length: %u): %s", source_address_length, GET_ISONSAP_STRING(pptr, source_address_length));
             pptr += source_address_length;
             li -= source_address_length;
             break;
@@ -1388,7 +1392,7 @@ esis_print(netdissect_options *ndo,
             const uint8_t *tptr;
 
             if (li < 2) {
-                ND_PRINT(", bad opts/li");
+                ND_PRINT(C_RESET, ", bad opts/li");
                 return;
             }
             op = GET_U_1(pptr);
@@ -1396,13 +1400,13 @@ esis_print(netdissect_options *ndo,
             pptr += 2;
             li -= 2;
             if (opli > li) {
-                ND_PRINT(", opt (%u) too long", op);
+                ND_PRINT(C_RESET, ", opt (%u) too long", op);
                 return;
             }
             li -= opli;
             tptr = pptr;
 
-            ND_PRINT("\n\t  %s Option #%u, length %u, value: ",
+            ND_PRINT(C_RESET, "\n\t  %s Option #%u, length %u, value: ",
                    tok2str(esis_option_values,"Unknown",op),
                    op,
                    opli);
@@ -1412,20 +1416,20 @@ esis_print(netdissect_options *ndo,
             case ESIS_OPTION_ES_CONF_TIME:
                 if (opli == 2) {
                     ND_TCHECK_2(pptr);
-                    ND_PRINT("%us", GET_BE_U_2(tptr));
+                    ND_PRINT(C_RESET, "%us", GET_BE_U_2(tptr));
                 } else
-                    ND_PRINT("(bad length)");
+                    ND_PRINT(C_RESET, "(bad length)");
                 break;
 
             case ESIS_OPTION_PROTOCOLS:
                 while (opli>0) {
-                    ND_PRINT("%s (0x%02x)",
+                    ND_PRINT(C_RESET, "%s (0x%02x)",
                            tok2str(nlpid_values,
                                    "unknown",
                                    GET_U_1(tptr)),
                            GET_U_1(tptr));
                     if (opli>1) /* further NPLIDs ? - put comma */
-                        ND_PRINT(", ");
+                        ND_PRINT(C_RESET, ", ");
                     tptr++;
                     opli--;
                 }
@@ -1463,16 +1467,16 @@ isis_print_mcid(netdissect_options *ndo,
   int i;
 
   ND_TCHECK_SIZE(mcid);
-  ND_PRINT("ID: %u, Name: ", GET_U_1(mcid->format_id));
+  ND_PRINT(C_RESET, "ID: %u, Name: ", GET_U_1(mcid->format_id));
 
   nd_printjnp(ndo, mcid->name, sizeof(mcid->name));
 
-  ND_PRINT("\n\t              Lvl: %u", GET_BE_U_2(mcid->revision_lvl));
+  ND_PRINT(C_RESET, "\n\t              Lvl: %u", GET_BE_U_2(mcid->revision_lvl));
 
-  ND_PRINT(", Digest: ");
+  ND_PRINT(C_RESET, ", Digest: ");
 
   for(i=0;i<16;i++)
-    ND_PRINT("%.2x ", mcid->digest[i]);
+    ND_PRINT(C_RESET, "%.2x ", mcid->digest[i]);
   return;
 
 trunc:
@@ -1493,7 +1497,7 @@ isis_print_mt_port_cap_subtlv(netdissect_options *ndo,
     stlv_len  = GET_U_1(tptr + 1);
 
     /* first lets see if we know the subTLVs name*/
-    ND_PRINT("\n\t       %s subTLV #%u, length: %u",
+    ND_PRINT(C_RESET, "\n\t       %s subTLV #%u, length: %u",
                tok2str(isis_mt_port_cap_subtlv_values, "unknown", stlv_type),
                stlv_type,
                stlv_len);
@@ -1517,13 +1521,13 @@ isis_print_mt_port_cap_subtlv(netdissect_options *ndo,
 
         subtlv_spb_mcid = (const struct isis_subtlv_spb_mcid *)tptr;
 
-        ND_PRINT("\n\t         MCID: ");
+        ND_PRINT(C_RESET, "\n\t         MCID: ");
         isis_print_mcid(ndo, &(subtlv_spb_mcid->mcid));
 
           /*tptr += SPB_MCID_MIN_LEN;
             len -= SPB_MCID_MIN_LEN; */
 
-        ND_PRINT("\n\t         AUX-MCID: ");
+        ND_PRINT(C_RESET, "\n\t         AUX-MCID: ");
         isis_print_mcid(ndo, &(subtlv_spb_mcid->aux_mcid));
 
           /*tptr += SPB_MCID_MIN_LEN;
@@ -1540,7 +1544,7 @@ isis_print_mt_port_cap_subtlv(netdissect_options *ndo,
         if (stlv_len < ISIS_SUBTLV_SPB_DIGEST_MIN_LEN)
           goto subtlv_too_short;
 
-        ND_PRINT("\n\t        RES: %u V: %u A: %u D: %u",
+        ND_PRINT(C_RESET, "\n\t        RES: %u V: %u A: %u D: %u",
                         (GET_U_1(tptr) >> 5),
                         ((GET_U_1(tptr) >> 4) & 0x01),
                         ((GET_U_1(tptr) >> 2) & 0x03),
@@ -1548,13 +1552,13 @@ isis_print_mt_port_cap_subtlv(netdissect_options *ndo,
 
         tptr++;
 
-        ND_PRINT("\n\t         Digest: ");
+        ND_PRINT(C_RESET, "\n\t         Digest: ");
 
         for(i=1;i<=8; i++)
         {
-            ND_PRINT("%08x ", GET_BE_U_4(tptr));
+            ND_PRINT(C_RESET, "%08x ", GET_BE_U_4(tptr));
             if (i%4 == 0 && i != 8)
-              ND_PRINT("\n\t                 ");
+              ND_PRINT(C_RESET, "\n\t                 ");
             tptr += 4;
         }
 
@@ -1570,7 +1574,7 @@ isis_print_mt_port_cap_subtlv(netdissect_options *ndo,
         {
           if (stlv_len < 4)
             goto subtlv_too_short;
-          ND_PRINT("\n\t           ECT: %08x",
+          ND_PRINT(C_RESET, "\n\t           ECT: %08x",
                       GET_BE_U_4(tptr));
 
           tptr += 4;
@@ -1579,7 +1583,7 @@ isis_print_mt_port_cap_subtlv(netdissect_options *ndo,
 
           if (stlv_len < 2)
             goto subtlv_too_short;
-          ND_PRINT(" BVID: %u, U:%01x M:%01x ",
+          ND_PRINT(C_RESET, " BVID: %u, U:%01x M:%01x ",
                      (GET_BE_U_2(tptr) >> 4) ,
                      (GET_BE_U_2(tptr) >> 3) & 0x01,
                      (GET_BE_U_2(tptr) >> 2) & 0x01);
@@ -1605,11 +1609,11 @@ trunc:
   return (1);
 
 subtlv_too_long:
-  ND_PRINT(" (> containing TLV length)");
+  ND_PRINT(C_RESET, " (> containing TLV length)");
   return (1);
 
 subtlv_too_short:
-  ND_PRINT(" (too short)");
+  ND_PRINT(C_RESET, " (too short)");
   return (1);
 }
 
@@ -1627,7 +1631,7 @@ isis_print_mt_capability_subtlv(netdissect_options *ndo,
     len -= 2;
 
     /* first lets see if we know the subTLVs name*/
-    ND_PRINT("\n\t      %s subTLV #%u, length: %u",
+    ND_PRINT(C_RESET, "\n\t      %s subTLV #%u, length: %u",
                tok2str(isis_mt_capability_subtlv_values, "unknown", stlv_type),
                stlv_type,
                stlv_len);
@@ -1644,22 +1648,22 @@ isis_print_mt_capability_subtlv(netdissect_options *ndo,
           if (stlv_len < ISIS_SUBTLV_SPB_INSTANCE_MIN_LEN)
             goto subtlv_too_short;
 
-          ND_PRINT("\n\t        CIST Root-ID: %08x", GET_BE_U_4(tptr));
+          ND_PRINT(C_RESET, "\n\t        CIST Root-ID: %08x", GET_BE_U_4(tptr));
           tptr += 4;
-          ND_PRINT(" %08x", GET_BE_U_4(tptr));
+          ND_PRINT(C_RESET, " %08x", GET_BE_U_4(tptr));
           tptr += 4;
-          ND_PRINT(", Path Cost: %08x", GET_BE_U_4(tptr));
+          ND_PRINT(C_RESET, ", Path Cost: %08x", GET_BE_U_4(tptr));
           tptr += 4;
-          ND_PRINT(", Prio: %u", GET_BE_U_2(tptr));
+          ND_PRINT(C_RESET, ", Prio: %u", GET_BE_U_2(tptr));
           tptr += 2;
-          ND_PRINT("\n\t        RES: %u",
+          ND_PRINT(C_RESET, "\n\t        RES: %u",
                     GET_BE_U_2(tptr) >> 5);
-          ND_PRINT(", V: %u",
+          ND_PRINT(C_RESET, ", V: %u",
                     (GET_BE_U_2(tptr) >> 4) & 0x0001);
-          ND_PRINT(", SPSource-ID: %u",
+          ND_PRINT(C_RESET, ", SPSource-ID: %u",
                     (GET_BE_U_4(tptr) & 0x000fffff));
           tptr += 4;
-          ND_PRINT(", No of Trees: %x", GET_U_1(tptr));
+          ND_PRINT(C_RESET, ", No of Trees: %x", GET_U_1(tptr));
 
           treecount = GET_U_1(tptr);
           tptr++;
@@ -1672,7 +1676,7 @@ isis_print_mt_capability_subtlv(netdissect_options *ndo,
             if (stlv_len < ISIS_SUBTLV_SPB_INSTANCE_VLAN_TUPLE_LEN)
               goto trunc;
 
-            ND_PRINT("\n\t         U:%u, M:%u, A:%u, RES:%u",
+            ND_PRINT(C_RESET, "\n\t         U:%u, M:%u, A:%u, RES:%u",
                       GET_U_1(tptr) >> 7,
                       (GET_U_1(tptr) >> 6) & 0x01,
                       (GET_U_1(tptr) >> 5) & 0x01,
@@ -1680,11 +1684,11 @@ isis_print_mt_capability_subtlv(netdissect_options *ndo,
 
             tptr++;
 
-            ND_PRINT(", ECT: %08x", GET_BE_U_4(tptr));
+            ND_PRINT(C_RESET, ", ECT: %08x", GET_BE_U_4(tptr));
 
             tptr += 4;
 
-            ND_PRINT(", BVID: %u, SPVID: %u",
+            ND_PRINT(C_RESET, ", BVID: %u, SPVID: %u",
                       (GET_BE_U_3(tptr) >> 12) & 0x000fff,
                       GET_BE_U_3(tptr) & 0x000fff);
 
@@ -1700,12 +1704,12 @@ isis_print_mt_capability_subtlv(netdissect_options *ndo,
           if (stlv_len < 8)
             goto trunc;
 
-          ND_PRINT("\n\t        BMAC: %08x", GET_BE_U_4(tptr));
+          ND_PRINT(C_RESET, "\n\t        BMAC: %08x", GET_BE_U_4(tptr));
           tptr += 4;
-          ND_PRINT("%04x", GET_BE_U_2(tptr));
+          ND_PRINT(C_RESET, "%04x", GET_BE_U_2(tptr));
           tptr += 2;
 
-          ND_PRINT(", RES: %u, VID: %u", GET_BE_U_2(tptr) >> 12,
+          ND_PRINT(C_RESET, ", RES: %u, VID: %u", GET_BE_U_2(tptr) >> 12,
                     (GET_BE_U_2(tptr)) & 0x0fff);
 
           tptr += 2;
@@ -1713,7 +1717,7 @@ isis_print_mt_capability_subtlv(netdissect_options *ndo,
           stlv_len -= 8;
 
           while (stlv_len >= 4) {
-            ND_PRINT("\n\t        T: %u, R: %u, RES: %u, ISID: %u",
+            ND_PRINT(C_RESET, "\n\t        T: %u, R: %u, RES: %u, ISID: %u",
                     (GET_BE_U_4(tptr) >> 31),
                     (GET_BE_U_4(tptr) >> 30) & 0x01,
                     (GET_BE_U_4(tptr) >> 24) & 0x03f,
@@ -1739,11 +1743,11 @@ trunc:
   return (1);
 
 subtlv_too_long:
-  ND_PRINT(" (> containing TLV length)");
+  ND_PRINT(C_RESET, " (> containing TLV length)");
   return (1);
 
 subtlv_too_short:
-  ND_PRINT(" (too short)");
+  ND_PRINT(C_RESET, " (too short)");
   return (1);
 }
 
@@ -1781,19 +1785,19 @@ static int
 isis_print_metric_block(netdissect_options *ndo,
                         const struct isis_metric_block *isis_metric_block)
 {
-    ND_PRINT(", Default Metric: %u, %s",
+    ND_PRINT(C_RESET, ", Default Metric: %u, %s",
            ISIS_LSP_TLV_METRIC_VALUE(isis_metric_block->metric_default),
            ISIS_LSP_TLV_METRIC_IE(isis_metric_block->metric_default) ? "External" : "Internal");
     if (!ISIS_LSP_TLV_METRIC_SUPPORTED(isis_metric_block->metric_delay))
-        ND_PRINT("\n\t\t  Delay Metric: %u, %s",
+        ND_PRINT(C_RESET, "\n\t\t  Delay Metric: %u, %s",
                ISIS_LSP_TLV_METRIC_VALUE(isis_metric_block->metric_delay),
                ISIS_LSP_TLV_METRIC_IE(isis_metric_block->metric_delay) ? "External" : "Internal");
     if (!ISIS_LSP_TLV_METRIC_SUPPORTED(isis_metric_block->metric_expense))
-        ND_PRINT("\n\t\t  Expense Metric: %u, %s",
+        ND_PRINT(C_RESET, "\n\t\t  Expense Metric: %u, %s",
                ISIS_LSP_TLV_METRIC_VALUE(isis_metric_block->metric_expense),
                ISIS_LSP_TLV_METRIC_IE(isis_metric_block->metric_expense) ? "External" : "Internal");
     if (!ISIS_LSP_TLV_METRIC_SUPPORTED(isis_metric_block->metric_error))
-        ND_PRINT("\n\t\t  Error Metric: %u, %s",
+        ND_PRINT(C_RESET, "\n\t\t  Error Metric: %u, %s",
                ISIS_LSP_TLV_METRIC_VALUE(isis_metric_block->metric_error),
                ISIS_LSP_TLV_METRIC_IE(isis_metric_block->metric_error) ? "External" : "Internal");
 
@@ -1811,7 +1815,7 @@ isis_print_tlv_ip_reach(netdissect_options *ndo,
 
 	while (length > 0) {
 		if ((size_t)length < sizeof(*tlv_ip_reach)) {
-			ND_PRINT("short IPv4 Reachability (%u vs %zu)",
+			ND_PRINT(C_RESET, "short IPv4 Reachability (%u vs %zu)",
                                length,
                                sizeof(*tlv_ip_reach));
 			return (0);
@@ -1822,35 +1826,35 @@ isis_print_tlv_ip_reach(netdissect_options *ndo,
 		prefix_len = mask2plen(GET_IPV4_TO_HOST_ORDER(tlv_ip_reach->mask));
 
 		if (prefix_len == -1)
-			ND_PRINT("%sIPv4 prefix: %s mask %s",
+			ND_PRINT(C_RESET, "%sIPv4 prefix: %s mask %s",
                                indent,
 			       GET_IPADDR_STRING(tlv_ip_reach->prefix),
 			       GET_IPADDR_STRING(tlv_ip_reach->mask));
 		else
-			ND_PRINT("%sIPv4 prefix: %15s/%u",
+			ND_PRINT(C_RESET, "%sIPv4 prefix: %15s/%u",
                                indent,
 			       GET_IPADDR_STRING(tlv_ip_reach->prefix),
 			       prefix_len);
 
-		ND_PRINT(", Distribution: %s, Metric: %u, %s",
+		ND_PRINT(C_RESET, ", Distribution: %s, Metric: %u, %s",
                        ISIS_LSP_TLV_METRIC_UPDOWN(tlv_ip_reach->isis_metric_block.metric_default) ? "down" : "up",
                        ISIS_LSP_TLV_METRIC_VALUE(tlv_ip_reach->isis_metric_block.metric_default),
                        ISIS_LSP_TLV_METRIC_IE(tlv_ip_reach->isis_metric_block.metric_default) ? "External" : "Internal");
 
 		if (!ISIS_LSP_TLV_METRIC_SUPPORTED(tlv_ip_reach->isis_metric_block.metric_delay))
-                    ND_PRINT("%s  Delay Metric: %u, %s",
+                    ND_PRINT(C_RESET, "%s  Delay Metric: %u, %s",
                            indent,
                            ISIS_LSP_TLV_METRIC_VALUE(tlv_ip_reach->isis_metric_block.metric_delay),
                            ISIS_LSP_TLV_METRIC_IE(tlv_ip_reach->isis_metric_block.metric_delay) ? "External" : "Internal");
 
 		if (!ISIS_LSP_TLV_METRIC_SUPPORTED(tlv_ip_reach->isis_metric_block.metric_expense))
-                    ND_PRINT("%s  Expense Metric: %u, %s",
+                    ND_PRINT(C_RESET, "%s  Expense Metric: %u, %s",
                            indent,
                            ISIS_LSP_TLV_METRIC_VALUE(tlv_ip_reach->isis_metric_block.metric_expense),
                            ISIS_LSP_TLV_METRIC_IE(tlv_ip_reach->isis_metric_block.metric_expense) ? "External" : "Internal");
 
 		if (!ISIS_LSP_TLV_METRIC_SUPPORTED(tlv_ip_reach->isis_metric_block.metric_error))
-                    ND_PRINT("%s  Error Metric: %u, %s",
+                    ND_PRINT(C_RESET, "%s  Error Metric: %u, %s",
                            indent,
                            ISIS_LSP_TLV_METRIC_VALUE(tlv_ip_reach->isis_metric_block.metric_error),
                            ISIS_LSP_TLV_METRIC_IE(tlv_ip_reach->isis_metric_block.metric_error) ? "External" : "Internal");
@@ -1874,7 +1878,7 @@ isis_print_ip_reach_subtlv(netdissect_options *ndo,
                            const char *indent)
 {
     /* first lets see if we know the subTLVs name*/
-    ND_PRINT("%s%s subTLV #%u, length: %u",
+    ND_PRINT(C_RESET, "%s%s subTLV #%u, length: %u",
               indent, tok2str(isis_ext_ip_reach_subtlv_values, "unknown", subt),
               subt, subl);
 
@@ -1884,7 +1888,7 @@ isis_print_ip_reach_subtlv(netdissect_options *ndo,
     case ISIS_SUBTLV_EXTD_IP_REACH_MGMT_PREFIX_COLOR: /* fall through */
     case ISIS_SUBTLV_EXTD_IP_REACH_ADMIN_TAG32:
         while (subl >= 4) {
-	    ND_PRINT(", 0x%08x (=%u)",
+	    ND_PRINT(C_RESET, ", 0x%08x (=%u)",
 		   GET_BE_U_4(tptr),
 		   GET_BE_U_4(tptr));
 	    tptr+=4;
@@ -1893,7 +1897,7 @@ isis_print_ip_reach_subtlv(netdissect_options *ndo,
 	break;
     case ISIS_SUBTLV_EXTD_IP_REACH_ADMIN_TAG64:
         while (subl >= 8) {
-	    ND_PRINT(", 0x%08x%08x",
+	    ND_PRINT(C_RESET, ", 0x%08x%08x",
 		   GET_BE_U_4(tptr),
 		   GET_BE_U_4(tptr + 4));
 	    tptr+=8;
@@ -1922,7 +1926,7 @@ isis_print_ip_reach_subtlv(netdissect_options *ndo,
 		subl-=6;
 	    }
 
-	    ND_PRINT(", Flags [%s], Algo %s (%u), %s %u",
+	    ND_PRINT(C_RESET, ", Flags [%s], Algo %s (%u), %s %u",
 		     bittok2str(prefix_sid_flag_values, "None", flags),
 		     tok2str(prefix_sid_algo_values, "Unknown", algo), algo,
 		     flags & ISIS_PREFIX_SID_FLAG_V ? "label" : "index",
@@ -1964,7 +1968,7 @@ isis_print_ext_is_reach(netdissect_options *ndo,
     if (tlv_remaining < NODE_ID_LEN)
         return(0);
 
-    ND_PRINT("%sIS Neighbor: %s", indent, isis_print_id(ndo, tptr, NODE_ID_LEN));
+    ND_PRINT(C_RESET, "%sIS Neighbor: %s", indent, isis_print_id(ndo, tptr, NODE_ID_LEN));
     tptr+=NODE_ID_LEN;
     tlv_remaining-=NODE_ID_LEN;
     proc_bytes+=NODE_ID_LEN;
@@ -1973,7 +1977,7 @@ isis_print_ext_is_reach(netdissect_options *ndo,
         ND_TCHECK_3(tptr);
 	if (tlv_remaining < 3)
 	    return(0);
-	ND_PRINT(", Metric: %u", GET_BE_U_3(tptr));
+	ND_PRINT(C_RESET, ", Metric: %u", GET_BE_U_3(tptr));
 	tptr+=3;
 	tlv_remaining-=3;
 	proc_bytes+=3;
@@ -1986,21 +1990,21 @@ isis_print_ext_is_reach(netdissect_options *ndo,
     tptr++;
     tlv_remaining--;
     proc_bytes++;
-    ND_PRINT(", %ssub-TLVs present",subtlv_sum_len ? "" : "no ");
+    ND_PRINT(C_RESET, ", %ssub-TLVs present",subtlv_sum_len ? "" : "no ");
     if (subtlv_sum_len) {
-        ND_PRINT(" (%u)", subtlv_sum_len);
+        ND_PRINT(C_RESET, " (%u)", subtlv_sum_len);
         /* prepend the indent string */
         snprintf(indent_buffer, sizeof(indent_buffer), "%s  ", indent);
         indent = indent_buffer;
         while (subtlv_sum_len != 0) {
             ND_TCHECK_2(tptr);
             if (tlv_remaining < 2) {
-                ND_PRINT("%sRemaining data in TLV shorter than a subTLV header", indent);
+                ND_PRINT(C_RESET, "%sRemaining data in TLV shorter than a subTLV header", indent);
                 proc_bytes += tlv_remaining;
                 break;
             }
             if (subtlv_sum_len < 2) {
-                ND_PRINT("%sRemaining data in subTLVs shorter than a subTLV header", indent);
+                ND_PRINT(C_RESET, "%sRemaining data in subTLVs shorter than a subTLV header", indent);
                 proc_bytes += subtlv_sum_len;
                 break;
             }
@@ -2010,18 +2014,18 @@ isis_print_ext_is_reach(netdissect_options *ndo,
             tlv_remaining -= 2;
             subtlv_sum_len -= 2;
             proc_bytes += 2;
-            ND_PRINT("%s%s subTLV #%u, length: %u",
+            ND_PRINT(C_RESET, "%s%s subTLV #%u, length: %u",
                       indent, tok2str(isis_ext_is_reach_subtlv_values, "unknown", subtlv_type),
                       subtlv_type, subtlv_len);
 
             if (subtlv_sum_len < subtlv_len) {
-                ND_PRINT(" (remaining data in subTLVs shorter than the current subTLV)");
+                ND_PRINT(C_RESET, " (remaining data in subTLVs shorter than the current subTLV)");
                 proc_bytes += subtlv_sum_len;
                 break;
             }
 
             if (tlv_remaining < subtlv_len) {
-                ND_PRINT(" (> remaining tlv length)");
+                ND_PRINT(C_RESET, " (> remaining tlv length)");
                 proc_bytes += tlv_remaining;
                 break;
             }
@@ -2033,28 +2037,28 @@ isis_print_ext_is_reach(netdissect_options *ndo,
             case ISIS_SUBTLV_EXT_IS_REACH_LINK_LOCAL_REMOTE_ID:
             case ISIS_SUBTLV_EXT_IS_REACH_LINK_REMOTE_ID:
                 if (subtlv_len >= 4) {
-                    ND_PRINT(", 0x%08x", GET_BE_U_4(tptr));
+                    ND_PRINT(C_RESET, ", 0x%08x", GET_BE_U_4(tptr));
                     if (subtlv_len == 8) /* rfc4205 */
-                        ND_PRINT(", 0x%08x", GET_BE_U_4(tptr + 4));
+                        ND_PRINT(C_RESET, ", 0x%08x", GET_BE_U_4(tptr + 4));
                 }
                 break;
             case ISIS_SUBTLV_EXT_IS_REACH_IPV4_INTF_ADDR:
             case ISIS_SUBTLV_EXT_IS_REACH_IPV4_NEIGHBOR_ADDR:
                 if (subtlv_len >= sizeof(nd_ipv4))
-                    ND_PRINT(", %s", GET_IPADDR_STRING(tptr));
+                    ND_PRINT(C_RESET, ", %s", GET_IPADDR_STRING(tptr));
                 break;
             case ISIS_SUBTLV_EXT_IS_REACH_MAX_LINK_BW :
             case ISIS_SUBTLV_EXT_IS_REACH_RESERVABLE_BW:
                 if (subtlv_len >= 4) {
                     bw.i = GET_BE_U_4(tptr);
-                    ND_PRINT(", %.3f Mbps", bw.f * 8 / 1000000);
+                    ND_PRINT(C_RESET, ", %.3f Mbps", bw.f * 8 / 1000000);
                 }
                 break;
             case ISIS_SUBTLV_EXT_IS_REACH_UNRESERVED_BW :
                 if (subtlv_len >= 32) {
                     for (te_class = 0; te_class < 8; te_class++) {
                         bw.i = GET_BE_U_4(tptr);
-                        ND_PRINT("%s  TE-Class %u: %.3f Mbps",
+                        ND_PRINT(C_RESET, "%s  TE-Class %u: %.3f Mbps",
                                   indent,
                                   te_class,
                                   bw.f * 8 / 1000000);
@@ -2069,7 +2073,7 @@ isis_print_ext_is_reach(netdissect_options *ndo,
             case ISIS_SUBTLV_EXT_IS_REACH_BW_CONSTRAINTS_OLD:
                 if (subtlv_len == 0)
                     break;
-                ND_PRINT("%sBandwidth Constraints Model ID: %s (%u)",
+                ND_PRINT(C_RESET, "%sBandwidth Constraints Model ID: %s (%u)",
                           indent,
                           tok2str(diffserv_te_bc_values, "unknown", GET_U_1(tptr)),
                           GET_U_1(tptr));
@@ -2082,7 +2086,7 @@ isis_print_ext_is_reach(netdissect_options *ndo,
                     if (subtlv_len < 4)
                         break;
                     bw.i = GET_BE_U_4(tptr);
-                    ND_PRINT("%s  Bandwidth constraint CT%u: %.3f Mbps",
+                    ND_PRINT(C_RESET, "%s  Bandwidth constraint CT%u: %.3f Mbps",
                               indent,
                               te_class,
                               bw.f * 8 / 1000000);
@@ -2094,11 +2098,11 @@ isis_print_ext_is_reach(netdissect_options *ndo,
                 break;
             case ISIS_SUBTLV_EXT_IS_REACH_TE_METRIC:
                 if (subtlv_len >= 3)
-                    ND_PRINT(", %u", GET_BE_U_3(tptr));
+                    ND_PRINT(C_RESET, ", %u", GET_BE_U_3(tptr));
                 break;
             case ISIS_SUBTLV_EXT_IS_REACH_LINK_ATTRIBUTE:
                 if (subtlv_len == 2) {
-                    ND_PRINT(", [ %s ] (0x%04x)",
+                    ND_PRINT(C_RESET, ", [ %s ] (0x%04x)",
                               bittok2str(isis_subtlv_link_attribute_values,
                                          "Unknown",
                                          GET_BE_U_2(tptr)),
@@ -2107,42 +2111,42 @@ isis_print_ext_is_reach(netdissect_options *ndo,
                 break;
             case ISIS_SUBTLV_EXT_IS_REACH_LINK_PROTECTION_TYPE:
                 if (subtlv_len >= 2) {
-                    ND_PRINT(", %s, Priority %u",
+                    ND_PRINT(C_RESET, ", %s, Priority %u",
                               bittok2str(gmpls_link_prot_values, "none", GET_U_1(tptr)),
                               GET_U_1(tptr + 1));
                 }
                 break;
             case ISIS_SUBTLV_SPB_METRIC:
                 if (subtlv_len >= 6) {
-                    ND_PRINT(", LM: %u", GET_BE_U_3(tptr));
+                    ND_PRINT(C_RESET, ", LM: %u", GET_BE_U_3(tptr));
                     tptr += 3;
                     subtlv_len -= 3;
                     subtlv_sum_len -= 3;
                     proc_bytes += 3;
-                    ND_PRINT(", P: %u", GET_U_1(tptr));
+                    ND_PRINT(C_RESET, ", P: %u", GET_U_1(tptr));
                     tptr++;
                     subtlv_len--;
                     subtlv_sum_len--;
                     proc_bytes++;
-                    ND_PRINT(", P-ID: %u", GET_BE_U_2(tptr));
+                    ND_PRINT(C_RESET, ", P-ID: %u", GET_BE_U_2(tptr));
                 }
                 break;
             case ISIS_SUBTLV_EXT_IS_REACH_INTF_SW_CAP_DESCR:
                 if (subtlv_len >= 36) {
                     gmpls_switch_cap = GET_U_1(tptr);
-                    ND_PRINT("%s  Interface Switching Capability:%s",
+                    ND_PRINT(C_RESET, "%s  Interface Switching Capability:%s",
                               indent,
                               tok2str(gmpls_switch_cap_values, "Unknown", gmpls_switch_cap));
-                    ND_PRINT(", LSP Encoding: %s",
+                    ND_PRINT(C_RESET, ", LSP Encoding: %s",
                               tok2str(gmpls_encoding_values, "Unknown", GET_U_1((tptr + 1))));
                     tptr += 4;
                     subtlv_len -= 4;
                     subtlv_sum_len -= 4;
                     proc_bytes += 4;
-                    ND_PRINT("%s  Max LSP Bandwidth:", indent);
+                    ND_PRINT(C_RESET, "%s  Max LSP Bandwidth:", indent);
                     for (priority_level = 0; priority_level < 8; priority_level++) {
                         bw.i = GET_BE_U_4(tptr);
-                        ND_PRINT("%s    priority level %u: %.3f Mbps",
+                        ND_PRINT(C_RESET, "%s    priority level %u: %.3f Mbps",
                                   indent,
                                   priority_level,
                                   bw.f * 8 / 1000000);
@@ -2159,16 +2163,16 @@ isis_print_ext_is_reach(netdissect_options *ndo,
                         if (subtlv_len < 6)
                             break;
                         bw.i = GET_BE_U_4(tptr);
-                        ND_PRINT("%s  Min LSP Bandwidth: %.3f Mbps", indent, bw.f * 8 / 1000000);
-                        ND_PRINT("%s  Interface MTU: %u", indent,
+                        ND_PRINT(C_RESET, "%s  Min LSP Bandwidth: %.3f Mbps", indent, bw.f * 8 / 1000000);
+                        ND_PRINT(C_RESET, "%s  Interface MTU: %u", indent,
                                  GET_BE_U_2(tptr + 4));
                         break;
                     case GMPLS_TSC:
                         if (subtlv_len < 8)
                             break;
                         bw.i = GET_BE_U_4(tptr);
-                        ND_PRINT("%s  Min LSP Bandwidth: %.3f Mbps", indent, bw.f * 8 / 1000000);
-                        ND_PRINT("%s  Indication %s", indent,
+                        ND_PRINT(C_RESET, "%s  Min LSP Bandwidth: %.3f Mbps", indent, bw.f * 8 / 1000000);
+                        ND_PRINT(C_RESET, "%s  Indication %s", indent,
                                   tok2str(gmpls_switch_cap_tsc_indication_values, "Unknown (%u)", GET_U_1((tptr + 4))));
                         break;
                     default:
@@ -2183,7 +2187,7 @@ isis_print_ext_is_reach(netdissect_options *ndo,
                 break;
             case ISIS_SUBTLV_EXT_IS_REACH_LAN_ADJ_SEGMENT_ID:
                 if (subtlv_len >= 8) {
-                    ND_PRINT("%s  Flags: [%s]", indent,
+                    ND_PRINT(C_RESET, "%s  Flags: [%s]", indent,
                               bittok2str(isis_lan_adj_sid_flag_values,
                                          "none",
                                          GET_U_1(tptr)));
@@ -2193,24 +2197,24 @@ isis_print_ext_is_reach(netdissect_options *ndo,
                     subtlv_len--;
                     subtlv_sum_len--;
                     proc_bytes++;
-                    ND_PRINT("%s  Weight: %u", indent, GET_U_1(tptr));
+                    ND_PRINT(C_RESET, "%s  Weight: %u", indent, GET_U_1(tptr));
                     tptr++;
                     subtlv_len--;
                     subtlv_sum_len--;
                     proc_bytes++;
                     if(subtlv_len>=SYSTEM_ID_LEN) {
                         ND_TCHECK_LEN(tptr, SYSTEM_ID_LEN);
-                        ND_PRINT("%s  Neighbor System-ID: %s", indent,
+                        ND_PRINT(C_RESET, "%s  Neighbor System-ID: %s", indent,
                             isis_print_id(ndo, tptr, SYSTEM_ID_LEN));
                     }
                     /* RFC 8667 section 2.2.2 */
                     /* if V-flag is set to 1 and L-flag is set to 1 ==> 3 octet label */
                     /* if V-flag is set to 0 and L-flag is set to 0 ==> 4 octet index */
                     if (vflag && lflag) {
-                        ND_PRINT("%s  Label: %u",
+                        ND_PRINT(C_RESET, "%s  Label: %u",
                                   indent, GET_BE_U_3(tptr+SYSTEM_ID_LEN));
                     } else if ((!vflag) && (!lflag)) {
-                        ND_PRINT("%s  Index: %u",
+                        ND_PRINT(C_RESET, "%s  Index: %u",
                                   indent, GET_BE_U_4(tptr+SYSTEM_ID_LEN));
                     } else
                         nd_print_invalid(ndo);
@@ -2246,13 +2250,13 @@ isis_print_mtid(netdissect_options *ndo,
     if (tlv_remaining < 2)
         goto trunc;
 
-    ND_PRINT("%s%s",
+    ND_PRINT(C_RESET, "%s%s",
            indent,
            tok2str(isis_mt_values,
                    "Reserved for IETF Consensus",
                    ISIS_MASK_MTID(GET_BE_U_2(tptr))));
 
-    ND_PRINT(" Topology (0x%03x), Flags: [%s]",
+    ND_PRINT(C_RESET, " Topology (0x%03x), Flags: [%s]",
            ISIS_MASK_MTID(GET_BE_U_2(tptr)),
            bittok2str(isis_mt_flag_values, "none",ISIS_MASK_MTFLAGS(GET_BE_U_2(tptr))));
 
@@ -2285,7 +2289,7 @@ isis_print_extd_ip_reach(netdissect_options *ndo,
         tptr++;
         bit_length = status_byte&0x3f;
         if (bit_length > 32) {
-            ND_PRINT("%sIPv4 prefix: bad bit length %u",
+            ND_PRINT(C_RESET, "%sIPv4 prefix: bad bit length %u",
                    indent,
                    bit_length);
             return (0);
@@ -2295,7 +2299,7 @@ isis_print_extd_ip_reach(netdissect_options *ndo,
         status_byte=GET_U_1(tptr);
         bit_length=GET_U_1(tptr + 1);
         if (bit_length > 128) {
-            ND_PRINT("%sIPv6 prefix: bad bit length %u",
+            ND_PRINT(C_RESET, "%sIPv6 prefix: bad bit length %u",
                    indent,
                    bit_length);
             return (0);
@@ -2313,24 +2317,24 @@ isis_print_extd_ip_reach(netdissect_options *ndo,
     processed+=byte_length;
 
     if (afi == AF_INET)
-        ND_PRINT("%sIPv4 prefix: %15s/%u",
+        ND_PRINT(C_RESET, "%sIPv4 prefix: %15s/%u",
                indent,
                ipaddr_string(ndo, prefix), /* local buffer, not packet data; don't use GET_IPADDR_STRING() */
                bit_length);
     else if (afi == AF_INET6)
-        ND_PRINT("%sIPv6 prefix: %s/%u",
+        ND_PRINT(C_RESET, "%sIPv6 prefix: %s/%u",
                indent,
                ip6addr_string(ndo, prefix), /* local buffer, not packet data; don't use GET_IP6ADDR_STRING() */
                bit_length);
 
-    ND_PRINT(", Distribution: %s, Metric: %u",
+    ND_PRINT(C_RESET, ", Distribution: %s, Metric: %u",
            ISIS_MASK_TLV_EXTD_IP_UPDOWN(status_byte) ? "down" : "up",
            metric);
 
     if (afi == AF_INET && ISIS_MASK_TLV_EXTD_IP_SUBTLV(status_byte))
-        ND_PRINT(", sub-TLVs present");
+        ND_PRINT(C_RESET, ", sub-TLVs present");
     else if (afi == AF_INET6)
-        ND_PRINT(", %s%s",
+        ND_PRINT(C_RESET, ", %s%s",
                ISIS_MASK_TLV_EXTD_IP6_IE(status_byte) ? "External" : "Internal",
                ISIS_MASK_TLV_EXTD_IP6_SUBTLV(status_byte) ? ", sub-TLVs present" : "");
 
@@ -2344,7 +2348,7 @@ isis_print_extd_ip_reach(netdissect_options *ndo,
         sublen=GET_U_1(tptr);
         tptr++;
         processed+=sublen+1;
-        ND_PRINT(" (%u)", sublen);   /* print out subTLV length */
+        ND_PRINT(C_RESET, " (%u)", sublen);   /* print out subTLV length */
 
         while (sublen>0) {
             subtlvtype=GET_U_1(tptr);
@@ -2373,7 +2377,7 @@ isis_print_router_cap_subtlv(netdissect_options *ndo, const uint8_t *tptr, uint8
 	tptr += 2;
 
 	/* first lets see if we know the subTLVs name*/
-	ND_PRINT("\n\t\t%s subTLV #%u, length: %u",
+	ND_PRINT(C_RESET, "\n\t\t%s subTLV #%u, length: %u",
               tok2str(isis_router_capability_subtlv_values, "unknown", subt),
               subt, subl);
 
@@ -2394,7 +2398,7 @@ isis_print_router_cap_subtlv(netdissect_options *ndo, const uint8_t *tptr, uint8
 
 		flags = GET_U_1(tptr);
 		range = GET_BE_U_3(tptr+1);
-		ND_PRINT(", Flags [%s], Range %u",
+		ND_PRINT(C_RESET, ", Flags [%s], Range %u",
 			 bittok2str(isis_router_capability_sr_flags, "None", flags),
 			 range);
 		sid_ptr = tptr + 4;
@@ -2416,11 +2420,11 @@ isis_print_router_cap_subtlv(netdissect_options *ndo, const uint8_t *tptr, uint8
 		    switch (sid_type) {
 		    case 1:
 			if (sid_len == 3) {
-			    ND_PRINT(", SID value %u", GET_BE_U_3(sid_ptr));
+			    ND_PRINT(C_RESET, ", SID value %u", GET_BE_U_3(sid_ptr));
 			} else if (sid_len == 4) {
-			    ND_PRINT(", SID value %u", GET_BE_U_4(sid_ptr));
+			    ND_PRINT(C_RESET, ", SID value %u", GET_BE_U_4(sid_ptr));
 			} else {
-			    ND_PRINT(", Unknown SID length%u", sid_len);
+			    ND_PRINT(C_RESET, ", Unknown SID length%u", sid_len);
 			}
 			break;
 		    default:
@@ -2465,7 +2469,7 @@ isis_clear_checksum_lifetime(void *header)
 
 #define INVALID_OR_DECREMENT(length,decr) \
     if ((length) < (decr)) { \
-        ND_PRINT(" [packet length %u < %zu]", (length), (decr)); \
+        ND_PRINT(C_RESET, " [packet length %u < %zu]", (length), (decr)); \
         nd_print_invalid(ndo); \
         return 1; \
     } \
@@ -2518,7 +2522,7 @@ isis_print(netdissect_options *ndo,
     header_psnp = (const struct isis_psnp_header *)pptr;
 
     if (!ndo->ndo_eflag)
-        ND_PRINT("IS-IS");
+        ND_PRINT(C_RESET, "IS-IS");
 
     /*
      * Sanity checking of the header.
@@ -2526,31 +2530,31 @@ isis_print(netdissect_options *ndo,
 
     version = GET_U_1(isis_header->version);
     if (version != ISIS_VERSION) {
-	ND_PRINT("version %u packet not supported", version);
+	ND_PRINT(C_RESET, "version %u packet not supported", version);
 	return (0);
     }
 
     pdu_id_length = GET_U_1(isis_header->id_length);
     if ((pdu_id_length != SYSTEM_ID_LEN) && (pdu_id_length != 0)) {
-	ND_PRINT("system ID length of %u is not supported",
+	ND_PRINT(C_RESET, "system ID length of %u is not supported",
 	       pdu_id_length);
 	return (0);
     }
 
     pdu_version = GET_U_1(isis_header->pdu_version);
     if (pdu_version != ISIS_VERSION) {
-	ND_PRINT("version %u packet not supported", pdu_version);
+	ND_PRINT(C_RESET, "version %u packet not supported", pdu_version);
 	return (0);
     }
 
     fixed_len = GET_U_1(isis_header->fixed_len);
     if (length < fixed_len) {
-	ND_PRINT("fixed header length %u > packet length %u", fixed_len, length);
+	ND_PRINT(C_RESET, "fixed header length %u > packet length %u", fixed_len, length);
 	return (0);
     }
 
     if (fixed_len < ISIS_COMMON_HEADER_SIZE) {
-	ND_PRINT("fixed header length %u < minimum header size %u", fixed_len, (u_int)ISIS_COMMON_HEADER_SIZE);
+	ND_PRINT(C_RESET, "fixed header length %u < minimum header size %u", fixed_len, (u_int)ISIS_COMMON_HEADER_SIZE);
 	return (0);
     }
 
@@ -2560,7 +2564,7 @@ isis_print(netdissect_options *ndo,
 	max_area = 3;	 /* silly shit */
 	break;
     case 255:
-	ND_PRINT("bad packet -- 255 areas");
+	ND_PRINT(C_RESET, "bad packet -- 255 areas");
 	return (0);
     default:
         max_area = pdu_max_area;
@@ -2591,7 +2595,7 @@ isis_print(netdissect_options *ndo,
 
     /* toss any non 6-byte sys-ID len PDUs */
     if (id_length != 6 ) {
-	ND_PRINT("bad packet -- illegal sys-ID length (%u)", id_length);
+	ND_PRINT(C_RESET, "bad packet -- illegal sys-ID length (%u)", id_length);
 	return (0);
     }
 
@@ -2599,14 +2603,14 @@ isis_print(netdissect_options *ndo,
 
     /* in non-verbose mode print the basic PDU Type plus PDU specific brief information*/
     if (ndo->ndo_vflag == 0) {
-        ND_PRINT("%s%s",
+        ND_PRINT(C_RESET, "%s%s",
                ndo->ndo_eflag ? "" : ", ",
                tok2str(isis_pdu_values, "unknown PDU-Type %u", pdu_type));
     } else {
         /* ok they seem to want to know everything - lets fully decode it */
-        ND_PRINT("%slength %u", ndo->ndo_eflag ? "" : ", ", length);
+        ND_PRINT(C_RESET, "%slength %u", ndo->ndo_eflag ? "" : ", ", length);
 
-        ND_PRINT("\n\t%s, hlen: %u, v: %u, pdu-v: %u, sys-id-len: %u (%u), max-area: %u (%u)",
+        ND_PRINT(C_RESET, "\n\t%s, hlen: %u, v: %u, pdu-v: %u, sys-id-len: %u (%u), max-area: %u (%u)",
                tok2str(isis_pdu_values,
                        "unknown, type %u",
                        pdu_type),
@@ -2629,7 +2633,7 @@ isis_print(netdissect_options *ndo,
     case ISIS_PDU_L1_LAN_IIH:
     case ISIS_PDU_L2_LAN_IIH:
         if (fixed_len != (ISIS_COMMON_HEADER_SIZE+ISIS_IIH_LAN_HEADER_SIZE)) {
-            ND_PRINT(", bogus fixed header length %u should be %zu",
+            ND_PRINT(C_RESET, ", bogus fixed header length %u should be %zu",
                      fixed_len, ISIS_COMMON_HEADER_SIZE+ISIS_IIH_LAN_HEADER_SIZE);
             return (0);
         }
@@ -2637,12 +2641,12 @@ isis_print(netdissect_options *ndo,
         if (length < ISIS_COMMON_HEADER_SIZE+ISIS_IIH_LAN_HEADER_SIZE)
             goto trunc;
         if (ndo->ndo_vflag == 0) {
-            ND_PRINT(", src-id %s",
+            ND_PRINT(C_RESET, ", src-id %s",
                       isis_print_id(ndo, header_iih_lan->source_id, SYSTEM_ID_LEN));
-            ND_PRINT(", lan-id %s, prio %u",
+            ND_PRINT(C_RESET, ", lan-id %s, prio %u",
                       isis_print_id(ndo, header_iih_lan->lan_id,NODE_ID_LEN),
                       GET_U_1(header_iih_lan->priority));
-            ND_PRINT(", length %u", length);
+            ND_PRINT(C_RESET, ", length %u", length);
             return (1);
         }
         pdu_len=GET_BE_U_2(header_iih_lan->pdu_len);
@@ -2651,14 +2655,14 @@ isis_print(netdissect_options *ndo,
            length=pdu_len;
         }
 
-        ND_PRINT("\n\t  source-id: %s,  holding time: %us, Flags: [%s]",
+        ND_PRINT(C_RESET, "\n\t  source-id: %s,  holding time: %us, Flags: [%s]",
                   isis_print_id(ndo, header_iih_lan->source_id,SYSTEM_ID_LEN),
                   GET_BE_U_2(header_iih_lan->holding_time),
                   tok2str(isis_iih_circuit_type_values,
                           "unknown circuit type 0x%02x",
                           GET_U_1(header_iih_lan->circuit_type)));
 
-        ND_PRINT("\n\t  lan-id:    %s, Priority: %u, PDU length: %u",
+        ND_PRINT(C_RESET, "\n\t  lan-id:    %s, Priority: %u, PDU length: %u",
                   isis_print_id(ndo, header_iih_lan->lan_id, NODE_ID_LEN),
                   GET_U_1(header_iih_lan->priority) & ISIS_LAN_PRIORITY_MASK,
                   pdu_len);
@@ -2674,7 +2678,7 @@ isis_print(netdissect_options *ndo,
 
     case ISIS_PDU_PTP_IIH:
         if (fixed_len != (ISIS_COMMON_HEADER_SIZE+ISIS_IIH_PTP_HEADER_SIZE)) {
-            ND_PRINT(", bogus fixed header length %u should be %zu",
+            ND_PRINT(C_RESET, ", bogus fixed header length %u should be %zu",
                       fixed_len, ISIS_COMMON_HEADER_SIZE+ISIS_IIH_PTP_HEADER_SIZE);
             return (0);
         }
@@ -2682,8 +2686,8 @@ isis_print(netdissect_options *ndo,
         if (length < ISIS_COMMON_HEADER_SIZE+ISIS_IIH_PTP_HEADER_SIZE)
             goto trunc;
         if (ndo->ndo_vflag == 0) {
-            ND_PRINT(", src-id %s", isis_print_id(ndo, header_iih_ptp->source_id, SYSTEM_ID_LEN));
-            ND_PRINT(", length %u", length);
+            ND_PRINT(C_RESET, ", src-id %s", isis_print_id(ndo, header_iih_ptp->source_id, SYSTEM_ID_LEN));
+            ND_PRINT(C_RESET, ", length %u", length);
             return (1);
         }
         pdu_len=GET_BE_U_2(header_iih_ptp->pdu_len);
@@ -2692,14 +2696,14 @@ isis_print(netdissect_options *ndo,
             length=pdu_len;
         }
 
-        ND_PRINT("\n\t  source-id: %s, holding time: %us, Flags: [%s]",
+        ND_PRINT(C_RESET, "\n\t  source-id: %s, holding time: %us, Flags: [%s]",
                   isis_print_id(ndo, header_iih_ptp->source_id,SYSTEM_ID_LEN),
                   GET_BE_U_2(header_iih_ptp->holding_time),
                   tok2str(isis_iih_circuit_type_values,
                           "unknown circuit type 0x%02x",
                           GET_U_1(header_iih_ptp->circuit_type)));
 
-        ND_PRINT("\n\t  circuit-id: 0x%02x, PDU length: %u",
+        ND_PRINT(C_RESET, "\n\t  circuit-id: 0x%02x, PDU length: %u",
                   GET_U_1(header_iih_ptp->circuit_id),
                   pdu_len);
 
@@ -2714,7 +2718,7 @@ isis_print(netdissect_options *ndo,
     case ISIS_PDU_L1_LSP:
     case ISIS_PDU_L2_LSP:
         if (fixed_len != (ISIS_COMMON_HEADER_SIZE+ISIS_LSP_HEADER_SIZE)) {
-            ND_PRINT(", bogus fixed header length %u should be %zu",
+            ND_PRINT(C_RESET, ", bogus fixed header length %u should be %zu",
                    fixed_len, ISIS_LSP_HEADER_SIZE);
             return (0);
         }
@@ -2722,11 +2726,11 @@ isis_print(netdissect_options *ndo,
         if (length < ISIS_COMMON_HEADER_SIZE+ISIS_LSP_HEADER_SIZE)
             goto trunc;
         if (ndo->ndo_vflag == 0) {
-            ND_PRINT(", lsp-id %s, seq 0x%08x, lifetime %5us",
+            ND_PRINT(C_RESET, ", lsp-id %s, seq 0x%08x, lifetime %5us",
                       isis_print_id(ndo, header_lsp->lsp_id, LSP_ID_LEN),
                       GET_BE_U_4(header_lsp->sequence_number),
                       GET_BE_U_2(header_lsp->remaining_lifetime));
-            ND_PRINT(", length %u", length);
+            ND_PRINT(C_RESET, ", length %u", length);
             return (1);
         }
         pdu_len=GET_BE_U_2(header_lsp->pdu_len);
@@ -2735,7 +2739,7 @@ isis_print(netdissect_options *ndo,
             length=pdu_len;
         }
 
-        ND_PRINT("\n\t  lsp-id: %s, seq: 0x%08x, lifetime: %5us\n\t  chksum: 0x%04x",
+        ND_PRINT(C_RESET, "\n\t  lsp-id: %s, seq: 0x%08x, lifetime: %5us\n\t  chksum: 0x%04x",
                isis_print_id(ndo, header_lsp->lsp_id, LSP_ID_LEN),
                GET_BE_U_4(header_lsp->sequence_number),
                GET_BE_U_2(header_lsp->remaining_lifetime),
@@ -2745,19 +2749,19 @@ isis_print(netdissect_options *ndo,
                         GET_BE_U_2(header_lsp->checksum),
                         12, length-12);
 
-        ND_PRINT(", PDU length: %u, Flags: [ %s",
+        ND_PRINT(C_RESET, ", PDU length: %u, Flags: [ %s",
                pdu_len,
                ISIS_MASK_LSP_OL_BIT(header_lsp->typeblock) ? "Overload bit set, " : "");
 
         if (ISIS_MASK_LSP_ATT_BITS(header_lsp->typeblock)) {
-            ND_PRINT("%s", ISIS_MASK_LSP_ATT_DEFAULT_BIT(header_lsp->typeblock) ? "default " : "");
-            ND_PRINT("%s", ISIS_MASK_LSP_ATT_DELAY_BIT(header_lsp->typeblock) ? "delay " : "");
-            ND_PRINT("%s", ISIS_MASK_LSP_ATT_EXPENSE_BIT(header_lsp->typeblock) ? "expense " : "");
-            ND_PRINT("%s", ISIS_MASK_LSP_ATT_ERROR_BIT(header_lsp->typeblock) ? "error " : "");
-            ND_PRINT("ATT bit set, ");
+            ND_PRINT(C_RESET, "%s", ISIS_MASK_LSP_ATT_DEFAULT_BIT(header_lsp->typeblock) ? "default " : "");
+            ND_PRINT(C_RESET, "%s", ISIS_MASK_LSP_ATT_DELAY_BIT(header_lsp->typeblock) ? "delay " : "");
+            ND_PRINT(C_RESET, "%s", ISIS_MASK_LSP_ATT_EXPENSE_BIT(header_lsp->typeblock) ? "expense " : "");
+            ND_PRINT(C_RESET, "%s", ISIS_MASK_LSP_ATT_ERROR_BIT(header_lsp->typeblock) ? "error " : "");
+            ND_PRINT(C_RESET, "ATT bit set, ");
         }
-        ND_PRINT("%s", ISIS_MASK_LSP_PARTITION_BIT(header_lsp->typeblock) ? "P bit set, " : "");
-        ND_PRINT("%s ]", tok2str(isis_lsp_istype_values, "Unknown(0x%x)",
+        ND_PRINT(C_RESET, "%s", ISIS_MASK_LSP_PARTITION_BIT(header_lsp->typeblock) ? "P bit set, " : "");
+        ND_PRINT(C_RESET, "%s ]", tok2str(isis_lsp_istype_values, "Unknown(0x%x)",
                   ISIS_MASK_LSP_ISTYPE_BITS(header_lsp->typeblock)));
 
         if (ndo->ndo_vflag > 1) {
@@ -2772,7 +2776,7 @@ isis_print(netdissect_options *ndo,
     case ISIS_PDU_L1_CSNP:
     case ISIS_PDU_L2_CSNP:
         if (fixed_len != (ISIS_COMMON_HEADER_SIZE+ISIS_CSNP_HEADER_SIZE)) {
-            ND_PRINT(", bogus fixed header length %u should be %zu",
+            ND_PRINT(C_RESET, ", bogus fixed header length %u should be %zu",
                       fixed_len, ISIS_COMMON_HEADER_SIZE+ISIS_CSNP_HEADER_SIZE);
             return (0);
         }
@@ -2780,8 +2784,8 @@ isis_print(netdissect_options *ndo,
         if (length < ISIS_COMMON_HEADER_SIZE+ISIS_CSNP_HEADER_SIZE)
             goto trunc;
         if (ndo->ndo_vflag == 0) {
-            ND_PRINT(", src-id %s", isis_print_id(ndo, header_csnp->source_id, NODE_ID_LEN));
-            ND_PRINT(", length %u", length);
+            ND_PRINT(C_RESET, ", src-id %s", isis_print_id(ndo, header_csnp->source_id, NODE_ID_LEN));
+            ND_PRINT(C_RESET, ", length %u", length);
             return (1);
         }
         pdu_len=GET_BE_U_2(header_csnp->pdu_len);
@@ -2790,12 +2794,12 @@ isis_print(netdissect_options *ndo,
             length=pdu_len;
         }
 
-        ND_PRINT("\n\t  source-id:    %s, PDU length: %u",
+        ND_PRINT(C_RESET, "\n\t  source-id:    %s, PDU length: %u",
                isis_print_id(ndo, header_csnp->source_id, NODE_ID_LEN),
                pdu_len);
-        ND_PRINT("\n\t  start lsp-id: %s",
+        ND_PRINT(C_RESET, "\n\t  start lsp-id: %s",
                isis_print_id(ndo, header_csnp->start_lsp_id, LSP_ID_LEN));
-        ND_PRINT("\n\t  end lsp-id:   %s",
+        ND_PRINT(C_RESET, "\n\t  end lsp-id:   %s",
                isis_print_id(ndo, header_csnp->end_lsp_id, LSP_ID_LEN));
 
         if (ndo->ndo_vflag > 1) {
@@ -2810,7 +2814,7 @@ isis_print(netdissect_options *ndo,
     case ISIS_PDU_L1_PSNP:
     case ISIS_PDU_L2_PSNP:
         if (fixed_len != (ISIS_COMMON_HEADER_SIZE+ISIS_PSNP_HEADER_SIZE)) {
-            ND_PRINT("- bogus fixed header length %u should be %zu",
+            ND_PRINT(C_RESET, "- bogus fixed header length %u should be %zu",
                    fixed_len, ISIS_COMMON_HEADER_SIZE+ISIS_PSNP_HEADER_SIZE);
             return (0);
         }
@@ -2818,8 +2822,8 @@ isis_print(netdissect_options *ndo,
         if (length < ISIS_COMMON_HEADER_SIZE+ISIS_PSNP_HEADER_SIZE)
             goto trunc;
         if (ndo->ndo_vflag == 0) {
-            ND_PRINT(", src-id %s", isis_print_id(ndo, header_psnp->source_id, NODE_ID_LEN));
-            ND_PRINT(", length %u", length);
+            ND_PRINT(C_RESET, ", src-id %s", isis_print_id(ndo, header_psnp->source_id, NODE_ID_LEN));
+            ND_PRINT(C_RESET, ", length %u", length);
             return (1);
         }
         pdu_len=GET_BE_U_2(header_psnp->pdu_len);
@@ -2828,7 +2832,7 @@ isis_print(netdissect_options *ndo,
             length=pdu_len;
         }
 
-        ND_PRINT("\n\t  source-id:    %s, PDU length: %u",
+        ND_PRINT(C_RESET, "\n\t  source-id:    %s, PDU length: %u",
                isis_print_id(ndo, header_psnp->source_id, NODE_ID_LEN),
                pdu_len);
 
@@ -2843,7 +2847,7 @@ isis_print(netdissect_options *ndo,
 
     default:
         if (ndo->ndo_vflag == 0) {
-            ND_PRINT(", length %u", length);
+            ND_PRINT(C_RESET, ", length %u", length);
             return (1);
         }
 	(void)print_unknown_data(ndo, pptr, "\n\t  ", length);
@@ -2866,7 +2870,7 @@ isis_print(netdissect_options *ndo,
         tptr = pptr;
 
         /* first lets see if we know the TLVs name*/
-	ND_PRINT("\n\t    %s TLV #%u, length: %u",
+	ND_PRINT(C_RESET, "\n\t    %s TLV #%u, length: %u",
                tok2str(isis_tlv_values,
                        "unknown",
                        tlv_type),
@@ -2885,7 +2889,7 @@ isis_print(netdissect_options *ndo,
 		tlen--;
 		if (tlen < alen)
 		    goto tlv_trunc;
-		ND_PRINT("\n\t      Area address (length: %u): %s",
+		ND_PRINT(C_RESET, "\n\t      Area address (length: %u): %s",
                        alen,
                        GET_ISONSAP_STRING(tptr, alen));
 		tptr += alen;
@@ -2897,7 +2901,7 @@ isis_print(netdissect_options *ndo,
 		if (tlen < MAC_ADDR_LEN)
 		    goto tlv_trunc;
                 ND_TCHECK_LEN(tptr, MAC_ADDR_LEN);
-                ND_PRINT("\n\t      SNPA: %s", isis_print_id(ndo, tptr, MAC_ADDR_LEN));
+                ND_PRINT(C_RESET, "\n\t      SNPA: %s", isis_print_id(ndo, tptr, MAC_ADDR_LEN));
                 tlen -= MAC_ADDR_LEN;
                 tptr += MAC_ADDR_LEN;
 	    }
@@ -2907,15 +2911,15 @@ isis_print(netdissect_options *ndo,
             if (tlen < 4)
                 goto tlv_trunc;
             num_vals = (tlen-2)/2;
-            ND_PRINT("\n\t      Instance ID: %u, ITIDs(%u)%s ",
+            ND_PRINT(C_RESET, "\n\t      Instance ID: %u, ITIDs(%u)%s ",
                      GET_BE_U_2(tptr), num_vals,
                      num_vals ? ":" : "");
             tptr += 2;
             tlen -= 2;
             for (i=0; i < num_vals; i++) {
-                ND_PRINT("%u", GET_BE_U_2(tptr));
+                ND_PRINT(C_RESET, "%u", GET_BE_U_2(tptr));
                 if (i < (num_vals - 1)) {
-                   ND_PRINT(", ");
+                   ND_PRINT(C_RESET, ", ");
                 }
                 tptr += 2;
                 tlen -= 2;
@@ -2936,7 +2940,7 @@ isis_print(netdissect_options *ndo,
                 if (ext_is_len == 0) /* did something go wrong ? */
                     goto trunc;
                 if (tlen < ext_is_len) {
-                    ND_PRINT(" [remaining tlv length %u < %u]", tlen, ext_is_len);
+                    ND_PRINT(C_RESET, " [remaining tlv length %u < %u]", tlen, ext_is_len);
                     nd_print_invalid(ndo);
                     break;
                 }
@@ -2951,7 +2955,7 @@ isis_print(netdissect_options *ndo,
 		if (ext_is_len == 0) /* did something go wrong ? */
 	            goto trunc;
                 if (tlen < ext_is_len) {
-                    ND_PRINT(" [remaining tlv length %u < %u]", tlen, ext_is_len);
+                    ND_PRINT(C_RESET, " [remaining tlv length %u < %u]", tlen, ext_is_len);
                     nd_print_invalid(ndo);
                     break;
                 }
@@ -2966,7 +2970,7 @@ isis_print(netdissect_options *ndo,
                 if (ext_is_len == 0) /* did something go wrong ? */
                     goto trunc;
                 if (tlen < ext_is_len) {
-                    ND_PRINT(" [remaining tlv length %u < %u]", tlen, ext_is_len);
+                    ND_PRINT(C_RESET, " [remaining tlv length %u < %u]", tlen, ext_is_len);
                     nd_print_invalid(ndo);
                     break;
                 }
@@ -2977,7 +2981,7 @@ isis_print(netdissect_options *ndo,
         case ISIS_TLV_IS_REACH:
             if (tlen < 1)
                 goto tlv_trunc;
-            ND_PRINT("\n\t      %s",
+            ND_PRINT(C_RESET, "\n\t      %s",
                    tok2str(isis_is_reach_virtual_values,
                            "bogus virtual flag 0x%02x",
                            GET_U_1(tptr)));
@@ -2988,7 +2992,7 @@ isis_print(netdissect_options *ndo,
                 if (tlen < sizeof(struct isis_tlv_is_reach))
                     goto tlv_trunc;
 		ND_TCHECK_SIZE(tlv_is_reach);
-		ND_PRINT("\n\t      IS Neighbor: %s",
+		ND_PRINT(C_RESET, "\n\t      IS Neighbor: %s",
 		       isis_print_id(ndo, tlv_is_reach->neighbor_nodeid, NODE_ID_LEN));
 		isis_print_metric_block(ndo, &tlv_is_reach->isis_metric_block);
 		tlen -= sizeof(struct isis_tlv_is_reach);
@@ -3002,7 +3006,7 @@ isis_print(netdissect_options *ndo,
                 if (tlen < sizeof(struct isis_tlv_es_reach))
                     goto tlv_trunc;
 		ND_TCHECK_SIZE(tlv_es_reach);
-		ND_PRINT("\n\t      ES Neighbor: %s",
+		ND_PRINT(C_RESET, "\n\t      ES Neighbor: %s",
                        isis_print_id(ndo, tlv_es_reach->neighbor_sysid, SYSTEM_ID_LEN));
 		isis_print_metric_block(ndo, &tlv_es_reach->isis_metric_block);
 		tlen -= sizeof(struct isis_tlv_es_reach);
@@ -3023,7 +3027,7 @@ isis_print(netdissect_options *ndo,
                 if (ext_ip_len == 0) /* did something go wrong ? */
                     goto trunc;
                 if (tlen < ext_ip_len) {
-                    ND_PRINT(" [remaining tlv length %u < %u]", tlen, ext_ip_len);
+                    ND_PRINT(C_RESET, " [remaining tlv length %u < %u]", tlen, ext_ip_len);
                     nd_print_invalid(ndo);
                     break;
                 }
@@ -3045,7 +3049,7 @@ isis_print(netdissect_options *ndo,
                 if (ext_ip_len == 0) /* did something go wrong ? */
                     goto trunc;
                 if (tlen < ext_ip_len) {
-                    ND_PRINT(" [remaining tlv length %u < %u]", tlen, ext_ip_len);
+                    ND_PRINT(C_RESET, " [remaining tlv length %u < %u]", tlen, ext_ip_len);
                     nd_print_invalid(ndo);
                     break;
                 }
@@ -3060,7 +3064,7 @@ isis_print(netdissect_options *ndo,
                 if (ext_ip_len == 0) /* did something go wrong ? */
                     goto trunc;
                 if (tlen < ext_ip_len) {
-                    ND_PRINT(" [remaining tlv length %u < %u]", tlen, ext_ip_len);
+                    ND_PRINT(C_RESET, " [remaining tlv length %u < %u]", tlen, ext_ip_len);
                     nd_print_invalid(ndo);
                     break;
                 }
@@ -3082,7 +3086,7 @@ isis_print(netdissect_options *ndo,
                 if (ext_ip_len == 0) /* did something go wrong ? */
                     goto trunc;
                 if (tlen < ext_ip_len) {
-                    ND_PRINT(" [remaining tlv length %u < %u]", tlen, ext_ip_len);
+                    ND_PRINT(C_RESET, " [remaining tlv length %u < %u]", tlen, ext_ip_len);
                     nd_print_invalid(ndo);
                     break;
                 }
@@ -3095,7 +3099,7 @@ isis_print(netdissect_options *ndo,
 	    while (tlen != 0) {
                 if (tlen < sizeof(nd_ipv6))
                     goto tlv_trunc;
-                ND_PRINT("\n\t      IPv6 interface address: %s",
+                ND_PRINT(C_RESET, "\n\t      IPv6 interface address: %s",
 		       GET_IP6ADDR_STRING(tptr));
 
 		tptr += sizeof(nd_ipv6);
@@ -3109,7 +3113,7 @@ isis_print(netdissect_options *ndo,
 	    tptr++;
 	    tlen--;
 
-            ND_PRINT("\n\t      %s: ",
+            ND_PRINT(C_RESET, "\n\t      %s: ",
                    tok2str(isis_subtlv_auth_values,
                            "unknown Authentication type 0x%02x",
                            auth_type));
@@ -3120,26 +3124,26 @@ isis_print(netdissect_options *ndo,
 		break;
 	    case ISIS_SUBTLV_AUTH_MD5:
 		for(i=0;i<tlen;i++) {
-		    ND_PRINT("%02x", GET_U_1(tptr + i));
+		    ND_PRINT(C_RESET, "%02x", GET_U_1(tptr + i));
 		}
 		if (tlen != ISIS_SUBTLV_AUTH_MD5_LEN)
-                    ND_PRINT(", (invalid subTLV) ");
+                    ND_PRINT(C_RESET, ", (invalid subTLV) ");
 
                 sigcheck = signature_verify(ndo, optr, length, tptr,
                                             isis_clear_checksum_lifetime,
                                             header_lsp);
-                ND_PRINT(" (%s)", tok2str(signature_check_values, "Unknown", sigcheck));
+                ND_PRINT(C_RESET, " (%s)", tok2str(signature_check_values, "Unknown", sigcheck));
 
 		break;
             case ISIS_SUBTLV_AUTH_GENERIC:
                 if (tlen < 2)
                     goto tlv_trunc;
                 key_id = GET_BE_U_2(tptr);
-                ND_PRINT("%u, password: ", key_id);
+                ND_PRINT(C_RESET, "%u, password: ", key_id);
                 tptr += 2;
                 tlen -= 2;
                 for(i=0;i<tlen;i++) {
-                    ND_PRINT("%02x", GET_U_1(tptr + i));
+                    ND_PRINT(C_RESET, "%02x", GET_U_1(tptr + i));
                 }
                 break;
 	    case ISIS_SUBTLV_AUTH_PRIVATE:
@@ -3153,38 +3157,38 @@ isis_print(netdissect_options *ndo,
 	case ISIS_TLV_PTP_ADJ:
 	    tlv_ptp_adj = (const struct isis_tlv_ptp_adj *)tptr;
 	    if(tlen>=1) {
-		ND_PRINT("\n\t      Adjacency State: %s (%u)",
+		ND_PRINT(C_RESET, "\n\t      Adjacency State: %s (%u)",
 		       tok2str(isis_ptp_adjancey_values, "unknown", GET_U_1(tptr)),
 		       GET_U_1(tptr));
 		tlen--;
 	    }
 	    if(tlen>sizeof(tlv_ptp_adj->extd_local_circuit_id)) {
-		ND_PRINT("\n\t      Extended Local circuit-ID: 0x%08x",
+		ND_PRINT(C_RESET, "\n\t      Extended Local circuit-ID: 0x%08x",
 		       GET_BE_U_4(tlv_ptp_adj->extd_local_circuit_id));
 		tlen-=sizeof(tlv_ptp_adj->extd_local_circuit_id);
 	    }
 	    if(tlen>=SYSTEM_ID_LEN) {
 		ND_TCHECK_LEN(tlv_ptp_adj->neighbor_sysid, SYSTEM_ID_LEN);
-		ND_PRINT("\n\t      Neighbor System-ID: %s",
+		ND_PRINT(C_RESET, "\n\t      Neighbor System-ID: %s",
 		       isis_print_id(ndo, tlv_ptp_adj->neighbor_sysid, SYSTEM_ID_LEN));
 		tlen-=SYSTEM_ID_LEN;
 	    }
 	    if(tlen>=sizeof(tlv_ptp_adj->neighbor_extd_local_circuit_id)) {
-		ND_PRINT("\n\t      Neighbor Extended Local circuit-ID: 0x%08x",
+		ND_PRINT(C_RESET, "\n\t      Neighbor Extended Local circuit-ID: 0x%08x",
 		       GET_BE_U_4(tlv_ptp_adj->neighbor_extd_local_circuit_id));
 	    }
 	    break;
 
 	case ISIS_TLV_PROTOCOLS:
-	    ND_PRINT("\n\t      NLPID(s): ");
+	    ND_PRINT(C_RESET, "\n\t      NLPID(s): ");
 	    while (tlen != 0) {
-		ND_PRINT("%s (0x%02x)",
+		ND_PRINT(C_RESET, "%s (0x%02x)",
                        tok2str(nlpid_values,
                                "unknown",
                                GET_U_1(tptr)),
                        GET_U_1(tptr));
 		if (tlen>1) /* further NPLIDs ? - put comma */
-		    ND_PRINT(", ");
+		    ND_PRINT(C_RESET, ", ");
                 tptr++;
                 tlen--;
 	    }
@@ -3195,7 +3199,7 @@ isis_print(netdissect_options *ndo,
             if (tlen < 2)
                 goto tlv_trunc;
 
-            ND_PRINT("\n\t       RES: %u, MTID(s): %u",
+            ND_PRINT(C_RESET, "\n\t       RES: %u, MTID(s): %u",
                     (GET_BE_U_2(tptr) >> 12),
                     (GET_BE_U_2(tptr) & 0x0fff));
 
@@ -3212,7 +3216,7 @@ isis_print(netdissect_options *ndo,
             if (tlen < 2)
                 goto tlv_trunc;
 
-            ND_PRINT("\n\t      O: %u, RES: %u, MTID(s): %u",
+            ND_PRINT(C_RESET, "\n\t      O: %u, RES: %u, MTID(s): %u",
                       (GET_BE_U_2(tptr) >> 15) & 0x01,
                       (GET_BE_U_2(tptr) >> 12) & 0x07,
                       GET_BE_U_2(tptr) & 0x0fff);
@@ -3228,21 +3232,21 @@ isis_print(netdissect_options *ndo,
 	case ISIS_TLV_TE_ROUTER_ID:
 	    if (tlen < sizeof(nd_ipv4))
 	        goto tlv_trunc;
-	    ND_PRINT("\n\t      Traffic Engineering Router ID: %s", GET_IPADDR_STRING(pptr));
+	    ND_PRINT(C_RESET, "\n\t      Traffic Engineering Router ID: %s", GET_IPADDR_STRING(pptr));
 	    break;
 
 	case ISIS_TLV_IPADDR:
 	    while (tlen != 0) {
                 if (tlen < sizeof(nd_ipv4))
                     goto tlv_trunc;
-		ND_PRINT("\n\t      IPv4 interface address: %s", GET_IPADDR_STRING(tptr));
+		ND_PRINT(C_RESET, "\n\t      IPv4 interface address: %s", GET_IPADDR_STRING(tptr));
 		tptr += sizeof(nd_ipv4);
 		tlen -= sizeof(nd_ipv4);
 	    }
 	    break;
 
 	case ISIS_TLV_HOSTNAME:
-	    ND_PRINT("\n\t      Hostname: ");
+	    ND_PRINT(C_RESET, "\n\t      Hostname: ");
 	    nd_printjnp(ndo, tptr, tlen);
 	    break;
 
@@ -3250,33 +3254,33 @@ isis_print(netdissect_options *ndo,
 	    if (tlen < NODE_ID_LEN)
 	        break;
 	    ND_TCHECK_LEN(tptr, NODE_ID_LEN);
-	    ND_PRINT("\n\t      IS Neighbor: %s", isis_print_id(ndo, tptr, NODE_ID_LEN));
+	    ND_PRINT(C_RESET, "\n\t      IS Neighbor: %s", isis_print_id(ndo, tptr, NODE_ID_LEN));
 	    tptr+=NODE_ID_LEN;
 	    tlen-=NODE_ID_LEN;
 
 	    if (tlen < 1)
 	        break;
-	    ND_PRINT(", Flags: [%s]",
+	    ND_PRINT(C_RESET, ", Flags: [%s]",
                      ISIS_MASK_TLV_SHARED_RISK_GROUP(GET_U_1(tptr)) ? "numbered" : "unnumbered");
 	    tptr++;
 	    tlen--;
 
 	    if (tlen < sizeof(nd_ipv4))
 	        break;
-	    ND_PRINT("\n\t      IPv4 interface address: %s", GET_IPADDR_STRING(tptr));
+	    ND_PRINT(C_RESET, "\n\t      IPv4 interface address: %s", GET_IPADDR_STRING(tptr));
 	    tptr+=sizeof(nd_ipv4);
 	    tlen-=sizeof(nd_ipv4);
 
 	    if (tlen < sizeof(nd_ipv4))
 	        break;
-	    ND_PRINT("\n\t      IPv4 neighbor address: %s", GET_IPADDR_STRING(tptr));
+	    ND_PRINT(C_RESET, "\n\t      IPv4 neighbor address: %s", GET_IPADDR_STRING(tptr));
 	    tptr+=sizeof(nd_ipv4);
 	    tlen-=sizeof(nd_ipv4);
 
 	    while (tlen != 0) {
 		if (tlen < 4)
 		    goto tlv_trunc;
-                ND_PRINT("\n\t      Link-ID: 0x%08x", GET_BE_U_4(tptr));
+                ND_PRINT(C_RESET, "\n\t      Link-ID: 0x%08x", GET_BE_U_4(tptr));
                 tptr+=4;
                 tlen-=4;
 	    }
@@ -3288,13 +3292,13 @@ isis_print(netdissect_options *ndo,
 		if (tlen < sizeof(struct isis_tlv_lsp))
 		    goto tlv_trunc;
 		ND_TCHECK_1(tlv_lsp->lsp_id + LSP_ID_LEN - 1);
-		ND_PRINT("\n\t      lsp-id: %s",
+		ND_PRINT(C_RESET, "\n\t      lsp-id: %s",
                        isis_print_id(ndo, tlv_lsp->lsp_id, LSP_ID_LEN));
-		ND_PRINT(", seq: 0x%08x",
+		ND_PRINT(C_RESET, ", seq: 0x%08x",
                          GET_BE_U_4(tlv_lsp->sequence_number));
-		ND_PRINT(", lifetime: %5ds",
+		ND_PRINT(C_RESET, ", lifetime: %5ds",
                          GET_BE_U_2(tlv_lsp->remaining_lifetime));
-		ND_PRINT(", chksum: 0x%04x", GET_BE_U_2(tlv_lsp->checksum));
+		ND_PRINT(C_RESET, ", chksum: 0x%04x", GET_BE_U_2(tlv_lsp->checksum));
 		tlen-=sizeof(struct isis_tlv_lsp);
 		tlv_lsp++;
 	    }
@@ -3304,7 +3308,7 @@ isis_print(netdissect_options *ndo,
 	    if (tlen < ISIS_TLV_CHECKSUM_MINLEN)
 	        break;
 	    ND_TCHECK_LEN(tptr, ISIS_TLV_CHECKSUM_MINLEN);
-	    ND_PRINT("\n\t      checksum: 0x%04x ", GET_BE_U_2(tptr));
+	    ND_PRINT(C_RESET, "\n\t      checksum: 0x%04x ", GET_BE_U_2(tptr));
             /* do not attempt to verify the checksum if it is zero
              * most likely a HMAC-MD5 TLV is also present and
              * to avoid conflicts the checksum TLV is zeroed.
@@ -3322,12 +3326,12 @@ isis_print(netdissect_options *ndo,
 	    tlen--;
 	    if (num_system_ids == 0) {
 		/* Not valid */
-		ND_PRINT(" No system IDs supplied");
+		ND_PRINT(C_RESET, " No system IDs supplied");
 	    } else {
 		if (tlen < SYSTEM_ID_LEN)
 		    goto tlv_trunc;
 		ND_TCHECK_LEN(tptr, SYSTEM_ID_LEN);
-		ND_PRINT("\n\t      Purge Originator System-ID: %s",
+		ND_PRINT(C_RESET, "\n\t      Purge Originator System-ID: %s",
 		       isis_print_id(ndo, tptr, SYSTEM_ID_LEN));
 		tptr += SYSTEM_ID_LEN;
 		tlen -= SYSTEM_ID_LEN;
@@ -3337,7 +3341,7 @@ isis_print(netdissect_options *ndo,
 			goto tlv_trunc;
 		    ND_TCHECK_LEN(tptr, SYSTEM_ID_LEN);
 		    ND_TCHECK_LEN(tptr, 2 * SYSTEM_ID_LEN + 1);
-		    ND_PRINT("\n\t      Received from System-ID: %s",
+		    ND_PRINT(C_RESET, "\n\t      Received from System-ID: %s",
 			   isis_print_id(ndo, tptr, SYSTEM_ID_LEN));
 		}
 	    }
@@ -3354,7 +3358,7 @@ isis_print(netdissect_options *ndo,
                     tptr+=mt_len;
                     tlen-=mt_len;
 		} else {
-		    ND_PRINT("\n\t      invalid MT-ID");
+		    ND_PRINT(C_RESET, "\n\t      invalid MT-ID");
 		    break;
 		}
 	    }
@@ -3365,7 +3369,7 @@ isis_print(netdissect_options *ndo,
             if (tlen < ISIS_TLV_RESTART_SIGNALING_FLAGLEN)
                 break;
             ND_TCHECK_LEN(tptr, ISIS_TLV_RESTART_SIGNALING_FLAGLEN);
-            ND_PRINT("\n\t      Flags [%s]",
+            ND_PRINT(C_RESET, "\n\t      Flags [%s]",
                    bittok2str(isis_restart_flag_values, "none", GET_U_1(tptr)));
             tptr+=ISIS_TLV_RESTART_SIGNALING_FLAGLEN;
             tlen-=ISIS_TLV_RESTART_SIGNALING_FLAGLEN;
@@ -3378,14 +3382,14 @@ isis_print(netdissect_options *ndo,
                 break;
             ND_TCHECK_LEN(tptr, ISIS_TLV_RESTART_SIGNALING_HOLDTIMELEN);
 
-            ND_PRINT(", Remaining holding time %us", GET_BE_U_2(tptr));
+            ND_PRINT(C_RESET, ", Remaining holding time %us", GET_BE_U_2(tptr));
             tptr+=ISIS_TLV_RESTART_SIGNALING_HOLDTIMELEN;
             tlen-=ISIS_TLV_RESTART_SIGNALING_HOLDTIMELEN;
 
             /* is there an additional sysid field present ?*/
             if (tlen == SYSTEM_ID_LEN) {
                     ND_TCHECK_LEN(tptr, SYSTEM_ID_LEN);
-                    ND_PRINT(", for %s", isis_print_id(ndo, tptr,SYSTEM_ID_LEN));
+                    ND_PRINT(C_RESET, ", for %s", isis_print_id(ndo, tptr,SYSTEM_ID_LEN));
             }
 	    break;
 
@@ -3393,7 +3397,7 @@ isis_print(netdissect_options *ndo,
 	    if (tlen < 1)
 	        break;
             isis_subtlv_idrp = GET_U_1(tptr);
-            ND_PRINT("\n\t      Inter-Domain Information Type: %s",
+            ND_PRINT(C_RESET, "\n\t      Inter-Domain Information Type: %s",
                    tok2str(isis_subtlv_idrp_values,
                            "Unknown (0x%02x)",
                            isis_subtlv_idrp));
@@ -3403,7 +3407,7 @@ isis_print(netdissect_options *ndo,
             case ISIS_SUBTLV_IDRP_ASN:
                 if (tlen < 2)
                     goto tlv_trunc;
-                ND_PRINT("AS Number: %u", GET_BE_U_2(tptr));
+                ND_PRINT(C_RESET, "AS Number: %u", GET_BE_U_2(tptr));
                 break;
             case ISIS_SUBTLV_IDRP_LOCAL:
             case ISIS_SUBTLV_IDRP_RES:
@@ -3417,7 +3421,7 @@ isis_print(netdissect_options *ndo,
         case ISIS_TLV_LSP_BUFFERSIZE:
 	    if (tlen < 2)
 	        break;
-            ND_PRINT("\n\t      LSP Buffersize: %u", GET_BE_U_2(tptr));
+            ND_PRINT(C_RESET, "\n\t      LSP Buffersize: %u", GET_BE_U_2(tptr));
             break;
 
         case ISIS_TLV_PART_DIS:
@@ -3425,7 +3429,7 @@ isis_print(netdissect_options *ndo,
                 if (tlen < SYSTEM_ID_LEN)
                     goto tlv_trunc;
                 ND_TCHECK_LEN(tptr, SYSTEM_ID_LEN);
-                ND_PRINT("\n\t      %s", isis_print_id(ndo, tptr, SYSTEM_ID_LEN));
+                ND_PRINT(C_RESET, "\n\t      %s", isis_print_id(ndo, tptr, SYSTEM_ID_LEN));
                 tptr+=SYSTEM_ID_LEN;
                 tlen-=SYSTEM_ID_LEN;
             }
@@ -3435,7 +3439,7 @@ isis_print(netdissect_options *ndo,
 	    if (tlen < sizeof(struct isis_metric_block))
 	        break;
             ND_TCHECK_LEN(tptr, sizeof(struct isis_metric_block));
-            ND_PRINT("\n\t      Metric Block");
+            ND_PRINT(C_RESET, "\n\t      Metric Block");
             isis_print_metric_block(ndo, (const struct isis_metric_block *)tptr);
             tptr+=sizeof(struct isis_metric_block);
             tlen-=sizeof(struct isis_metric_block);
@@ -3445,12 +3449,12 @@ isis_print(netdissect_options *ndo,
                 tptr++;
                 tlen--;
                 if (prefix_len < 2) {
-                    ND_PRINT("\n\t\tAddress: prefix length %u < 2", prefix_len);
+                    ND_PRINT(C_RESET, "\n\t\tAddress: prefix length %u < 2", prefix_len);
                     break;
                 }
                 if (tlen < prefix_len/2)
                     break;
-                ND_PRINT("\n\t\tAddress: %s/%u",
+                ND_PRINT(C_RESET, "\n\t\tAddress: %s/%u",
                        GET_ISONSAP_STRING(tptr, prefix_len / 2), prefix_len * 4);
                 tptr+=prefix_len/2;
                 tlen-=prefix_len/2;
@@ -3460,17 +3464,17 @@ isis_print(netdissect_options *ndo,
         case ISIS_TLV_IIH_SEQNR:
 	    if (tlen < 4)
 	        break;
-            ND_PRINT("\n\t      Sequence number: %u", GET_BE_U_4(tptr));
+            ND_PRINT(C_RESET, "\n\t      Sequence number: %u", GET_BE_U_4(tptr));
             break;
 
         case ISIS_TLV_ROUTER_CAPABILITY:
             if (tlen < 5) {
-                ND_PRINT(" [object length %u < 5]", tlen);
+                ND_PRINT(C_RESET, " [object length %u < 5]", tlen);
                 nd_print_invalid(ndo);
                 break;
             }
-            ND_PRINT("\n\t      Router-ID %s", GET_IPADDR_STRING(tptr));
-            ND_PRINT(", Flags [%s]",
+            ND_PRINT(C_RESET, "\n\t      Router-ID %s", GET_IPADDR_STRING(tptr));
+            ND_PRINT(C_RESET, ", Flags [%s]",
 		     bittok2str(isis_tlv_router_capability_flags, "none", GET_U_1(tptr+4)));
 
 	    /* Optional set of sub-TLV */
@@ -3483,7 +3487,7 @@ isis_print(netdissect_options *ndo,
 	    if (tlen < 3)
 	        break;
             vendor_id = GET_BE_U_3(tptr);
-            ND_PRINT("\n\t      Vendor: %s (%u)",
+            ND_PRINT(C_RESET, "\n\t      Vendor: %s (%u)",
                    tok2str(oui_values, "Unknown", vendor_id),
                    vendor_id);
             tptr+=3;
@@ -3522,7 +3526,7 @@ tlv_trunc:
     }
 
     if (packet_len != 0) {
-	ND_PRINT("\n\t      %u straggler bytes", packet_len);
+	ND_PRINT(C_RESET, "\n\t      %u straggler bytes", packet_len);
     }
     return (1);
 
@@ -3546,16 +3550,16 @@ osi_print_cksum(netdissect_options *ndo, const uint8_t *pptr,
             || !ND_TTEST_2(pptr + checksum_offset)
             || (u_int)checksum_offset > length
             || !ND_TTEST_LEN(pptr, length)) {
-                ND_PRINT(" (unverified)");
+                ND_PRINT(C_RESET, " (unverified)");
         } else {
 #if 0
-                ND_PRINT("\nosi_print_cksum: %p %d %u\n", pptr, checksum_offset, length);
+                ND_PRINT(C_RESET, "\nosi_print_cksum: %p %d %u\n", pptr, checksum_offset, length);
 #endif
                 calculated_checksum = create_osi_cksum(pptr, checksum_offset, length);
                 if (checksum == calculated_checksum) {
-                        ND_PRINT(" (correct)");
+                        ND_PRINT(C_RESET, " (correct)");
                 } else {
-                        ND_PRINT(" (incorrect should be 0x%04x)", calculated_checksum);
+                        ND_PRINT(C_RESET, " (incorrect should be 0x%04x)", calculated_checksum);
                 }
         }
 }

--- a/print-juniper.c
+++ b/print-juniper.c
@@ -498,7 +498,7 @@ juniper_ggsn_if_print(netdissect_options *ndo,
         /* use EXTRACT_, not GET_ (not packet buffer pointer) */
         proto = EXTRACT_U_1(gh->proto);
         if (ndo->ndo_eflag) {
-            ND_PRINT("proto %s (%u), vlan %u: ",
+            ND_PRINT(C_RESET, C_RESET "proto %s (%u), vlan %u: ",
                    tok2str(juniper_protocol_values,"Unknown",proto),
                    proto,
                    EXTRACT_BE_U_2(gh->vlan_id));
@@ -513,7 +513,7 @@ juniper_ggsn_if_print(netdissect_options *ndo,
             break;
         default:
             if (!ndo->ndo_eflag)
-                ND_PRINT("unknown GGSN proto (%u)", proto);
+                ND_PRINT(C_RESET, C_RESET "unknown GGSN proto (%u)", proto);
         }
 
         ndo->ndo_ll_hdr_len += l2info.header_len;
@@ -562,7 +562,7 @@ juniper_es_if_print(netdissect_options *ndo,
             es_type_bundle = 0;
             break;
         default:
-            ND_PRINT("ES Invalid type %u, length %u",
+            ND_PRINT(C_RESET, C_RESET "ES Invalid type %u, length %u",
                    GET_U_1(ih->type),
                    l2info.length);
             ndo->ndo_ll_hdr_len += l2info.header_len;
@@ -574,7 +574,7 @@ juniper_es_if_print(netdissect_options *ndo,
 
         if (ndo->ndo_eflag) {
             if (!es_type_bundle) {
-                ND_PRINT("ES SA, index %u, ttl %u type %s (%u), spi %u, Tunnel %s > %s, length %u\n",
+                ND_PRINT(C_RESET, C_RESET "ES SA, index %u, ttl %u type %s (%u), spi %u, Tunnel %s > %s, length %u\n",
                        GET_BE_U_2(ih->sa_index),
                        GET_U_1(ih->ttl),
                        tok2str(juniper_ipsec_type_values,"Unknown",GET_U_1(ih->type)),
@@ -584,7 +584,7 @@ juniper_es_if_print(netdissect_options *ndo,
                        GET_IPADDR_STRING(ih->dst_ip),
                        l2info.length);
             } else {
-                ND_PRINT("ES SA, index %u, ttl %u type %s (%u), length %u\n",
+                ND_PRINT(C_RESET, C_RESET "ES SA, index %u, ttl %u type %s (%u), length %u\n",
                        GET_BE_U_2(ih->sa_index),
                        GET_U_1(ih->ttl),
                        tok2str(juniper_ipsec_type_values,"Unknown",GET_U_1(ih->type)),
@@ -625,7 +625,7 @@ juniper_monitor_if_print(netdissect_options *ndo,
 
         ND_TCHECK_SIZE(mh);
         if (ndo->ndo_eflag)
-            ND_PRINT("service-id %u, iif %u, pkt-type %u: ",
+            ND_PRINT(C_RESET, C_RESET "service-id %u, iif %u, pkt-type %u: ",
                    GET_BE_U_4(mh->service_id),
                    GET_BE_U_2(mh->iif),
                    GET_U_1(mh->pkt_type));
@@ -665,7 +665,7 @@ juniper_services_if_print(netdissect_options *ndo,
 
         ND_TCHECK_SIZE(sh);
         if (ndo->ndo_eflag)
-            ND_PRINT("service-id %u flags 0x%02x service-set-id 0x%04x iif %u: ",
+            ND_PRINT(C_RESET, C_RESET "service-id %u flags 0x%02x service-set-id 0x%04x iif %u: ",
                    GET_U_1(sh->svc_id),
                    GET_U_1(sh->flags_len),
                    GET_BE_U_2(sh->svc_set_id),
@@ -816,7 +816,7 @@ juniper_pppoe_atm_if_print(netdissect_options *ndo,
                               l2info.caplen-ETHERTYPE_LEN,
                               NULL, NULL) == 0)
             /* ether_type not known, probably it wasn't one */
-            ND_PRINT("unknown ethertype 0x%04x", extracted_ethertype);
+            ND_PRINT(C_RESET, C_RESET "unknown ethertype 0x%04x", extracted_ethertype);
 
         ndo->ndo_ll_hdr_len += l2info.header_len;
 }
@@ -844,7 +844,7 @@ juniper_mlppp_if_print(netdissect_options *ndo,
             EXTRACT_BE_U_2(&l2info.cookie) != PPP_OSI &&
             /* use EXTRACT_, not GET_ (not packet buffer pointer) */
             EXTRACT_BE_U_2(&l2info.cookie) !=  (PPP_ADDRESS << 8 | PPP_CONTROL))
-            ND_PRINT("Bundle-ID %u: ", l2info.bundle);
+            ND_PRINT(C_RESET, C_RESET "Bundle-ID %u: ", l2info.bundle);
 
         p+=l2info.header_len;
 
@@ -946,7 +946,7 @@ juniper_mfr_if_print(netdissect_options *ndo,
         /* suppress Bundle-ID if frame was captured on a child-link */
         /* use EXTRACT_, not GET_ (not packet buffer pointer) */
         if (ndo->ndo_eflag && EXTRACT_BE_U_4(l2info.cookie) != 1)
-            ND_PRINT("Bundle-ID %u, ", l2info.bundle);
+            ND_PRINT(C_RESET, C_RESET "Bundle-ID %u, ", l2info.bundle);
         switch (l2info.proto) {
         case (LLCSAP_ISONS<<8 | LLCSAP_ISONS):
             /* At least one byte is required */
@@ -960,7 +960,7 @@ juniper_mfr_if_print(netdissect_options *ndo,
             isoclns_print(ndo, p - 1, l2info.length + 1);
             break;
         default:
-            ND_PRINT("unknown protocol 0x%04x, length %u", l2info.proto, l2info.length);
+            ND_PRINT(C_RESET, C_RESET "unknown protocol 0x%04x, length %u", l2info.proto, l2info.length);
         }
 
         ndo->ndo_ll_hdr_len += l2info.header_len;
@@ -987,7 +987,7 @@ juniper_mlfr_if_print(netdissect_options *ndo,
         /* suppress Bundle-ID if frame was captured on a child-link */
         /* use EXTRACT_, not GET_ (not packet buffer pointer) */
         if (ndo->ndo_eflag && EXTRACT_BE_U_4(l2info.cookie) != 1)
-            ND_PRINT("Bundle-ID %u, ", l2info.bundle);
+            ND_PRINT(C_RESET, C_RESET "Bundle-ID %u, ", l2info.bundle);
         switch (l2info.proto) {
         case (LLC_UI):
         case (LLC_UI<<8):
@@ -1000,7 +1000,7 @@ juniper_mlfr_if_print(netdissect_options *ndo,
             isoclns_print(ndo, p - 1, l2info.length + 1);
             break;
         default:
-            ND_PRINT("unknown protocol 0x%04x, length %u", l2info.proto, l2info.length);
+            ND_PRINT(C_RESET, C_RESET "unknown protocol 0x%04x, length %u", l2info.proto, l2info.length);
         }
 
         ndo->ndo_ll_hdr_len += l2info.header_len;
@@ -1288,18 +1288,18 @@ juniper_parse_header(netdissect_options *ndo,
     l2info->direction = GET_U_1(p + 3) & JUNIPER_BPF_PKT_IN;
 
     if (GET_BE_U_3(p) != JUNIPER_MGC_NUMBER) { /* magic number found ? */
-        ND_PRINT("no magic-number found!");
+        ND_PRINT(C_RESET, C_RESET "no magic-number found!");
         return 0;
     }
 
     if (ndo->ndo_eflag) /* print direction */
-        ND_PRINT("%3s ", tok2str(juniper_direction_values, "---", l2info->direction));
+        ND_PRINT(C_RESET, C_RESET "%3s ", tok2str(juniper_direction_values, "---", l2info->direction));
 
     /* magic number + flags */
     jnx_header_len = 4;
 
     if (ndo->ndo_vflag > 1)
-        ND_PRINT("\n\tJuniper PCAP Flags [%s]",
+        ND_PRINT(C_RESET, C_RESET "\n\tJuniper PCAP Flags [%s]",
                bittok2str(jnx_flag_values, "none", l2info->flags));
 
     /* extensions present ?  - calculate how much bytes to skip */
@@ -1318,7 +1318,7 @@ juniper_parse_header(netdissect_options *ndo,
         jnx_header_len += extension_length;
 
         if (ndo->ndo_vflag > 1)
-            ND_PRINT(", PCAP Extension(s) total length %u", extension_length);
+            ND_PRINT(C_RESET, C_RESET ", PCAP Extension(s) total length %u", extension_length);
 
         ND_TCHECK_LEN(tptr, extension_length);
         while (extension_length > JUNIPER_EXT_TLV_OVERHEAD) {
@@ -1335,7 +1335,7 @@ juniper_parse_header(netdissect_options *ndo,
                         tlv_len + JUNIPER_EXT_TLV_OVERHEAD);
 
             if (ndo->ndo_vflag > 1)
-                ND_PRINT("\n\t  %s Extension TLV #%u, length %u, value ",
+                ND_PRINT(C_RESET, C_RESET "\n\t  %s Extension TLV #%u, length %u, value ",
                        tok2str(jnx_ext_tlv_values,"Unknown",tlv_type),
                        tlv_type,
                        tlv_len);
@@ -1349,7 +1349,7 @@ juniper_parse_header(netdissect_options *ndo,
             case JUNIPER_EXT_TLV_TTP_IFD_MEDIATYPE:
                 if (tlv_value != -1) {
                     if (ndo->ndo_vflag > 1)
-                        ND_PRINT("%s (%u)",
+                        ND_PRINT(C_RESET, C_RESET "%s (%u)",
                                tok2str(juniper_ifmt_values, "Unknown", tlv_value),
                                tlv_value);
                 }
@@ -1358,7 +1358,7 @@ juniper_parse_header(netdissect_options *ndo,
             case JUNIPER_EXT_TLV_TTP_IFL_ENCAPS:
                 if (tlv_value != -1) {
                     if (ndo->ndo_vflag > 1)
-                        ND_PRINT("%s (%u)",
+                        ND_PRINT(C_RESET, C_RESET "%s (%u)",
                                tok2str(juniper_ifle_values, "Unknown", tlv_value),
                                tlv_value);
                 }
@@ -1369,7 +1369,7 @@ juniper_parse_header(netdissect_options *ndo,
             default:
                 if (tlv_value != -1) {
                     if (ndo->ndo_vflag > 1)
-                        ND_PRINT("%u", tlv_value);
+                        ND_PRINT(C_RESET, C_RESET "%u", tlv_value);
                 }
                 break;
             }
@@ -1379,12 +1379,12 @@ juniper_parse_header(netdissect_options *ndo,
         }
 
         if (ndo->ndo_vflag > 1)
-            ND_PRINT("\n\t-----original packet-----\n\t");
+            ND_PRINT(C_RESET, C_RESET "\n\t-----original packet-----\n\t");
     }
 
     if ((l2info->flags & JUNIPER_BPF_NO_L2 ) == JUNIPER_BPF_NO_L2 ) {
         if (ndo->ndo_eflag)
-            ND_PRINT("no-L2-hdr, ");
+            ND_PRINT(C_RESET, C_RESET "no-L2-hdr, ");
 
         /* there is no link-layer present -
          * perform the v4/v6 heuristics
@@ -1393,7 +1393,7 @@ juniper_parse_header(netdissect_options *ndo,
         ND_TCHECK_1(p + (jnx_header_len + 4));
         if (ip_heuristic_guess(ndo, p + jnx_header_len + 4,
                                l2info->length - (jnx_header_len + 4)) == 0)
-            ND_PRINT("no IP-hdr found!");
+            ND_PRINT(C_RESET, C_RESET "no IP-hdr found!");
 
         l2info->header_len=jnx_header_len+4;
         return 0; /* stop parsing the output further */
@@ -1447,7 +1447,7 @@ juniper_parse_header(netdissect_options *ndo,
         l2info->caplen -= l2info->cookie_len;
 
         if (ndo->ndo_eflag)
-            ND_PRINT("%s-PIC, cookie-len %u",
+            ND_PRINT(C_RESET, C_RESET "%s-PIC, cookie-len %u",
                    lp->s,
                    l2info->cookie_len);
 
@@ -1459,14 +1459,14 @@ juniper_parse_header(netdissect_options *ndo,
         if (l2info->cookie_len > 0) {
             ND_TCHECK_LEN(p, l2info->cookie_len);
             if (ndo->ndo_eflag)
-                ND_PRINT(", cookie 0x");
+                ND_PRINT(C_RESET, C_RESET ", cookie 0x");
             for (idx = 0; idx < l2info->cookie_len; idx++) {
                 l2info->cookie[idx] = GET_U_1(p + idx); /* copy cookie data */
-                if (ndo->ndo_eflag) ND_PRINT("%02x", GET_U_1(p + idx));
+                if (ndo->ndo_eflag) ND_PRINT(C_RESET, C_RESET "%02x", GET_U_1(p + idx));
             }
         }
 
-        if (ndo->ndo_eflag) ND_PRINT(": "); /* print demarc b/w L2/L3*/
+        if (ndo->ndo_eflag) ND_PRINT(C_RESET, C_RESET ": "); /* print demarc b/w L2/L3*/
 
 
         l2info->proto = GET_BE_U_2(p + l2info->cookie_len);
@@ -1555,7 +1555,7 @@ juniper_parse_header(netdissect_options *ndo,
             }
 
             if (ndo->ndo_eflag)
-                ND_PRINT("control-word 0x%08x ", control_word);
+                ND_PRINT(C_RESET, C_RESET "control-word 0x%08x ", control_word);
         }
         break;
 #endif
@@ -1605,12 +1605,12 @@ juniper_parse_header(netdissect_options *ndo,
 #endif
 
     default:
-        ND_PRINT("Unknown Juniper DLT_ type %u: ", l2info->pictype);
+        ND_PRINT(C_RESET, C_RESET "Unknown Juniper DLT_ type %u: ", l2info->pictype);
         break;
     }
 
     if (ndo->ndo_eflag)
-        ND_PRINT("hlen %u, proto 0x%04x, ", l2info->header_len, l2info->proto);
+        ND_PRINT(C_RESET, C_RESET "hlen %u, proto 0x%04x, ", l2info->header_len, l2info->proto);
 
     return 1; /* everything went ok so far. continue parsing */
 invalid:

--- a/print-juniper.c
+++ b/print-juniper.c
@@ -498,7 +498,7 @@ juniper_ggsn_if_print(netdissect_options *ndo,
         /* use EXTRACT_, not GET_ (not packet buffer pointer) */
         proto = EXTRACT_U_1(gh->proto);
         if (ndo->ndo_eflag) {
-            ND_PRINT(C_RESET, C_RESET "proto %s (%u), vlan %u: ",
+            ND_PRINT(C_RESET, "proto %s (%u), vlan %u: ",
                    tok2str(juniper_protocol_values,"Unknown",proto),
                    proto,
                    EXTRACT_BE_U_2(gh->vlan_id));
@@ -513,7 +513,7 @@ juniper_ggsn_if_print(netdissect_options *ndo,
             break;
         default:
             if (!ndo->ndo_eflag)
-                ND_PRINT(C_RESET, C_RESET "unknown GGSN proto (%u)", proto);
+                ND_PRINT(C_RESET, "unknown GGSN proto (%u)", proto);
         }
 
         ndo->ndo_ll_hdr_len += l2info.header_len;
@@ -562,7 +562,7 @@ juniper_es_if_print(netdissect_options *ndo,
             es_type_bundle = 0;
             break;
         default:
-            ND_PRINT(C_RESET, C_RESET "ES Invalid type %u, length %u",
+            ND_PRINT(C_RESET, "ES Invalid type %u, length %u",
                    GET_U_1(ih->type),
                    l2info.length);
             ndo->ndo_ll_hdr_len += l2info.header_len;
@@ -574,7 +574,7 @@ juniper_es_if_print(netdissect_options *ndo,
 
         if (ndo->ndo_eflag) {
             if (!es_type_bundle) {
-                ND_PRINT(C_RESET, C_RESET "ES SA, index %u, ttl %u type %s (%u), spi %u, Tunnel %s > %s, length %u\n",
+                ND_PRINT(C_RESET, "ES SA, index %u, ttl %u type %s (%u), spi %u, Tunnel %s > %s, length %u\n",
                        GET_BE_U_2(ih->sa_index),
                        GET_U_1(ih->ttl),
                        tok2str(juniper_ipsec_type_values,"Unknown",GET_U_1(ih->type)),
@@ -584,7 +584,7 @@ juniper_es_if_print(netdissect_options *ndo,
                        GET_IPADDR_STRING(ih->dst_ip),
                        l2info.length);
             } else {
-                ND_PRINT(C_RESET, C_RESET "ES SA, index %u, ttl %u type %s (%u), length %u\n",
+                ND_PRINT(C_RESET, "ES SA, index %u, ttl %u type %s (%u), length %u\n",
                        GET_BE_U_2(ih->sa_index),
                        GET_U_1(ih->ttl),
                        tok2str(juniper_ipsec_type_values,"Unknown",GET_U_1(ih->type)),
@@ -625,7 +625,7 @@ juniper_monitor_if_print(netdissect_options *ndo,
 
         ND_TCHECK_SIZE(mh);
         if (ndo->ndo_eflag)
-            ND_PRINT(C_RESET, C_RESET "service-id %u, iif %u, pkt-type %u: ",
+            ND_PRINT(C_RESET, "service-id %u, iif %u, pkt-type %u: ",
                    GET_BE_U_4(mh->service_id),
                    GET_BE_U_2(mh->iif),
                    GET_U_1(mh->pkt_type));
@@ -665,7 +665,7 @@ juniper_services_if_print(netdissect_options *ndo,
 
         ND_TCHECK_SIZE(sh);
         if (ndo->ndo_eflag)
-            ND_PRINT(C_RESET, C_RESET "service-id %u flags 0x%02x service-set-id 0x%04x iif %u: ",
+            ND_PRINT(C_RESET, "service-id %u flags 0x%02x service-set-id 0x%04x iif %u: ",
                    GET_U_1(sh->svc_id),
                    GET_U_1(sh->flags_len),
                    GET_BE_U_2(sh->svc_set_id),
@@ -816,7 +816,7 @@ juniper_pppoe_atm_if_print(netdissect_options *ndo,
                               l2info.caplen-ETHERTYPE_LEN,
                               NULL, NULL) == 0)
             /* ether_type not known, probably it wasn't one */
-            ND_PRINT(C_RESET, C_RESET "unknown ethertype 0x%04x", extracted_ethertype);
+            ND_PRINT(C_RESET, "unknown ethertype 0x%04x", extracted_ethertype);
 
         ndo->ndo_ll_hdr_len += l2info.header_len;
 }
@@ -844,7 +844,7 @@ juniper_mlppp_if_print(netdissect_options *ndo,
             EXTRACT_BE_U_2(&l2info.cookie) != PPP_OSI &&
             /* use EXTRACT_, not GET_ (not packet buffer pointer) */
             EXTRACT_BE_U_2(&l2info.cookie) !=  (PPP_ADDRESS << 8 | PPP_CONTROL))
-            ND_PRINT(C_RESET, C_RESET "Bundle-ID %u: ", l2info.bundle);
+            ND_PRINT(C_RESET, "Bundle-ID %u: ", l2info.bundle);
 
         p+=l2info.header_len;
 
@@ -946,7 +946,7 @@ juniper_mfr_if_print(netdissect_options *ndo,
         /* suppress Bundle-ID if frame was captured on a child-link */
         /* use EXTRACT_, not GET_ (not packet buffer pointer) */
         if (ndo->ndo_eflag && EXTRACT_BE_U_4(l2info.cookie) != 1)
-            ND_PRINT(C_RESET, C_RESET "Bundle-ID %u, ", l2info.bundle);
+            ND_PRINT(C_RESET, "Bundle-ID %u, ", l2info.bundle);
         switch (l2info.proto) {
         case (LLCSAP_ISONS<<8 | LLCSAP_ISONS):
             /* At least one byte is required */
@@ -960,7 +960,7 @@ juniper_mfr_if_print(netdissect_options *ndo,
             isoclns_print(ndo, p - 1, l2info.length + 1);
             break;
         default:
-            ND_PRINT(C_RESET, C_RESET "unknown protocol 0x%04x, length %u", l2info.proto, l2info.length);
+            ND_PRINT(C_RESET, "unknown protocol 0x%04x, length %u", l2info.proto, l2info.length);
         }
 
         ndo->ndo_ll_hdr_len += l2info.header_len;
@@ -987,7 +987,7 @@ juniper_mlfr_if_print(netdissect_options *ndo,
         /* suppress Bundle-ID if frame was captured on a child-link */
         /* use EXTRACT_, not GET_ (not packet buffer pointer) */
         if (ndo->ndo_eflag && EXTRACT_BE_U_4(l2info.cookie) != 1)
-            ND_PRINT(C_RESET, C_RESET "Bundle-ID %u, ", l2info.bundle);
+            ND_PRINT(C_RESET, "Bundle-ID %u, ", l2info.bundle);
         switch (l2info.proto) {
         case (LLC_UI):
         case (LLC_UI<<8):
@@ -1000,7 +1000,7 @@ juniper_mlfr_if_print(netdissect_options *ndo,
             isoclns_print(ndo, p - 1, l2info.length + 1);
             break;
         default:
-            ND_PRINT(C_RESET, C_RESET "unknown protocol 0x%04x, length %u", l2info.proto, l2info.length);
+            ND_PRINT(C_RESET, "unknown protocol 0x%04x, length %u", l2info.proto, l2info.length);
         }
 
         ndo->ndo_ll_hdr_len += l2info.header_len;
@@ -1288,18 +1288,18 @@ juniper_parse_header(netdissect_options *ndo,
     l2info->direction = GET_U_1(p + 3) & JUNIPER_BPF_PKT_IN;
 
     if (GET_BE_U_3(p) != JUNIPER_MGC_NUMBER) { /* magic number found ? */
-        ND_PRINT(C_RESET, C_RESET "no magic-number found!");
+        ND_PRINT(C_RESET, "no magic-number found!");
         return 0;
     }
 
     if (ndo->ndo_eflag) /* print direction */
-        ND_PRINT(C_RESET, C_RESET "%3s ", tok2str(juniper_direction_values, "---", l2info->direction));
+        ND_PRINT(C_RESET, "%3s ", tok2str(juniper_direction_values, "---", l2info->direction));
 
     /* magic number + flags */
     jnx_header_len = 4;
 
     if (ndo->ndo_vflag > 1)
-        ND_PRINT(C_RESET, C_RESET "\n\tJuniper PCAP Flags [%s]",
+        ND_PRINT(C_RESET, "\n\tJuniper PCAP Flags [%s]",
                bittok2str(jnx_flag_values, "none", l2info->flags));
 
     /* extensions present ?  - calculate how much bytes to skip */
@@ -1318,7 +1318,7 @@ juniper_parse_header(netdissect_options *ndo,
         jnx_header_len += extension_length;
 
         if (ndo->ndo_vflag > 1)
-            ND_PRINT(C_RESET, C_RESET ", PCAP Extension(s) total length %u", extension_length);
+            ND_PRINT(C_RESET, ", PCAP Extension(s) total length %u", extension_length);
 
         ND_TCHECK_LEN(tptr, extension_length);
         while (extension_length > JUNIPER_EXT_TLV_OVERHEAD) {
@@ -1335,7 +1335,7 @@ juniper_parse_header(netdissect_options *ndo,
                         tlv_len + JUNIPER_EXT_TLV_OVERHEAD);
 
             if (ndo->ndo_vflag > 1)
-                ND_PRINT(C_RESET, C_RESET "\n\t  %s Extension TLV #%u, length %u, value ",
+                ND_PRINT(C_RESET, "\n\t  %s Extension TLV #%u, length %u, value ",
                        tok2str(jnx_ext_tlv_values,"Unknown",tlv_type),
                        tlv_type,
                        tlv_len);
@@ -1349,7 +1349,7 @@ juniper_parse_header(netdissect_options *ndo,
             case JUNIPER_EXT_TLV_TTP_IFD_MEDIATYPE:
                 if (tlv_value != -1) {
                     if (ndo->ndo_vflag > 1)
-                        ND_PRINT(C_RESET, C_RESET "%s (%u)",
+                        ND_PRINT(C_RESET, "%s (%u)",
                                tok2str(juniper_ifmt_values, "Unknown", tlv_value),
                                tlv_value);
                 }
@@ -1358,7 +1358,7 @@ juniper_parse_header(netdissect_options *ndo,
             case JUNIPER_EXT_TLV_TTP_IFL_ENCAPS:
                 if (tlv_value != -1) {
                     if (ndo->ndo_vflag > 1)
-                        ND_PRINT(C_RESET, C_RESET "%s (%u)",
+                        ND_PRINT(C_RESET, "%s (%u)",
                                tok2str(juniper_ifle_values, "Unknown", tlv_value),
                                tlv_value);
                 }
@@ -1369,7 +1369,7 @@ juniper_parse_header(netdissect_options *ndo,
             default:
                 if (tlv_value != -1) {
                     if (ndo->ndo_vflag > 1)
-                        ND_PRINT(C_RESET, C_RESET "%u", tlv_value);
+                        ND_PRINT(C_RESET, "%u", tlv_value);
                 }
                 break;
             }
@@ -1379,12 +1379,12 @@ juniper_parse_header(netdissect_options *ndo,
         }
 
         if (ndo->ndo_vflag > 1)
-            ND_PRINT(C_RESET, C_RESET "\n\t-----original packet-----\n\t");
+            ND_PRINT(C_RESET, "\n\t-----original packet-----\n\t");
     }
 
     if ((l2info->flags & JUNIPER_BPF_NO_L2 ) == JUNIPER_BPF_NO_L2 ) {
         if (ndo->ndo_eflag)
-            ND_PRINT(C_RESET, C_RESET "no-L2-hdr, ");
+            ND_PRINT(C_RESET, "no-L2-hdr, ");
 
         /* there is no link-layer present -
          * perform the v4/v6 heuristics
@@ -1393,7 +1393,7 @@ juniper_parse_header(netdissect_options *ndo,
         ND_TCHECK_1(p + (jnx_header_len + 4));
         if (ip_heuristic_guess(ndo, p + jnx_header_len + 4,
                                l2info->length - (jnx_header_len + 4)) == 0)
-            ND_PRINT(C_RESET, C_RESET "no IP-hdr found!");
+            ND_PRINT(C_RESET, "no IP-hdr found!");
 
         l2info->header_len=jnx_header_len+4;
         return 0; /* stop parsing the output further */
@@ -1447,7 +1447,7 @@ juniper_parse_header(netdissect_options *ndo,
         l2info->caplen -= l2info->cookie_len;
 
         if (ndo->ndo_eflag)
-            ND_PRINT(C_RESET, C_RESET "%s-PIC, cookie-len %u",
+            ND_PRINT(C_RESET, "%s-PIC, cookie-len %u",
                    lp->s,
                    l2info->cookie_len);
 
@@ -1459,14 +1459,14 @@ juniper_parse_header(netdissect_options *ndo,
         if (l2info->cookie_len > 0) {
             ND_TCHECK_LEN(p, l2info->cookie_len);
             if (ndo->ndo_eflag)
-                ND_PRINT(C_RESET, C_RESET ", cookie 0x");
+                ND_PRINT(C_RESET, ", cookie 0x");
             for (idx = 0; idx < l2info->cookie_len; idx++) {
                 l2info->cookie[idx] = GET_U_1(p + idx); /* copy cookie data */
-                if (ndo->ndo_eflag) ND_PRINT(C_RESET, C_RESET "%02x", GET_U_1(p + idx));
+                if (ndo->ndo_eflag) ND_PRINT(C_RESET, "%02x", GET_U_1(p + idx));
             }
         }
 
-        if (ndo->ndo_eflag) ND_PRINT(C_RESET, C_RESET ": "); /* print demarc b/w L2/L3*/
+        if (ndo->ndo_eflag) ND_PRINT(C_RESET, ": "); /* print demarc b/w L2/L3*/
 
 
         l2info->proto = GET_BE_U_2(p + l2info->cookie_len);
@@ -1555,7 +1555,7 @@ juniper_parse_header(netdissect_options *ndo,
             }
 
             if (ndo->ndo_eflag)
-                ND_PRINT(C_RESET, C_RESET "control-word 0x%08x ", control_word);
+                ND_PRINT(C_RESET, "control-word 0x%08x ", control_word);
         }
         break;
 #endif
@@ -1605,12 +1605,12 @@ juniper_parse_header(netdissect_options *ndo,
 #endif
 
     default:
-        ND_PRINT(C_RESET, C_RESET "Unknown Juniper DLT_ type %u: ", l2info->pictype);
+        ND_PRINT(C_RESET, "Unknown Juniper DLT_ type %u: ", l2info->pictype);
         break;
     }
 
     if (ndo->ndo_eflag)
-        ND_PRINT(C_RESET, C_RESET "hlen %u, proto 0x%04x, ", l2info->header_len, l2info->proto);
+        ND_PRINT(C_RESET, "hlen %u, proto 0x%04x, ", l2info->header_len, l2info->proto);
 
     return 1; /* everything went ok so far. continue parsing */
 invalid:

--- a/print-krb.c
+++ b/print-krb.c
@@ -140,9 +140,9 @@ krb4_print_hdr(netdissect_options *ndo,
 #define PRINT		if ((cp = c_print(ndo, cp, ndo->ndo_snapend)) == NULL) goto trunc
 
 	PRINT;
-	ND_PRINT(".");
+	ND_PRINT(C_RESET, ".");
 	PRINT;
-	ND_PRINT("@");
+	ND_PRINT(C_RESET, "@");
 	PRINT;
 	return (cp);
 
@@ -170,7 +170,7 @@ krb4_print(netdissect_options *ndo,
 
 	type = GET_U_1(kp->type) & (0xFF << 1);
 
-	ND_PRINT(" %s %s: ",
+	ND_PRINT(C_RESET, " %s %s: ",
 	    IS_LENDIAN(kp) ? "le" : "be", tok2str(type2str, NULL, type));
 
 	switch (type) {
@@ -179,21 +179,21 @@ krb4_print(netdissect_options *ndo,
 		if ((cp = krb4_print_hdr(ndo, cp)) == NULL)
 			return;
 		cp += 4;	/* ctime */
-		ND_PRINT(" %umin ", GET_U_1(cp) * 5);
+		ND_PRINT(C_RESET, " %umin ", GET_U_1(cp) * 5);
 		cp++;
 		PRINT;
-		ND_PRINT(".");
+		ND_PRINT(C_RESET, ".");
 		PRINT;
 		break;
 
 	case AUTH_MSG_APPL_REQUEST:
 		cp += 2;
-		ND_PRINT("v%u ", GET_U_1(cp));
+		ND_PRINT(C_RESET, "v%u ", GET_U_1(cp));
 		cp++;
 		PRINT;
-		ND_PRINT(" (%u)", GET_U_1(cp));
+		ND_PRINT(C_RESET, " (%u)", GET_U_1(cp));
 		cp++;
-		ND_PRINT(" (%u)", GET_U_1(cp));
+		ND_PRINT(C_RESET, " (%u)", GET_U_1(cp));
 		break;
 
 	case AUTH_MSG_KDC_REPLY:
@@ -201,20 +201,20 @@ krb4_print(netdissect_options *ndo,
 			return;
 		cp += 10;	/* timestamp + n + exp + kvno */
 		len = KTOHSP(kp, cp);
-		ND_PRINT(" (%u)", len);
+		ND_PRINT(C_RESET, " (%u)", len);
 		break;
 
 	case AUTH_MSG_ERR_REPLY:
 		if ((cp = krb4_print_hdr(ndo, cp)) == NULL)
 			return;
 		cp += 4; 	  /* timestamp */
-		ND_PRINT(" %s ", tok2str(kerr2str, NULL, KTOHSP(kp, cp)));
+		ND_PRINT(C_RESET, " %s ", tok2str(kerr2str, NULL, KTOHSP(kp, cp)));
 		cp += 4;
 		PRINT;
 		break;
 
 	default:
-		ND_PRINT("(unknown)");
+		ND_PRINT(C_RESET, "(unknown)");
 		break;
 	}
 
@@ -239,17 +239,17 @@ krb_print(netdissect_options *ndo,
 	case 1:
 	case 2:
 	case 3:
-		ND_PRINT(" v%u", GET_U_1(kp->pvno));
+		ND_PRINT(C_RESET, " v%u", GET_U_1(kp->pvno));
 		break;
 
 	case 4:
-		ND_PRINT(" v%u", GET_U_1(kp->pvno));
+		ND_PRINT(C_RESET, " v%u", GET_U_1(kp->pvno));
 		krb4_print(ndo, (const u_char *)kp);
 		break;
 
 	case 106:
 	case 107:
-		ND_PRINT(" v5");
+		ND_PRINT(C_RESET, " v5");
 		/* Decode ASN.1 here "someday" */
 		break;
 	}

--- a/print-l2tp.c
+++ b/print-l2tp.c
@@ -280,7 +280,7 @@ print_octets(netdissect_options *ndo, const u_char *dat, u_int length)
 {
 	u_int i;
 	for (i=0; i<length; i++) {
-		ND_PRINT("%02x", GET_U_1(dat));
+		ND_PRINT(C_RESET, "%02x", GET_U_1(dat));
 		dat++;
 	}
 }
@@ -288,13 +288,13 @@ print_octets(netdissect_options *ndo, const u_char *dat, u_int length)
 static void
 print_16bits_val(netdissect_options *ndo, const uint8_t *dat)
 {
-	ND_PRINT("%u", GET_BE_U_2(dat));
+	ND_PRINT(C_RESET, "%u", GET_BE_U_2(dat));
 }
 
 static void
 print_32bits_val(netdissect_options *ndo, const uint8_t *dat)
 {
-	ND_PRINT("%u", GET_BE_U_4(dat));
+	ND_PRINT(C_RESET, "%u", GET_BE_U_4(dat));
 }
 
 /***********************************/
@@ -304,10 +304,10 @@ static void
 l2tp_msgtype_print(netdissect_options *ndo, const u_char *dat, u_int length)
 {
 	if (length < 2) {
-		ND_PRINT("AVP too short");
+		ND_PRINT(C_RESET, "AVP too short");
 		return;
 	}
-	ND_PRINT("%s", tok2str(l2tp_msgtype2str, "MSGTYPE-#%u",
+	ND_PRINT(C_RESET, "%s", tok2str(l2tp_msgtype2str, "MSGTYPE-#%u",
 	    GET_BE_U_2(dat)));
 }
 
@@ -316,10 +316,10 @@ l2tp_result_code_print(netdissect_options *ndo, const u_char *dat, u_int length)
 {
 	/* Result Code */
 	if (length < 2) {
-		ND_PRINT("AVP too short");
+		ND_PRINT(C_RESET, "AVP too short");
 		return;
 	}
-	ND_PRINT("%u", GET_BE_U_2(dat));
+	ND_PRINT(C_RESET, "%u", GET_BE_U_2(dat));
 	dat += 2;
 	length -= 2;
 
@@ -327,17 +327,17 @@ l2tp_result_code_print(netdissect_options *ndo, const u_char *dat, u_int length)
 	if (length == 0)
 		return;
 	if (length < 2) {
-		ND_PRINT(" AVP too short");
+		ND_PRINT(C_RESET, " AVP too short");
 		return;
 	}
-	ND_PRINT("/%u", GET_BE_U_2(dat));
+	ND_PRINT(C_RESET, "/%u", GET_BE_U_2(dat));
 	dat += 2;
 	length -= 2;
 
 	/* Error Message (opt) */
 	if (length == 0)
 		return;
-	ND_PRINT(" ");
+	ND_PRINT(C_RESET, " ");
 	print_string(ndo, dat, length);
 }
 
@@ -345,10 +345,10 @@ static void
 l2tp_proto_ver_print(netdissect_options *ndo, const u_char *dat, u_int length)
 {
 	if (length < 2) {
-		ND_PRINT("AVP too short");
+		ND_PRINT(C_RESET, "AVP too short");
 		return;
 	}
-	ND_PRINT("%u.%u", (GET_BE_U_2(dat) >> 8),
+	ND_PRINT(C_RESET, "%u.%u", (GET_BE_U_2(dat) >> 8),
 		  (GET_BE_U_2(dat) & 0xff));
 }
 
@@ -356,14 +356,14 @@ static void
 l2tp_framing_cap_print(netdissect_options *ndo, const u_char *dat, u_int length)
 {
 	if (length < 4) {
-		ND_PRINT("AVP too short");
+		ND_PRINT(C_RESET, "AVP too short");
 		return;
 	}
 	if (GET_BE_U_4(dat) &  L2TP_FRAMING_CAP_ASYNC_MASK) {
-		ND_PRINT("A");
+		ND_PRINT(C_RESET, "A");
 	}
 	if (GET_BE_U_4(dat) &  L2TP_FRAMING_CAP_SYNC_MASK) {
-		ND_PRINT("S");
+		ND_PRINT(C_RESET, "S");
 	}
 }
 
@@ -371,14 +371,14 @@ static void
 l2tp_bearer_cap_print(netdissect_options *ndo, const u_char *dat, u_int length)
 {
 	if (length < 4) {
-		ND_PRINT("AVP too short");
+		ND_PRINT(C_RESET, "AVP too short");
 		return;
 	}
 	if (GET_BE_U_4(dat) &  L2TP_BEARER_CAP_ANALOG_MASK) {
-		ND_PRINT("A");
+		ND_PRINT(C_RESET, "A");
 	}
 	if (GET_BE_U_4(dat) &  L2TP_BEARER_CAP_DIGITAL_MASK) {
-		ND_PRINT("D");
+		ND_PRINT(C_RESET, "D");
 	}
 }
 
@@ -386,15 +386,15 @@ static void
 l2tp_q931_cc_print(netdissect_options *ndo, const u_char *dat, u_int length)
 {
 	if (length < 3) {
-		ND_PRINT("AVP too short");
+		ND_PRINT(C_RESET, "AVP too short");
 		return;
 	}
 	print_16bits_val(ndo, dat);
-	ND_PRINT(", %02x", GET_U_1(dat + 2));
+	ND_PRINT(C_RESET, ", %02x", GET_U_1(dat + 2));
 	dat += 3;
 	length -= 3;
 	if (length != 0) {
-		ND_PRINT(" ");
+		ND_PRINT(C_RESET, " ");
 		print_string(ndo, dat, length);
 	}
 }
@@ -403,14 +403,14 @@ static void
 l2tp_bearer_type_print(netdissect_options *ndo, const u_char *dat, u_int length)
 {
 	if (length < 4) {
-		ND_PRINT("AVP too short");
+		ND_PRINT(C_RESET, "AVP too short");
 		return;
 	}
 	if (GET_BE_U_4(dat) &  L2TP_BEARER_TYPE_ANALOG_MASK) {
-		ND_PRINT("A");
+		ND_PRINT(C_RESET, "A");
 	}
 	if (GET_BE_U_4(dat) &  L2TP_BEARER_TYPE_DIGITAL_MASK) {
-		ND_PRINT("D");
+		ND_PRINT(C_RESET, "D");
 	}
 }
 
@@ -418,31 +418,31 @@ static void
 l2tp_framing_type_print(netdissect_options *ndo, const u_char *dat, u_int length)
 {
 	if (length < 4) {
-		ND_PRINT("AVP too short");
+		ND_PRINT(C_RESET, "AVP too short");
 		return;
 	}
 	if (GET_BE_U_4(dat) &  L2TP_FRAMING_TYPE_ASYNC_MASK) {
-		ND_PRINT("A");
+		ND_PRINT(C_RESET, "A");
 	}
 	if (GET_BE_U_4(dat) &  L2TP_FRAMING_TYPE_SYNC_MASK) {
-		ND_PRINT("S");
+		ND_PRINT(C_RESET, "S");
 	}
 }
 
 static void
 l2tp_packet_proc_delay_print(netdissect_options *ndo)
 {
-	ND_PRINT("obsolete");
+	ND_PRINT(C_RESET, "obsolete");
 }
 
 static void
 l2tp_proxy_auth_type_print(netdissect_options *ndo, const u_char *dat, u_int length)
 {
 	if (length < 2) {
-		ND_PRINT("AVP too short");
+		ND_PRINT(C_RESET, "AVP too short");
 		return;
 	}
-	ND_PRINT("%s", tok2str(l2tp_authentype2str,
+	ND_PRINT(C_RESET, "%s", tok2str(l2tp_authentype2str,
 			     "AuthType-#%u", GET_BE_U_2(dat)));
 }
 
@@ -450,10 +450,10 @@ static void
 l2tp_proxy_auth_id_print(netdissect_options *ndo, const u_char *dat, u_int length)
 {
 	if (length < 2) {
-		ND_PRINT("AVP too short");
+		ND_PRINT(C_RESET, "AVP too short");
 		return;
 	}
-	ND_PRINT("%u", GET_BE_U_2(dat) & L2TP_PROXY_AUTH_ID_MASK);
+	ND_PRINT(C_RESET, "%u", GET_BE_U_2(dat) & L2TP_PROXY_AUTH_ID_MASK);
 }
 
 static void
@@ -462,53 +462,53 @@ l2tp_call_errors_print(netdissect_options *ndo, const u_char *dat, u_int length)
 	uint32_t val;
 
 	if (length < 2) {
-		ND_PRINT("AVP too short");
+		ND_PRINT(C_RESET, "AVP too short");
 		return;
 	}
 	dat += 2;	/* skip "Reserved" */
 	length -= 2;
 
 	if (length < 4) {
-		ND_PRINT("AVP too short");
+		ND_PRINT(C_RESET, "AVP too short");
 		return;
 	}
 	val = GET_BE_U_4(dat); dat += 4; length -= 4;
-	ND_PRINT("CRCErr=%u ", val);
+	ND_PRINT(C_RESET, "CRCErr=%u ", val);
 
 	if (length < 4) {
-		ND_PRINT("AVP too short");
+		ND_PRINT(C_RESET, "AVP too short");
 		return;
 	}
 	val = GET_BE_U_4(dat); dat += 4; length -= 4;
-	ND_PRINT("FrameErr=%u ", val);
+	ND_PRINT(C_RESET, "FrameErr=%u ", val);
 
 	if (length < 4) {
-		ND_PRINT("AVP too short");
+		ND_PRINT(C_RESET, "AVP too short");
 		return;
 	}
 	val = GET_BE_U_4(dat); dat += 4; length -= 4;
-	ND_PRINT("HardOver=%u ", val);
+	ND_PRINT(C_RESET, "HardOver=%u ", val);
 
 	if (length < 4) {
-		ND_PRINT("AVP too short");
+		ND_PRINT(C_RESET, "AVP too short");
 		return;
 	}
 	val = GET_BE_U_4(dat); dat += 4; length -= 4;
-	ND_PRINT("BufOver=%u ", val);
+	ND_PRINT(C_RESET, "BufOver=%u ", val);
 
 	if (length < 4) {
-		ND_PRINT("AVP too short");
+		ND_PRINT(C_RESET, "AVP too short");
 		return;
 	}
 	val = GET_BE_U_4(dat); dat += 4; length -= 4;
-	ND_PRINT("Timeout=%u ", val);
+	ND_PRINT(C_RESET, "Timeout=%u ", val);
 
 	if (length < 4) {
-		ND_PRINT("AVP too short");
+		ND_PRINT(C_RESET, "AVP too short");
 		return;
 	}
 	val = GET_BE_U_4(dat); dat += 4; length -= 4;
-	ND_PRINT("AlignErr=%u ", val);
+	ND_PRINT(C_RESET, "AlignErr=%u ", val);
 }
 
 static void
@@ -517,50 +517,50 @@ l2tp_accm_print(netdissect_options *ndo, const u_char *dat, u_int length)
 	uint32_t val;
 
 	if (length < 2) {
-		ND_PRINT("AVP too short");
+		ND_PRINT(C_RESET, "AVP too short");
 		return;
 	}
 	dat += 2;	/* skip "Reserved" */
 	length -= 2;
 
 	if (length < 4) {
-		ND_PRINT("AVP too short");
+		ND_PRINT(C_RESET, "AVP too short");
 		return;
 	}
 	val = GET_BE_U_4(dat); dat += 4; length -= 4;
-	ND_PRINT("send=%08x ", val);
+	ND_PRINT(C_RESET, "send=%08x ", val);
 
 	if (length < 4) {
-		ND_PRINT("AVP too short");
+		ND_PRINT(C_RESET, "AVP too short");
 		return;
 	}
 	val = GET_BE_U_4(dat); dat += 4; length -= 4;
-	ND_PRINT("recv=%08x ", val);
+	ND_PRINT(C_RESET, "recv=%08x ", val);
 }
 
 static void
 l2tp_ppp_discon_cc_print(netdissect_options *ndo, const u_char *dat, u_int length)
 {
 	if (length < 5) {
-		ND_PRINT("AVP too short");
+		ND_PRINT(C_RESET, "AVP too short");
 		return;
 	}
 	/* Disconnect Code */
-	ND_PRINT("%04x, ", GET_BE_U_2(dat));
+	ND_PRINT(C_RESET, "%04x, ", GET_BE_U_2(dat));
 	dat += 2;
 	length -= 2;
 	/* Control Protocol Number */
-	ND_PRINT("%04x ",  GET_BE_U_2(dat));
+	ND_PRINT(C_RESET, "%04x ",  GET_BE_U_2(dat));
 	dat += 2;
 	length -= 2;
 	/* Direction */
-	ND_PRINT("%s", tok2str(l2tp_cc_direction2str,
+	ND_PRINT(C_RESET, "%s", tok2str(l2tp_cc_direction2str,
 			     "Direction-#%u", GET_U_1(dat)));
 	dat++;
 	length--;
 
 	if (length != 0) {
-		ND_PRINT(" ");
+		ND_PRINT(C_RESET, " ");
 		print_string(ndo, (const u_char *)dat, length);
 	}
 }
@@ -572,7 +572,7 @@ l2tp_avp_print(netdissect_options *ndo, const u_char *dat, u_int length)
 	uint16_t attr_type;
 	int hidden = FALSE;
 
-	ND_PRINT(" ");
+	ND_PRINT(C_RESET, " ");
 	/* Flags & Length */
 	len = GET_BE_U_2(dat) & L2TP_AVP_HDR_LEN_MASK;
 
@@ -582,7 +582,7 @@ l2tp_avp_print(netdissect_options *ndo, const u_char *dat, u_int length)
 	/* If it goes past the end of the remaining length of the packet,
 	   we'll give up. */
 	if (len > length) {
-		ND_PRINT(" (len > %u)", length);
+		ND_PRINT(C_RESET, " (len > %u)", length);
 		goto invalid;
 	}
 
@@ -597,29 +597,29 @@ l2tp_avp_print(netdissect_options *ndo, const u_char *dat, u_int length)
 	 */
 
 	if (GET_BE_U_2(dat) & L2TP_AVP_HDR_FLAG_MANDATORY) {
-		ND_PRINT("*");
+		ND_PRINT(C_RESET, "*");
 	}
 	if (GET_BE_U_2(dat) & L2TP_AVP_HDR_FLAG_HIDDEN) {
 		hidden = TRUE;
-		ND_PRINT("?");
+		ND_PRINT(C_RESET, "?");
 	}
 	dat += 2;
 
 	if (GET_BE_U_2(dat)) {
 		/* Vendor Specific Attribute */
-	        ND_PRINT("VENDOR%04x:", GET_BE_U_2(dat)); dat += 2;
-		ND_PRINT("ATTR%04x", GET_BE_U_2(dat)); dat += 2;
-		ND_PRINT("(");
+	        ND_PRINT(C_RESET, "VENDOR%04x:", GET_BE_U_2(dat)); dat += 2;
+		ND_PRINT(C_RESET, "ATTR%04x", GET_BE_U_2(dat)); dat += 2;
+		ND_PRINT(C_RESET, "(");
 		print_octets(ndo, dat, len-6);
-		ND_PRINT(")");
+		ND_PRINT(C_RESET, ")");
 	} else {
 		/* IETF-defined Attributes */
 		dat += 2;
 		attr_type = GET_BE_U_2(dat); dat += 2;
-		ND_PRINT("%s", tok2str(l2tp_avp2str, "AVP-#%u", attr_type));
-		ND_PRINT("(");
+		ND_PRINT(C_RESET, "%s", tok2str(l2tp_avp2str, "AVP-#%u", attr_type));
+		ND_PRINT(C_RESET, "(");
 		if (hidden) {
-			ND_PRINT("???");
+			ND_PRINT(C_RESET, "???");
 		} else {
 			switch (attr_type) {
 			case L2TP_AVP_MSGTYPE:
@@ -639,7 +639,7 @@ l2tp_avp_print(netdissect_options *ndo, const u_char *dat, u_int length)
 				break;
 			case L2TP_AVP_TIE_BREAKER:
 				if (len-6 < 8) {
-					ND_PRINT("AVP too short");
+					ND_PRINT(C_RESET, "AVP too short");
 					break;
 				}
 				print_octets(ndo, dat, 8);
@@ -649,7 +649,7 @@ l2tp_avp_print(netdissect_options *ndo, const u_char *dat, u_int length)
 			case L2TP_AVP_RECV_WIN_SIZE:
 			case L2TP_AVP_ASSND_SESS_ID:
 				if (len-6 < 2) {
-					ND_PRINT("AVP too short");
+					ND_PRINT(C_RESET, "AVP too short");
 					break;
 				}
 				print_16bits_val(ndo, dat);
@@ -677,7 +677,7 @@ l2tp_avp_print(netdissect_options *ndo, const u_char *dat, u_int length)
 				break;
 			case L2TP_AVP_CHALLENGE_RESP:
 				if (len-6 < 16) {
-					ND_PRINT("AVP too short");
+					ND_PRINT(C_RESET, "AVP too short");
 					break;
 				}
 				print_octets(ndo, dat, 16);
@@ -689,7 +689,7 @@ l2tp_avp_print(netdissect_options *ndo, const u_char *dat, u_int length)
 			case L2TP_AVP_PHY_CHANNEL_ID:
 			case L2TP_AVP_RX_CONN_SPEED:
 				if (len-6 < 4) {
-					ND_PRINT("AVP too short");
+					ND_PRINT(C_RESET, "AVP too short");
 					break;
 				}
 				print_32bits_val(ndo, dat);
@@ -724,7 +724,7 @@ l2tp_avp_print(netdissect_options *ndo, const u_char *dat, u_int length)
 				break;
 			}
 		}
-		ND_PRINT(")");
+		ND_PRINT(C_RESET, ")");
 	}
 
 	return (len);
@@ -747,35 +747,35 @@ l2tp_print(netdissect_options *ndo, const u_char *dat, u_int length)
 	flag_t = flag_l = flag_s = flag_o = FALSE;
 
 	if ((GET_BE_U_2(ptr) & L2TP_VERSION_MASK) == L2TP_VERSION_L2TP) {
-		ND_PRINT(" l2tp:");
+		ND_PRINT(C_RESET, " l2tp:");
 	} else if ((GET_BE_U_2(ptr) & L2TP_VERSION_MASK) == L2TP_VERSION_L2F) {
-		ND_PRINT(" l2f:");
+		ND_PRINT(C_RESET, " l2f:");
 		return;		/* nothing to do */
 	} else {
-		ND_PRINT(" Unknown Version, neither L2F(1) nor L2TP(2)");
+		ND_PRINT(C_RESET, " Unknown Version, neither L2F(1) nor L2TP(2)");
 		return;		/* nothing we can do */
 	}
 
-	ND_PRINT("[");
+	ND_PRINT(C_RESET, "[");
 	if (GET_BE_U_2(ptr) & L2TP_FLAG_TYPE) {
 		flag_t = TRUE;
-		ND_PRINT("T");
+		ND_PRINT(C_RESET, "T");
 	}
 	if (GET_BE_U_2(ptr) & L2TP_FLAG_LENGTH) {
 		flag_l = TRUE;
-		ND_PRINT("L");
+		ND_PRINT(C_RESET, "L");
 	}
 	if (GET_BE_U_2(ptr) & L2TP_FLAG_SEQUENCE) {
 		flag_s = TRUE;
-		ND_PRINT("S");
+		ND_PRINT(C_RESET, "S");
 	}
 	if (GET_BE_U_2(ptr) & L2TP_FLAG_OFFSET) {
 		flag_o = TRUE;
-		ND_PRINT("O");
+		ND_PRINT(C_RESET, "O");
 	}
 	if (GET_BE_U_2(ptr) & L2TP_FLAG_PRIORITY)
-		ND_PRINT("P");
-	ND_PRINT("]");
+		ND_PRINT(C_RESET, "P");
+	ND_PRINT(C_RESET, "]");
 
 	ptr += 2;
 	cnt += 2;
@@ -788,19 +788,19 @@ l2tp_print(netdissect_options *ndo, const u_char *dat, u_int length)
 		l2tp_len = 0;
 	}
 	/* Tunnel ID */
-	ND_PRINT("(%u/", GET_BE_U_2(ptr));
+	ND_PRINT(C_RESET, "(%u/", GET_BE_U_2(ptr));
 	ptr += 2;
 	cnt += 2;
 	/* Session ID */
-	ND_PRINT("%u)",  GET_BE_U_2(ptr));
+	ND_PRINT(C_RESET, "%u)",  GET_BE_U_2(ptr));
 	ptr += 2;
 	cnt += 2;
 
 	if (flag_s) {
-		ND_PRINT("Ns=%u,", GET_BE_U_2(ptr));
+		ND_PRINT(C_RESET, "Ns=%u,", GET_BE_U_2(ptr));
 		ptr += 2;
 		cnt += 2;
-		ND_PRINT("Nr=%u",  GET_BE_U_2(ptr));
+		ND_PRINT(C_RESET, "Nr=%u",  GET_BE_U_2(ptr));
 		ptr += 2;
 		cnt += 2;
 	}
@@ -815,22 +815,22 @@ l2tp_print(netdissect_options *ndo, const u_char *dat, u_int length)
 
 	if (flag_l) {
 		if (length < l2tp_len) {
-			ND_PRINT(" Length %u larger than packet", l2tp_len);
+			ND_PRINT(C_RESET, " Length %u larger than packet", l2tp_len);
 			goto invalid;
 		}
 		length = l2tp_len;
 	}
 	if (length < cnt) {
-		ND_PRINT(" Length %u smaller than header length", length);
+		ND_PRINT(C_RESET, " Length %u smaller than header length", length);
 		goto invalid;
 	}
 	if (flag_t) {
 		if (!flag_l) {
-			ND_PRINT(" No length");
+			ND_PRINT(C_RESET, " No length");
 			goto invalid;
 		}
 		if (length - cnt == 0) {
-			ND_PRINT(" ZLB");
+			ND_PRINT(C_RESET, " ZLB");
 		} else {
 			/*
 			 * Print AVPs.
@@ -847,9 +847,9 @@ l2tp_print(netdissect_options *ndo, const u_char *dat, u_int length)
 			}
 		}
 	} else {
-		ND_PRINT(" {");
+		ND_PRINT(C_RESET, " {");
 		ppp_print(ndo, ptr, length - cnt);
-		ND_PRINT("}");
+		ND_PRINT(C_RESET, "}");
 	}
 	return;
 invalid:

--- a/print-lane.c
+++ b/print-lane.c
@@ -69,7 +69,7 @@ static const struct tok lecop2str[] = {
 static void
 lane_hdr_print(netdissect_options *ndo, const u_char *bp)
 {
-	ND_PRINT("lecid:%x ", GET_BE_U_2(bp));
+	ND_PRINT(C_RESET, C_RESET "lecid:%x ", GET_BE_U_2(bp));
 }
 
 /*
@@ -87,7 +87,7 @@ lane_print(netdissect_options *ndo, const u_char *p, u_int length, u_int caplen)
 		/*
 		 * LE Control.
 		 */
-		ND_PRINT("lec: proto %x vers %x %s",
+		ND_PRINT(C_RESET, C_RESET "lec: proto %x vers %x %s",
 			 GET_U_1(lec->lec_proto),
 			 GET_U_1(lec->lec_vers),
 			 tok2str(lecop2str, "opcode-#%u", GET_BE_U_2(lec->lec_opcode)));

--- a/print-lane.c
+++ b/print-lane.c
@@ -69,7 +69,7 @@ static const struct tok lecop2str[] = {
 static void
 lane_hdr_print(netdissect_options *ndo, const u_char *bp)
 {
-	ND_PRINT(C_RESET, C_RESET "lecid:%x ", GET_BE_U_2(bp));
+	ND_PRINT(C_RESET, "lecid:%x ", GET_BE_U_2(bp));
 }
 
 /*
@@ -87,7 +87,7 @@ lane_print(netdissect_options *ndo, const u_char *p, u_int length, u_int caplen)
 		/*
 		 * LE Control.
 		 */
-		ND_PRINT(C_RESET, C_RESET "lec: proto %x vers %x %s",
+		ND_PRINT(C_RESET, "lec: proto %x vers %x %s",
 			 GET_U_1(lec->lec_proto),
 			 GET_U_1(lec->lec_vers),
 			 tok2str(lecop2str, "opcode-#%u", GET_BE_U_2(lec->lec_opcode)));

--- a/print-ldp.c
+++ b/print-ldp.c
@@ -232,7 +232,7 @@ static u_int ldp_pdu_print(netdissect_options *, const u_char *);
 
 #define TLV_TCHECK(minlen) \
     if (tlv_tlen < minlen) { \
-        ND_PRINT(" [tlv length %u < %u]", tlv_tlen, minlen); \
+        ND_PRINT(C_RESET, " [tlv length %u < %u]", tlv_tlen, minlen); \
         nd_print_invalid(ndo); \
         goto invalid; \
     }
@@ -258,14 +258,14 @@ ldp_tlv_print(netdissect_options *ndo,
     ND_TCHECK_SIZE(ldp_tlv_header);
     tlv_len=GET_BE_U_2(ldp_tlv_header->length);
     if (tlv_len + 4U > msg_tlen) {
-        ND_PRINT("\n\t\t TLV contents go past end of message");
+        ND_PRINT(C_RESET, "\n\t\t TLV contents go past end of message");
         return 0;
     }
     tlv_tlen=tlv_len;
     tlv_type=LDP_MASK_TLV_TYPE(GET_BE_U_2(ldp_tlv_header->type));
 
     /* FIXME vendor private / experimental check */
-    ND_PRINT("\n\t    %s TLV (0x%04x), length: %u, Flags: [%s and %s forward if unknown]",
+    ND_PRINT(C_RESET, "\n\t    %s TLV (0x%04x), length: %u, Flags: [%s and %s forward if unknown]",
            tok2str(ldp_tlv_values,
                    "Unknown",
                    tlv_type),
@@ -280,7 +280,7 @@ ldp_tlv_print(netdissect_options *ndo,
 
     case LDP_TLV_COMMON_HELLO:
         TLV_TCHECK(4);
-        ND_PRINT("\n\t      Hold Time: %us, Flags: [%s Hello%s]",
+        ND_PRINT(C_RESET, "\n\t      Hold Time: %us, Flags: [%s Hello%s]",
                GET_BE_U_2(tptr),
                (GET_BE_U_2(tptr + 2)&0x8000) ? "Targeted" : "Link",
                (GET_BE_U_2(tptr + 2)&0x4000) ? ", Request for targeted Hellos" : "");
@@ -288,15 +288,15 @@ ldp_tlv_print(netdissect_options *ndo,
 
     case LDP_TLV_IPV4_TRANSPORT_ADDR:
         TLV_TCHECK(4);
-        ND_PRINT("\n\t      IPv4 Transport Address: %s", GET_IPADDR_STRING(tptr));
+        ND_PRINT(C_RESET, "\n\t      IPv4 Transport Address: %s", GET_IPADDR_STRING(tptr));
         break;
     case LDP_TLV_IPV6_TRANSPORT_ADDR:
         TLV_TCHECK(16);
-        ND_PRINT("\n\t      IPv6 Transport Address: %s", GET_IP6ADDR_STRING(tptr));
+        ND_PRINT(C_RESET, "\n\t      IPv6 Transport Address: %s", GET_IP6ADDR_STRING(tptr));
         break;
     case LDP_TLV_CONFIG_SEQ_NUMBER:
         TLV_TCHECK(4);
-        ND_PRINT("\n\t      Sequence Number: %u", GET_BE_U_4(tptr));
+        ND_PRINT(C_RESET, "\n\t      Sequence Number: %u", GET_BE_U_4(tptr));
         break;
 
     case LDP_TLV_ADDRESS_LIST:
@@ -304,19 +304,19 @@ ldp_tlv_print(netdissect_options *ndo,
 	af = GET_BE_U_2(tptr);
 	tptr+=LDP_TLV_ADDRESS_LIST_AFNUM_LEN;
         tlv_tlen -= LDP_TLV_ADDRESS_LIST_AFNUM_LEN;
-	ND_PRINT("\n\t      Address Family: %s, addresses",
+	ND_PRINT(C_RESET, "\n\t      Address Family: %s, addresses",
                tok2str(af_values, "Unknown (%u)", af));
         switch (af) {
         case AFNUM_INET:
 	    while(tlv_tlen >= sizeof(nd_ipv4)) {
-		ND_PRINT(" %s", GET_IPADDR_STRING(tptr));
+		ND_PRINT(C_RESET, " %s", GET_IPADDR_STRING(tptr));
 		tlv_tlen-=sizeof(nd_ipv4);
 		tptr+=sizeof(nd_ipv4);
 	    }
             break;
         case AFNUM_INET6:
 	    while(tlv_tlen >= sizeof(nd_ipv6)) {
-		ND_PRINT(" %s", GET_IP6ADDR_STRING(tptr));
+		ND_PRINT(C_RESET, " %s", GET_IP6ADDR_STRING(tptr));
 		tlv_tlen-=sizeof(nd_ipv6);
 		tptr+=sizeof(nd_ipv6);
 	    }
@@ -329,7 +329,7 @@ ldp_tlv_print(netdissect_options *ndo,
 
     case LDP_TLV_COMMON_SESSION:
 	TLV_TCHECK(8);
-	ND_PRINT("\n\t      Version: %u, Keepalive: %us, Flags: [Downstream %s, Loop Detection %s]",
+	ND_PRINT(C_RESET, "\n\t      Version: %u, Keepalive: %us, Flags: [Downstream %s, Loop Detection %s]",
 	       GET_BE_U_2(tptr), GET_BE_U_2(tptr + 2),
 	       (GET_BE_U_2(tptr + 6)&0x8000) ? "On Demand" : "Unsolicited",
 	       (GET_BE_U_2(tptr + 6)&0x4000) ? "Enabled" : "Disabled"
@@ -339,7 +339,7 @@ ldp_tlv_print(netdissect_options *ndo,
     case LDP_TLV_FEC:
         TLV_TCHECK(1);
         fec_type = GET_U_1(tptr);
-	ND_PRINT("\n\t      %s FEC (0x%02x)",
+	ND_PRINT(C_RESET, "\n\t      %s FEC (0x%02x)",
 	       tok2str(ldp_fec_values, "Unknown", fec_type),
 	       fec_type);
 
@@ -359,25 +359,25 @@ ldp_tlv_print(netdissect_options *ndo,
 		if (i == -2)
 		    goto trunc;
 		if (i == -3)
-		    ND_PRINT(": IPv4 prefix (goes past end of TLV)");
+		    ND_PRINT(C_RESET, ": IPv4 prefix (goes past end of TLV)");
 		else if (i == -1)
-		    ND_PRINT(": IPv4 prefix (invalid length)");
+		    ND_PRINT(C_RESET, ": IPv4 prefix (invalid length)");
 		else
-		    ND_PRINT(": IPv4 prefix %s", buf);
+		    ND_PRINT(C_RESET, ": IPv4 prefix %s", buf);
 	    }
 	    else if (af == AFNUM_INET6) {
 		i=decode_prefix6(ndo, tptr, tlv_tlen, buf, sizeof(buf));
 		if (i == -2)
 		    goto trunc;
 		if (i == -3)
-		    ND_PRINT(": IPv4 prefix (goes past end of TLV)");
+		    ND_PRINT(C_RESET, ": IPv4 prefix (goes past end of TLV)");
 		else if (i == -1)
-		    ND_PRINT(": IPv6 prefix (invalid length)");
+		    ND_PRINT(C_RESET, ": IPv6 prefix (invalid length)");
 		else
-		    ND_PRINT(": IPv6 prefix %s", buf);
+		    ND_PRINT(C_RESET, ": IPv6 prefix %s", buf);
 	    }
 	    else
-		ND_PRINT(": Address family %u prefix", af);
+		ND_PRINT(C_RESET, ": Address family %u prefix", af);
 	    break;
 	case LDP_FEC_HOSTADDRESS:
 	    break;
@@ -395,7 +395,7 @@ ldp_tlv_print(netdissect_options *ndo,
 	     * there's no VC ID.
 	     */
             if (vc_info_len == 0) {
-                ND_PRINT(": %s, %scontrol word, group-ID %u, VC-info-length: %u",
+                ND_PRINT(C_RESET, ": %s, %scontrol word, group-ID %u, VC-info-length: %u",
                        tok2str(mpls_pw_types_values, "Unknown", GET_BE_U_2(tptr)&0x7fff),
                        GET_BE_U_2(tptr)&0x8000 ? "" : "no ",
                        GET_BE_U_4(tptr + 3),
@@ -405,7 +405,7 @@ ldp_tlv_print(netdissect_options *ndo,
 
             /* Make sure we have the VC ID as well */
             TLV_TCHECK(11);
-	    ND_PRINT(": %s, %scontrol word, group-ID %u, VC-ID %u, VC-info-length: %u",
+	    ND_PRINT(C_RESET, ": %s, %scontrol word, group-ID %u, VC-ID %u, VC-info-length: %u",
 		   tok2str(mpls_pw_types_values, "Unknown", GET_BE_U_2(tptr)&0x7fff),
 		   GET_BE_U_2(tptr)&0x8000 ? "" : "no ",
 		   GET_BE_U_4(tptr + 3),
@@ -413,7 +413,7 @@ ldp_tlv_print(netdissect_options *ndo,
 		   vc_info_len);
             if (vc_info_len < 4) {
                 /* minimum 4, for the VC ID */
-                ND_PRINT(" (invalid, < 4");
+                ND_PRINT(C_RESET, " (invalid, < 4");
                 return(tlv_len+4); /* Type & Length fields not included */
 	    }
             vc_info_len -= 4; /* subtract out the VC ID, giving the length of the interface parameters */
@@ -431,27 +431,27 @@ ldp_tlv_print(netdissect_options *ndo,
                 if (vc_info_len < vc_info_tlv_len)
                     break;
 
-                ND_PRINT("\n\t\tInterface Parameter: %s (0x%02x), len %u",
+                ND_PRINT(C_RESET, "\n\t\tInterface Parameter: %s (0x%02x), len %u",
                        tok2str(ldp_fec_martini_ifparm_values,"Unknown",vc_info_tlv_type),
                        vc_info_tlv_type,
                        vc_info_tlv_len);
 
                 switch(vc_info_tlv_type) {
                 case LDP_FEC_MARTINI_IFPARM_MTU:
-                    ND_PRINT(": %u", GET_BE_U_2(tptr + 2));
+                    ND_PRINT(C_RESET, ": %u", GET_BE_U_2(tptr + 2));
                     break;
 
                 case LDP_FEC_MARTINI_IFPARM_DESC:
-                    ND_PRINT(": ");
+                    ND_PRINT(C_RESET, ": ");
                     for (idx = 2; idx < vc_info_tlv_len; idx++)
                         fn_print_char(ndo, GET_U_1(tptr + idx));
                     break;
 
                 case LDP_FEC_MARTINI_IFPARM_VCCV:
-                    ND_PRINT("\n\t\t  Control Channels (0x%02x) = [%s]",
+                    ND_PRINT(C_RESET, "\n\t\t  Control Channels (0x%02x) = [%s]",
                            GET_U_1((tptr + 2)),
                            bittok2str(ldp_fec_martini_ifparm_vccv_cc_values, "none", GET_U_1((tptr + 2))));
-                    ND_PRINT("\n\t\t  CV Types (0x%02x) = [%s]",
+                    ND_PRINT(C_RESET, "\n\t\t  CV Types (0x%02x) = [%s]",
                            GET_U_1((tptr + 3)),
                            bittok2str(ldp_fec_martini_ifparm_vccv_cv_values, "none", GET_U_1((tptr + 3))));
                     break;
@@ -471,27 +471,27 @@ ldp_tlv_print(netdissect_options *ndo,
 
     case LDP_TLV_GENERIC_LABEL:
 	TLV_TCHECK(4);
-	ND_PRINT("\n\t      Label: %u", GET_BE_U_4(tptr) & 0xfffff);
+	ND_PRINT(C_RESET, "\n\t      Label: %u", GET_BE_U_4(tptr) & 0xfffff);
 	break;
 
     case LDP_TLV_STATUS:
 	TLV_TCHECK(8);
 	ui = GET_BE_U_4(tptr);
 	tptr+=4;
-	ND_PRINT("\n\t      Status: 0x%02x, Flags: [%s and %s forward]",
+	ND_PRINT(C_RESET, "\n\t      Status: 0x%02x, Flags: [%s and %s forward]",
 	       ui&0x3fffffff,
 	       ui&0x80000000 ? "Fatal error" : "Advisory Notification",
 	       ui&0x40000000 ? "do" : "don't");
 	ui = GET_BE_U_4(tptr);
 	tptr+=4;
 	if (ui)
-	    ND_PRINT(", causing Message ID: 0x%08x", ui);
+	    ND_PRINT(C_RESET, ", causing Message ID: 0x%08x", ui);
 	break;
 
     case LDP_TLV_FT_SESSION:
 	TLV_TCHECK(12);
 	ft_flags = GET_BE_U_2(tptr);
-	ND_PRINT("\n\t      Flags: [%sReconnect, %sSave State, %sAll-Label Protection, %s Checkpoint, %sRe-Learn State]",
+	ND_PRINT(C_RESET, "\n\t      Flags: [%sReconnect, %sSave State, %sAll-Label Protection, %s Checkpoint, %sRe-Learn State]",
 	       ft_flags&0x8000 ? "" : "No ",
 	       ft_flags&0x8 ? "" : "Don't ",
 	       ft_flags&0x4 ? "" : "No ",
@@ -501,16 +501,16 @@ ldp_tlv_print(netdissect_options *ndo,
 	tptr+=4;
 	ui = GET_BE_U_4(tptr);
 	if (ui)
-	    ND_PRINT(", Reconnect Timeout: %ums", ui);
+	    ND_PRINT(C_RESET, ", Reconnect Timeout: %ums", ui);
 	tptr+=4;
 	ui = GET_BE_U_4(tptr);
 	if (ui)
-	    ND_PRINT(", Recovery Time: %ums", ui);
+	    ND_PRINT(C_RESET, ", Recovery Time: %ums", ui);
 	break;
 
     case LDP_TLV_MTU:
 	TLV_TCHECK(2);
-	ND_PRINT("\n\t      MTU: %u", GET_BE_U_2(tptr));
+	ND_PRINT(C_RESET, "\n\t      MTU: %u", GET_BE_U_2(tptr));
 	break;
 
 
@@ -556,7 +556,7 @@ ldp_print(netdissect_options *ndo,
         if (processed == 0)
             return;
         if (len < processed) {
-            ND_PRINT(" [remaining length %u < %u]", len, processed);
+            ND_PRINT(C_RESET, " [remaining length %u < %u]", len, processed);
             nd_print_invalid(ndo);
             break;
         }
@@ -584,7 +584,7 @@ ldp_pdu_print(netdissect_options *ndo,
      * Sanity checking of the header.
      */
     if (GET_BE_U_2(ldp_com_header->version) != LDP_VERSION) {
-	ND_PRINT("%sLDP version %u packet not supported",
+	ND_PRINT(C_RESET, "%sLDP version %u packet not supported",
                (ndo->ndo_vflag < 1) ? "" : "\n\t",
                GET_BE_U_2(ldp_com_header->version));
 	return 0;
@@ -593,7 +593,7 @@ ldp_pdu_print(netdissect_options *ndo,
     pdu_len = GET_BE_U_2(ldp_com_header->pdu_length);
     if (pdu_len < sizeof(struct ldp_common_header)-4) {
         /* length too short */
-        ND_PRINT("%sLDP, pdu-length: %u (too short, < %zu)",
+        ND_PRINT(C_RESET, "%sLDP, pdu-length: %u (too short, < %zu)",
                  (ndo->ndo_vflag < 1) ? "" : "\n\t",
                  pdu_len,
                  sizeof(struct ldp_common_header)-4);
@@ -601,7 +601,7 @@ ldp_pdu_print(netdissect_options *ndo,
     }
 
     /* print the LSR-ID, label-space & length */
-    ND_PRINT("%sLDP, Label-Space-ID: %s:%u, pdu-length: %u",
+    ND_PRINT(C_RESET, "%sLDP, Label-Space-ID: %s:%u, pdu-length: %u",
            (ndo->ndo_vflag < 1) ? "" : "\n\t",
            GET_IPADDR_STRING(ldp_com_header->lsr_id),
            GET_BE_U_2(ldp_com_header->label_space),
@@ -626,7 +626,7 @@ ldp_pdu_print(netdissect_options *ndo,
         if (msg_len < sizeof(struct ldp_msg_header)-4) {
             /* length too short */
             /* FIXME vendor private / experimental check */
-            ND_PRINT("\n\t  %s Message (0x%04x), length: %u (too short, < %zu)",
+            ND_PRINT(C_RESET, "\n\t  %s Message (0x%04x), length: %u (too short, < %zu)",
                      tok2str(ldp_msg_values,
                              "Unknown",
                              msg_type),
@@ -637,7 +637,7 @@ ldp_pdu_print(netdissect_options *ndo,
         }
 
         /* FIXME vendor private / experimental check */
-        ND_PRINT("\n\t  %s Message (0x%04x), length: %u, Message ID: 0x%08x, Flags: [%s if unknown]",
+        ND_PRINT(C_RESET, "\n\t  %s Message (0x%04x), length: %u, Message ID: 0x%08x, Flags: [%s if unknown]",
                tok2str(ldp_msg_values,
                        "Unknown",
                        msg_type),

--- a/print-lisp.c
+++ b/print-lisp.c
@@ -269,13 +269,13 @@ lisp_print(netdissect_options *ndo, const u_char *bp, u_int length)
 
 	if (ndo->ndo_vflag) {
 		key_id = GET_BE_U_2(lisp_hdr->key_id);
-		ND_PRINT("\n    %u record(s), ", record_count);
-		ND_PRINT("Authentication %s,",
+		ND_PRINT(C_RESET, "\n    %u record(s), ", record_count);
+		ND_PRINT(C_RESET, "Authentication %s,",
 			tok2str(auth_type, "unknown-type", key_id));
 		hex_print(ndo, "\n    Authentication-Data: ", packet_iterator +
 						packet_offset, auth_data_len);
 	} else {
-		ND_PRINT(" %u record(s),", record_count);
+		ND_PRINT(C_RESET, " %u record(s),", record_count);
 	}
 	packet_offset += auth_data_len;
 
@@ -287,7 +287,7 @@ lisp_print(netdissect_options *ndo, const u_char *bp, u_int length)
 		record_count--;
 		ND_TCHECK_LEN(packet_iterator + packet_offset,
 			      MAP_REGISTER_EID_LEN);
-		ND_PRINT("\n");
+		ND_PRINT(C_RESET, "\n");
 		lisp_eid = (const lisp_map_register_eid *)
 				((const u_char *)lisp_hdr + packet_offset);
 		packet_offset += MAP_REGISTER_EID_LEN;
@@ -297,21 +297,21 @@ lisp_print(netdissect_options *ndo, const u_char *bp, u_int length)
 
 		if (ndo->ndo_vflag) {
 			ttl = GET_BE_U_4(lisp_eid->ttl);
-			ND_PRINT("      Record TTL %u,", ttl);
+			ND_PRINT(C_RESET, "      Record TTL %u,", ttl);
 			action_flag(ndo, GET_U_1(lisp_eid->act_auth_inc_res));
 			map_version = GET_BE_U_2(lisp_eid->reserved_and_version) & 0x0FFF;
-			ND_PRINT(" Map Version: %u,", map_version);
+			ND_PRINT(C_RESET, " Map Version: %u,", map_version);
 		}
 
 		switch (eid_afi) {
 		case IPv4_AFI:
-			ND_PRINT(" EID %s/%u,",
+			ND_PRINT(C_RESET, " EID %s/%u,",
 				GET_IPADDR_STRING(packet_iterator + packet_offset),
 				mask_len);
 			packet_offset += 4;
 			break;
 		case IPv6_AFI:
-			ND_PRINT(" EID %s/%u,",
+			ND_PRINT(C_RESET, " EID %s/%u,",
 				GET_IP6ADDR_STRING(packet_iterator + packet_offset),
 				mask_len);
 			packet_offset += 16;
@@ -324,7 +324,7 @@ lisp_print(netdissect_options *ndo, const u_char *bp, u_int length)
 			break;
 		}
 
-		ND_PRINT(" %u locator(s)", loc_count);
+		ND_PRINT(C_RESET, " %u locator(s)", loc_count);
 
 		while (loc_count != 0) {
 			loc_count--;
@@ -336,24 +336,24 @@ lisp_print(netdissect_options *ndo, const u_char *bp, u_int length)
 			loc_afi = GET_BE_U_2(lisp_loc->locator_afi);
 
 			if (ndo->ndo_vflag)
-				ND_PRINT("\n       ");
+				ND_PRINT(C_RESET, "\n       ");
 
 			switch (loc_afi) {
 			case IPv4_AFI:
 				ND_TCHECK_4(packet_iterator + packet_offset);
-				ND_PRINT(" LOC %s", GET_IPADDR_STRING(loc_ip_pointer));
+				ND_PRINT(C_RESET, " LOC %s", GET_IPADDR_STRING(loc_ip_pointer));
 				packet_offset += 4;
 				break;
 			case IPv6_AFI:
 				ND_TCHECK_16(packet_iterator + packet_offset);
-				ND_PRINT(" LOC %s", GET_IP6ADDR_STRING(loc_ip_pointer));
+				ND_PRINT(C_RESET, " LOC %s", GET_IP6ADDR_STRING(loc_ip_pointer));
 				packet_offset += 16;
 				break;
 			default:
 				break;
 			}
 			if (ndo->ndo_vflag) {
-				ND_PRINT("\n          Priority/Weight %u/%u,"
+				ND_PRINT(C_RESET, "\n          Priority/Weight %u/%u,"
 						" Multicast Priority/Weight %u/%u,",
 						GET_U_1(lisp_loc->priority),
 						GET_U_1(lisp_loc->weight),
@@ -374,7 +374,7 @@ lisp_print(netdissect_options *ndo, const u_char *bp, u_int length)
 		if (!ND_TTEST_LEN(packet_iterator + packet_offset, 24))
 			goto invalid;
 		hex_print(ndo, "\n    xTR-ID: ", packet_iterator + packet_offset, 16);
-		ND_PRINT("\n    SITE-ID: %" PRIu64,
+		ND_PRINT(C_RESET, "\n    SITE-ID: %" PRIu64,
 			GET_BE_U_8(packet_iterator + packet_offset + 16));
 	} else {
 		/* Check if packet isn't over yet */
@@ -415,17 +415,17 @@ static void lisp_hdr_flag(netdissect_options *ndo, const lisp_map_register_hdr *
 	uint8_t type = extract_lisp_type(GET_U_1(lisp_hdr->type_and_flag));
 
 	if (!ndo->ndo_vflag) {
-		ND_PRINT("%s,", tok2str(lisp_type, "unknown-type-%u", type));
+		ND_PRINT(C_RESET, "%s,", tok2str(lisp_type, "unknown-type-%u", type));
 		return;
 	} else {
-		ND_PRINT("%s,", tok2str(lisp_type, "unknown-type-%u", type));
+		ND_PRINT(C_RESET, "%s,", tok2str(lisp_type, "unknown-type-%u", type));
 	}
 
 	if (type == LISP_MAP_REGISTER) {
-		ND_PRINT(" flags [%s],", bittok2str(map_register_hdr_flag,
+		ND_PRINT(C_RESET, " flags [%s],", bittok2str(map_register_hdr_flag,
 			 "none", GET_BE_U_4(lisp_hdr)));
 	} else if (type == LISP_MAP_NOTIFY) {
-		ND_PRINT(" flags [%s],", bittok2str(map_notify_hdr_flag,
+		ND_PRINT(C_RESET, " flags [%s],", bittok2str(map_notify_hdr_flag,
 			 "none", GET_BE_U_4(lisp_hdr)));
 	}
 }
@@ -438,16 +438,16 @@ static void action_flag(netdissect_options *ndo, uint8_t act_auth_inc_res)
 	authoritative  = ((act_auth_inc_res >> 4) & 1);
 
 	if (authoritative)
-		ND_PRINT(" Authoritative,");
+		ND_PRINT(C_RESET, " Authoritative,");
 	else
-		ND_PRINT(" Non-Authoritative,");
+		ND_PRINT(C_RESET, " Non-Authoritative,");
 
 	action = act_auth_inc_res >> 5;
-	ND_PRINT(" %s,", tok2str(lisp_eid_action, "unknown", action));
+	ND_PRINT(C_RESET, " %s,", tok2str(lisp_eid_action, "unknown", action));
 }
 
 static void loc_hdr_flag(netdissect_options *ndo, uint16_t flag)
 {
-	ND_PRINT(" flags [%s],", bittok2str(lisp_loc_flag, "none", flag));
+	ND_PRINT(C_RESET, " flags [%s],", bittok2str(lisp_loc_flag, "none", flag));
 }
 

--- a/print-llc.c
+++ b/print-llc.c
@@ -224,7 +224,7 @@ llc_print(netdissect_options *ndo, const u_char *p, u_int length, u_int caplen,
 		 */
 
             if (ndo->ndo_eflag)
-		ND_PRINT("IPX 802.3: ");
+		ND_PRINT(C_RESET, "IPX 802.3: ");
 
             ipx_print(ndo, p, length);
             return (0);		/* no LLC header */
@@ -234,7 +234,7 @@ llc_print(netdissect_options *ndo, const u_char *p, u_int length, u_int caplen,
 	ssap = ssap_field & ~LLC_GSAP;
 
 	if (ndo->ndo_eflag) {
-                ND_PRINT("LLC, dsap %s (0x%02x) %s, ssap %s (0x%02x) %s",
+                ND_PRINT(C_RESET, "LLC, dsap %s (0x%02x) %s, ssap %s (0x%02x) %s",
                        tok2str(llc_values, "Unknown", dsap),
                        dsap,
                        tok2str(llc_ig_flag_values, "Unknown", dsap_field & LLC_IG),
@@ -243,9 +243,9 @@ llc_print(netdissect_options *ndo, const u_char *p, u_int length, u_int caplen,
                        tok2str(llc_flag_values, "Unknown", ssap_field & LLC_GSAP));
 
 		if (is_u) {
-			ND_PRINT(", ctrl 0x%02x: ", control);
+			ND_PRINT(C_RESET, ", ctrl 0x%02x: ", control);
 		} else {
-			ND_PRINT(", ctrl 0x%04x: ", control);
+			ND_PRINT(C_RESET, ", ctrl 0x%04x: ", control);
 		}
 	}
 
@@ -300,7 +300,7 @@ llc_print(netdissect_options *ndo, const u_char *p, u_int length, u_int caplen,
 		 * destination SAPs being the IPX SAP.
 		 */
                 if (ndo->ndo_eflag)
-                        ND_PRINT("IPX 802.2: ");
+                        ND_PRINT(C_RESET, "IPX 802.2: ");
 
 		ipx_print(ndo, p, length);
 		return (hdrlen);
@@ -332,19 +332,19 @@ llc_print(netdissect_options *ndo, const u_char *p, u_int length, u_int caplen,
 	if (!ndo->ndo_eflag) {
 		if (ssap == dsap) {
 			if (src == NULL || dst == NULL)
-				ND_PRINT("%s ", tok2str(llc_values, "Unknown DSAP 0x%02x", dsap));
+				ND_PRINT(C_RESET, "%s ", tok2str(llc_values, "Unknown DSAP 0x%02x", dsap));
 			else
-				ND_PRINT("%s > %s %s ",
+				ND_PRINT(C_RESET, "%s > %s %s ",
 						(src->addr_string)(ndo, src->addr),
 						(dst->addr_string)(ndo, dst->addr),
 						tok2str(llc_values, "Unknown DSAP 0x%02x", dsap));
 		} else {
 			if (src == NULL || dst == NULL)
-				ND_PRINT("%s > %s ",
+				ND_PRINT(C_RESET, "%s > %s ",
                                         tok2str(llc_values, "Unknown SSAP 0x%02x", ssap),
 					tok2str(llc_values, "Unknown DSAP 0x%02x", dsap));
 			else
-				ND_PRINT("%s %s > %s %s ",
+				ND_PRINT(C_RESET, "%s %s > %s %s ",
 					(src->addr_string)(ndo, src->addr),
                                         tok2str(llc_values, "Unknown SSAP 0x%02x", ssap),
 					(dst->addr_string)(ndo, dst->addr),
@@ -353,7 +353,7 @@ llc_print(netdissect_options *ndo, const u_char *p, u_int length, u_int caplen,
 	}
 
 	if (is_u) {
-		ND_PRINT("Unnumbered, %s, Flags [%s], length %u",
+		ND_PRINT(C_RESET, "Unnumbered, %s, Flags [%s], length %u",
                        tok2str(llc_cmd_values, "%02x", LLC_U_CMD(control)),
                        tok2str(llc_flag_values,"?",(ssap_field & LLC_GSAP) | (control & LLC_U_POLL)),
                        length + hdrlen);
@@ -379,7 +379,7 @@ llc_print(netdissect_options *ndo, const u_char *p, u_int length, u_int caplen,
 					if (caplen > 0)
 						ND_DEFAULTPRINT((const u_char *)p, caplen);
 				} else
-					ND_PRINT(": %02x %02x",
+					ND_PRINT(C_RESET, ": %02x %02x",
 						  GET_U_1(p + 1),
 						  GET_U_1(p + 2));
 				return (hdrlen);
@@ -387,14 +387,14 @@ llc_print(netdissect_options *ndo, const u_char *p, u_int length, u_int caplen,
 		}
 	} else {
 		if ((control & LLC_S_FMT) == LLC_S_FMT) {
-			ND_PRINT("Supervisory, %s, rcv seq %u, Flags [%s], length %u",
+			ND_PRINT(C_RESET, "Supervisory, %s, rcv seq %u, Flags [%s], length %u",
 				tok2str(llc_supervisory_values,"?",LLC_S_CMD(control)),
 				LLC_IS_NR(control),
 				tok2str(llc_flag_values,"?",(ssap_field & LLC_GSAP) | (control & LLC_IS_POLL)),
                                 length + hdrlen);
 			return (hdrlen);	/* no payload to print */
 		} else {
-			ND_PRINT("Information, send seq %u, rcv seq %u, Flags [%s], length %u",
+			ND_PRINT(C_RESET, "Information, send seq %u, rcv seq %u, Flags [%s], length %u",
 				LLC_I_NS(control),
 				LLC_IS_NR(control),
 				tok2str(llc_flag_values,"?",(ssap_field & LLC_GSAP) | (control & LLC_IS_POLL)),
@@ -441,7 +441,7 @@ snap_print(netdissect_options *ndo, const u_char *p, u_int length, u_int caplen,
 		 * are any, so just print the SNAP header, not the MAC
 		 * addresses.
 		 */
-		ND_PRINT("oui %s (0x%06x), %s %s (0x%04x), length %u: ",
+		ND_PRINT(C_RESET, "oui %s (0x%06x), %s %s (0x%04x), length %u: ",
 		     tok2str(oui_values, "Unknown", orgcode),
 		     orgcode,
 		     (orgcode == 0x000000 ? "ethertype" : "pid"),
@@ -581,7 +581,7 @@ snap_print(netdissect_options *ndo, const u_char *p, u_int length, u_int caplen,
 		 * we have any.
 		 */
 		if (src != NULL && dst != NULL) {
-			ND_PRINT("%s > %s ",
+			ND_PRINT(C_RESET, "%s > %s ",
 				(src->addr_string)(ndo, src->addr),
 				(dst->addr_string)(ndo, dst->addr));
 		}
@@ -591,11 +591,11 @@ snap_print(netdissect_options *ndo, const u_char *p, u_int length, u_int caplen,
 		 * ethertype.
 		 */
 		if (orgcode == 0x000000) {
-			ND_PRINT("SNAP, ethertype %s (0x%04x), length %u: ",
+			ND_PRINT(C_RESET, "SNAP, ethertype %s (0x%04x), length %u: ",
 			     tok2str(ethertype_values, "Unknown", et),
 			     et, length);
 		} else {
-			ND_PRINT("SNAP, oui %s (0x%06x), pid %s (0x%04x), length %u: ",
+			ND_PRINT(C_RESET, "SNAP, oui %s (0x%06x), pid %s (0x%04x), length %u: ",
 			     tok2str(oui_values, "Unknown", orgcode),
 			     orgcode,
 			     tok2str(oui_to_struct_tok(orgcode), "Unknown", et),

--- a/print-lldp.c
+++ b/print-lldp.c
@@ -616,9 +616,9 @@ static void
 print_ets_priority_assignment_table(netdissect_options *ndo,
                                     const u_char *ptr)
 {
-    ND_PRINT("\n\t    Priority Assignment Table");
-    ND_PRINT("\n\t     Priority : 0   1   2   3   4   5   6   7");
-    ND_PRINT("\n\t     Value    : %-3d %-3d %-3d %-3d %-3d %-3d %-3d %-3d",
+    ND_PRINT(C_RESET, "\n\t    Priority Assignment Table");
+    ND_PRINT(C_RESET, "\n\t     Priority : 0   1   2   3   4   5   6   7");
+    ND_PRINT(C_RESET, "\n\t     Value    : %-3d %-3d %-3d %-3d %-3d %-3d %-3d %-3d",
               GET_U_1(ptr) >> 4, GET_U_1(ptr) & 0x0f,
               GET_U_1(ptr + 1) >> 4, GET_U_1(ptr + 1) & 0x0f,
               GET_U_1(ptr + 2) >> 4, GET_U_1(ptr + 2) & 0x0f,
@@ -629,9 +629,9 @@ static void
 print_tc_bandwidth_table(netdissect_options *ndo,
                          const u_char *ptr)
 {
-    ND_PRINT("\n\t    TC Bandwidth Table");
-    ND_PRINT("\n\t     TC%%   : 0   1   2   3   4   5   6   7");
-    ND_PRINT("\n\t     Value : %-3d %-3d %-3d %-3d %-3d %-3d %-3d %-3d",
+    ND_PRINT(C_RESET, "\n\t    TC Bandwidth Table");
+    ND_PRINT(C_RESET, "\n\t     TC%%   : 0   1   2   3   4   5   6   7");
+    ND_PRINT(C_RESET, "\n\t     Value : %-3d %-3d %-3d %-3d %-3d %-3d %-3d %-3d",
               GET_U_1(ptr), GET_U_1(ptr + 1), GET_U_1(ptr + 2),
               GET_U_1(ptr + 3), GET_U_1(ptr + 4), GET_U_1(ptr + 5),
               GET_U_1(ptr + 6), GET_U_1(ptr + 7));
@@ -641,9 +641,9 @@ static void
 print_tsa_assignment_table(netdissect_options *ndo,
                            const u_char *ptr)
 {
-    ND_PRINT("\n\t    TSA Assignment Table");
-    ND_PRINT("\n\t     Traffic Class: 0   1   2   3   4   5   6   7");
-    ND_PRINT("\n\t     Value        : %-3d %-3d %-3d %-3d %-3d %-3d %-3d %-3d",
+    ND_PRINT(C_RESET, "\n\t    TSA Assignment Table");
+    ND_PRINT(C_RESET, "\n\t     Traffic Class: 0   1   2   3   4   5   6   7");
+    ND_PRINT(C_RESET, "\n\t     Value        : %-3d %-3d %-3d %-3d %-3d %-3d %-3d %-3d",
               GET_U_1(ptr), GET_U_1(ptr + 1), GET_U_1(ptr + 2),
               GET_U_1(ptr + 3), GET_U_1(ptr + 4), GET_U_1(ptr + 5),
               GET_U_1(ptr + 6), GET_U_1(ptr + 7));
@@ -667,7 +667,7 @@ lldp_private_8021_print(netdissect_options *ndo,
     }
     subtype = GET_U_1(tptr + 3);
 
-    ND_PRINT("\n\t  %s Subtype (%u)",
+    ND_PRINT(C_RESET, "\n\t  %s Subtype (%u)",
            tok2str(lldp_8021_subtype_values, "unknown", subtype),
            subtype);
 
@@ -676,14 +676,14 @@ lldp_private_8021_print(netdissect_options *ndo,
         if (tlv_len < 6) {
             return hexdump;
         }
-        ND_PRINT("\n\t    port vlan id (PVID): %u",
+        ND_PRINT(C_RESET, "\n\t    port vlan id (PVID): %u",
                GET_BE_U_2(tptr + 4));
         break;
     case LLDP_PRIVATE_8021_SUBTYPE_PROTOCOL_VLAN_ID:
         if (tlv_len < 7) {
             return hexdump;
         }
-        ND_PRINT("\n\t    port and protocol vlan id (PPVID): %u, flags [%s] (0x%02x)",
+        ND_PRINT(C_RESET, "\n\t    port and protocol vlan id (PPVID): %u, flags [%s] (0x%02x)",
                GET_BE_U_2(tptr + 5),
                bittok2str(lldp_8021_port_protocol_id_values, "none", GET_U_1(tptr + 4)),
                GET_U_1(tptr + 4));
@@ -692,7 +692,7 @@ lldp_private_8021_print(netdissect_options *ndo,
         if (tlv_len < 6) {
             return hexdump;
         }
-        ND_PRINT("\n\t    vlan id (VID): %u", GET_BE_U_2(tptr + 4));
+        ND_PRINT(C_RESET, "\n\t    vlan id (VID): %u", GET_BE_U_2(tptr + 4));
         if (tlv_len < 7) {
             return hexdump;
         }
@@ -700,7 +700,7 @@ lldp_private_8021_print(netdissect_options *ndo,
         if (tlv_len < 7+sublen) {
             return hexdump;
         }
-        ND_PRINT("\n\t    vlan name: ");
+        ND_PRINT(C_RESET, "\n\t    vlan name: ");
         nd_printjnp(ndo, tptr + 7, sublen);
         break;
     case LLDP_PRIVATE_8021_SUBTYPE_PROTOCOL_IDENTITY:
@@ -711,7 +711,7 @@ lldp_private_8021_print(netdissect_options *ndo,
         if (tlv_len < 5+sublen) {
             return hexdump;
         }
-        ND_PRINT("\n\t    protocol identity: ");
+        ND_PRINT(C_RESET, "\n\t    protocol identity: ");
         nd_printjnp(ndo, tptr + 5, sublen);
         break;
 
@@ -719,7 +719,7 @@ lldp_private_8021_print(netdissect_options *ndo,
         if (tlv_len < 9) {
             return hexdump;
         }
-        ND_PRINT("\n\t    aggregation status [%s], aggregation port ID %u",
+        ND_PRINT(C_RESET, "\n\t    aggregation status [%s], aggregation port ID %u",
                bittok2str(lldp_aggregation_values, "none", GET_U_1((tptr + 4))),
                GET_BE_U_4(tptr + 5));
         break;
@@ -729,17 +729,17 @@ lldp_private_8021_print(netdissect_options *ndo,
 		return hexdump;
         }
         tval=GET_U_1(tptr + 4);
-        ND_PRINT("\n\t    Pre-Priority CNPV Indicator");
-        ND_PRINT("\n\t     Priority : 0  1  2  3  4  5  6  7");
-        ND_PRINT("\n\t     Value    : ");
+        ND_PRINT(C_RESET, "\n\t    Pre-Priority CNPV Indicator");
+        ND_PRINT(C_RESET, "\n\t     Priority : 0  1  2  3  4  5  6  7");
+        ND_PRINT(C_RESET, "\n\t     Value    : ");
         for(i=0;i<NO_OF_BITS;i++)
-            ND_PRINT("%-2d ", (tval >> i) & 0x01);
+            ND_PRINT(C_RESET, "%-2d ", (tval >> i) & 0x01);
         tval=GET_U_1(tptr + 5);
-        ND_PRINT("\n\t    Pre-Priority Ready Indicator");
-        ND_PRINT("\n\t     Priority : 0  1  2  3  4  5  6  7");
-        ND_PRINT("\n\t     Value    : ");
+        ND_PRINT(C_RESET, "\n\t    Pre-Priority Ready Indicator");
+        ND_PRINT(C_RESET, "\n\t     Priority : 0  1  2  3  4  5  6  7");
+        ND_PRINT(C_RESET, "\n\t     Value    : ");
         for(i=0;i<NO_OF_BITS;i++)
-            ND_PRINT("%-2d ", (tval >> i) & 0x01);
+            ND_PRINT(C_RESET, "%-2d ", (tval >> i) & 0x01);
         break;
 
     case LLDP_PRIVATE_8021_SUBTYPE_ETS_CONFIGURATION:
@@ -747,7 +747,7 @@ lldp_private_8021_print(netdissect_options *ndo,
             return hexdump;
         }
         tval=GET_U_1(tptr + 4);
-        ND_PRINT("\n\t    Willing:%u, CBS:%u, RES:%u, Max TCs:%u",
+        ND_PRINT(C_RESET, "\n\t    Willing:%u, CBS:%u, RES:%u, Max TCs:%u",
 		tval >> 7, (tval >> 6) & 0x02, (tval >> 3) & 0x07, tval & 0x07);
 
         /*Print Priority Assignment Table*/
@@ -765,7 +765,7 @@ lldp_private_8021_print(netdissect_options *ndo,
         if(tlv_len<LLDP_PRIVATE_8021_SUBTYPE_ETS_RECOMMENDATION_LENGTH) {
 		return hexdump;
         }
-        ND_PRINT("\n\t    RES: %u", GET_U_1(tptr + 4));
+        ND_PRINT(C_RESET, "\n\t    RES: %u", GET_U_1(tptr + 4));
         /*Print Priority Assignment Table */
         print_ets_priority_assignment_table(ndo, tptr + 5);
         /*Print TC Bandwidth Table */
@@ -779,21 +779,21 @@ lldp_private_8021_print(netdissect_options *ndo,
             return hexdump;
         }
         tval=GET_U_1(tptr + 4);
-        ND_PRINT("\n\t    Willing: %u, MBC: %u, RES: %u, PFC cap:%u ",
+        ND_PRINT(C_RESET, "\n\t    Willing: %u, MBC: %u, RES: %u, PFC cap:%u ",
 		tval >> 7, (tval >> 6) & 0x01, (tval >> 4) & 0x03, (tval & 0x0f));
-        ND_PRINT("\n\t    PFC Enable");
+        ND_PRINT(C_RESET, "\n\t    PFC Enable");
         tval=GET_U_1(tptr + 5);
-        ND_PRINT("\n\t     Priority : 0  1  2  3  4  5  6  7");
-        ND_PRINT("\n\t     Value    : ");
+        ND_PRINT(C_RESET, "\n\t     Priority : 0  1  2  3  4  5  6  7");
+        ND_PRINT(C_RESET, "\n\t     Value    : ");
         for(i=0;i<NO_OF_BITS;i++)
-            ND_PRINT("%-2d ", (tval >> i) & 0x01);
+            ND_PRINT(C_RESET, "%-2d ", (tval >> i) & 0x01);
         break;
 
     case LLDP_PRIVATE_8021_SUBTYPE_APPLICATION_PRIORITY:
         if(tlv_len<LLDP_PRIVATE_8021_SUBTYPE_APPLICATION_PRIORITY_MIN_LENGTH) {
             return hexdump;
         }
-        ND_PRINT("\n\t    RES: %u", GET_U_1(tptr + 4));
+        ND_PRINT(C_RESET, "\n\t    RES: %u", GET_U_1(tptr + 4));
         if(tlv_len<=LLDP_PRIVATE_8021_SUBTYPE_APPLICATION_PRIORITY_MIN_LENGTH){
 		return hexdump;
         }
@@ -803,10 +803,10 @@ lldp_private_8021_print(netdissect_options *ndo,
 		return hexdump;
         }
         i=0;
-        ND_PRINT("\n\t    Application Priority Table");
+        ND_PRINT(C_RESET, "\n\t    Application Priority Table");
         while(i<sublen) {
 		tval=GET_U_1(tptr + i + 5);
-		ND_PRINT("\n\t      Priority: %u, RES: %u, Sel: %u, Protocol ID: %u",
+		ND_PRINT(C_RESET, "\n\t      Priority: %u, RES: %u, Sel: %u, Protocol ID: %u",
 			 tval >> 5, (tval >> 3) & 0x03, (tval & 0x07),
 			 GET_BE_U_2(tptr + i + 6));
 		i=i+3;
@@ -816,22 +816,22 @@ lldp_private_8021_print(netdissect_options *ndo,
         if(tlv_len<LLDP_PRIVATE_8021_SUBTYPE_EVB_LENGTH){
 		return hexdump;
         }
-        ND_PRINT("\n\t    EVB Bridge Status");
+        ND_PRINT(C_RESET, "\n\t    EVB Bridge Status");
         tval=GET_U_1(tptr + 4);
-        ND_PRINT("\n\t      RES: %u, BGID: %u, RRCAP: %u, RRCTR: %u",
+        ND_PRINT(C_RESET, "\n\t      RES: %u, BGID: %u, RRCAP: %u, RRCTR: %u",
 		tval >> 3, (tval >> 2) & 0x01, (tval >> 1) & 0x01, tval & 0x01);
-        ND_PRINT("\n\t    EVB Station Status");
+        ND_PRINT(C_RESET, "\n\t    EVB Station Status");
         tval=GET_U_1(tptr + 5);
-        ND_PRINT("\n\t      RES: %u, SGID: %u, RRREQ: %u,RRSTAT: %u",
+        ND_PRINT(C_RESET, "\n\t      RES: %u, SGID: %u, RRREQ: %u,RRSTAT: %u",
 		tval >> 4, (tval >> 3) & 0x01, (tval >> 2) & 0x01, tval & 0x03);
         tval=GET_U_1(tptr + 6);
-        ND_PRINT("\n\t    R: %u, RTE: %u, ",tval >> 5, tval & 0x1f);
+        ND_PRINT(C_RESET, "\n\t    R: %u, RTE: %u, ",tval >> 5, tval & 0x1f);
         tval=GET_U_1(tptr + 7);
-        ND_PRINT("EVB Mode: %s [%u]",
+        ND_PRINT(C_RESET, "EVB Mode: %s [%u]",
 		tok2str(lldp_evb_mode_values, "unknown", tval >> 6), tval >> 6);
-        ND_PRINT("\n\t    ROL: %u, RWD: %u, ", (tval >> 5) & 0x01, tval & 0x1f);
+        ND_PRINT(C_RESET, "\n\t    ROL: %u, RWD: %u, ", (tval >> 5) & 0x01, tval & 0x1f);
         tval=GET_U_1(tptr + 8);
-        ND_PRINT("RES: %u, ROL: %u, RKA: %u", tval >> 6, (tval >> 5) & 0x01, tval & 0x1f);
+        ND_PRINT(C_RESET, "RES: %u, ROL: %u, RKA: %u", tval >> 6, (tval >> 5) & 0x01, tval & 0x1f);
         break;
 
     case LLDP_PRIVATE_8021_SUBTYPE_CDCP:
@@ -839,9 +839,9 @@ lldp_private_8021_print(netdissect_options *ndo,
 		return hexdump;
         }
         tval=GET_U_1(tptr + 4);
-        ND_PRINT("\n\t    Role: %u, RES: %u, Scomp: %u ",
+        ND_PRINT(C_RESET, "\n\t    Role: %u, RES: %u, Scomp: %u ",
 		tval >> 7, (tval >> 4) & 0x07, (tval >> 3) & 0x01);
-        ND_PRINT("ChnCap: %u", GET_BE_U_2(tptr + 6) & 0x0fff);
+        ND_PRINT(C_RESET, "ChnCap: %u", GET_BE_U_2(tptr + 6) & 0x0fff);
         sublen=tlv_len-8;
         if(sublen%3!=0) {
 		return hexdump;
@@ -849,7 +849,7 @@ lldp_private_8021_print(netdissect_options *ndo,
         i=0;
         while(i<sublen) {
 		tval=GET_BE_U_3(tptr + i + 8);
-		ND_PRINT("\n\t    SCID: %u, SVID: %u",
+		ND_PRINT(C_RESET, "\n\t    SCID: %u, SVID: %u",
 			tval >> 12, tval & 0x000fff);
 		i=i+3;
         }
@@ -878,7 +878,7 @@ lldp_private_8023_print(netdissect_options *ndo,
     }
     subtype = GET_U_1(tptr + 3);
 
-    ND_PRINT("\n\t  %s Subtype (%u)",
+    ND_PRINT(C_RESET, "\n\t  %s Subtype (%u)",
            tok2str(lldp_8023_subtype_values, "unknown", subtype),
            subtype);
 
@@ -887,13 +887,13 @@ lldp_private_8023_print(netdissect_options *ndo,
         if (tlv_len < 9) {
             return hexdump;
         }
-        ND_PRINT("\n\t    autonegotiation [%s] (0x%02x)",
+        ND_PRINT(C_RESET, "\n\t    autonegotiation [%s] (0x%02x)",
                bittok2str(lldp_8023_autonegotiation_values, "none", GET_U_1(tptr + 4)),
                GET_U_1(tptr + 4));
-        ND_PRINT("\n\t    PMD autoneg capability [%s] (0x%04x)",
+        ND_PRINT(C_RESET, "\n\t    PMD autoneg capability [%s] (0x%04x)",
                bittok2str(lldp_pmd_capability_values,"unknown", GET_BE_U_2(tptr + 5)),
                GET_BE_U_2(tptr + 5));
-        ND_PRINT("\n\t    MAU type %s (0x%04x)",
+        ND_PRINT(C_RESET, "\n\t    MAU type %s (0x%04x)",
                tok2str(lldp_mau_types_values, "unknown", GET_BE_U_2(tptr + 7)),
                GET_BE_U_2(tptr + 7));
         break;
@@ -902,7 +902,7 @@ lldp_private_8023_print(netdissect_options *ndo,
         if (tlv_len < 7) {
             return hexdump;
         }
-        ND_PRINT("\n\t    MDI power support [%s], power pair %s, power class %s",
+        ND_PRINT(C_RESET, "\n\t    MDI power support [%s], power pair %s, power class %s",
                bittok2str(lldp_mdi_values, "none", GET_U_1((tptr + 4))),
                tok2str(lldp_mdi_power_pairs_values, "unknown", GET_U_1((tptr + 5))),
                tok2str(lldp_mdi_power_class_values, "unknown", GET_U_1((tptr + 6))));
@@ -912,7 +912,7 @@ lldp_private_8023_print(netdissect_options *ndo,
         if (tlv_len < 9) {
             return hexdump;
         }
-        ND_PRINT("\n\t    aggregation status [%s], aggregation port ID %u",
+        ND_PRINT(C_RESET, "\n\t    aggregation status [%s], aggregation port ID %u",
                bittok2str(lldp_aggregation_values, "none", GET_U_1((tptr + 4))),
                GET_BE_U_4(tptr + 5));
         break;
@@ -921,7 +921,7 @@ lldp_private_8023_print(netdissect_options *ndo,
         if (tlv_len < 6) {
             return hexdump;
         }
-        ND_PRINT("\n\t    MTU size %u", GET_BE_U_2(tptr + 4));
+        ND_PRINT(C_RESET, "\n\t    MTU size %u", GET_BE_U_2(tptr + 4));
         break;
 
     default:
@@ -963,13 +963,13 @@ lldp_private_iana_print(netdissect_options *ndo,
     }
     subtype = GET_U_1(tptr + 3);
 
-    ND_PRINT("\n\t  %s Subtype (%u)",
+    ND_PRINT(C_RESET, "\n\t  %s Subtype (%u)",
            tok2str(lldp_iana_subtype_values, "unknown", subtype),
            subtype);
 
     switch (subtype) {
     case LLDP_IANA_SUBTYPE_MUDURL:
-        ND_PRINT("\n\t  MUD-URL=");
+        ND_PRINT(C_RESET, "\n\t  MUD-URL=");
         nd_printjn(ndo, tptr+4, tlv_len-4);
         break;
     default:
@@ -1000,7 +1000,7 @@ lldp_private_tia_print(netdissect_options *ndo,
     }
     subtype = GET_U_1(tptr + 3);
 
-    ND_PRINT("\n\t  %s Subtype (%u)",
+    ND_PRINT(C_RESET, "\n\t  %s Subtype (%u)",
            tok2str(lldp_tia_subtype_values, "unknown", subtype),
            subtype);
 
@@ -1009,10 +1009,10 @@ lldp_private_tia_print(netdissect_options *ndo,
         if (tlv_len < 7) {
             return hexdump;
         }
-        ND_PRINT("\n\t    Media capabilities [%s] (0x%04x)",
+        ND_PRINT(C_RESET, "\n\t    Media capabilities [%s] (0x%04x)",
                bittok2str(lldp_tia_capabilities_values, "none",
                           GET_BE_U_2(tptr + 4)), GET_BE_U_2(tptr + 4));
-        ND_PRINT("\n\t    Device type [%s] (0x%02x)",
+        ND_PRINT(C_RESET, "\n\t    Device type [%s] (0x%02x)",
                tok2str(lldp_tia_device_type_values, "unknown", GET_U_1(tptr + 6)),
                GET_U_1(tptr + 6));
         break;
@@ -1021,16 +1021,16 @@ lldp_private_tia_print(netdissect_options *ndo,
         if (tlv_len < 8) {
             return hexdump;
         }
-        ND_PRINT("\n\t    Application type [%s] (0x%02x)",
+        ND_PRINT(C_RESET, "\n\t    Application type [%s] (0x%02x)",
                tok2str(lldp_tia_application_type_values, "none", GET_U_1(tptr + 4)),
                GET_U_1(tptr + 4));
-        ND_PRINT(", Flags [%s]", bittok2str(
+        ND_PRINT(C_RESET, ", Flags [%s]", bittok2str(
                    lldp_tia_network_policy_bits_values, "none", GET_U_1((tptr + 5))));
-        ND_PRINT("\n\t    Vlan id %u",
+        ND_PRINT(C_RESET, "\n\t    Vlan id %u",
                LLDP_EXTRACT_NETWORK_POLICY_VLAN(GET_BE_U_2(tptr + 5)));
-        ND_PRINT(", L2 priority %u",
+        ND_PRINT(C_RESET, ", L2 priority %u",
                LLDP_EXTRACT_NETWORK_POLICY_L2_PRIORITY(GET_BE_U_2(tptr + 6)));
-        ND_PRINT(", DSCP value %u",
+        ND_PRINT(C_RESET, ", DSCP value %u",
                LLDP_EXTRACT_NETWORK_POLICY_DSCP(GET_BE_U_2(tptr + 6)));
         break;
 
@@ -1039,7 +1039,7 @@ lldp_private_tia_print(netdissect_options *ndo,
             return hexdump;
         }
         location_format = GET_U_1(tptr + 4);
-        ND_PRINT("\n\t    Location data format %s (0x%02x)",
+        ND_PRINT(C_RESET, "\n\t    Location data format %s (0x%02x)",
                tok2str(lldp_tia_location_data_format_values, "unknown", location_format),
                location_format);
 
@@ -1048,19 +1048,19 @@ lldp_private_tia_print(netdissect_options *ndo,
             if (tlv_len < 21) {
                 return hexdump;
             }
-            ND_PRINT("\n\t    Latitude resolution %u, latitude value %" PRIu64,
+            ND_PRINT(C_RESET, "\n\t    Latitude resolution %u, latitude value %" PRIu64,
                    (GET_U_1(tptr + 5) >> 2),
                    lldp_extract_latlon(ndo, tptr + 5));
-            ND_PRINT("\n\t    Longitude resolution %u, longitude value %" PRIu64,
+            ND_PRINT(C_RESET, "\n\t    Longitude resolution %u, longitude value %" PRIu64,
                    (GET_U_1(tptr + 10) >> 2),
                    lldp_extract_latlon(ndo, tptr + 10));
-            ND_PRINT("\n\t    Altitude type %s (%u)",
+            ND_PRINT(C_RESET, "\n\t    Altitude type %s (%u)",
                    tok2str(lldp_tia_location_altitude_type_values, "unknown",GET_U_1(tptr + 15) >> 4),
                    (GET_U_1(tptr + 15) >> 4));
-            ND_PRINT("\n\t    Altitude resolution %u, altitude value 0x%x",
+            ND_PRINT(C_RESET, "\n\t    Altitude resolution %u, altitude value 0x%x",
                    (GET_BE_U_2(tptr + 15)>>6)&0x3f,
                    (GET_BE_U_4(tptr + 16) & 0x3fffffff));
-            ND_PRINT("\n\t    Datum %s (0x%02x)",
+            ND_PRINT(C_RESET, "\n\t    Datum %s (0x%02x)",
                    tok2str(lldp_tia_location_datum_type_values, "unknown", GET_U_1(tptr + 20)),
                    GET_U_1(tptr + 20));
             break;
@@ -1076,7 +1076,7 @@ lldp_private_tia_print(netdissect_options *ndo,
             if (tlv_len < 7+lci_len) {
                 return hexdump;
             }
-            ND_PRINT("\n\t    LCI length %u, LCI what %s (0x%02x), Country-code ",
+            ND_PRINT(C_RESET, "\n\t    LCI length %u, LCI what %s (0x%02x), Country-code ",
                    lci_len,
                    tok2str(lldp_tia_location_lci_what_values, "unknown", GET_U_1(tptr + 6)),
                    GET_U_1(tptr + 6));
@@ -1098,7 +1098,7 @@ lldp_private_tia_print(netdissect_options *ndo,
 		tptr += 2;
                 lci_len -= 2;
 
-                ND_PRINT("\n\t      CA type \'%s\' (%u), length %u: ",
+                ND_PRINT(C_RESET, "\n\t      CA type \'%s\' (%u), length %u: ",
                        tok2str(lldp_tia_location_lci_catype_values, "unknown", ca_type),
                        ca_type, ca_len);
 
@@ -1117,12 +1117,12 @@ lldp_private_tia_print(netdissect_options *ndo,
             break;
 
         case LLDP_TIA_LOCATION_DATA_FORMAT_ECS_ELIN:
-            ND_PRINT("\n\t    ECS ELIN id ");
+            ND_PRINT(C_RESET, "\n\t    ECS ELIN id ");
             nd_printjnp(ndo, tptr + 5, tlv_len - 5);
             break;
 
         default:
-            ND_PRINT("\n\t    Location ID ");
+            ND_PRINT(C_RESET, "\n\t    Location ID ");
             print_unknown_data(ndo, tptr + 5, "\n\t      ", tlv_len - 5);
         }
         break;
@@ -1131,18 +1131,18 @@ lldp_private_tia_print(netdissect_options *ndo,
         if (tlv_len < 7) {
             return hexdump;
         }
-        ND_PRINT("\n\t    Power type [%s]",
+        ND_PRINT(C_RESET, "\n\t    Power type [%s]",
                (GET_U_1(tptr + 4) & 0xC0 >> 6) ? "PD device" : "PSE device");
-        ND_PRINT(", Power source [%s]",
+        ND_PRINT(C_RESET, ", Power source [%s]",
                tok2str(lldp_tia_power_source_values, "none", (GET_U_1((tptr + 4)) & 0x30) >> 4));
-        ND_PRINT("\n\t    Power priority [%s] (0x%02x)",
+        ND_PRINT(C_RESET, "\n\t    Power priority [%s] (0x%02x)",
                tok2str(lldp_tia_power_priority_values, "none", GET_U_1(tptr + 4) & 0x0f),
                GET_U_1(tptr + 4) & 0x0f);
         power_val = GET_BE_U_2(tptr + 5);
         if (power_val < LLDP_TIA_POWER_VAL_MAX) {
-            ND_PRINT(", Power %.1f Watts", ((float)power_val) / 10);
+            ND_PRINT(C_RESET, ", Power %.1f Watts", ((float)power_val) / 10);
         } else {
-            ND_PRINT(", Power %u (Reserved)", power_val);
+            ND_PRINT(C_RESET, ", Power %u (Reserved)", power_val);
         }
         break;
 
@@ -1153,7 +1153,7 @@ lldp_private_tia_print(netdissect_options *ndo,
     case LLDP_PRIVATE_TIA_SUBTYPE_INVENTORY_MANUFACTURER_NAME:
     case LLDP_PRIVATE_TIA_SUBTYPE_INVENTORY_MODEL_NAME:
     case LLDP_PRIVATE_TIA_SUBTYPE_INVENTORY_ASSET_ID:
-        ND_PRINT("\n\t  %s ",
+        ND_PRINT(C_RESET, "\n\t  %s ",
                tok2str(lldp_tia_inventory_values, "unknown", subtype));
         nd_printjnp(ndo, tptr + 4, tlv_len - 4);
         break;
@@ -1187,7 +1187,7 @@ lldp_private_dcbx_print(netdissect_options *ndo,
     }
     subtype = GET_U_1(pptr + 3);
 
-    ND_PRINT("\n\t  %s Subtype (%u)",
+    ND_PRINT(C_RESET, "\n\t  %s Subtype (%u)",
            tok2str(lldp_dcbx_subtype_values, "unknown", subtype),
            subtype);
 
@@ -1227,29 +1227,29 @@ lldp_private_dcbx_print(netdissect_options *ndo,
             if (tlv_len < 10) {
                 goto trunc;
             }
-	    ND_PRINT("\n\t    Control - Protocol Control (type 0x%x, length %u)",
+	    ND_PRINT(C_RESET, "\n\t    Control - Protocol Control (type 0x%x, length %u)",
 		LLDP_DCBX_CONTROL_TLV, tlv_len);
-	    ND_PRINT("\n\t      Oper_Version: %u", GET_U_1(tptr));
-	    ND_PRINT("\n\t      Max_Version: %u", GET_U_1(tptr + 1));
-	    ND_PRINT("\n\t      Sequence Number: %u", GET_BE_U_4(tptr + 2));
-	    ND_PRINT("\n\t      Acknowledgement Number: %u",
+	    ND_PRINT(C_RESET, "\n\t      Oper_Version: %u", GET_U_1(tptr));
+	    ND_PRINT(C_RESET, "\n\t      Max_Version: %u", GET_U_1(tptr + 1));
+	    ND_PRINT(C_RESET, "\n\t      Sequence Number: %u", GET_BE_U_4(tptr + 2));
+	    ND_PRINT(C_RESET, "\n\t      Acknowledgement Number: %u",
 					GET_BE_U_4(tptr + 6));
 	    break;
         case LLDP_DCBX_PRIORITY_GROUPS_TLV:
             if (tlv_len < 17) {
                 goto trunc;
             }
-	    ND_PRINT("\n\t    Feature - Priority Group (type 0x%x, length %u)",
+	    ND_PRINT(C_RESET, "\n\t    Feature - Priority Group (type 0x%x, length %u)",
 		LLDP_DCBX_PRIORITY_GROUPS_TLV, tlv_len);
-	    ND_PRINT("\n\t      Oper_Version: %u", GET_U_1(tptr));
-	    ND_PRINT("\n\t      Max_Version: %u", GET_U_1(tptr + 1));
-	    ND_PRINT("\n\t      Info block(0x%02X): ", GET_U_1(tptr + 2));
+	    ND_PRINT(C_RESET, "\n\t      Oper_Version: %u", GET_U_1(tptr));
+	    ND_PRINT(C_RESET, "\n\t      Max_Version: %u", GET_U_1(tptr + 1));
+	    ND_PRINT(C_RESET, "\n\t      Info block(0x%02X): ", GET_U_1(tptr + 2));
 	    tval = GET_U_1(tptr + 2);
-	    ND_PRINT("Enable bit: %u, Willing bit: %u, Error Bit: %u",
+	    ND_PRINT(C_RESET, "Enable bit: %u, Willing bit: %u, Error Bit: %u",
 		(tval &  0x80) ? 1 : 0, (tval &  0x40) ? 1 : 0,
 		(tval &  0x20) ? 1 : 0);
-	    ND_PRINT("\n\t      SubType: %u", GET_U_1(tptr + 3));
-	    ND_PRINT("\n\t      Priority Allocation");
+	    ND_PRINT(C_RESET, "\n\t      SubType: %u", GET_U_1(tptr + 3));
+	    ND_PRINT(C_RESET, "\n\t      Priority Allocation");
 
 	    /*
 	     * Array of 8 4-bit priority group ID values; we fetch all
@@ -1257,63 +1257,63 @@ lldp_private_dcbx_print(netdissect_options *ndo,
 	     */
 	    pgval = GET_BE_U_4(tptr + 4);
 	    for (i = 0; i <= 7; i++) {
-		ND_PRINT("\n\t          PgId_%u: %u",
+		ND_PRINT(C_RESET, "\n\t          PgId_%u: %u",
 			i, (pgval >> (28 - 4 * i)) & 0xF);
 	    }
-	    ND_PRINT("\n\t      Priority Group Allocation");
+	    ND_PRINT(C_RESET, "\n\t      Priority Group Allocation");
 	    for (i = 0; i <= 7; i++)
-		ND_PRINT("\n\t          Pg percentage[%u]: %u", i,
+		ND_PRINT(C_RESET, "\n\t          Pg percentage[%u]: %u", i,
                          GET_U_1(tptr + 8 + i));
-	    ND_PRINT("\n\t      NumTCsSupported: %u", GET_U_1(tptr + 8 + 8));
+	    ND_PRINT(C_RESET, "\n\t      NumTCsSupported: %u", GET_U_1(tptr + 8 + 8));
 	    break;
         case LLDP_DCBX_PRIORITY_FLOW_CONTROL_TLV:
             if (tlv_len < 6) {
                 goto trunc;
             }
-	    ND_PRINT("\n\t    Feature - Priority Flow Control");
-	    ND_PRINT(" (type 0x%x, length %u)",
+	    ND_PRINT(C_RESET, "\n\t    Feature - Priority Flow Control");
+	    ND_PRINT(C_RESET, " (type 0x%x, length %u)",
 		LLDP_DCBX_PRIORITY_FLOW_CONTROL_TLV, tlv_len);
-	    ND_PRINT("\n\t      Oper_Version: %u", GET_U_1(tptr));
-	    ND_PRINT("\n\t      Max_Version: %u", GET_U_1(tptr + 1));
-	    ND_PRINT("\n\t      Info block(0x%02X): ", GET_U_1(tptr + 2));
+	    ND_PRINT(C_RESET, "\n\t      Oper_Version: %u", GET_U_1(tptr));
+	    ND_PRINT(C_RESET, "\n\t      Max_Version: %u", GET_U_1(tptr + 1));
+	    ND_PRINT(C_RESET, "\n\t      Info block(0x%02X): ", GET_U_1(tptr + 2));
 	    tval = GET_U_1(tptr + 2);
-	    ND_PRINT("Enable bit: %u, Willing bit: %u, Error Bit: %u",
+	    ND_PRINT(C_RESET, "Enable bit: %u, Willing bit: %u, Error Bit: %u",
 		(tval &  0x80) ? 1 : 0, (tval &  0x40) ? 1 : 0,
 		(tval &  0x20) ? 1 : 0);
-	    ND_PRINT("\n\t      SubType: %u", GET_U_1(tptr + 3));
+	    ND_PRINT(C_RESET, "\n\t      SubType: %u", GET_U_1(tptr + 3));
 	    tval = GET_U_1(tptr + 4);
-	    ND_PRINT("\n\t      PFC Config (0x%02X)", GET_U_1(tptr + 4));
+	    ND_PRINT(C_RESET, "\n\t      PFC Config (0x%02X)", GET_U_1(tptr + 4));
 	    for (i = 0; i <= 7; i++)
-		ND_PRINT("\n\t          Priority Bit %u: %s",
+		ND_PRINT(C_RESET, "\n\t          Priority Bit %u: %s",
 		    i, (tval & (1 << i)) ? "Enabled" : "Disabled");
-	    ND_PRINT("\n\t      NumTCPFCSupported: %u", GET_U_1(tptr + 5));
+	    ND_PRINT(C_RESET, "\n\t      NumTCPFCSupported: %u", GET_U_1(tptr + 5));
 	    break;
         case LLDP_DCBX_APPLICATION_TLV:
             if (tlv_len < 4) {
                 goto trunc;
             }
-	    ND_PRINT("\n\t    Feature - Application (type 0x%x, length %u)",
+	    ND_PRINT(C_RESET, "\n\t    Feature - Application (type 0x%x, length %u)",
 		LLDP_DCBX_APPLICATION_TLV, tlv_len);
-	    ND_PRINT("\n\t      Oper_Version: %u", GET_U_1(tptr));
-	    ND_PRINT("\n\t      Max_Version: %u", GET_U_1(tptr + 1));
-	    ND_PRINT("\n\t      Info block(0x%02X): ", GET_U_1(tptr + 2));
+	    ND_PRINT(C_RESET, "\n\t      Oper_Version: %u", GET_U_1(tptr));
+	    ND_PRINT(C_RESET, "\n\t      Max_Version: %u", GET_U_1(tptr + 1));
+	    ND_PRINT(C_RESET, "\n\t      Info block(0x%02X): ", GET_U_1(tptr + 2));
 	    tval = GET_U_1(tptr + 2);
-	    ND_PRINT("Enable bit: %u, Willing bit: %u, Error Bit: %u",
+	    ND_PRINT(C_RESET, "Enable bit: %u, Willing bit: %u, Error Bit: %u",
 		(tval &  0x80) ? 1 : 0, (tval &  0x40) ? 1 : 0,
 		(tval &  0x20) ? 1 : 0);
-	    ND_PRINT("\n\t      SubType: %u", GET_U_1(tptr + 3));
+	    ND_PRINT(C_RESET, "\n\t      SubType: %u", GET_U_1(tptr + 3));
 	    tval = tlv_len - 4;
 	    mptr = tptr + 4;
 	    while (tval >= 6) {
-		ND_PRINT("\n\t      Application Value");
-		ND_PRINT("\n\t          Application Protocol ID: 0x%04x",
+		ND_PRINT(C_RESET, "\n\t      Application Value");
+		ND_PRINT(C_RESET, "\n\t          Application Protocol ID: 0x%04x",
 			GET_BE_U_2(mptr));
 		uval = GET_BE_U_3(mptr + 2);
-		ND_PRINT("\n\t          SF (0x%x) Application Protocol ID is %s",
+		ND_PRINT(C_RESET, "\n\t          SF (0x%x) Application Protocol ID is %s",
 			(uval >> 22),
 			(uval >> 22) ? "Socket Number" : "L2 EtherType");
-		ND_PRINT("\n\t          OUI: 0x%06x", uval & 0x3fffff);
-		ND_PRINT("\n\t          User Priority Map: 0x%02x",
+		ND_PRINT(C_RESET, "\n\t          OUI: 0x%06x", uval & 0x3fffff);
+		ND_PRINT(C_RESET, "\n\t          User Priority Map: 0x%02x",
                          GET_U_1(mptr + 5));
 		tval = tval - 6;
 		mptr = mptr + 6;
@@ -1407,7 +1407,7 @@ lldp_mgmt_addr_tlv_print(netdissect_options *ndo,
     if (mgmt_addr == NULL) {
         return 0;
     }
-    ND_PRINT("\n\t  Management Address length %u, %s",
+    ND_PRINT(C_RESET, "\n\t  Management Address length %u, %s",
            mgmt_addr_len, mgmt_addr);
     tptr += mgmt_addr_len;
     tlen -= mgmt_addr_len;
@@ -1417,7 +1417,7 @@ lldp_mgmt_addr_tlv_print(netdissect_options *ndo,
     }
 
     intf_num_subtype = GET_U_1(tptr);
-    ND_PRINT("\n\t  %s Interface Numbering (%u): %u",
+    ND_PRINT(C_RESET, "\n\t  %s Interface Numbering (%u): %u",
            tok2str(lldp_intf_numb_subtype_values, "Unknown", intf_num_subtype),
            intf_num_subtype,
            GET_BE_U_4(tptr + 1));
@@ -1435,7 +1435,7 @@ lldp_mgmt_addr_tlv_print(netdissect_options *ndo,
             return 0;
         }
         if (oid_len) {
-            ND_PRINT("\n\t  OID length %u", oid_len);
+            ND_PRINT(C_RESET, "\n\t  OID length %u", oid_len);
             nd_printjnp(ndo, tptr + 1, oid_len);
         }
     }
@@ -1457,7 +1457,7 @@ lldp_print(netdissect_options *ndo,
     tptr = pptr;
     tlen = len;
 
-    ND_PRINT("LLDP, length %u", len);
+    ND_PRINT(C_RESET, "LLDP, length %u", len);
 
     while (tlen >= sizeof(tlv)) {
 
@@ -1473,7 +1473,7 @@ lldp_print(netdissect_options *ndo,
         tptr += sizeof(tlv);
 
         if (ndo->ndo_vflag) {
-            ND_PRINT("\n\t%s TLV (%u), length %u",
+            ND_PRINT(C_RESET, "\n\t%s TLV (%u), length %u",
                    tok2str(lldp_tlv_values, "Unknown", tlv_type),
                    tlv_type, tlv_len);
         }
@@ -1496,7 +1496,7 @@ lldp_print(netdissect_options *ndo,
                     goto trunc;
                 }
                 subtype = GET_U_1(tptr);
-                ND_PRINT("\n\t  Subtype %s (%u): ",
+                ND_PRINT(C_RESET, "\n\t  Subtype %s (%u): ",
                        tok2str(lldp_chassis_subtype_values, "Unknown", subtype),
                        subtype);
 
@@ -1505,7 +1505,7 @@ lldp_print(netdissect_options *ndo,
                     if (tlv_len < 1+6) {
                         goto trunc;
                     }
-                    ND_PRINT("%s", GET_ETHERADDR_STRING(tptr + 1));
+                    ND_PRINT(C_RESET, "%s", GET_ETHERADDR_STRING(tptr + 1));
                     break;
 
                 case LLDP_CHASSIS_INTF_NAME_SUBTYPE: /* fall through */
@@ -1521,7 +1521,7 @@ lldp_print(netdissect_options *ndo,
                     if (network_addr == NULL) {
                         goto trunc;
                     }
-                    ND_PRINT("%s", network_addr);
+                    ND_PRINT(C_RESET, "%s", network_addr);
                     break;
 
                 default:
@@ -1537,7 +1537,7 @@ lldp_print(netdissect_options *ndo,
                     goto trunc;
                 }
                 subtype = GET_U_1(tptr);
-                ND_PRINT("\n\t  Subtype %s (%u): ",
+                ND_PRINT(C_RESET, "\n\t  Subtype %s (%u): ",
                        tok2str(lldp_port_subtype_values, "Unknown", subtype),
                        subtype);
 
@@ -1546,7 +1546,7 @@ lldp_print(netdissect_options *ndo,
                     if (tlv_len < 1+6) {
                         goto trunc;
                     }
-                    ND_PRINT("%s", GET_ETHERADDR_STRING(tptr + 1));
+                    ND_PRINT(C_RESET, "%s", GET_ETHERADDR_STRING(tptr + 1));
                     break;
 
                 case LLDP_PORT_INTF_NAME_SUBTYPE: /* fall through */
@@ -1562,7 +1562,7 @@ lldp_print(netdissect_options *ndo,
                     if (network_addr == NULL) {
                         goto trunc;
                     }
-                    ND_PRINT("%s", network_addr);
+                    ND_PRINT(C_RESET, "%s", network_addr);
                     break;
 
                 default:
@@ -1577,13 +1577,13 @@ lldp_print(netdissect_options *ndo,
                 if (tlv_len < 2) {
                     goto trunc;
                 }
-                ND_PRINT(": TTL %us", GET_BE_U_2(tptr));
+                ND_PRINT(C_RESET, ": TTL %us", GET_BE_U_2(tptr));
             }
             break;
 
         case LLDP_PORT_DESCR_TLV:
             if (ndo->ndo_vflag) {
-                ND_PRINT(": ");
+                ND_PRINT(C_RESET, ": ");
                 nd_printjnp(ndo, tptr, tlv_len);
             }
             break;
@@ -1593,13 +1593,13 @@ lldp_print(netdissect_options *ndo,
              * The system name is also print in non-verbose mode
              * similar to the CDP printer.
              */
-            ND_PRINT(": ");
+            ND_PRINT(C_RESET, ": ");
             nd_printjnp(ndo, tptr, tlv_len);
             break;
 
         case LLDP_SYSTEM_DESCR_TLV:
             if (ndo->ndo_vflag) {
-                ND_PRINT("\n\t  ");
+                ND_PRINT(C_RESET, "\n\t  ");
                 nd_printjnp(ndo, tptr, tlv_len);
             }
             break;
@@ -1617,9 +1617,9 @@ lldp_print(netdissect_options *ndo,
                 }
                 cap = GET_BE_U_2(tptr);
                 ena_cap = GET_BE_U_2(tptr + 2);
-                ND_PRINT("\n\t  System  Capabilities [%s] (0x%04x)",
+                ND_PRINT(C_RESET, "\n\t  System  Capabilities [%s] (0x%04x)",
                        bittok2str(lldp_cap_values, "none", cap), cap);
-                ND_PRINT("\n\t  Enabled Capabilities [%s] (0x%04x)",
+                ND_PRINT(C_RESET, "\n\t  Enabled Capabilities [%s] (0x%04x)",
                        bittok2str(lldp_cap_values, "none", ena_cap), ena_cap);
             }
             break;
@@ -1638,7 +1638,7 @@ lldp_print(netdissect_options *ndo,
                     goto trunc;
                 }
                 oui = GET_BE_U_3(tptr);
-                ND_PRINT(": OUI %s (0x%06x)", tok2str(oui_values, "Unknown", oui), oui);
+                ND_PRINT(C_RESET, ": OUI %s (0x%06x)", tok2str(oui_values, "Unknown", oui), oui);
 
                 switch (oui) {
                 case OUI_IEEE_8021_PRIVATE:

--- a/print-lmp.c
+++ b/print-lmp.c
@@ -371,45 +371,45 @@ lmp_print_data_link_subobjs(netdissect_options *ndo, const u_char *obj_tptr,
     while (total_subobj_len > 0 && hexdump == FALSE ) {
 	subobj_type = GET_U_1(obj_tptr + offset);
 	subobj_len  = GET_U_1(obj_tptr + offset + 1);
-	ND_PRINT("\n\t    Subobject, Type: %s (%u), Length: %u",
+	ND_PRINT(C_RESET, "\n\t    Subobject, Type: %s (%u), Length: %u",
 		tok2str(lmp_data_link_subobj,
 			"Unknown",
 			subobj_type),
 			subobj_type,
 			subobj_len);
 	if (subobj_len < 4) {
-	    ND_PRINT(" (too short)");
+	    ND_PRINT(C_RESET, " (too short)");
 	    break;
 	}
 	if ((subobj_len % 4) != 0) {
-	    ND_PRINT(" (not a multiple of 4)");
+	    ND_PRINT(C_RESET, " (not a multiple of 4)");
 	    break;
 	}
 	if (total_subobj_len < subobj_len) {
-	    ND_PRINT(" (goes past the end of the object)");
+	    ND_PRINT(C_RESET, " (goes past the end of the object)");
 	    break;
 	}
 	switch(subobj_type) {
 	case INT_SWITCHING_TYPE_SUBOBJ:
-	    ND_PRINT("\n\t      Switching Type: %s (%u)",
+	    ND_PRINT(C_RESET, "\n\t      Switching Type: %s (%u)",
 		tok2str(gmpls_switch_cap_values,
 			"Unknown",
 			GET_U_1(obj_tptr + offset + 2)),
 		GET_U_1(obj_tptr + offset + 2));
-	    ND_PRINT("\n\t      Encoding Type: %s (%u)",
+	    ND_PRINT(C_RESET, "\n\t      Encoding Type: %s (%u)",
 		tok2str(gmpls_encoding_values,
 			"Unknown",
 			GET_U_1(obj_tptr + offset + 3)),
 		GET_U_1(obj_tptr + offset + 3));
 	    bw.i = GET_BE_U_4(obj_tptr + offset + 4);
-	    ND_PRINT("\n\t      Min Reservable Bandwidth: %.3f Mbps",
+	    ND_PRINT(C_RESET, "\n\t      Min Reservable Bandwidth: %.3f Mbps",
                 bw.f*8/1000000);
 	    bw.i = GET_BE_U_4(obj_tptr + offset + 8);
-	    ND_PRINT("\n\t      Max Reservable Bandwidth: %.3f Mbps",
+	    ND_PRINT(C_RESET, "\n\t      Max Reservable Bandwidth: %.3f Mbps",
                 bw.f*8/1000000);
 	    break;
 	case WAVELENGTH_SUBOBJ:
-	    ND_PRINT("\n\t      Wavelength: %u",
+	    ND_PRINT(C_RESET, "\n\t      Wavelength: %u",
 		GET_BE_U_4(obj_tptr + offset + 4));
 	    break;
 	default:
@@ -450,14 +450,14 @@ lmp_print(netdissect_options *ndo,
      * Sanity checking of the header.
      */
     if (LMP_EXTRACT_VERSION(version_res) != LMP_VERSION) {
-	ND_PRINT("LMP version %u packet not supported",
+	ND_PRINT(C_RESET, "LMP version %u packet not supported",
                LMP_EXTRACT_VERSION(version_res));
 	return;
     }
 
     /* in non-verbose mode just lets print the basic Message Type*/
     if (ndo->ndo_vflag < 1) {
-        ND_PRINT("LMPv%u %s Message, length: %u",
+        ND_PRINT(C_RESET, "LMPv%u %s Message, length: %u",
                LMP_EXTRACT_VERSION(version_res),
                tok2str(lmp_msg_type_values, "unknown (%u)",GET_U_1(lmp_com_header->msg_type)),
                length);
@@ -468,17 +468,17 @@ lmp_print(netdissect_options *ndo,
 
     tlen=GET_BE_U_2(lmp_com_header->length);
 
-    ND_PRINT("\n\tLMPv%u, msg-type: %s, Flags: [%s], length: %u",
+    ND_PRINT(C_RESET, "\n\tLMPv%u, msg-type: %s, Flags: [%s], length: %u",
            LMP_EXTRACT_VERSION(version_res),
            tok2str(lmp_msg_type_values, "unknown, type: %u",GET_U_1(lmp_com_header->msg_type)),
            bittok2str(lmp_header_flag_values,"none",GET_U_1(lmp_com_header->flags)),
            tlen);
     if (tlen < sizeof(struct lmp_common_header)) {
-        ND_PRINT(" (too short)");
+        ND_PRINT(C_RESET, " (too short)");
         return;
     }
     if (tlen > length) {
-        ND_PRINT(" (too long)");
+        ND_PRINT(C_RESET, " (too long)");
         tlen = length;
     }
 
@@ -491,7 +491,7 @@ lmp_print(netdissect_options *ndo,
         lmp_obj_len=GET_BE_U_2(lmp_obj_header->length);
         lmp_obj_ctype=GET_U_1(lmp_obj_header->ctype)&0x7f;
 
-        ND_PRINT("\n\t  %s Object (%u), Class-Type: %s (%u) Flags: [%snegotiable], length: %u",
+        ND_PRINT(C_RESET, "\n\t  %s Object (%u), Class-Type: %s (%u) Flags: [%snegotiable], length: %u",
                tok2str(lmp_obj_values,
                        "Unknown",
                        GET_U_1(lmp_obj_header->class_num)),
@@ -504,11 +504,11 @@ lmp_print(netdissect_options *ndo,
                lmp_obj_len);
 
         if (lmp_obj_len < 4) {
-            ND_PRINT(" (too short)");
+            ND_PRINT(C_RESET, " (too short)");
             return;
         }
         if ((lmp_obj_len % 4) != 0) {
-            ND_PRINT(" (not a multiple of 4)");
+            ND_PRINT(C_RESET, " (not a multiple of 4)");
             return;
         }
 
@@ -526,10 +526,10 @@ lmp_print(netdissect_options *ndo,
             case LMP_CTYPE_LOC:
             case LMP_CTYPE_RMT:
                 if (obj_tlen != 4) {
-                    ND_PRINT(" (not correct for object)");
+                    ND_PRINT(C_RESET, " (not correct for object)");
                     break;
                 }
-                ND_PRINT("\n\t    Control Channel ID: %u (0x%08x)",
+                ND_PRINT(C_RESET, "\n\t    Control Channel ID: %u (0x%08x)",
                        GET_BE_U_4(obj_tptr),
                        GET_BE_U_4(obj_tptr));
                 break;
@@ -545,30 +545,30 @@ lmp_print(netdissect_options *ndo,
             case LMP_CTYPE_IPV4_LOC:
             case LMP_CTYPE_IPV4_RMT:
                 if (obj_tlen != 4) {
-                    ND_PRINT(" (not correct for object)");
+                    ND_PRINT(C_RESET, " (not correct for object)");
                     break;
                 }
-                ND_PRINT("\n\t    IPv4 Link ID: %s (0x%08x)",
+                ND_PRINT(C_RESET, "\n\t    IPv4 Link ID: %s (0x%08x)",
                        GET_IPADDR_STRING(obj_tptr),
                        GET_BE_U_4(obj_tptr));
                 break;
             case LMP_CTYPE_IPV6_LOC:
             case LMP_CTYPE_IPV6_RMT:
                 if (obj_tlen != 16) {
-                    ND_PRINT(" (not correct for object)");
+                    ND_PRINT(C_RESET, " (not correct for object)");
                     break;
                 }
-                ND_PRINT("\n\t    IPv6 Link ID: %s (0x%08x)",
+                ND_PRINT(C_RESET, "\n\t    IPv6 Link ID: %s (0x%08x)",
                        GET_IP6ADDR_STRING(obj_tptr),
                        GET_BE_U_4(obj_tptr));
                 break;
             case LMP_CTYPE_UNMD_LOC:
             case LMP_CTYPE_UNMD_RMT:
                 if (obj_tlen != 4) {
-                    ND_PRINT(" (not correct for object)");
+                    ND_PRINT(C_RESET, " (not correct for object)");
                     break;
                 }
-                ND_PRINT("\n\t    Link ID: %u (0x%08x)",
+                ND_PRINT(C_RESET, "\n\t    Link ID: %u (0x%08x)",
                        GET_BE_U_4(obj_tptr),
                        GET_BE_U_4(obj_tptr));
                 break;
@@ -581,19 +581,19 @@ lmp_print(netdissect_options *ndo,
             switch(lmp_obj_ctype) {
             case LMP_CTYPE_1:
                 if (obj_tlen != 4) {
-                    ND_PRINT(" (not correct for object)");
+                    ND_PRINT(C_RESET, " (not correct for object)");
                     break;
                 }
-                ND_PRINT("\n\t    Message ID: %u (0x%08x)",
+                ND_PRINT(C_RESET, "\n\t    Message ID: %u (0x%08x)",
                        GET_BE_U_4(obj_tptr),
                        GET_BE_U_4(obj_tptr));
                 break;
             case LMP_CTYPE_2:
                 if (obj_tlen != 4) {
-                    ND_PRINT(" (not correct for object)");
+                    ND_PRINT(C_RESET, " (not correct for object)");
                     break;
                 }
-                ND_PRINT("\n\t    Message ID Ack: %u (0x%08x)",
+                ND_PRINT(C_RESET, "\n\t    Message ID Ack: %u (0x%08x)",
                        GET_BE_U_4(obj_tptr),
                        GET_BE_U_4(obj_tptr));
                 break;
@@ -607,10 +607,10 @@ lmp_print(netdissect_options *ndo,
             case LMP_CTYPE_LOC:
             case LMP_CTYPE_RMT:
                 if (obj_tlen != 4) {
-                    ND_PRINT(" (not correct for object)");
+                    ND_PRINT(C_RESET, " (not correct for object)");
                     break;
                 }
-                ND_PRINT("\n\t    Node ID: %s (0x%08x)",
+                ND_PRINT(C_RESET, "\n\t    Node ID: %s (0x%08x)",
                        GET_IPADDR_STRING(obj_tptr),
                        GET_BE_U_4(obj_tptr));
                 break;
@@ -624,10 +624,10 @@ lmp_print(netdissect_options *ndo,
             switch(lmp_obj_ctype) {
             case LMP_CTYPE_HELLO_CONFIG:
                 if (obj_tlen != 4) {
-                    ND_PRINT(" (not correct for object)");
+                    ND_PRINT(C_RESET, " (not correct for object)");
                     break;
                 }
-                ND_PRINT("\n\t    Hello Interval: %u\n\t    Hello Dead Interval: %u",
+                ND_PRINT(C_RESET, "\n\t    Hello Interval: %u\n\t    Hello Dead Interval: %u",
                        GET_BE_U_2(obj_tptr),
                        GET_BE_U_2(obj_tptr + 2));
                 break;
@@ -641,10 +641,10 @@ lmp_print(netdissect_options *ndo,
             switch(lmp_obj_ctype) {
 	    case LMP_CTYPE_HELLO:
                 if (obj_tlen != 8) {
-                    ND_PRINT(" (not correct for object)");
+                    ND_PRINT(C_RESET, " (not correct for object)");
                     break;
                 }
-                ND_PRINT("\n\t    Tx Seq: %u, Rx Seq: %u",
+                ND_PRINT(C_RESET, "\n\t    Tx Seq: %u, Rx Seq: %u",
                        GET_BE_U_4(obj_tptr),
                        GET_BE_U_4(obj_tptr + 4));
                 break;
@@ -658,15 +658,15 @@ lmp_print(netdissect_options *ndo,
 	    switch(lmp_obj_ctype) {
 	    case LMP_CTYPE_IPV4:
                 if (obj_tlen != 12) {
-                    ND_PRINT(" (not correct for object)");
+                    ND_PRINT(C_RESET, " (not correct for object)");
                     break;
                 }
-		ND_PRINT("\n\t    Flags: [%s]",
+		ND_PRINT(C_RESET, "\n\t    Flags: [%s]",
 		    bittok2str(lmp_obj_te_link_flag_values,
 			"none",
 			GET_U_1(obj_tptr)));
 
-		ND_PRINT("\n\t    Local Link-ID: %s (0x%08x)"
+		ND_PRINT(C_RESET, "\n\t    Local Link-ID: %s (0x%08x)"
 		       "\n\t    Remote Link-ID: %s (0x%08x)",
                        GET_IPADDR_STRING(obj_tptr+4),
                        GET_BE_U_4(obj_tptr + 4),
@@ -676,15 +676,15 @@ lmp_print(netdissect_options *ndo,
 
 	    case LMP_CTYPE_IPV6:
                 if (obj_tlen != 36) {
-                    ND_PRINT(" (not correct for object)");
+                    ND_PRINT(C_RESET, " (not correct for object)");
                     break;
                 }
-		ND_PRINT("\n\t    Flags: [%s]",
+		ND_PRINT(C_RESET, "\n\t    Flags: [%s]",
 		    bittok2str(lmp_obj_te_link_flag_values,
 			"none",
 			GET_U_1(obj_tptr)));
 
-		ND_PRINT("\n\t    Local Link-ID: %s (0x%08x)"
+		ND_PRINT(C_RESET, "\n\t    Local Link-ID: %s (0x%08x)"
 		       "\n\t    Remote Link-ID: %s (0x%08x)",
                        GET_IP6ADDR_STRING(obj_tptr+4),
                        GET_BE_U_4(obj_tptr + 4),
@@ -694,15 +694,15 @@ lmp_print(netdissect_options *ndo,
 
 	    case LMP_CTYPE_UNMD:
                 if (obj_tlen != 12) {
-                    ND_PRINT(" (not correct for object)");
+                    ND_PRINT(C_RESET, " (not correct for object)");
                     break;
                 }
-		ND_PRINT("\n\t    Flags: [%s]",
+		ND_PRINT(C_RESET, "\n\t    Flags: [%s]",
 		    bittok2str(lmp_obj_te_link_flag_values,
 			"none",
 			GET_U_1(obj_tptr)));
 
-		ND_PRINT("\n\t    Local Link-ID: %u (0x%08x)"
+		ND_PRINT(C_RESET, "\n\t    Local Link-ID: %u (0x%08x)"
 		       "\n\t    Remote Link-ID: %u (0x%08x)",
                        GET_BE_U_4(obj_tptr + 4),
                        GET_BE_U_4(obj_tptr + 4),
@@ -719,14 +719,14 @@ lmp_print(netdissect_options *ndo,
 	    switch(lmp_obj_ctype) {
 	    case LMP_CTYPE_IPV4:
                 if (obj_tlen < 12) {
-                    ND_PRINT(" (not correct for object)");
+                    ND_PRINT(C_RESET, " (not correct for object)");
                     break;
                 }
-	        ND_PRINT("\n\t    Flags: [%s]",
+	        ND_PRINT(C_RESET, "\n\t    Flags: [%s]",
 		    bittok2str(lmp_obj_data_link_flag_values,
 			"none",
 			GET_U_1(obj_tptr)));
-                ND_PRINT("\n\t    Local Interface ID: %s (0x%08x)"
+                ND_PRINT(C_RESET, "\n\t    Local Interface ID: %s (0x%08x)"
                        "\n\t    Remote Interface ID: %s (0x%08x)",
                        GET_IPADDR_STRING(obj_tptr+4),
                        GET_BE_U_4(obj_tptr + 4),
@@ -739,14 +739,14 @@ lmp_print(netdissect_options *ndo,
 
 	    case LMP_CTYPE_IPV6:
                 if (obj_tlen < 36) {
-                    ND_PRINT(" (not correct for object)");
+                    ND_PRINT(C_RESET, " (not correct for object)");
                     break;
                 }
-	        ND_PRINT("\n\t    Flags: [%s]",
+	        ND_PRINT(C_RESET, "\n\t    Flags: [%s]",
 		    bittok2str(lmp_obj_data_link_flag_values,
 			"none",
 			GET_U_1(obj_tptr)));
-                ND_PRINT("\n\t    Local Interface ID: %s (0x%08x)"
+                ND_PRINT(C_RESET, "\n\t    Local Interface ID: %s (0x%08x)"
                        "\n\t    Remote Interface ID: %s (0x%08x)",
                        GET_IP6ADDR_STRING(obj_tptr+4),
                        GET_BE_U_4(obj_tptr + 4),
@@ -759,14 +759,14 @@ lmp_print(netdissect_options *ndo,
 
 	    case LMP_CTYPE_UNMD:
                 if (obj_tlen < 12) {
-                    ND_PRINT(" (not correct for object)");
+                    ND_PRINT(C_RESET, " (not correct for object)");
                     break;
                 }
-	        ND_PRINT("\n\t    Flags: [%s]",
+	        ND_PRINT(C_RESET, "\n\t    Flags: [%s]",
 		    bittok2str(lmp_obj_data_link_flag_values,
 			"none",
 			GET_U_1(obj_tptr)));
-                ND_PRINT("\n\t    Local Interface ID: %u (0x%08x)"
+                ND_PRINT(C_RESET, "\n\t    Local Interface ID: %u (0x%08x)"
                        "\n\t    Remote Interface ID: %u (0x%08x)",
                        GET_BE_U_4(obj_tptr + 4),
                        GET_BE_U_4(obj_tptr + 4),
@@ -786,26 +786,26 @@ lmp_print(netdissect_options *ndo,
 	    switch(lmp_obj_ctype) {
             case LMP_CTYPE_1:
                 if (obj_tlen != 20) {
-                    ND_PRINT(" (not correct for object)");
+                    ND_PRINT(C_RESET, " (not correct for object)");
                     break;
                 }
-		ND_PRINT("\n\t    Flags: %s",
+		ND_PRINT(C_RESET, "\n\t    Flags: %s",
 		bittok2str(lmp_obj_begin_verify_flag_values,
 			"none",
 			GET_BE_U_2(obj_tptr)));
-		ND_PRINT("\n\t    Verify Interval: %u",
+		ND_PRINT(C_RESET, "\n\t    Verify Interval: %u",
 			GET_BE_U_2(obj_tptr + 2));
-		ND_PRINT("\n\t    Data links: %u",
+		ND_PRINT(C_RESET, "\n\t    Data links: %u",
 			GET_BE_U_4(obj_tptr + 4));
-                ND_PRINT("\n\t    Encoding type: %s",
+                ND_PRINT(C_RESET, "\n\t    Encoding type: %s",
 			tok2str(gmpls_encoding_values, "Unknown", GET_U_1((obj_tptr + 8))));
-                ND_PRINT("\n\t    Verify Transport Mechanism: %u (0x%x)%s",
+                ND_PRINT(C_RESET, "\n\t    Verify Transport Mechanism: %u (0x%x)%s",
 			GET_BE_U_2(obj_tptr + 10),
 			GET_BE_U_2(obj_tptr + 10),
 			GET_BE_U_2(obj_tptr + 10)&8000 ? " (Payload test messages capable)" : "");
                 bw.i = GET_BE_U_4(obj_tptr + 12);
-		ND_PRINT("\n\t    Transmission Rate: %.3f Mbps",bw.f*8/1000000);
-		ND_PRINT("\n\t    Wavelength: %u",
+		ND_PRINT(C_RESET, "\n\t    Transmission Rate: %.3f Mbps",bw.f*8/1000000);
+		ND_PRINT(C_RESET, "\n\t    Wavelength: %u",
 			GET_BE_U_4(obj_tptr + 16));
 		break;
 
@@ -818,10 +818,10 @@ lmp_print(netdissect_options *ndo,
 	    switch(lmp_obj_ctype) {
             case LMP_CTYPE_1:
                 if (obj_tlen != 4) {
-                    ND_PRINT(" (not correct for object)");
+                    ND_PRINT(C_RESET, " (not correct for object)");
                     break;
                 }
-                ND_PRINT("\n\t    Verify Dead Interval: %u"
+                ND_PRINT(C_RESET, "\n\t    Verify Dead Interval: %u"
                        "\n\t    Verify Transport Response: %u",
                        GET_BE_U_2(obj_tptr),
                        GET_BE_U_2(obj_tptr + 2));
@@ -836,10 +836,10 @@ lmp_print(netdissect_options *ndo,
 	    switch(lmp_obj_ctype) {
             case LMP_CTYPE_1:
                 if (obj_tlen != 4) {
-                    ND_PRINT(" (not correct for object)");
+                    ND_PRINT(C_RESET, " (not correct for object)");
                     break;
                 }
-                ND_PRINT("\n\t    Verify ID: %u",
+                ND_PRINT(C_RESET, "\n\t    Verify ID: %u",
                        GET_BE_U_4(obj_tptr));
                 break;
 
@@ -854,21 +854,21 @@ lmp_print(netdissect_options *ndo,
 		offset = 0;
 		/* Decode pairs: <Interface_ID (4 bytes), Channel_status (4 bytes)> */
 		while (offset+8 <= obj_tlen) {
-			ND_PRINT("\n\t    Interface ID: %s (0x%08x)",
+			ND_PRINT(C_RESET, "\n\t    Interface ID: %s (0x%08x)",
 			GET_IPADDR_STRING(obj_tptr+offset),
 			GET_BE_U_4(obj_tptr + offset));
 
-			ND_PRINT("\n\t\t    Active: %s (%u)",
+			ND_PRINT(C_RESET, "\n\t\t    Active: %s (%u)",
 				(GET_BE_U_4(obj_tptr + offset + 4)>>31) ?
 				"Allocated" : "Non-allocated",
 				(GET_BE_U_4(obj_tptr + offset + 4)>>31));
 
-			ND_PRINT("\n\t\t    Direction: %s (%u)",
+			ND_PRINT(C_RESET, "\n\t\t    Direction: %s (%u)",
 				(GET_BE_U_4(obj_tptr + offset + 4)>>30)&0x1 ?
 				"Transmit" : "Receive",
 				(GET_BE_U_4(obj_tptr + offset + 4)>>30)&0x1);
 
-			ND_PRINT("\n\t\t    Channel Status: %s (%u)",
+			ND_PRINT(C_RESET, "\n\t\t    Channel Status: %s (%u)",
 					tok2str(lmp_obj_channel_status_values,
 					"Unknown",
 					GET_BE_U_4(obj_tptr + offset + 4)&0x3FFFFFF),
@@ -881,21 +881,21 @@ lmp_print(netdissect_options *ndo,
 		offset = 0;
 		/* Decode pairs: <Interface_ID (16 bytes), Channel_status (4 bytes)> */
 		while (offset+20 <= obj_tlen) {
-			ND_PRINT("\n\t    Interface ID: %s (0x%08x)",
+			ND_PRINT(C_RESET, "\n\t    Interface ID: %s (0x%08x)",
 			GET_IP6ADDR_STRING(obj_tptr+offset),
 			GET_BE_U_4(obj_tptr + offset));
 
-			ND_PRINT("\n\t\t    Active: %s (%u)",
+			ND_PRINT(C_RESET, "\n\t\t    Active: %s (%u)",
 				(GET_BE_U_4(obj_tptr + offset + 16)>>31) ?
 				"Allocated" : "Non-allocated",
 				(GET_BE_U_4(obj_tptr + offset + 16)>>31));
 
-			ND_PRINT("\n\t\t    Direction: %s (%u)",
+			ND_PRINT(C_RESET, "\n\t\t    Direction: %s (%u)",
 				(GET_BE_U_4(obj_tptr + offset + 16)>>30)&0x1 ?
 				"Transmit" : "Receive",
 				(GET_BE_U_4(obj_tptr + offset + 16)>>30)&0x1);
 
-			ND_PRINT("\n\t\t    Channel Status: %s (%u)",
+			ND_PRINT(C_RESET, "\n\t\t    Channel Status: %s (%u)",
 					tok2str(lmp_obj_channel_status_values,
 					"Unknown",
 					GET_BE_U_4(obj_tptr + offset + 16)&0x3FFFFFF),
@@ -908,21 +908,21 @@ lmp_print(netdissect_options *ndo,
 		offset = 0;
 		/* Decode pairs: <Interface_ID (4 bytes), Channel_status (4 bytes)> */
 		while (offset+8 <= obj_tlen) {
-			ND_PRINT("\n\t    Interface ID: %u (0x%08x)",
+			ND_PRINT(C_RESET, "\n\t    Interface ID: %u (0x%08x)",
 			GET_BE_U_4(obj_tptr + offset),
 			GET_BE_U_4(obj_tptr + offset));
 
-			ND_PRINT("\n\t\t    Active: %s (%u)",
+			ND_PRINT(C_RESET, "\n\t\t    Active: %s (%u)",
 				(GET_BE_U_4(obj_tptr + offset + 4)>>31) ?
 				"Allocated" : "Non-allocated",
 				(GET_BE_U_4(obj_tptr + offset + 4)>>31));
 
-			ND_PRINT("\n\t\t    Direction: %s (%u)",
+			ND_PRINT(C_RESET, "\n\t\t    Direction: %s (%u)",
 				(GET_BE_U_4(obj_tptr + offset + 4)>>30)&0x1 ?
 				"Transmit" : "Receive",
 				(GET_BE_U_4(obj_tptr + offset + 4)>>30)&0x1);
 
-			ND_PRINT("\n\t\t    Channel Status: %s (%u)",
+			ND_PRINT(C_RESET, "\n\t\t    Channel Status: %s (%u)",
 					tok2str(lmp_obj_channel_status_values,
 					"Unknown",
 					GET_BE_U_4(obj_tptr + offset + 4)&0x3FFFFFF),
@@ -941,7 +941,7 @@ lmp_print(netdissect_options *ndo,
 	    case LMP_CTYPE_IPV4:
 		offset = 0;
 		while (offset+4 <= obj_tlen) {
-			ND_PRINT("\n\t    Interface ID: %s (0x%08x)",
+			ND_PRINT(C_RESET, "\n\t    Interface ID: %s (0x%08x)",
 			GET_IPADDR_STRING(obj_tptr+offset),
 			GET_BE_U_4(obj_tptr + offset));
 			offset+=4;
@@ -951,7 +951,7 @@ lmp_print(netdissect_options *ndo,
 	    case LMP_CTYPE_IPV6:
 		offset = 0;
 		while (offset+16 <= obj_tlen) {
-			ND_PRINT("\n\t    Interface ID: %s (0x%08x)",
+			ND_PRINT(C_RESET, "\n\t    Interface ID: %s (0x%08x)",
 			GET_IP6ADDR_STRING(obj_tptr+offset),
 			GET_BE_U_4(obj_tptr + offset));
 			offset+=16;
@@ -961,7 +961,7 @@ lmp_print(netdissect_options *ndo,
 	    case LMP_CTYPE_UNMD:
 		offset = 0;
 		while (offset+4 <= obj_tlen) {
-			ND_PRINT("\n\t    Interface ID: %u (0x%08x)",
+			ND_PRINT(C_RESET, "\n\t    Interface ID: %u (0x%08x)",
 			GET_BE_U_4(obj_tptr + offset),
 			GET_BE_U_4(obj_tptr + offset));
 			offset+=4;
@@ -977,10 +977,10 @@ lmp_print(netdissect_options *ndo,
 	    switch(lmp_obj_ctype) {
             case LMP_CTYPE_BEGIN_VERIFY_ERROR:
                 if (obj_tlen != 4) {
-                    ND_PRINT(" (not correct for object)");
+                    ND_PRINT(C_RESET, " (not correct for object)");
                     break;
                 }
-		ND_PRINT("\n\t    Error Code: %s",
+		ND_PRINT(C_RESET, "\n\t    Error Code: %s",
 		bittok2str(lmp_obj_begin_verify_error_values,
 			"none",
 			GET_BE_U_4(obj_tptr)));
@@ -988,10 +988,10 @@ lmp_print(netdissect_options *ndo,
 
             case LMP_CTYPE_LINK_SUMMARY_ERROR:
                 if (obj_tlen != 4) {
-                    ND_PRINT(" (not correct for object)");
+                    ND_PRINT(C_RESET, " (not correct for object)");
                     break;
                 }
-		ND_PRINT("\n\t    Error Code: %s",
+		ND_PRINT(C_RESET, "\n\t    Error Code: %s",
 		bittok2str(lmp_obj_link_summary_error_values,
 			"none",
 			GET_BE_U_4(obj_tptr)));
@@ -1005,35 +1005,35 @@ lmp_print(netdissect_options *ndo,
 	    switch (lmp_obj_ctype) {
 	    case LMP_CTYPE_SERVICE_CONFIG_SP:
                 if (obj_tlen != 4) {
-                    ND_PRINT(" (not correct for object)");
+                    ND_PRINT(C_RESET, " (not correct for object)");
                     break;
                 }
-		ND_PRINT("\n\t Flags: %s",
+		ND_PRINT(C_RESET, "\n\t Flags: %s",
 		       bittok2str(lmp_obj_service_config_sp_flag_values,
 				  "none",
 				  GET_U_1(obj_tptr)));
 
-		ND_PRINT("\n\t  UNI Version: %u",
+		ND_PRINT(C_RESET, "\n\t  UNI Version: %u",
 		       GET_U_1(obj_tptr + 1));
 
 		break;
 
             case LMP_CTYPE_SERVICE_CONFIG_CPSA:
                 if (obj_tlen != 16) {
-                    ND_PRINT(" (not correct for object)");
+                    ND_PRINT(C_RESET, " (not correct for object)");
                     break;
                 }
 
 		link_type = GET_U_1(obj_tptr);
 
-		ND_PRINT("\n\t Link Type: %s (%u)",
+		ND_PRINT(C_RESET, "\n\t Link Type: %s (%u)",
 		       tok2str(lmp_sd_service_config_cpsa_link_type_values,
 			       "Unknown", link_type),
 		       link_type);
 
 		switch (link_type) {
 		case LMP_SD_SERVICE_CONFIG_CPSA_LINK_TYPE_SDH:
-		    ND_PRINT("\n\t Signal Type: %s (%u)",
+		    ND_PRINT(C_RESET, "\n\t Signal Type: %s (%u)",
 			   tok2str(lmp_sd_service_config_cpsa_signal_type_sdh_values,
 				   "Unknown",
 				   GET_U_1(obj_tptr + 1)),
@@ -1041,7 +1041,7 @@ lmp_print(netdissect_options *ndo,
 		    break;
 
 		case LMP_SD_SERVICE_CONFIG_CPSA_LINK_TYPE_SONET:
-		    ND_PRINT("\n\t Signal Type: %s (%u)",
+		    ND_PRINT(C_RESET, "\n\t Signal Type: %s (%u)",
 			   tok2str(lmp_sd_service_config_cpsa_signal_type_sonet_values,
 				   "Unknown",
 				   GET_U_1(obj_tptr + 1)),
@@ -1049,29 +1049,29 @@ lmp_print(netdissect_options *ndo,
 		    break;
 		}
 
-		ND_PRINT("\n\t Transparency: %s",
+		ND_PRINT(C_RESET, "\n\t Transparency: %s",
 		       bittok2str(lmp_obj_service_config_cpsa_tp_flag_values,
 				  "none",
 				  GET_U_1(obj_tptr + 2)));
 
-		ND_PRINT("\n\t Contiguous Concatenation Types: %s",
+		ND_PRINT(C_RESET, "\n\t Contiguous Concatenation Types: %s",
 		       bittok2str(lmp_obj_service_config_cpsa_cct_flag_values,
 				  "none",
 				  GET_U_1(obj_tptr + 3)));
 
-		ND_PRINT("\n\t Minimum NCC: %u",
+		ND_PRINT(C_RESET, "\n\t Minimum NCC: %u",
 		       GET_BE_U_2(obj_tptr + 4));
 
-		ND_PRINT("\n\t Maximum NCC: %u",
+		ND_PRINT(C_RESET, "\n\t Maximum NCC: %u",
 		       GET_BE_U_2(obj_tptr + 6));
 
-		ND_PRINT("\n\t Minimum NVC:%u",
+		ND_PRINT(C_RESET, "\n\t Minimum NVC:%u",
 		       GET_BE_U_2(obj_tptr + 8));
 
-		ND_PRINT("\n\t Maximum NVC:%u",
+		ND_PRINT(C_RESET, "\n\t Maximum NVC:%u",
 		       GET_BE_U_2(obj_tptr + 10));
 
-		ND_PRINT("\n\t    Local Interface ID: %s (0x%08x)",
+		ND_PRINT(C_RESET, "\n\t    Local Interface ID: %s (0x%08x)",
 		       GET_IPADDR_STRING(obj_tptr+12),
 		       GET_BE_U_4(obj_tptr + 12));
 
@@ -1079,17 +1079,17 @@ lmp_print(netdissect_options *ndo,
 
 	    case LMP_CTYPE_SERVICE_CONFIG_TRANSPARENCY_TCM:
                 if (obj_tlen != 8) {
-                    ND_PRINT(" (not correct for object)");
+                    ND_PRINT(C_RESET, " (not correct for object)");
                     break;
                 }
 
-		ND_PRINT("\n\t Transparency Flags: %s",
+		ND_PRINT(C_RESET, "\n\t Transparency Flags: %s",
 		       bittok2str(
 			   lmp_obj_service_config_nsa_transparency_flag_values,
 			   "none",
 			   GET_BE_U_4(obj_tptr)));
 
-		ND_PRINT("\n\t TCM Monitoring Flags: %s",
+		ND_PRINT(C_RESET, "\n\t TCM Monitoring Flags: %s",
 		       bittok2str(
 			   lmp_obj_service_config_nsa_tcm_flag_values,
 			   "none",
@@ -1099,11 +1099,11 @@ lmp_print(netdissect_options *ndo,
 
 	    case LMP_CTYPE_SERVICE_CONFIG_NETWORK_DIVERSITY:
                 if (obj_tlen != 4) {
-                    ND_PRINT(" (not correct for object)");
+                    ND_PRINT(C_RESET, " (not correct for object)");
                     break;
                 }
 
-		ND_PRINT("\n\t Diversity: Flags: %s",
+		ND_PRINT(C_RESET, "\n\t Diversity: Flags: %s",
 		       bittok2str(
 			   lmp_obj_service_config_nsa_network_diversity_flag_values,
 			   "none",
@@ -1127,7 +1127,7 @@ lmp_print(netdissect_options *ndo,
                                lmp_obj_len-sizeof(struct lmp_object_header));
 
         if (tlen < lmp_obj_len) {
-            ND_PRINT(" [remaining objects length %u < %u]", tlen, lmp_obj_len);
+            ND_PRINT(C_RESET, " [remaining objects length %u < %u]", tlen, lmp_obj_len);
             nd_print_invalid(ndo);
             break;
         }

--- a/print-loopback.c
+++ b/print-loopback.c
@@ -65,29 +65,29 @@ loopback_message_print(netdissect_options *ndo,
 	function = GET_LE_U_2(cp);
 	cp += 2;
 	len -= 2;
-	ND_PRINT(", %s", tok2str(fcode_str, " invalid (%u)", function));
+	ND_PRINT(C_RESET, ", %s", tok2str(fcode_str, " invalid (%u)", function));
 
 	switch (function) {
 		case LOOPBACK_REPLY:
 			if (len < 2)
 				goto invalid;
 			/* receipt number */
-			ND_PRINT(", receipt number %u", GET_LE_U_2(cp));
+			ND_PRINT(C_RESET, ", receipt number %u", GET_LE_U_2(cp));
 			cp += 2;
 			len -= 2;
 			/* data */
-			ND_PRINT(", data (%u octets)", len);
+			ND_PRINT(C_RESET, ", data (%u octets)", len);
 			ND_TCHECK_LEN(cp, len);
 			break;
 		case LOOPBACK_FWDDATA:
 			if (len < MAC_ADDR_LEN)
 				goto invalid;
 			/* forwarding address */
-			ND_PRINT(", forwarding address %s", GET_ETHERADDR_STRING(cp));
+			ND_PRINT(C_RESET, ", forwarding address %s", GET_ETHERADDR_STRING(cp));
 			cp += MAC_ADDR_LEN;
 			len -= MAC_ADDR_LEN;
 			/* data */
-			ND_PRINT(", data (%u octets)", len);
+			ND_PRINT(C_RESET, ", data (%u octets)", len);
 			ND_TCHECK_LEN(cp, len);
 			break;
 		default:
@@ -108,16 +108,16 @@ loopback_print(netdissect_options *ndo,
 	uint16_t skipCount;
 
 	ndo->ndo_protocol = "loopback";
-	ND_PRINT("Loopback");
+	ND_PRINT(C_RESET, "Loopback");
 	if (len < 2)
 		goto invalid;
 	/* skipCount */
 	skipCount = GET_LE_U_2(cp);
 	cp += 2;
 	len -= 2;
-	ND_PRINT(", skipCount %u", skipCount);
+	ND_PRINT(C_RESET, ", skipCount %u", skipCount);
 	if (skipCount % 8)
-		ND_PRINT(" (bogus)");
+		ND_PRINT(C_RESET, " (bogus)");
 	if (skipCount > len)
 		goto invalid;
 	/* the octets to skip */

--- a/print-lspping.c
+++ b/print-lspping.c
@@ -535,14 +535,14 @@ lspping_print(netdissect_options *ndo,
      * Sanity checking of the header.
      */
     if (GET_BE_U_2(lspping_com_header->version) != LSPPING_VERSION) {
-	ND_PRINT("LSP-PING version %u packet not supported",
+	ND_PRINT(C_RESET, "LSP-PING version %u packet not supported",
                GET_BE_U_2(lspping_com_header->version));
 	return;
     }
 
     /* in non-verbose mode just lets print the basic Message Type*/
     if (ndo->ndo_vflag < 1) {
-        ND_PRINT("LSP-PINGv%u, %s, seq %u, length: %u",
+        ND_PRINT(C_RESET, "LSP-PINGv%u, %s, seq %u, length: %u",
                GET_BE_U_2(lspping_com_header->version),
                tok2str(lspping_msg_type_values, "unknown (%u)",GET_U_1(lspping_com_header->msg_type)),
                GET_BE_U_4(lspping_com_header->seq_number),
@@ -554,7 +554,7 @@ lspping_print(netdissect_options *ndo,
 
     tlen=len;
 
-    ND_PRINT("\n\tLSP-PINGv%u, msg-type: %s (%u), length: %u\n\t  reply-mode: %s (%u)",
+    ND_PRINT(C_RESET, "\n\tLSP-PINGv%u, msg-type: %s (%u), length: %u\n\t  reply-mode: %s (%u)",
            GET_BE_U_2(lspping_com_header->version),
            tok2str(lspping_msg_type_values, "unknown",GET_U_1(lspping_com_header->msg_type)),
            GET_U_1(lspping_com_header->msg_type),
@@ -574,32 +574,32 @@ lspping_print(netdissect_options *ndo,
         return_code == 10 ||
         return_code == 11 ||
         return_code == 12 )
-        ND_PRINT("\n\t  Return Code: %s %u (%u)\n\t  Return Subcode: (%u)",
+        ND_PRINT(C_RESET, "\n\t  Return Code: %s %u (%u)\n\t  Return Subcode: (%u)",
                tok2str(lspping_return_code_values, "unknown",return_code),
                return_subcode,
                return_code,
                return_subcode);
     else
-        ND_PRINT("\n\t  Return Code: %s (%u)\n\t  Return Subcode: (%u)",
+        ND_PRINT(C_RESET, "\n\t  Return Code: %s (%u)\n\t  Return Subcode: (%u)",
                tok2str(lspping_return_code_values, "unknown",return_code),
                return_code,
                return_subcode);
 
-    ND_PRINT("\n\t  Sender Handle: 0x%08x, Sequence: %u",
+    ND_PRINT(C_RESET, "\n\t  Sender Handle: 0x%08x, Sequence: %u",
            GET_BE_U_4(lspping_com_header->sender_handle),
            GET_BE_U_4(lspping_com_header->seq_number));
 
-    ND_PRINT("\n\t  Sender Timestamp: ");
+    ND_PRINT(C_RESET, "\n\t  Sender Timestamp: ");
     p_ntp_time(ndo, &lspping_com_header->ts_sent);
-    ND_PRINT(" ");
+    ND_PRINT(C_RESET, " ");
 
     int_part=GET_BE_U_4(lspping_com_header->ts_rcvd.int_part);
     fraction=GET_BE_U_4(lspping_com_header->ts_rcvd.fraction);
-    ND_PRINT("Receiver Timestamp: ");
+    ND_PRINT(C_RESET, "Receiver Timestamp: ");
     if (! (int_part == 0 && fraction == 0))
         p_ntp_time(ndo, &lspping_com_header->ts_rcvd);
     else
-        ND_PRINT("no timestamp");
+        ND_PRINT(C_RESET, "no timestamp");
 
     tptr+=sizeof(struct lspping_common_header);
     tlen-=sizeof(struct lspping_common_header);
@@ -613,7 +613,7 @@ lspping_print(netdissect_options *ndo,
         lspping_tlv_type=GET_BE_U_2(lspping_tlv_header->type);
         lspping_tlv_len=GET_BE_U_2(lspping_tlv_header->length);
 
-        ND_PRINT("\n\t  %s TLV (%u), length: %u",
+        ND_PRINT(C_RESET, "\n\t  %s TLV (%u), length: %u",
                tok2str(lspping_tlv_values,
                        "Unknown",
                        lspping_tlv_type),
@@ -642,7 +642,7 @@ lspping_print(netdissect_options *ndo,
             while (tlv_tlen != 0) {
                 /* Does the subTLV header go past the end of the TLV? */
                 if (tlv_tlen < sizeof(struct lspping_tlv_header)) {
-                    ND_PRINT("\n\t      TLV is too short");
+                    ND_PRINT(C_RESET, "\n\t      TLV is too short");
                     tlv_hexdump = TRUE;
                     goto tlv_tooshort;
                 }
@@ -655,7 +655,7 @@ lspping_print(netdissect_options *ndo,
 
                 /* Does the subTLV go past the end of the TLV? */
                 if (tlv_tlen < lspping_subtlv_len+sizeof(struct lspping_tlv_header)) {
-                    ND_PRINT("\n\t      TLV is too short");
+                    ND_PRINT(C_RESET, "\n\t      TLV is too short");
                     tlv_hexdump = TRUE;
                     goto tlv_tooshort;
                 }
@@ -663,7 +663,7 @@ lspping_print(netdissect_options *ndo,
                 /* Did we capture enough for fully decoding the subTLV? */
                 ND_TCHECK_LEN(subtlv_tptr, lspping_subtlv_len);
 
-                ND_PRINT("\n\t    %s subTLV (%u), length: %u",
+                ND_PRINT(C_RESET, "\n\t    %s subTLV (%u), length: %u",
                        tok2str(lspping_tlvtargetfec_subtlv_values,
                                "Unknown",
                                lspping_subtlv_type),
@@ -675,12 +675,12 @@ lspping_print(netdissect_options *ndo,
                 case LSPPING_TLV_TARGETFEC_SUBTLV_LDP_IPV4:
                     /* Is the subTLV length correct? */
                     if (lspping_subtlv_len != 5) {
-                        ND_PRINT("\n\t      invalid subTLV length, should be 5");
+                        ND_PRINT(C_RESET, "\n\t      invalid subTLV length, should be 5");
                         subtlv_hexdump=TRUE; /* unknown subTLV just hexdump it */
                     } else {
                         subtlv_ptr.lspping_tlv_targetfec_subtlv_ldp_ipv4 =
                             (const struct lspping_tlv_targetfec_subtlv_ldp_ipv4_t *)subtlv_tptr;
-                        ND_PRINT("\n\t      %s/%u",
+                        ND_PRINT(C_RESET, "\n\t      %s/%u",
                                GET_IPADDR_STRING(subtlv_ptr.lspping_tlv_targetfec_subtlv_ldp_ipv4->prefix),
                                GET_U_1(subtlv_ptr.lspping_tlv_targetfec_subtlv_ldp_ipv4->prefix_len));
                     }
@@ -689,12 +689,12 @@ lspping_print(netdissect_options *ndo,
                 case LSPPING_TLV_TARGETFEC_SUBTLV_LDP_IPV6:
                     /* Is the subTLV length correct? */
                     if (lspping_subtlv_len != 17) {
-                        ND_PRINT("\n\t      invalid subTLV length, should be 17");
+                        ND_PRINT(C_RESET, "\n\t      invalid subTLV length, should be 17");
                         subtlv_hexdump=TRUE; /* unknown subTLV just hexdump it */
                     } else {
                         subtlv_ptr.lspping_tlv_targetfec_subtlv_ldp_ipv6 =
                             (const struct lspping_tlv_targetfec_subtlv_ldp_ipv6_t *)subtlv_tptr;
-                        ND_PRINT("\n\t      %s/%u",
+                        ND_PRINT(C_RESET, "\n\t      %s/%u",
                                GET_IP6ADDR_STRING(subtlv_ptr.lspping_tlv_targetfec_subtlv_ldp_ipv6->prefix),
                                GET_U_1(subtlv_ptr.lspping_tlv_targetfec_subtlv_ldp_ipv6->prefix_len));
                     }
@@ -703,12 +703,12 @@ lspping_print(netdissect_options *ndo,
                 case LSPPING_TLV_TARGETFEC_SUBTLV_BGP_IPV4:
                     /* Is the subTLV length correct? */
                     if (lspping_subtlv_len != 5) {
-                        ND_PRINT("\n\t      invalid subTLV length, should be 5");
+                        ND_PRINT(C_RESET, "\n\t      invalid subTLV length, should be 5");
                         subtlv_hexdump=TRUE; /* unknown subTLV just hexdump it */
                     } else {
                         subtlv_ptr.lspping_tlv_targetfec_subtlv_bgp_ipv4 =
                             (const struct lspping_tlv_targetfec_subtlv_bgp_ipv4_t *)subtlv_tptr;
-                        ND_PRINT("\n\t      %s/%u",
+                        ND_PRINT(C_RESET, "\n\t      %s/%u",
                                GET_IPADDR_STRING(subtlv_ptr.lspping_tlv_targetfec_subtlv_bgp_ipv4->prefix),
                                GET_U_1(subtlv_ptr.lspping_tlv_targetfec_subtlv_bgp_ipv4->prefix_len));
                     }
@@ -717,12 +717,12 @@ lspping_print(netdissect_options *ndo,
                 case LSPPING_TLV_TARGETFEC_SUBTLV_BGP_IPV6:
                     /* Is the subTLV length correct? */
                     if (lspping_subtlv_len != 17) {
-                        ND_PRINT("\n\t      invalid subTLV length, should be 17");
+                        ND_PRINT(C_RESET, "\n\t      invalid subTLV length, should be 17");
                         subtlv_hexdump=TRUE; /* unknown subTLV just hexdump it */
                     } else {
                         subtlv_ptr.lspping_tlv_targetfec_subtlv_bgp_ipv6 =
                             (const struct lspping_tlv_targetfec_subtlv_bgp_ipv6_t *)subtlv_tptr;
-                        ND_PRINT("\n\t      %s/%u",
+                        ND_PRINT(C_RESET, "\n\t      %s/%u",
                                GET_IP6ADDR_STRING(subtlv_ptr.lspping_tlv_targetfec_subtlv_bgp_ipv6->prefix),
                                GET_U_1(subtlv_ptr.lspping_tlv_targetfec_subtlv_bgp_ipv6->prefix_len));
                     }
@@ -731,12 +731,12 @@ lspping_print(netdissect_options *ndo,
                 case LSPPING_TLV_TARGETFEC_SUBTLV_RSVP_IPV4:
                     /* Is the subTLV length correct? */
                     if (lspping_subtlv_len != 20) {
-                        ND_PRINT("\n\t      invalid subTLV length, should be 20");
+                        ND_PRINT(C_RESET, "\n\t      invalid subTLV length, should be 20");
                         subtlv_hexdump=TRUE; /* unknown subTLV just hexdump it */
                     } else {
                         subtlv_ptr.lspping_tlv_targetfec_subtlv_rsvp_ipv4 =
                             (const struct lspping_tlv_targetfec_subtlv_rsvp_ipv4_t *)subtlv_tptr;
-                        ND_PRINT("\n\t      tunnel end-point %s, tunnel sender %s, lsp-id 0x%04x"
+                        ND_PRINT(C_RESET, "\n\t      tunnel end-point %s, tunnel sender %s, lsp-id 0x%04x"
                                "\n\t      tunnel-id 0x%04x, extended tunnel-id %s",
                                GET_IPADDR_STRING(subtlv_ptr.lspping_tlv_targetfec_subtlv_rsvp_ipv4->tunnel_endpoint),
                                GET_IPADDR_STRING(subtlv_ptr.lspping_tlv_targetfec_subtlv_rsvp_ipv4->tunnel_sender),
@@ -749,12 +749,12 @@ lspping_print(netdissect_options *ndo,
                 case LSPPING_TLV_TARGETFEC_SUBTLV_RSVP_IPV6:
                     /* Is the subTLV length correct? */
                     if (lspping_subtlv_len != 56) {
-                        ND_PRINT("\n\t      invalid subTLV length, should be 56");
+                        ND_PRINT(C_RESET, "\n\t      invalid subTLV length, should be 56");
                         subtlv_hexdump=TRUE; /* unknown subTLV just hexdump it */
                     } else {
                         subtlv_ptr.lspping_tlv_targetfec_subtlv_rsvp_ipv6 =
                             (const struct lspping_tlv_targetfec_subtlv_rsvp_ipv6_t *)subtlv_tptr;
-                        ND_PRINT("\n\t      tunnel end-point %s, tunnel sender %s, lsp-id 0x%04x"
+                        ND_PRINT(C_RESET, "\n\t      tunnel end-point %s, tunnel sender %s, lsp-id 0x%04x"
                                "\n\t      tunnel-id 0x%04x, extended tunnel-id %s",
                                GET_IP6ADDR_STRING(subtlv_ptr.lspping_tlv_targetfec_subtlv_rsvp_ipv6->tunnel_endpoint),
                                GET_IP6ADDR_STRING(subtlv_ptr.lspping_tlv_targetfec_subtlv_rsvp_ipv6->tunnel_sender),
@@ -767,12 +767,12 @@ lspping_print(netdissect_options *ndo,
                 case LSPPING_TLV_TARGETFEC_SUBTLV_L3VPN_IPV4:
                     /* Is the subTLV length correct? */
                     if (lspping_subtlv_len != 13) {
-                        ND_PRINT("\n\t      invalid subTLV length, should be 13");
+                        ND_PRINT(C_RESET, "\n\t      invalid subTLV length, should be 13");
                         subtlv_hexdump=TRUE; /* unknown subTLV just hexdump it */
                     } else {
                         subtlv_ptr.lspping_tlv_targetfec_subtlv_l3vpn_ipv4 =
                             (const struct lspping_tlv_targetfec_subtlv_l3vpn_ipv4_t *)subtlv_tptr;
-                        ND_PRINT("\n\t      RD: %s, %s/%u",
+                        ND_PRINT(C_RESET, "\n\t      RD: %s, %s/%u",
                                bgp_vpn_rd_print(ndo, subtlv_ptr.lspping_tlv_targetfec_subtlv_l3vpn_ipv4->rd),
                                GET_IPADDR_STRING(subtlv_ptr.lspping_tlv_targetfec_subtlv_l3vpn_ipv4->prefix),
                                GET_U_1(subtlv_ptr.lspping_tlv_targetfec_subtlv_l3vpn_ipv4->prefix_len));
@@ -782,12 +782,12 @@ lspping_print(netdissect_options *ndo,
                 case LSPPING_TLV_TARGETFEC_SUBTLV_L3VPN_IPV6:
                     /* Is the subTLV length correct? */
                     if (lspping_subtlv_len != 25) {
-                        ND_PRINT("\n\t      invalid subTLV length, should be 25");
+                        ND_PRINT(C_RESET, "\n\t      invalid subTLV length, should be 25");
                         subtlv_hexdump=TRUE; /* unknown subTLV just hexdump it */
                     } else {
                         subtlv_ptr.lspping_tlv_targetfec_subtlv_l3vpn_ipv6 =
                             (const struct lspping_tlv_targetfec_subtlv_l3vpn_ipv6_t *)subtlv_tptr;
-                        ND_PRINT("\n\t      RD: %s, %s/%u",
+                        ND_PRINT(C_RESET, "\n\t      RD: %s, %s/%u",
                                bgp_vpn_rd_print(ndo, subtlv_ptr.lspping_tlv_targetfec_subtlv_l3vpn_ipv6->rd),
                                GET_IP6ADDR_STRING(subtlv_ptr.lspping_tlv_targetfec_subtlv_l3vpn_ipv6->prefix),
                                GET_U_1(subtlv_ptr.lspping_tlv_targetfec_subtlv_l3vpn_ipv6->prefix_len));
@@ -797,12 +797,12 @@ lspping_print(netdissect_options *ndo,
                 case LSPPING_TLV_TARGETFEC_SUBTLV_L2VPN_ENDPT:
                     /* Is the subTLV length correct? */
                     if (lspping_subtlv_len != 14) {
-                        ND_PRINT("\n\t      invalid subTLV length, should be 14");
+                        ND_PRINT(C_RESET, "\n\t      invalid subTLV length, should be 14");
                         subtlv_hexdump=TRUE; /* unknown subTLV just hexdump it */
                     } else {
                         subtlv_ptr.lspping_tlv_targetfec_subtlv_l2vpn_endpt =
                             (const struct lspping_tlv_targetfec_subtlv_l2vpn_endpt_t *)subtlv_tptr;
-                        ND_PRINT("\n\t      RD: %s, Sender VE ID: %u, Receiver VE ID: %u"
+                        ND_PRINT(C_RESET, "\n\t      RD: %s, Sender VE ID: %u, Receiver VE ID: %u"
                                "\n\t      Encapsulation Type: %s (%u)",
                                bgp_vpn_rd_print(ndo, subtlv_ptr.lspping_tlv_targetfec_subtlv_l2vpn_endpt->rd),
                                GET_BE_U_2(subtlv_ptr.lspping_tlv_targetfec_subtlv_l2vpn_endpt->sender_ve_id),
@@ -818,12 +818,12 @@ lspping_print(netdissect_options *ndo,
                 case LSPPING_TLV_TARGETFEC_SUBTLV_FEC_128_PW_OLD:
                     /* Is the subTLV length correct? */
                     if (lspping_subtlv_len != 10) {
-                        ND_PRINT("\n\t      invalid subTLV length, should be 10");
+                        ND_PRINT(C_RESET, "\n\t      invalid subTLV length, should be 10");
                         subtlv_hexdump=TRUE; /* unknown subTLV just hexdump it */
                     } else {
                         subtlv_ptr.lspping_tlv_targetfec_subtlv_l2vpn_vcid_old =
                             (const struct lspping_tlv_targetfec_subtlv_fec_128_pw_old *)subtlv_tptr;
-                        ND_PRINT("\n\t      Remote PE: %s"
+                        ND_PRINT(C_RESET, "\n\t      Remote PE: %s"
                                "\n\t      PW ID: 0x%08x, PW Type: %s (%u)",
                                GET_IPADDR_STRING(subtlv_ptr.lspping_tlv_targetfec_subtlv_l2vpn_vcid_old->remote_pe_address),
                                GET_BE_U_4(subtlv_ptr.lspping_tlv_targetfec_subtlv_l2vpn_vcid_old->pw_id),
@@ -837,12 +837,12 @@ lspping_print(netdissect_options *ndo,
                 case LSPPING_TLV_TARGETFEC_SUBTLV_FEC_128_PW:
                     /* Is the subTLV length correct? */
                     if (lspping_subtlv_len != 14) {
-                        ND_PRINT("\n\t      invalid subTLV length, should be 14");
+                        ND_PRINT(C_RESET, "\n\t      invalid subTLV length, should be 14");
                         subtlv_hexdump=TRUE; /* unknown subTLV just hexdump it */
                     } else {
                         subtlv_ptr.lspping_tlv_targetfec_subtlv_l2vpn_vcid =
                             (const struct lspping_tlv_targetfec_subtlv_fec_128_pw *)subtlv_tptr;
-                        ND_PRINT("\n\t      Sender PE: %s, Remote PE: %s"
+                        ND_PRINT(C_RESET, "\n\t      Sender PE: %s, Remote PE: %s"
                                "\n\t      PW ID: 0x%08x, PW Type: %s (%u)",
                                GET_IPADDR_STRING(subtlv_ptr.lspping_tlv_targetfec_subtlv_l2vpn_vcid->sender_pe_address),
                                GET_IPADDR_STRING(subtlv_ptr.lspping_tlv_targetfec_subtlv_l2vpn_vcid->remote_pe_address),
@@ -869,7 +869,7 @@ lspping_print(netdissect_options *ndo,
                     lspping_subtlv_len += 4 - (lspping_subtlv_len % 4);
                     /* Does the subTLV, including padding, go past the end of the TLV? */
                     if (tlv_tlen < lspping_subtlv_len+sizeof(struct lspping_tlv_header)) {
-                        ND_PRINT("\n\t\t TLV is too short");
+                        ND_PRINT(C_RESET, "\n\t\t TLV is too short");
                         return;
                     }
                 }
@@ -881,7 +881,7 @@ lspping_print(netdissect_options *ndo,
         case LSPPING_TLV_DOWNSTREAM_MAPPING:
             /* Does the header go past the end of the TLV? */
             if (tlv_tlen < sizeof(struct lspping_tlv_downstream_map_t)) {
-                ND_PRINT("\n\t      TLV is too short");
+                ND_PRINT(C_RESET, "\n\t      TLV is too short");
                 tlv_hexdump = TRUE;
                 goto tlv_tooshort;
             }
@@ -897,7 +897,7 @@ lspping_print(netdissect_options *ndo,
              * we find the address-type, we recast the tlv_tptr and move on. */
 
             address_type = GET_U_1(tlv_ptr.lspping_tlv_downstream_map->address_type);
-            ND_PRINT("\n\t    MTU: %u, Address-Type: %s (%u)",
+            ND_PRINT(C_RESET, "\n\t    MTU: %u, Address-Type: %s (%u)",
                    GET_BE_U_2(tlv_ptr.lspping_tlv_downstream_map->mtu),
                    tok2str(lspping_tlv_downstream_addr_values,
                            "unknown",
@@ -909,7 +909,7 @@ lspping_print(netdissect_options *ndo,
             case LSPPING_AFI_IPV4:
                 /* Does the data go past the end of the TLV? */
                 if (tlv_tlen < sizeof(struct lspping_tlv_downstream_map_ipv4_t)) {
-                    ND_PRINT("\n\t      TLV is too short");
+                    ND_PRINT(C_RESET, "\n\t      TLV is too short");
                     tlv_hexdump = TRUE;
                     goto tlv_tooshort;
                 }
@@ -919,7 +919,7 @@ lspping_print(netdissect_options *ndo,
 
                 tlv_ptr.lspping_tlv_downstream_map_ipv4=
                     (const struct lspping_tlv_downstream_map_ipv4_t *)tlv_tptr;
-                ND_PRINT("\n\t    Downstream IP: %s"
+                ND_PRINT(C_RESET, "\n\t    Downstream IP: %s"
                        "\n\t    Downstream Interface IP: %s",
                        GET_IPADDR_STRING(tlv_ptr.lspping_tlv_downstream_map_ipv4->downstream_ip),
                        GET_IPADDR_STRING(tlv_ptr.lspping_tlv_downstream_map_ipv4->downstream_interface));
@@ -929,7 +929,7 @@ lspping_print(netdissect_options *ndo,
             case LSPPING_AFI_IPV4_UNMB:
                 /* Does the data go past the end of the TLV? */
                 if (tlv_tlen < sizeof(struct lspping_tlv_downstream_map_ipv4_unmb_t)) {
-                    ND_PRINT("\n\t      TLV is too short");
+                    ND_PRINT(C_RESET, "\n\t      TLV is too short");
                     tlv_hexdump = TRUE;
                     goto tlv_tooshort;
                 }
@@ -939,7 +939,7 @@ lspping_print(netdissect_options *ndo,
 
                 tlv_ptr.lspping_tlv_downstream_map_ipv4_unmb=
                     (const struct lspping_tlv_downstream_map_ipv4_unmb_t *)tlv_tptr;
-                ND_PRINT("\n\t    Downstream IP: %s"
+                ND_PRINT(C_RESET, "\n\t    Downstream IP: %s"
                        "\n\t    Downstream Interface Index: 0x%08x",
                        GET_IPADDR_STRING(tlv_ptr.lspping_tlv_downstream_map_ipv4_unmb->downstream_ip),
                        GET_BE_U_4(tlv_ptr.lspping_tlv_downstream_map_ipv4_unmb->downstream_interface));
@@ -949,7 +949,7 @@ lspping_print(netdissect_options *ndo,
             case LSPPING_AFI_IPV6:
                 /* Does the data go past the end of the TLV? */
                 if (tlv_tlen < sizeof(struct lspping_tlv_downstream_map_ipv6_t)) {
-                    ND_PRINT("\n\t      TLV is too short");
+                    ND_PRINT(C_RESET, "\n\t      TLV is too short");
                     tlv_hexdump = TRUE;
                     goto tlv_tooshort;
                 }
@@ -959,7 +959,7 @@ lspping_print(netdissect_options *ndo,
 
                 tlv_ptr.lspping_tlv_downstream_map_ipv6=
                     (const struct lspping_tlv_downstream_map_ipv6_t *)tlv_tptr;
-                ND_PRINT("\n\t    Downstream IP: %s"
+                ND_PRINT(C_RESET, "\n\t    Downstream IP: %s"
                        "\n\t    Downstream Interface IP: %s",
                        GET_IP6ADDR_STRING(tlv_ptr.lspping_tlv_downstream_map_ipv6->downstream_ip),
                        GET_IP6ADDR_STRING(tlv_ptr.lspping_tlv_downstream_map_ipv6->downstream_interface));
@@ -969,7 +969,7 @@ lspping_print(netdissect_options *ndo,
              case LSPPING_AFI_IPV6_UNMB:
                 /* Does the data go past the end of the TLV? */
                 if (tlv_tlen < sizeof(struct lspping_tlv_downstream_map_ipv6_unmb_t)) {
-                    ND_PRINT("\n\t      TLV is too short");
+                    ND_PRINT(C_RESET, "\n\t      TLV is too short");
                     tlv_hexdump = TRUE;
                     goto tlv_tooshort;
                 }
@@ -979,7 +979,7 @@ lspping_print(netdissect_options *ndo,
 
                 tlv_ptr.lspping_tlv_downstream_map_ipv6_unmb=
                    (const struct lspping_tlv_downstream_map_ipv6_unmb_t *)tlv_tptr;
-                ND_PRINT("\n\t    Downstream IP: %s"
+                ND_PRINT(C_RESET, "\n\t    Downstream IP: %s"
                        "\n\t    Downstream Interface Index: 0x%08x",
                        GET_IP6ADDR_STRING(tlv_ptr.lspping_tlv_downstream_map_ipv6_unmb->downstream_ip),
                        GET_BE_U_4(tlv_ptr.lspping_tlv_downstream_map_ipv6_unmb->downstream_interface));
@@ -994,7 +994,7 @@ lspping_print(netdissect_options *ndo,
 
             /* Does the data go past the end of the TLV? */
             if (tlv_tlen < sizeof(struct lspping_tlv_downstream_map_info_t)) {
-                ND_PRINT("\n\t      TLV is too short");
+                ND_PRINT(C_RESET, "\n\t      TLV is too short");
                 tlv_hexdump = TRUE;
                 goto tlv_tooshort;
             }
@@ -1018,11 +1018,11 @@ lspping_print(netdissect_options *ndo,
 
         case LSPPING_TLV_BFD_DISCRIMINATOR:
             if (tlv_tlen < LSPPING_TLV_BFD_DISCRIMINATOR_LEN) {
-                ND_PRINT("\n\t      TLV is too short");
+                ND_PRINT(C_RESET, "\n\t      TLV is too short");
                 tlv_hexdump = TRUE;
                 goto tlv_tooshort;
             } else {
-                ND_PRINT("\n\t    BFD Discriminator 0x%08x", GET_BE_U_4(tlv_tptr));
+                ND_PRINT(C_RESET, "\n\t    BFD Discriminator 0x%08x", GET_BE_U_4(tlv_tptr));
             }
             break;
 
@@ -1031,12 +1031,12 @@ lspping_print(netdissect_options *ndo,
             uint32_t vendor_id;
 
             if (tlv_tlen < LSPPING_TLV_VENDOR_ENTERPRISE_LEN) {
-                ND_PRINT("\n\t      TLV is too short");
+                ND_PRINT(C_RESET, "\n\t      TLV is too short");
                 tlv_hexdump = TRUE;
                 goto tlv_tooshort;
             } else {
                 vendor_id = GET_BE_U_4(tlv_tptr);
-                ND_PRINT("\n\t    Vendor: %s (0x%04x)",
+                ND_PRINT(C_RESET, "\n\t    Vendor: %s (0x%04x)",
                        tok2str(smi_values, "Unknown", vendor_id),
                        vendor_id);
             }
@@ -1076,5 +1076,5 @@ lspping_print(netdissect_options *ndo,
     }
     return;
 tooshort:
-    ND_PRINT("\n\t\t packet is too short");
+    ND_PRINT(C_RESET, "\n\t\t packet is too short");
 }

--- a/print-lwapp.c
+++ b/print-lwapp.c
@@ -190,14 +190,14 @@ lwapp_control_print(netdissect_options *ndo,
      * Sanity checking of the header.
      */
     if (LWAPP_EXTRACT_VERSION(version) != LWAPP_VERSION) {
-	ND_PRINT("LWAPP version %u packet not supported",
+	ND_PRINT(C_RESET, "LWAPP version %u packet not supported",
                LWAPP_EXTRACT_VERSION(version));
 	return;
     }
 
     /* non-verbose */
     if (ndo->ndo_vflag < 1) {
-        ND_PRINT("LWAPPv%u, %s frame, Flags [%s], length %u",
+        ND_PRINT(C_RESET, "LWAPPv%u, %s frame, Flags [%s], length %u",
                LWAPP_EXTRACT_VERSION(version),
                LWAPP_EXTRACT_CONTROL_BIT(version) ? "Control" : "Data",
                bittok2str(lwapp_header_bits_values,"none",version&0x07),
@@ -208,7 +208,7 @@ lwapp_control_print(netdissect_options *ndo,
     /* ok they seem to want to know everything - lets fully decode it */
     tlen=GET_BE_U_2(lwapp_trans_header->length);
 
-    ND_PRINT("LWAPPv%u, %s frame, Radio-id %u, Flags [%s], Frag-id %u, length %u",
+    ND_PRINT(C_RESET, "LWAPPv%u, %s frame, Radio-id %u, Flags [%s], Frag-id %u, length %u",
            LWAPP_EXTRACT_VERSION(version),
            LWAPP_EXTRACT_CONTROL_BIT(version) ? "Control" : "Data",
            LWAPP_EXTRACT_RID(version),
@@ -217,7 +217,7 @@ lwapp_control_print(netdissect_options *ndo,
 	   tlen);
 
     if (has_ap_ident) {
-        ND_PRINT("\n\tAP identity: %s", GET_ETHERADDR_STRING(tptr));
+        ND_PRINT(C_RESET, "\n\tAP identity: %s", GET_ETHERADDR_STRING(tptr));
         tptr+=sizeof(struct lwapp_transport_header)+6;
     } else {
         tptr+=sizeof(struct lwapp_transport_header);
@@ -228,20 +228,20 @@ lwapp_control_print(netdissect_options *ndo,
         /* did we capture enough for fully decoding the object header ? */
         ND_TCHECK_LEN(tptr, sizeof(struct lwapp_control_header));
         if (tlen < sizeof(struct lwapp_control_header)) {
-            ND_PRINT("\n\t  Msg goes past end of PDU");
+            ND_PRINT(C_RESET, "\n\t  Msg goes past end of PDU");
             break;
         }
 
         lwapp_control_header = (const struct lwapp_control_header *)tptr;
 	msg_tlen = GET_BE_U_2(lwapp_control_header->len);
         if (tlen < sizeof(struct lwapp_control_header) + msg_tlen) {
-            ND_PRINT("\n\t  Msg goes past end of PDU");
+            ND_PRINT(C_RESET, "\n\t  Msg goes past end of PDU");
             break;
         }
 
 	/* print message header */
 	msg_type = GET_U_1(lwapp_control_header->msg_type);
-        ND_PRINT("\n\t  Msg type: %s (%u), Seqnum: %u, Msg len: %u, Session: 0x%08x",
+        ND_PRINT(C_RESET, "\n\t  Msg type: %s (%u), Seqnum: %u, Msg len: %u, Session: 0x%08x",
                tok2str(lwapp_msg_type_values,"Unknown",msg_type),
                msg_type,
                GET_U_1(lwapp_control_header->seq_num),
@@ -319,14 +319,14 @@ lwapp_data_print(netdissect_options *ndo,
      * Sanity checking of the header.
      */
     if (LWAPP_EXTRACT_VERSION(version) != LWAPP_VERSION) {
-        ND_PRINT("LWAPP version %u packet not supported",
+        ND_PRINT(C_RESET, "LWAPP version %u packet not supported",
                LWAPP_EXTRACT_VERSION(version));
         return;
     }
 
     /* non-verbose */
     if (ndo->ndo_vflag < 1) {
-        ND_PRINT("LWAPPv%u, %s frame, Flags [%s], length %u",
+        ND_PRINT(C_RESET, "LWAPPv%u, %s frame, Flags [%s], length %u",
                LWAPP_EXTRACT_VERSION(version),
                LWAPP_EXTRACT_CONTROL_BIT(version) ? "Control" : "Data",
                bittok2str(lwapp_header_bits_values,"none",version&0x07),
@@ -337,7 +337,7 @@ lwapp_data_print(netdissect_options *ndo,
     /* ok they seem to want to know everything - lets fully decode it */
     tlen=GET_BE_U_2(lwapp_trans_header->length);
     if (tlen < sizeof(struct lwapp_transport_header)) {
-        ND_PRINT("LWAPPv%u, %s frame, Radio-id  %u, Flags [%s], length %u < transport header length",
+        ND_PRINT(C_RESET, "LWAPPv%u, %s frame, Radio-id  %u, Flags [%s], length %u < transport header length",
                LWAPP_EXTRACT_VERSION(version),
                LWAPP_EXTRACT_CONTROL_BIT(version) ? "Control" : "Data",
                LWAPP_EXTRACT_RID(version),
@@ -346,7 +346,7 @@ lwapp_data_print(netdissect_options *ndo,
         return;
     }
 
-    ND_PRINT("LWAPPv%u, %s frame, Radio-id  %u, Flags [%s], Frag-id  %u, length %u",
+    ND_PRINT(C_RESET, "LWAPPv%u, %s frame, Radio-id  %u, Flags [%s], Frag-id  %u, length %u",
            LWAPP_EXTRACT_VERSION(version),
            LWAPP_EXTRACT_CONTROL_BIT(version) ? "Control" : "Data",
            LWAPP_EXTRACT_RID(version),

--- a/print-lwres.c
+++ b/print-lwres.c
@@ -193,11 +193,11 @@ static unsigned
 lwres_printname(netdissect_options *ndo,
                 u_int l, const u_char *p0)
 {
-	ND_PRINT(" ");
+	ND_PRINT(C_RESET, " ");
 	nd_printjn(ndo, p0, l);
 	p0 += l;
 	if (GET_U_1(p0))
-		ND_PRINT(" (not NUL-terminated!)");
+		ND_PRINT(C_RESET, " (not NUL-terminated!)");
 	return l + 1;
 }
 
@@ -225,7 +225,7 @@ lwres_printbinlen(netdissect_options *ndo,
 	l = GET_BE_U_2(p);
 	p += 2;
 	for (i = 0; i < l; i++) {
-		ND_PRINT("%02x", GET_U_1(p));
+		ND_PRINT(C_RESET, "%02x", GET_U_1(p));
 		p++;
 	}
 	return 2 + l;
@@ -250,19 +250,19 @@ lwres_printaddr(netdissect_options *ndo,
 	case 1:	/* IPv4 */
 		if (l < 4)
 			return -1;
-		ND_PRINT(" %s", GET_IPADDR_STRING(p));
+		ND_PRINT(C_RESET, " %s", GET_IPADDR_STRING(p));
 		p += sizeof(nd_ipv4);
 		break;
 	case 2:	/* IPv6 */
 		if (l < 16)
 			return -1;
-		ND_PRINT(" %s", GET_IP6ADDR_STRING(p));
+		ND_PRINT(C_RESET, " %s", GET_IP6ADDR_STRING(p));
 		p += sizeof(nd_ipv6);
 		break;
 	default:
-		ND_PRINT(" %u/", GET_BE_U_4(ap->family));
+		ND_PRINT(C_RESET, " %u/", GET_BE_U_4(ap->family));
 		for (i = 0; i < l; i++) {
-			ND_PRINT("%02x", GET_U_1(p));
+			ND_PRINT(C_RESET, "%02x", GET_U_1(p));
 			p++;
 		}
 	}
@@ -286,10 +286,10 @@ lwres_print(netdissect_options *ndo,
 	np = (const struct lwres_lwpacket *)bp;
 	ND_TCHECK_2(np->authlength);
 
-	ND_PRINT(" lwres");
+	ND_PRINT(C_RESET, " lwres");
 	v = GET_BE_U_2(np->version);
 	if (ndo->ndo_vflag || v != LWRES_LWPACKETVERSION_0)
-		ND_PRINT(" v%u", v);
+		ND_PRINT(C_RESET, " v%u", v);
 	if (v != LWRES_LWPACKETVERSION_0) {
 		s = bp + GET_BE_U_4(np->length);
 		goto tail;
@@ -299,25 +299,25 @@ lwres_print(netdissect_options *ndo,
 
 	/* opcode and pktflags */
 	v = GET_BE_U_4(np->opcode);
-	ND_PRINT(" %s%s", tok2str(opcode, "#0x%x", v), response ? "" : "?");
+	ND_PRINT(C_RESET, " %s%s", tok2str(opcode, "#0x%x", v), response ? "" : "?");
 
 	/* pktflags */
 	v = GET_BE_U_2(np->pktflags);
 	if (v & ~LWRES_LWPACKETFLAG_RESPONSE)
-		ND_PRINT("[0x%x]", v);
+		ND_PRINT(C_RESET, "[0x%x]", v);
 
 	if (ndo->ndo_vflag > 1) {
-		ND_PRINT(" (");	/*)*/
-		ND_PRINT("serial:0x%x", GET_BE_U_4(np->serial));
-		ND_PRINT(" result:0x%x", GET_BE_U_4(np->result));
-		ND_PRINT(" recvlen:%u", GET_BE_U_4(np->recvlength));
+		ND_PRINT(C_RESET, " (");	/*)*/
+		ND_PRINT(C_RESET, "serial:0x%x", GET_BE_U_4(np->serial));
+		ND_PRINT(C_RESET, " result:0x%x", GET_BE_U_4(np->result));
+		ND_PRINT(C_RESET, " recvlen:%u", GET_BE_U_4(np->recvlength));
 		/* BIND910: not used */
 		if (ndo->ndo_vflag > 2) {
-			ND_PRINT(" authtype:0x%x", GET_BE_U_2(np->authtype));
-			ND_PRINT(" authlen:%u", GET_BE_U_2(np->authlength));
+			ND_PRINT(C_RESET, " authtype:0x%x", GET_BE_U_2(np->authtype));
+			ND_PRINT(C_RESET, " authlen:%u", GET_BE_U_2(np->authlength));
 		}
 		/*(*/
-		ND_PRINT(")");
+		ND_PRINT(C_RESET, ")");
 	}
 
 	/* per-opcode content */
@@ -345,24 +345,24 @@ lwres_print(netdissect_options *ndo,
 
 			/* BIND910: not used */
 			if (ndo->ndo_vflag > 2) {
-				ND_PRINT(" flags:0x%x",
+				ND_PRINT(C_RESET, " flags:0x%x",
 				    GET_BE_U_4(gabn->flags));
 			}
 
 			v = GET_BE_U_4(gabn->addrtypes);
 			switch (v & (LWRES_ADDRTYPE_V4 | LWRES_ADDRTYPE_V6)) {
 			case LWRES_ADDRTYPE_V4:
-				ND_PRINT(" IPv4");
+				ND_PRINT(C_RESET, " IPv4");
 				break;
 			case LWRES_ADDRTYPE_V6:
-				ND_PRINT(" IPv6");
+				ND_PRINT(C_RESET, " IPv6");
 				break;
 			case LWRES_ADDRTYPE_V4 | LWRES_ADDRTYPE_V6:
-				ND_PRINT(" IPv4/6");
+				ND_PRINT(C_RESET, " IPv4/6");
 				break;
 			}
 			if (v & ~(LWRES_ADDRTYPE_V4 | LWRES_ADDRTYPE_V6))
-				ND_PRINT("[0x%x]", v);
+				ND_PRINT(C_RESET, "[0x%x]", v);
 
 			s = p + LWRES_GABNREQUEST_LEN;
 			l = GET_BE_U_2(gabn->namelen);
@@ -375,7 +375,7 @@ lwres_print(netdissect_options *ndo,
 
 			/* BIND910: not used */
 			if (ndo->ndo_vflag > 2) {
-				ND_PRINT(" flags:0x%x",
+				ND_PRINT(C_RESET, " flags:0x%x",
 				    GET_BE_U_4(gnba->flags));
 			}
 
@@ -392,14 +392,14 @@ lwres_print(netdissect_options *ndo,
 
 			/* BIND910: not used */
 			if (ndo->ndo_vflag > 2) {
-				ND_PRINT(" flags:0x%x",
+				ND_PRINT(C_RESET, " flags:0x%x",
 				    GET_BE_U_4(grbn->flags));
 			}
 
-			ND_PRINT(" %s", tok2str(ns_type2str, "Type%u",
+			ND_PRINT(C_RESET, " %s", tok2str(ns_type2str, "Type%u",
 			    GET_BE_U_2(grbn->rdtype)));
 			if (GET_BE_U_2(grbn->rdclass) != C_IN) {
-				ND_PRINT(" %s", tok2str(ns_class2str, "Class%u",
+				ND_PRINT(C_RESET, " %s", tok2str(ns_class2str, "Class%u",
 				    GET_BE_U_2(grbn->rdclass)));
 			}
 
@@ -438,11 +438,11 @@ lwres_print(netdissect_options *ndo,
 
 			/* BIND910: not used */
 			if (ndo->ndo_vflag > 2) {
-				ND_PRINT(" flags:0x%x",
+				ND_PRINT(C_RESET, " flags:0x%x",
 				    GET_BE_U_4(gabn->flags));
 			}
 
-			ND_PRINT(" %u/%u", GET_BE_U_2(gabn->naliases),
+			ND_PRINT(C_RESET, " %u/%u", GET_BE_U_2(gabn->naliases),
 				  GET_BE_U_2(gabn->naddrs));
 
 			s = p + LWRES_GABNRESPONSE_LEN;
@@ -472,11 +472,11 @@ lwres_print(netdissect_options *ndo,
 
 			/* BIND910: not used */
 			if (ndo->ndo_vflag > 2) {
-				ND_PRINT(" flags:0x%x",
+				ND_PRINT(C_RESET, " flags:0x%x",
 				    GET_BE_U_4(gnba->flags));
 			}
 
-			ND_PRINT(" %u", GET_BE_U_2(gnba->naliases));
+			ND_PRINT(C_RESET, " %u", GET_BE_U_2(gnba->naliases));
 
 			s = p + LWRES_GNBARESPONSE_LEN;
 			l = GET_BE_U_2(gnba->realnamelen);
@@ -497,20 +497,20 @@ lwres_print(netdissect_options *ndo,
 
 			/* BIND910: not used */
 			if (ndo->ndo_vflag > 2) {
-				ND_PRINT(" flags:0x%x",
+				ND_PRINT(C_RESET, " flags:0x%x",
 				    GET_BE_U_4(grbn->flags));
 			}
 
-			ND_PRINT(" %s", tok2str(ns_type2str, "Type%u",
+			ND_PRINT(C_RESET, " %s", tok2str(ns_type2str, "Type%u",
 			    GET_BE_U_2(grbn->rdtype)));
 			if (GET_BE_U_2(grbn->rdclass) != C_IN) {
-				ND_PRINT(" %s", tok2str(ns_class2str, "Class%u",
+				ND_PRINT(C_RESET, " %s", tok2str(ns_class2str, "Class%u",
 				    GET_BE_U_2(grbn->rdclass)));
 			}
-			ND_PRINT(" TTL ");
+			ND_PRINT(C_RESET, " TTL ");
 			unsigned_relts_print(ndo,
 					     GET_BE_U_4(grbn->ttl));
-			ND_PRINT(" %u/%u", GET_BE_U_2(grbn->nrdatas),
+			ND_PRINT(C_RESET, " %u/%u", GET_BE_U_2(grbn->nrdatas),
 				  GET_BE_U_2(grbn->nsigs));
 
 			s = p + LWRES_GRBNRESPONSE_LEN;
@@ -543,11 +543,11 @@ lwres_print(netdissect_options *ndo,
   tail:
 	/* length mismatch */
 	if (GET_BE_U_4(np->length) != length) {
-		ND_PRINT(" [len: %u != %u]", GET_BE_U_4(np->length),
+		ND_PRINT(C_RESET, " [len: %u != %u]", GET_BE_U_4(np->length),
 			  length);
 	}
 	if (!unsupported && ND_BYTES_BETWEEN(s, bp) < GET_BE_U_4(np->length))
-		ND_PRINT("[extra]");
+		ND_PRINT(C_RESET, "[extra]");
 	return;
 
   invalid:

--- a/print-m3ua.c
+++ b/print-m3ua.c
@@ -229,11 +229,11 @@ tag_value_print(netdissect_options *ndo,
     /* buf and size don't include the header */
     if (size < 4)
       goto invalid;
-    ND_PRINT("0x%08x", GET_BE_U_4(buf));
+    ND_PRINT(C_RESET, "0x%08x", GET_BE_U_4(buf));
     break;
   /* ... */
   default:
-    ND_PRINT("(length %zu)", size + sizeof(struct m3ua_param_header));
+    ND_PRINT(C_RESET, "(length %zu)", size + sizeof(struct m3ua_param_header));
   }
   ND_TCHECK_LEN(buf, size);
   return;
@@ -268,7 +268,7 @@ m3ua_tags_print(netdissect_options *ndo,
       goto invalid;
     /* Parameter Tag */
     hdr_tag = GET_BE_U_2(p);
-    ND_PRINT("\n\t\t\t%s: ", tok2str(ParamName, "Unknown Parameter (0x%04x)", hdr_tag));
+    ND_PRINT(C_RESET, "\n\t\t\t%s: ", tok2str(ParamName, "Unknown Parameter (0x%04x)", hdr_tag));
     /* Parameter Length */
     hdr_len = GET_BE_U_2(p + 2);
     if (hdr_len < sizeof(struct m3ua_param_header))
@@ -317,13 +317,13 @@ m3ua_print(netdissect_options *ndo,
   msg_class = GET_U_1(hdr->msg_class);
   dict = uint2tokary(m3ua_msgc2tokary, msg_class);
 
-  ND_PRINT("\n\t\t%s", tok2str(MessageClasses, "Unknown message class %i", msg_class));
+  ND_PRINT(C_RESET, "\n\t\t%s", tok2str(MessageClasses, "Unknown message class %i", msg_class));
   if (dict != NULL)
-    ND_PRINT(" %s Message",
+    ND_PRINT(C_RESET, " %s Message",
              tok2str(dict, "Unknown (0x%02x)", GET_U_1(hdr->msg_type)));
 
   if (size != GET_BE_U_4(hdr->len))
-    ND_PRINT("\n\t\t\t@@@@@@ Corrupted length %u of message @@@@@@",
+    ND_PRINT(C_RESET, "\n\t\t\t@@@@@@ Corrupted length %u of message @@@@@@",
              GET_BE_U_4(hdr->len));
   else
     m3ua_tags_print(ndo, buf + sizeof(struct m3ua_common_header),

--- a/print-macsec.c
+++ b/print-macsec.c
@@ -92,19 +92,19 @@ macsec_print_header(netdissect_options *ndo,
 		    const struct macsec_sectag *sectag,
 		    u_int short_length)
 {
-	ND_PRINT("an %u, pn %u, flags %s",
+	ND_PRINT(C_RESET, "an %u, pn %u, flags %s",
 		 GET_U_1(sectag->tci_an) & MACSEC_AN_MASK,
 		 GET_BE_U_4(sectag->packet_number),
 		 bittok2str_nosep(macsec_flag_values, "none",
 				  GET_U_1(sectag->tci_an) & MACSEC_TCI_FLAGS));
 
 	if (short_length != 0)
-		ND_PRINT(", sl %u", short_length);
+		ND_PRINT(C_RESET, ", sl %u", short_length);
 
 	if (GET_U_1(sectag->tci_an) & MACSEC_TCI_SC)
-		ND_PRINT(", sci " SCI_FMT, GET_BE_U_8(sectag->secure_channel_id));
+		ND_PRINT(C_RESET, ", sci " SCI_FMT, GET_BE_U_8(sectag->secure_channel_id));
 
-	ND_PRINT(", ");
+	ND_PRINT(C_RESET, ", ");
 }
 
 /* returns < 0 iff the packet can be decoded completely */
@@ -182,12 +182,12 @@ macsec_print(netdissect_options *ndo, const u_char **bp,
 			 * so print them, if we have any.
 			 */
 			if (src != NULL && dst != NULL) {
-				ND_PRINT("%s > %s ",
+				ND_PRINT(C_RESET, "%s > %s ",
 					(src->addr_string)(ndo, src->addr),
 					(dst->addr_string)(ndo, dst->addr));
 			}
 
-			ND_PRINT("802.1AE MACsec, ");
+			ND_PRINT(C_RESET, "802.1AE MACsec, ");
 
 			/*
 			 * Print the MACsec header.

--- a/print-mobile.c
+++ b/print-mobile.c
@@ -77,7 +77,7 @@ mobile_print(netdissect_options *ndo, const u_char *bp, u_int length)
 		nd_print_trunc(ndo);
 		return;
 	}
-	ND_PRINT("mobile: ");
+	ND_PRINT(C_RESET, "mobile: ");
 
 	proto = GET_BE_U_2(mob->proto);
 	crc =  GET_BE_U_2(mob->hcheck);
@@ -86,19 +86,19 @@ mobile_print(netdissect_options *ndo, const u_char *bp, u_int length)
 	}
 
 	if (osp)  {
-		ND_PRINT("[S] ");
+		ND_PRINT(C_RESET, "[S] ");
 		if (ndo->ndo_vflag)
-			ND_PRINT("%s ", GET_IPADDR_STRING(mob->osrc));
+			ND_PRINT(C_RESET, "%s ", GET_IPADDR_STRING(mob->osrc));
 	} else {
-		ND_PRINT("[] ");
+		ND_PRINT(C_RESET, "[] ");
 	}
 	if (ndo->ndo_vflag) {
-		ND_PRINT("> %s ", GET_IPADDR_STRING(mob->odst));
-		ND_PRINT("(oproto=%u)", proto>>8);
+		ND_PRINT(C_RESET, "> %s ", GET_IPADDR_STRING(mob->odst));
+		ND_PRINT(C_RESET, "(oproto=%u)", proto>>8);
 	}
 	vec[0].ptr = (const uint8_t *)(const void *)mob;
 	vec[0].len = osp ? 12 : 8;
 	if (in_cksum(vec, 1)!=0) {
-		ND_PRINT(" (bad checksum %u)", crc);
+		ND_PRINT(C_RESET, " (bad checksum %u)", crc);
 	}
 }

--- a/print-mobility.c
+++ b/print-mobility.c
@@ -140,54 +140,54 @@ mobility_opt_print(netdissect_options *ndo,
 
 		switch (GET_U_1(bp + i)) {
 		case IP6MOPT_PAD1:
-			ND_PRINT("(pad1)");
+			ND_PRINT(C_RESET, "(pad1)");
 			break;
 		case IP6MOPT_PADN:
 			if (len - i < IP6MOPT_MINLEN) {
-				ND_PRINT("(padn: trunc)");
+				ND_PRINT(C_RESET, "(padn: trunc)");
 				goto trunc;
 			}
-			ND_PRINT("(padn)");
+			ND_PRINT(C_RESET, "(padn)");
 			break;
 		case IP6MOPT_REFRESH:
 			if (len - i < IP6MOPT_REFRESH_MINLEN) {
-				ND_PRINT("(refresh: trunc)");
+				ND_PRINT(C_RESET, "(refresh: trunc)");
 				goto trunc;
 			}
 			/* units of 4 secs */
-			ND_PRINT("(refresh: %u)",
+			ND_PRINT(C_RESET, "(refresh: %u)",
 				GET_BE_U_2(bp + i + 2) << 2);
 			break;
 		case IP6MOPT_ALTCOA:
 			if (len - i < IP6MOPT_ALTCOA_MINLEN) {
-				ND_PRINT("(altcoa: trunc)");
+				ND_PRINT(C_RESET, "(altcoa: trunc)");
 				goto trunc;
 			}
-			ND_PRINT("(alt-CoA: %s)", GET_IP6ADDR_STRING(bp + i + 2));
+			ND_PRINT(C_RESET, "(alt-CoA: %s)", GET_IP6ADDR_STRING(bp + i + 2));
 			break;
 		case IP6MOPT_NONCEID:
 			if (len - i < IP6MOPT_NONCEID_MINLEN) {
-				ND_PRINT("(ni: trunc)");
+				ND_PRINT(C_RESET, "(ni: trunc)");
 				goto trunc;
 			}
-			ND_PRINT("(ni: ho=0x%04x co=0x%04x)",
+			ND_PRINT(C_RESET, "(ni: ho=0x%04x co=0x%04x)",
 				GET_BE_U_2(bp + i + 2),
 				GET_BE_U_2(bp + i + 4));
 			break;
 		case IP6MOPT_AUTH:
 			if (len - i < IP6MOPT_AUTH_MINLEN) {
-				ND_PRINT("(auth: trunc)");
+				ND_PRINT(C_RESET, "(auth: trunc)");
 				goto trunc;
 			}
-			ND_PRINT("(auth)");
+			ND_PRINT(C_RESET, "(auth)");
 			break;
 		default:
 			if (len - i < IP6MOPT_MINLEN) {
-				ND_PRINT("(sopt_type %u: trunc)",
+				ND_PRINT(C_RESET, "(sopt_type %u: trunc)",
 					 GET_U_1(bp + i));
 				goto trunc;
 			}
-			ND_PRINT("(type-0x%02x: len=%u)", GET_U_1(bp + i),
+			ND_PRINT(C_RESET, "(type-0x%02x: len=%u)", GET_U_1(bp + i),
 				 GET_U_1(bp + i + 1));
 			break;
 		}
@@ -238,10 +238,10 @@ mobility_print(netdissect_options *ndo,
 
 	type = GET_U_1(mh->ip6m_type);
 	if (type <= IP6M_MAX && mhlen < ip6m_hdrlen[type]) {
-		ND_PRINT("(header length %u is too small for type %u)", mhlen, type);
+		ND_PRINT(C_RESET, "(header length %u is too small for type %u)", mhlen, type);
 		goto trunc;
 	}
-	ND_PRINT("mobility: %s", tok2str(ip6m_str, "type-#%u", type));
+	ND_PRINT(C_RESET, "mobility: %s", tok2str(ip6m_str, "type-#%u", type));
 	switch (type) {
 	case IP6M_BINDING_REQUEST:
 		hlen = IP6M_MINLEN;
@@ -250,7 +250,7 @@ mobility_print(netdissect_options *ndo,
 	case IP6M_CAREOF_TEST_INIT:
 		hlen = IP6M_MINLEN;
 		if (ndo->ndo_vflag) {
-			ND_PRINT(" %s Init Cookie=%08x:%08x",
+			ND_PRINT(C_RESET, " %s Init Cookie=%08x:%08x",
 			       type == IP6M_HOME_TEST_INIT ? "Home" : "Care-of",
 			       GET_BE_U_4(bp + hlen),
 			       GET_BE_U_4(bp + hlen + 4));
@@ -259,17 +259,17 @@ mobility_print(netdissect_options *ndo,
 		break;
 	case IP6M_HOME_TEST:
 	case IP6M_CAREOF_TEST:
-		ND_PRINT(" nonce id=0x%x", GET_BE_U_2(mh->ip6m_data16[0]));
+		ND_PRINT(C_RESET, " nonce id=0x%x", GET_BE_U_2(mh->ip6m_data16[0]));
 		hlen = IP6M_MINLEN;
 		if (ndo->ndo_vflag) {
-			ND_PRINT(" %s Init Cookie=%08x:%08x",
+			ND_PRINT(C_RESET, " %s Init Cookie=%08x:%08x",
 			       type == IP6M_HOME_TEST ? "Home" : "Care-of",
 			       GET_BE_U_4(bp + hlen),
 			       GET_BE_U_4(bp + hlen + 4));
 		}
 		hlen += 8;
 		if (ndo->ndo_vflag) {
-			ND_PRINT(" %s Keygen Token=%08x:%08x",
+			ND_PRINT(C_RESET, " %s Keygen Token=%08x:%08x",
 			       type == IP6M_HOME_TEST ? "Home" : "Care-of",
 			       GET_BE_U_4(bp + hlen),
 			       GET_BE_U_4(bp + hlen + 4));
@@ -279,13 +279,13 @@ mobility_print(netdissect_options *ndo,
 	case IP6M_BINDING_UPDATE:
 	    {
 		int bits;
-		ND_PRINT(" seq#=%u", GET_BE_U_2(mh->ip6m_data16[0]));
+		ND_PRINT(C_RESET, " seq#=%u", GET_BE_U_2(mh->ip6m_data16[0]));
 		hlen = IP6M_MINLEN;
 		ND_TCHECK_2(bp + hlen);
 		bits = (GET_U_1(bp + hlen) & 0xf0) >> 4;
 		if (bits) {
-			ND_PRINT(" ");
-			ND_PRINT("%s",
+			ND_PRINT(C_RESET, " ");
+			ND_PRINT(C_RESET, "%s",
 				 bittok2str_nosep(ip6m_binding_update_bits,
 				 "bits-#0x%x", bits));
 		}
@@ -294,31 +294,31 @@ mobility_print(netdissect_options *ndo,
 		/* Reserved (8bits) */
 		hlen += 1;
 		/* units of 4 secs */
-		ND_PRINT(" lifetime=%u", GET_BE_U_2(bp + hlen) << 2);
+		ND_PRINT(C_RESET, " lifetime=%u", GET_BE_U_2(bp + hlen) << 2);
 		hlen += 2;
 		break;
 	    }
 	case IP6M_BINDING_ACK:
-		ND_PRINT(" status=%u", GET_U_1(mh->ip6m_data8[0]));
+		ND_PRINT(C_RESET, " status=%u", GET_U_1(mh->ip6m_data8[0]));
 		if (GET_U_1(mh->ip6m_data8[1]) & 0x80)
-			ND_PRINT(" K");
+			ND_PRINT(C_RESET, " K");
 		/* Reserved (7bits) */
 		hlen = IP6M_MINLEN;
-		ND_PRINT(" seq#=%u", GET_BE_U_2(bp + hlen));
+		ND_PRINT(C_RESET, " seq#=%u", GET_BE_U_2(bp + hlen));
 		hlen += 2;
 		/* units of 4 secs */
-		ND_PRINT(" lifetime=%u", GET_BE_U_2(bp + hlen) << 2);
+		ND_PRINT(C_RESET, " lifetime=%u", GET_BE_U_2(bp + hlen) << 2);
 		hlen += 2;
 		break;
 	case IP6M_BINDING_ERROR:
-		ND_PRINT(" status=%u", GET_U_1(mh->ip6m_data8[0]));
+		ND_PRINT(C_RESET, " status=%u", GET_U_1(mh->ip6m_data8[0]));
 		/* Reserved */
 		hlen = IP6M_MINLEN;
-		ND_PRINT(" homeaddr %s", GET_IP6ADDR_STRING(bp + hlen));
+		ND_PRINT(C_RESET, " homeaddr %s", GET_IP6ADDR_STRING(bp + hlen));
 		hlen += 16;
 		break;
 	default:
-		ND_PRINT(" len=%u", GET_U_1(mh->ip6m_len));
+		ND_PRINT(C_RESET, " len=%u", GET_U_1(mh->ip6m_len));
 		return(mhlen);
 		break;
 	}

--- a/print-mpcp.c
+++ b/print-mpcp.c
@@ -138,11 +138,11 @@ mpcp_print(netdissect_options *ndo, const u_char *pptr, u_int length)
 
     opcode = GET_BE_U_2(mpcp_common_header->opcode);
     timestamp = GET_BE_U_4(mpcp_common_header->timestamp);
-    ND_PRINT("MPCP, Opcode %s", tok2str(mpcp_opcode_values, "Unknown (%u)", opcode));
+    ND_PRINT(C_RESET, C_RESET "MPCP, Opcode %s", tok2str(mpcp_opcode_values, "Unknown (%u)", opcode));
     if (opcode != MPCP_OPCODE_PAUSE) {
-        ND_PRINT(", Timestamp %u ticks", timestamp);
+        ND_PRINT(C_RESET, C_RESET ", Timestamp %u ticks", timestamp);
     }
-    ND_PRINT(", length %u", length);
+    ND_PRINT(C_RESET, C_RESET ", length %u", length);
 
     if (!ndo->ndo_vflag)
         return;
@@ -155,7 +155,7 @@ mpcp_print(netdissect_options *ndo, const u_char *pptr, u_int length)
 
     case MPCP_OPCODE_GATE:
         grant_numbers = GET_U_1(tptr) & MPCP_GRANT_NUMBER_MASK;
-        ND_PRINT("\n\tGrant Numbers %u, Flags [ %s ]",
+        ND_PRINT(C_RESET, C_RESET "\n\tGrant Numbers %u, Flags [ %s ]",
                grant_numbers,
                bittok2str(mpcp_grant_flag_values,
                           "?",
@@ -164,25 +164,25 @@ mpcp_print(netdissect_options *ndo, const u_char *pptr, u_int length)
 
         for (grant = 1; grant <= grant_numbers; grant++) {
             const struct mpcp_grant_t *mpcp_grant = (const struct mpcp_grant_t *)tptr;
-            ND_PRINT("\n\tGrant #%u, Start-Time %u ticks, duration %u ticks",
+            ND_PRINT(C_RESET, C_RESET "\n\tGrant #%u, Start-Time %u ticks, duration %u ticks",
                    grant,
                    GET_BE_U_4(mpcp_grant->starttime),
                    GET_BE_U_2(mpcp_grant->duration));
             tptr += sizeof(struct mpcp_grant_t);
         }
 
-        ND_PRINT("\n\tSync-Time %u ticks", GET_BE_U_2(tptr));
+        ND_PRINT(C_RESET, C_RESET "\n\tSync-Time %u ticks", GET_BE_U_2(tptr));
         break;
 
 
     case MPCP_OPCODE_REPORT:
         queue_sets = GET_U_1(tptr);
         tptr+=MPCP_REPORT_QUEUESETS_LEN;
-        ND_PRINT("\n\tTotal Queue-Sets %u", queue_sets);
+        ND_PRINT(C_RESET, C_RESET "\n\tTotal Queue-Sets %u", queue_sets);
 
         for (queue_set = 1; queue_set < queue_sets; queue_set++) {
             report_bitmap = GET_U_1(tptr);
-            ND_PRINT("\n\t  Queue-Set #%u, Report-Bitmap [ %s ]",
+            ND_PRINT(C_RESET, C_RESET "\n\t  Queue-Set #%u, Report-Bitmap [ %s ]",
                    queue_sets,
                    bittok2str(mpcp_report_bitmap_values, "Unknown", report_bitmap));
             tptr++;
@@ -190,7 +190,7 @@ mpcp_print(netdissect_options *ndo, const u_char *pptr, u_int length)
             report=1;
             while (report_bitmap != 0) {
                 if (report_bitmap & 1) {
-                    ND_PRINT("\n\t    Q%u Report, Duration %u ticks",
+                    ND_PRINT(C_RESET, C_RESET "\n\t    Q%u Report, Duration %u ticks",
                            report,
                            GET_BE_U_2(tptr));
                     tptr += 2;
@@ -203,14 +203,14 @@ mpcp_print(netdissect_options *ndo, const u_char *pptr, u_int length)
 
     case MPCP_OPCODE_REG_REQ:
         mpcp_reg_req = (const struct mpcp_reg_req_t *)tptr;
-        ND_PRINT("\n\tFlags [ %s ], Pending-Grants %u",
+        ND_PRINT(C_RESET, C_RESET "\n\tFlags [ %s ], Pending-Grants %u",
                bittok2str(mpcp_reg_req_flag_values, "Reserved", GET_U_1(mpcp_reg_req->flags)),
                GET_U_1(mpcp_reg_req->pending_grants));
         break;
 
     case MPCP_OPCODE_REG:
         mpcp_reg = (const struct mpcp_reg_t *)tptr;
-        ND_PRINT("\n\tAssigned-Port %u, Flags [ %s ]"
+        ND_PRINT(C_RESET, C_RESET "\n\tAssigned-Port %u, Flags [ %s ]"
                "\n\tSync-Time %u ticks, Echoed-Pending-Grants %u",
                GET_BE_U_2(mpcp_reg->assigned_port),
                bittok2str(mpcp_reg_flag_values, "Reserved", GET_U_1(mpcp_reg->flags)),
@@ -220,7 +220,7 @@ mpcp_print(netdissect_options *ndo, const u_char *pptr, u_int length)
 
     case MPCP_OPCODE_REG_ACK:
         mpcp_reg_ack = (const struct mpcp_reg_ack_t *)tptr;
-        ND_PRINT("\n\tEchoed-Assigned-Port %u, Flags [ %s ]"
+        ND_PRINT(C_RESET, C_RESET "\n\tEchoed-Assigned-Port %u, Flags [ %s ]"
                "\n\tEchoed-Sync-Time %u ticks",
                GET_BE_U_2(mpcp_reg_ack->echoed_assigned_port),
                bittok2str(mpcp_reg_ack_flag_values, "Reserved", GET_U_1(mpcp_reg_ack->flags)),

--- a/print-mpcp.c
+++ b/print-mpcp.c
@@ -138,11 +138,11 @@ mpcp_print(netdissect_options *ndo, const u_char *pptr, u_int length)
 
     opcode = GET_BE_U_2(mpcp_common_header->opcode);
     timestamp = GET_BE_U_4(mpcp_common_header->timestamp);
-    ND_PRINT(C_RESET, C_RESET "MPCP, Opcode %s", tok2str(mpcp_opcode_values, "Unknown (%u)", opcode));
+    ND_PRINT(C_RESET, "MPCP, Opcode %s", tok2str(mpcp_opcode_values, "Unknown (%u)", opcode));
     if (opcode != MPCP_OPCODE_PAUSE) {
-        ND_PRINT(C_RESET, C_RESET ", Timestamp %u ticks", timestamp);
+        ND_PRINT(C_RESET, ", Timestamp %u ticks", timestamp);
     }
-    ND_PRINT(C_RESET, C_RESET ", length %u", length);
+    ND_PRINT(C_RESET, ", length %u", length);
 
     if (!ndo->ndo_vflag)
         return;
@@ -155,7 +155,7 @@ mpcp_print(netdissect_options *ndo, const u_char *pptr, u_int length)
 
     case MPCP_OPCODE_GATE:
         grant_numbers = GET_U_1(tptr) & MPCP_GRANT_NUMBER_MASK;
-        ND_PRINT(C_RESET, C_RESET "\n\tGrant Numbers %u, Flags [ %s ]",
+        ND_PRINT(C_RESET, "\n\tGrant Numbers %u, Flags [ %s ]",
                grant_numbers,
                bittok2str(mpcp_grant_flag_values,
                           "?",
@@ -164,25 +164,25 @@ mpcp_print(netdissect_options *ndo, const u_char *pptr, u_int length)
 
         for (grant = 1; grant <= grant_numbers; grant++) {
             const struct mpcp_grant_t *mpcp_grant = (const struct mpcp_grant_t *)tptr;
-            ND_PRINT(C_RESET, C_RESET "\n\tGrant #%u, Start-Time %u ticks, duration %u ticks",
+            ND_PRINT(C_RESET, "\n\tGrant #%u, Start-Time %u ticks, duration %u ticks",
                    grant,
                    GET_BE_U_4(mpcp_grant->starttime),
                    GET_BE_U_2(mpcp_grant->duration));
             tptr += sizeof(struct mpcp_grant_t);
         }
 
-        ND_PRINT(C_RESET, C_RESET "\n\tSync-Time %u ticks", GET_BE_U_2(tptr));
+        ND_PRINT(C_RESET, "\n\tSync-Time %u ticks", GET_BE_U_2(tptr));
         break;
 
 
     case MPCP_OPCODE_REPORT:
         queue_sets = GET_U_1(tptr);
         tptr+=MPCP_REPORT_QUEUESETS_LEN;
-        ND_PRINT(C_RESET, C_RESET "\n\tTotal Queue-Sets %u", queue_sets);
+        ND_PRINT(C_RESET, "\n\tTotal Queue-Sets %u", queue_sets);
 
         for (queue_set = 1; queue_set < queue_sets; queue_set++) {
             report_bitmap = GET_U_1(tptr);
-            ND_PRINT(C_RESET, C_RESET "\n\t  Queue-Set #%u, Report-Bitmap [ %s ]",
+            ND_PRINT(C_RESET, "\n\t  Queue-Set #%u, Report-Bitmap [ %s ]",
                    queue_sets,
                    bittok2str(mpcp_report_bitmap_values, "Unknown", report_bitmap));
             tptr++;
@@ -190,7 +190,7 @@ mpcp_print(netdissect_options *ndo, const u_char *pptr, u_int length)
             report=1;
             while (report_bitmap != 0) {
                 if (report_bitmap & 1) {
-                    ND_PRINT(C_RESET, C_RESET "\n\t    Q%u Report, Duration %u ticks",
+                    ND_PRINT(C_RESET, "\n\t    Q%u Report, Duration %u ticks",
                            report,
                            GET_BE_U_2(tptr));
                     tptr += 2;
@@ -203,14 +203,14 @@ mpcp_print(netdissect_options *ndo, const u_char *pptr, u_int length)
 
     case MPCP_OPCODE_REG_REQ:
         mpcp_reg_req = (const struct mpcp_reg_req_t *)tptr;
-        ND_PRINT(C_RESET, C_RESET "\n\tFlags [ %s ], Pending-Grants %u",
+        ND_PRINT(C_RESET, "\n\tFlags [ %s ], Pending-Grants %u",
                bittok2str(mpcp_reg_req_flag_values, "Reserved", GET_U_1(mpcp_reg_req->flags)),
                GET_U_1(mpcp_reg_req->pending_grants));
         break;
 
     case MPCP_OPCODE_REG:
         mpcp_reg = (const struct mpcp_reg_t *)tptr;
-        ND_PRINT(C_RESET, C_RESET "\n\tAssigned-Port %u, Flags [ %s ]"
+        ND_PRINT(C_RESET, "\n\tAssigned-Port %u, Flags [ %s ]"
                "\n\tSync-Time %u ticks, Echoed-Pending-Grants %u",
                GET_BE_U_2(mpcp_reg->assigned_port),
                bittok2str(mpcp_reg_flag_values, "Reserved", GET_U_1(mpcp_reg->flags)),
@@ -220,7 +220,7 @@ mpcp_print(netdissect_options *ndo, const u_char *pptr, u_int length)
 
     case MPCP_OPCODE_REG_ACK:
         mpcp_reg_ack = (const struct mpcp_reg_ack_t *)tptr;
-        ND_PRINT(C_RESET, C_RESET "\n\tEchoed-Assigned-Port %u, Flags [ %s ]"
+        ND_PRINT(C_RESET, "\n\tEchoed-Assigned-Port %u, Flags [ %s ]"
                "\n\tEchoed-Sync-Time %u ticks",
                GET_BE_U_2(mpcp_reg_ack->echoed_assigned_port),
                bittok2str(mpcp_reg_ack_flag_values, "Reserved", GET_U_1(mpcp_reg_ack->flags)),

--- a/print-mpls.c
+++ b/print-mpls.c
@@ -73,17 +73,17 @@ mpls_print(netdissect_options *ndo, const u_char *bp, u_int length)
 		if (length < sizeof(label_entry))
 			goto invalid;
 		label_entry = GET_BE_U_4(p);
-		ND_PRINT("%s(label %u",
+		ND_PRINT(C_RESET, "%s(label %u",
 		       (label_stack_depth && ndo->ndo_vflag) ? "\n\t" : " ",
        		       MPLS_LABEL(label_entry));
 		label_stack_depth++;
 		if (ndo->ndo_vflag &&
 		    MPLS_LABEL(label_entry) < sizeof(mpls_labelname) / sizeof(mpls_labelname[0]))
-			ND_PRINT(" (%s)", mpls_labelname[MPLS_LABEL(label_entry)]);
-		ND_PRINT(", tc %u", MPLS_TC(label_entry));
+			ND_PRINT(C_RESET, " (%s)", mpls_labelname[MPLS_LABEL(label_entry)]);
+		ND_PRINT(C_RESET, ", tc %u", MPLS_TC(label_entry));
 		if (MPLS_STACK(label_entry))
-			ND_PRINT(", [S]");
-		ND_PRINT(", ttl %u)", MPLS_TTL(label_entry));
+			ND_PRINT(C_RESET, ", [S]");
+		ND_PRINT(C_RESET, ", ttl %u)", MPLS_TTL(label_entry));
 
 		p += sizeof(label_entry);
 		length -= sizeof(label_entry);
@@ -152,17 +152,29 @@ mpls_print(netdissect_options *ndo, const u_char *bp, u_int length)
 		break;
 
 	case PT_IPV4:
-		ND_PRINT(ndo->ndo_vflag ? "\n\t" : " ");
+		if(ndo->ndo_vflag)
+			ND_PRINT(C_RESET, "\n\t");
+		else
+			ND_PRINT(C_RESET, " ");
+		
 		ip_print(ndo, p, length);
 		break;
 
 	case PT_IPV6:
-		ND_PRINT(ndo->ndo_vflag ? "\n\t" : " ");
+		if(ndo->ndo_vflag)
+			ND_PRINT(C_RESET, "\n\t");
+		else
+			ND_PRINT(C_RESET, " ");
+
 		ip6_print(ndo, p, length);
 		break;
 
 	case PT_OSI:
-		ND_PRINT(ndo->ndo_vflag ? "\n\t" : " ");
+		if(ndo->ndo_vflag)
+			ND_PRINT(C_RESET, "\n\t");
+		else
+			ND_PRINT(C_RESET, " ");
+
 		isoclns_print(ndo, p, length);
 		break;
 	}

--- a/print-mptcp.c
+++ b/print-mptcp.c
@@ -244,28 +244,28 @@ mp_capable_print(netdissect_options *ndo,
         switch (version) {
                 case 0: /* fall through */
                 case 1:
-                        ND_PRINT(" v%u", version);
+                        ND_PRINT(C_RESET, C_RESET " v%u", version);
                         break;
                 default:
-                        ND_PRINT(" Unknown Version (%u)", version);
+                        ND_PRINT(C_RESET, C_RESET " Unknown Version (%u)", version);
                         return 1;
         }
 
-        ND_PRINT(" flags [%s]", bittok2str_nosep(mp_capable_flags, "none",
+        ND_PRINT(C_RESET, C_RESET " flags [%s]", bittok2str_nosep(mp_capable_flags, "none",
                  GET_U_1(mpc->flags)));
 
         csum_enabled = GET_U_1(mpc->flags) & MP_CAPABLE_A;
         if (csum_enabled)
-                ND_PRINT(" csum");
+                ND_PRINT(C_RESET, C_RESET " csum");
         if (opt_len == 12 || opt_len >= 20) {
-                ND_PRINT(" {0x%" PRIx64, GET_BE_U_8(mpc->sender_key));
+                ND_PRINT(C_RESET, C_RESET " {0x%" PRIx64, GET_BE_U_8(mpc->sender_key));
                 if (opt_len >= 20)
-                        ND_PRINT(",0x%" PRIx64, GET_BE_U_8(mpc->receiver_key));
+                        ND_PRINT(C_RESET, C_RESET ",0x%" PRIx64, GET_BE_U_8(mpc->receiver_key));
 
                 /* RFC 8684 Section 3.1 */
                 if ((opt_len == 22 && !csum_enabled) || opt_len == 24)
-                        ND_PRINT(",data_len=%u", GET_BE_U_2(mpc->data_len));
-                ND_PRINT("}");
+                        ND_PRINT(C_RESET, C_RESET ",data_len=%u", GET_BE_U_2(mpc->data_len));
+                ND_PRINT(C_RESET, C_RESET "}");
         }
         return 1;
 }
@@ -283,26 +283,26 @@ mp_join_print(netdissect_options *ndo,
 
         if (opt_len != 24) {
                 if (GET_U_1(mpj->sub_b) & MP_JOIN_B)
-                        ND_PRINT(" backup");
-                ND_PRINT(" id %u", GET_U_1(mpj->addr_id));
+                        ND_PRINT(C_RESET, C_RESET " backup");
+                ND_PRINT(C_RESET, C_RESET " id %u", GET_U_1(mpj->addr_id));
         }
 
         switch (opt_len) {
         case 12: /* SYN */
-                ND_PRINT(" token 0x%x" " nonce 0x%x",
+                ND_PRINT(C_RESET, C_RESET " token 0x%x" " nonce 0x%x",
                         GET_BE_U_4(mpj->u.syn.token),
                         GET_BE_U_4(mpj->u.syn.nonce));
                 break;
         case 16: /* SYN/ACK */
-                ND_PRINT(" hmac 0x%" PRIx64 " nonce 0x%x",
+                ND_PRINT(C_RESET, C_RESET " hmac 0x%" PRIx64 " nonce 0x%x",
                         GET_BE_U_8(mpj->u.synack.mac),
                         GET_BE_U_4(mpj->u.synack.nonce));
                 break;
         case 24: {/* ACK */
                 size_t i;
-                ND_PRINT(" hmac 0x");
+                ND_PRINT(C_RESET, C_RESET " hmac 0x");
                 for (i = 0; i < sizeof(mpj->u.ack.mac); ++i)
-                        ND_PRINT("%02x", mpj->u.ack.mac[i]);
+                        ND_PRINT(C_RESET, C_RESET "%02x", mpj->u.ack.mac[i]);
         }
         default:
                 break;
@@ -326,13 +326,13 @@ mp_dss_print(netdissect_options *ndo,
 
         mdss_flags = GET_U_1(mdss->flags);
         if (mdss_flags & MP_DSS_F)
-                ND_PRINT(" fin");
+                ND_PRINT(C_RESET, C_RESET " fin");
 
         opt += 4;
         opt_len -= 4;
         if (mdss_flags & MP_DSS_A) {
                 /* Ack present */
-                ND_PRINT(" ack ");
+                ND_PRINT(C_RESET, C_RESET " ack ");
                 /*
                  * If the a flag is set, we have an 8-byte ack; if it's
                  * clear, we have a 4-byte ack.
@@ -340,13 +340,13 @@ mp_dss_print(netdissect_options *ndo,
                 if (mdss_flags & MP_DSS_a) {
                         if (opt_len < 8)
                                 return 0;
-                        ND_PRINT("%" PRIu64, GET_BE_U_8(opt));
+                        ND_PRINT(C_RESET, C_RESET "%" PRIu64, GET_BE_U_8(opt));
                         opt += 8;
                         opt_len -= 8;
                 } else {
                         if (opt_len < 4)
                                 return 0;
-                        ND_PRINT("%u", GET_BE_U_4(opt));
+                        ND_PRINT(C_RESET, C_RESET "%u", GET_BE_U_4(opt));
                         opt += 4;
                         opt_len -= 4;
                 }
@@ -357,7 +357,7 @@ mp_dss_print(netdissect_options *ndo,
                  * Data Sequence Number (DSN), Subflow Sequence Number (SSN),
                  * Data-Level Length present, and Checksum possibly present.
                  */
-                ND_PRINT(" seq ");
+                ND_PRINT(C_RESET, C_RESET " seq ");
                 /*
                  * If the m flag is set, we have an 8-byte NDS; if it's clear,
                  * we have a 4-byte DSN.
@@ -365,24 +365,24 @@ mp_dss_print(netdissect_options *ndo,
                 if (mdss_flags & MP_DSS_m) {
                         if (opt_len < 8)
                                 return 0;
-                        ND_PRINT("%" PRIu64, GET_BE_U_8(opt));
+                        ND_PRINT(C_RESET, C_RESET "%" PRIu64, GET_BE_U_8(opt));
                         opt += 8;
                         opt_len -= 8;
                 } else {
                         if (opt_len < 4)
                                 return 0;
-                        ND_PRINT("%u", GET_BE_U_4(opt));
+                        ND_PRINT(C_RESET, C_RESET "%u", GET_BE_U_4(opt));
                         opt += 4;
                         opt_len -= 4;
                 }
                 if (opt_len < 4)
                         return 0;
-                ND_PRINT(" subseq %u", GET_BE_U_4(opt));
+                ND_PRINT(C_RESET, C_RESET " subseq %u", GET_BE_U_4(opt));
                 opt += 4;
                 opt_len -= 4;
                 if (opt_len < 2)
                         return 0;
-                ND_PRINT(" len %u", GET_BE_U_2(opt));
+                ND_PRINT(C_RESET, C_RESET " len %u", GET_BE_U_2(opt));
                 opt += 2;
                 opt_len -= 2;
 
@@ -392,7 +392,7 @@ mp_dss_print(netdissect_options *ndo,
                  * bytes as the Checksum.
                  */
                 if (opt_len >= 2) {
-                        ND_PRINT(" csum 0x%x", GET_BE_U_2(opt));
+                        ND_PRINT(C_RESET, C_RESET " csum 0x%x", GET_BE_U_2(opt));
                         opt_len -= 2;
                 }
         }
@@ -411,28 +411,28 @@ add_addr_print(netdissect_options *ndo,
             opt_len == 20 || opt_len == 22 || opt_len == 28 || opt_len == 30))
                 return 0;
 
-        ND_PRINT(" %s",
+        ND_PRINT(C_RESET, C_RESET " %s",
                  tok2str(mptcp_addr_subecho_bits, "[bad version/echo]",
                          GET_U_1(add_addr->sub_echo) & 0xF));
-        ND_PRINT(" id %u", GET_U_1(add_addr->addr_id));
+        ND_PRINT(C_RESET, C_RESET " id %u", GET_U_1(add_addr->addr_id));
         if (opt_len == 8 || opt_len == 10 || opt_len == 16 || opt_len == 18) {
-                ND_PRINT(" %s", GET_IPADDR_STRING(add_addr->u.v4.addr));
+                ND_PRINT(C_RESET, C_RESET " %s", GET_IPADDR_STRING(add_addr->u.v4.addr));
                 if (opt_len == 10 || opt_len == 18)
-                        ND_PRINT(":%u", GET_BE_U_2(add_addr->u.v4.port));
+                        ND_PRINT(C_RESET, C_RESET ":%u", GET_BE_U_2(add_addr->u.v4.port));
                 if (opt_len == 16)
-                        ND_PRINT(" hmac 0x%" PRIx64, GET_BE_U_8(add_addr->u.v4np.mac));
+                        ND_PRINT(C_RESET, C_RESET " hmac 0x%" PRIx64, GET_BE_U_8(add_addr->u.v4np.mac));
                 if (opt_len == 18)
-                        ND_PRINT(" hmac 0x%" PRIx64, GET_BE_U_8(add_addr->u.v4.mac));
+                        ND_PRINT(C_RESET, C_RESET " hmac 0x%" PRIx64, GET_BE_U_8(add_addr->u.v4.mac));
         }
 
         if (opt_len == 20 || opt_len == 22 || opt_len == 28 || opt_len == 30) {
-                ND_PRINT(" %s", GET_IP6ADDR_STRING(add_addr->u.v6.addr));
+                ND_PRINT(C_RESET, C_RESET " %s", GET_IP6ADDR_STRING(add_addr->u.v6.addr));
                 if (opt_len == 22 || opt_len == 30)
-                        ND_PRINT(":%u", GET_BE_U_2(add_addr->u.v6.port));
+                        ND_PRINT(C_RESET, C_RESET ":%u", GET_BE_U_2(add_addr->u.v6.port));
                 if (opt_len == 28)
-                        ND_PRINT(" hmac 0x%" PRIx64, GET_BE_U_8(add_addr->u.v6np.mac));
+                        ND_PRINT(C_RESET, C_RESET " hmac 0x%" PRIx64, GET_BE_U_8(add_addr->u.v6np.mac));
                 if (opt_len == 30)
-                        ND_PRINT(" hmac 0x%" PRIx64, GET_BE_U_8(add_addr->u.v6.mac));
+                        ND_PRINT(C_RESET, C_RESET " hmac 0x%" PRIx64, GET_BE_U_8(add_addr->u.v6.mac));
         }
 
         return 1;
@@ -449,9 +449,9 @@ remove_addr_print(netdissect_options *ndo,
                 return 0;
 
         opt_len -= 3;
-        ND_PRINT(" id");
+        ND_PRINT(C_RESET, C_RESET " id");
         for (i = 0; i < opt_len; i++)
-                ND_PRINT(" %u", GET_U_1(remove_addr->addrs_id[i]));
+                ND_PRINT(C_RESET, C_RESET " %u", GET_U_1(remove_addr->addrs_id[i]));
         return 1;
 }
 
@@ -465,11 +465,11 @@ mp_prio_print(netdissect_options *ndo,
                 return 0;
 
         if (GET_U_1(mpp->sub_b) & MP_PRIO_B)
-                ND_PRINT(" backup");
+                ND_PRINT(C_RESET, C_RESET " backup");
         else
-                ND_PRINT(" non-backup");
+                ND_PRINT(C_RESET, C_RESET " non-backup");
         if (opt_len == 4)
-                ND_PRINT(" id %u", GET_U_1(mpp->addr_id));
+                ND_PRINT(C_RESET, C_RESET " id %u", GET_U_1(mpp->addr_id));
 
         return 1;
 }
@@ -481,7 +481,7 @@ mp_fail_print(netdissect_options *ndo,
         if (opt_len != 12)
                 return 0;
 
-        ND_PRINT(" seq %" PRIu64, GET_BE_U_8(opt + 4));
+        ND_PRINT(C_RESET, C_RESET " seq %" PRIu64, GET_BE_U_8(opt + 4));
         return 1;
 }
 
@@ -492,7 +492,7 @@ mp_fast_close_print(netdissect_options *ndo,
         if (opt_len != 12)
                 return 0;
 
-        ND_PRINT(" key 0x%" PRIx64, GET_BE_U_8(opt + 4));
+        ND_PRINT(C_RESET, C_RESET " key 0x%" PRIx64, GET_BE_U_8(opt + 4));
         return 1;
 }
 
@@ -505,10 +505,10 @@ mp_tcprst_print(netdissect_options *ndo,
         if (opt_len != 4)
                 return 0;
 
-        ND_PRINT(" flags [%s]", bittok2str_nosep(mp_tcprst_flags, "none",
+        ND_PRINT(C_RESET, C_RESET " flags [%s]", bittok2str_nosep(mp_tcprst_flags, "none",
                  GET_U_1(mpr->sub_b)));
 
-        ND_PRINT(" reason %s", tok2str(mp_tcprst_reasons, "unknown (0x%02x)",
+        ND_PRINT(C_RESET, C_RESET " reason %s", tok2str(mp_tcprst_reasons, "unknown (0x%02x)",
                  GET_U_1(mpr->reason)));
         return 1;
 }
@@ -544,8 +544,8 @@ mptcp_print(netdissect_options *ndo,
         subtype = MPTCP_OPT_SUBTYPE(GET_U_1(opt->sub_etc));
         subtype = ND_MIN(subtype, MPTCP_SUB_TCPRST + 1);
 
-        ND_PRINT(" %u", len);
+        ND_PRINT(C_RESET, C_RESET " %u", len);
 
-        ND_PRINT(" %s", mptcp_options[subtype].name);
+        ND_PRINT(C_RESET, C_RESET " %s", mptcp_options[subtype].name);
         return mptcp_options[subtype].print(ndo, cp, len, flags);
 }

--- a/print-mptcp.c
+++ b/print-mptcp.c
@@ -244,28 +244,28 @@ mp_capable_print(netdissect_options *ndo,
         switch (version) {
                 case 0: /* fall through */
                 case 1:
-                        ND_PRINT(C_RESET, C_RESET " v%u", version);
+                        ND_PRINT(C_RESET, " v%u", version);
                         break;
                 default:
-                        ND_PRINT(C_RESET, C_RESET " Unknown Version (%u)", version);
+                        ND_PRINT(C_RESET, " Unknown Version (%u)", version);
                         return 1;
         }
 
-        ND_PRINT(C_RESET, C_RESET " flags [%s]", bittok2str_nosep(mp_capable_flags, "none",
+        ND_PRINT(C_RESET, " flags [%s]", bittok2str_nosep(mp_capable_flags, "none",
                  GET_U_1(mpc->flags)));
 
         csum_enabled = GET_U_1(mpc->flags) & MP_CAPABLE_A;
         if (csum_enabled)
-                ND_PRINT(C_RESET, C_RESET " csum");
+                ND_PRINT(C_RESET, " csum");
         if (opt_len == 12 || opt_len >= 20) {
-                ND_PRINT(C_RESET, C_RESET " {0x%" PRIx64, GET_BE_U_8(mpc->sender_key));
+                ND_PRINT(C_RESET, " {0x%" PRIx64, GET_BE_U_8(mpc->sender_key));
                 if (opt_len >= 20)
-                        ND_PRINT(C_RESET, C_RESET ",0x%" PRIx64, GET_BE_U_8(mpc->receiver_key));
+                        ND_PRINT(C_RESET, ",0x%" PRIx64, GET_BE_U_8(mpc->receiver_key));
 
                 /* RFC 8684 Section 3.1 */
                 if ((opt_len == 22 && !csum_enabled) || opt_len == 24)
-                        ND_PRINT(C_RESET, C_RESET ",data_len=%u", GET_BE_U_2(mpc->data_len));
-                ND_PRINT(C_RESET, C_RESET "}");
+                        ND_PRINT(C_RESET, ",data_len=%u", GET_BE_U_2(mpc->data_len));
+                ND_PRINT(C_RESET, "}");
         }
         return 1;
 }
@@ -283,26 +283,26 @@ mp_join_print(netdissect_options *ndo,
 
         if (opt_len != 24) {
                 if (GET_U_1(mpj->sub_b) & MP_JOIN_B)
-                        ND_PRINT(C_RESET, C_RESET " backup");
-                ND_PRINT(C_RESET, C_RESET " id %u", GET_U_1(mpj->addr_id));
+                        ND_PRINT(C_RESET, " backup");
+                ND_PRINT(C_RESET, " id %u", GET_U_1(mpj->addr_id));
         }
 
         switch (opt_len) {
         case 12: /* SYN */
-                ND_PRINT(C_RESET, C_RESET " token 0x%x" " nonce 0x%x",
+                ND_PRINT(C_RESET, " token 0x%x" " nonce 0x%x",
                         GET_BE_U_4(mpj->u.syn.token),
                         GET_BE_U_4(mpj->u.syn.nonce));
                 break;
         case 16: /* SYN/ACK */
-                ND_PRINT(C_RESET, C_RESET " hmac 0x%" PRIx64 " nonce 0x%x",
+                ND_PRINT(C_RESET, " hmac 0x%" PRIx64 " nonce 0x%x",
                         GET_BE_U_8(mpj->u.synack.mac),
                         GET_BE_U_4(mpj->u.synack.nonce));
                 break;
         case 24: {/* ACK */
                 size_t i;
-                ND_PRINT(C_RESET, C_RESET " hmac 0x");
+                ND_PRINT(C_RESET, " hmac 0x");
                 for (i = 0; i < sizeof(mpj->u.ack.mac); ++i)
-                        ND_PRINT(C_RESET, C_RESET "%02x", mpj->u.ack.mac[i]);
+                        ND_PRINT(C_RESET, "%02x", mpj->u.ack.mac[i]);
         }
         default:
                 break;
@@ -326,13 +326,13 @@ mp_dss_print(netdissect_options *ndo,
 
         mdss_flags = GET_U_1(mdss->flags);
         if (mdss_flags & MP_DSS_F)
-                ND_PRINT(C_RESET, C_RESET " fin");
+                ND_PRINT(C_RESET, " fin");
 
         opt += 4;
         opt_len -= 4;
         if (mdss_flags & MP_DSS_A) {
                 /* Ack present */
-                ND_PRINT(C_RESET, C_RESET " ack ");
+                ND_PRINT(C_RESET, " ack ");
                 /*
                  * If the a flag is set, we have an 8-byte ack; if it's
                  * clear, we have a 4-byte ack.
@@ -340,13 +340,13 @@ mp_dss_print(netdissect_options *ndo,
                 if (mdss_flags & MP_DSS_a) {
                         if (opt_len < 8)
                                 return 0;
-                        ND_PRINT(C_RESET, C_RESET "%" PRIu64, GET_BE_U_8(opt));
+                        ND_PRINT(C_RESET, "%" PRIu64, GET_BE_U_8(opt));
                         opt += 8;
                         opt_len -= 8;
                 } else {
                         if (opt_len < 4)
                                 return 0;
-                        ND_PRINT(C_RESET, C_RESET "%u", GET_BE_U_4(opt));
+                        ND_PRINT(C_RESET, "%u", GET_BE_U_4(opt));
                         opt += 4;
                         opt_len -= 4;
                 }
@@ -357,7 +357,7 @@ mp_dss_print(netdissect_options *ndo,
                  * Data Sequence Number (DSN), Subflow Sequence Number (SSN),
                  * Data-Level Length present, and Checksum possibly present.
                  */
-                ND_PRINT(C_RESET, C_RESET " seq ");
+                ND_PRINT(C_RESET, " seq ");
                 /*
                  * If the m flag is set, we have an 8-byte NDS; if it's clear,
                  * we have a 4-byte DSN.
@@ -365,24 +365,24 @@ mp_dss_print(netdissect_options *ndo,
                 if (mdss_flags & MP_DSS_m) {
                         if (opt_len < 8)
                                 return 0;
-                        ND_PRINT(C_RESET, C_RESET "%" PRIu64, GET_BE_U_8(opt));
+                        ND_PRINT(C_RESET, "%" PRIu64, GET_BE_U_8(opt));
                         opt += 8;
                         opt_len -= 8;
                 } else {
                         if (opt_len < 4)
                                 return 0;
-                        ND_PRINT(C_RESET, C_RESET "%u", GET_BE_U_4(opt));
+                        ND_PRINT(C_RESET, "%u", GET_BE_U_4(opt));
                         opt += 4;
                         opt_len -= 4;
                 }
                 if (opt_len < 4)
                         return 0;
-                ND_PRINT(C_RESET, C_RESET " subseq %u", GET_BE_U_4(opt));
+                ND_PRINT(C_RESET, " subseq %u", GET_BE_U_4(opt));
                 opt += 4;
                 opt_len -= 4;
                 if (opt_len < 2)
                         return 0;
-                ND_PRINT(C_RESET, C_RESET " len %u", GET_BE_U_2(opt));
+                ND_PRINT(C_RESET, " len %u", GET_BE_U_2(opt));
                 opt += 2;
                 opt_len -= 2;
 
@@ -392,7 +392,7 @@ mp_dss_print(netdissect_options *ndo,
                  * bytes as the Checksum.
                  */
                 if (opt_len >= 2) {
-                        ND_PRINT(C_RESET, C_RESET " csum 0x%x", GET_BE_U_2(opt));
+                        ND_PRINT(C_RESET, " csum 0x%x", GET_BE_U_2(opt));
                         opt_len -= 2;
                 }
         }
@@ -411,28 +411,28 @@ add_addr_print(netdissect_options *ndo,
             opt_len == 20 || opt_len == 22 || opt_len == 28 || opt_len == 30))
                 return 0;
 
-        ND_PRINT(C_RESET, C_RESET " %s",
+        ND_PRINT(C_RESET, " %s",
                  tok2str(mptcp_addr_subecho_bits, "[bad version/echo]",
                          GET_U_1(add_addr->sub_echo) & 0xF));
-        ND_PRINT(C_RESET, C_RESET " id %u", GET_U_1(add_addr->addr_id));
+        ND_PRINT(C_RESET, " id %u", GET_U_1(add_addr->addr_id));
         if (opt_len == 8 || opt_len == 10 || opt_len == 16 || opt_len == 18) {
-                ND_PRINT(C_RESET, C_RESET " %s", GET_IPADDR_STRING(add_addr->u.v4.addr));
+                ND_PRINT(C_RESET, " %s", GET_IPADDR_STRING(add_addr->u.v4.addr));
                 if (opt_len == 10 || opt_len == 18)
-                        ND_PRINT(C_RESET, C_RESET ":%u", GET_BE_U_2(add_addr->u.v4.port));
+                        ND_PRINT(C_RESET, ":%u", GET_BE_U_2(add_addr->u.v4.port));
                 if (opt_len == 16)
-                        ND_PRINT(C_RESET, C_RESET " hmac 0x%" PRIx64, GET_BE_U_8(add_addr->u.v4np.mac));
+                        ND_PRINT(C_RESET, " hmac 0x%" PRIx64, GET_BE_U_8(add_addr->u.v4np.mac));
                 if (opt_len == 18)
-                        ND_PRINT(C_RESET, C_RESET " hmac 0x%" PRIx64, GET_BE_U_8(add_addr->u.v4.mac));
+                        ND_PRINT(C_RESET, " hmac 0x%" PRIx64, GET_BE_U_8(add_addr->u.v4.mac));
         }
 
         if (opt_len == 20 || opt_len == 22 || opt_len == 28 || opt_len == 30) {
-                ND_PRINT(C_RESET, C_RESET " %s", GET_IP6ADDR_STRING(add_addr->u.v6.addr));
+                ND_PRINT(C_RESET, " %s", GET_IP6ADDR_STRING(add_addr->u.v6.addr));
                 if (opt_len == 22 || opt_len == 30)
-                        ND_PRINT(C_RESET, C_RESET ":%u", GET_BE_U_2(add_addr->u.v6.port));
+                        ND_PRINT(C_RESET, ":%u", GET_BE_U_2(add_addr->u.v6.port));
                 if (opt_len == 28)
-                        ND_PRINT(C_RESET, C_RESET " hmac 0x%" PRIx64, GET_BE_U_8(add_addr->u.v6np.mac));
+                        ND_PRINT(C_RESET, " hmac 0x%" PRIx64, GET_BE_U_8(add_addr->u.v6np.mac));
                 if (opt_len == 30)
-                        ND_PRINT(C_RESET, C_RESET " hmac 0x%" PRIx64, GET_BE_U_8(add_addr->u.v6.mac));
+                        ND_PRINT(C_RESET, " hmac 0x%" PRIx64, GET_BE_U_8(add_addr->u.v6.mac));
         }
 
         return 1;
@@ -449,9 +449,9 @@ remove_addr_print(netdissect_options *ndo,
                 return 0;
 
         opt_len -= 3;
-        ND_PRINT(C_RESET, C_RESET " id");
+        ND_PRINT(C_RESET, " id");
         for (i = 0; i < opt_len; i++)
-                ND_PRINT(C_RESET, C_RESET " %u", GET_U_1(remove_addr->addrs_id[i]));
+                ND_PRINT(C_RESET, " %u", GET_U_1(remove_addr->addrs_id[i]));
         return 1;
 }
 
@@ -465,11 +465,11 @@ mp_prio_print(netdissect_options *ndo,
                 return 0;
 
         if (GET_U_1(mpp->sub_b) & MP_PRIO_B)
-                ND_PRINT(C_RESET, C_RESET " backup");
+                ND_PRINT(C_RESET, " backup");
         else
-                ND_PRINT(C_RESET, C_RESET " non-backup");
+                ND_PRINT(C_RESET, " non-backup");
         if (opt_len == 4)
-                ND_PRINT(C_RESET, C_RESET " id %u", GET_U_1(mpp->addr_id));
+                ND_PRINT(C_RESET, " id %u", GET_U_1(mpp->addr_id));
 
         return 1;
 }
@@ -481,7 +481,7 @@ mp_fail_print(netdissect_options *ndo,
         if (opt_len != 12)
                 return 0;
 
-        ND_PRINT(C_RESET, C_RESET " seq %" PRIu64, GET_BE_U_8(opt + 4));
+        ND_PRINT(C_RESET, " seq %" PRIu64, GET_BE_U_8(opt + 4));
         return 1;
 }
 
@@ -492,7 +492,7 @@ mp_fast_close_print(netdissect_options *ndo,
         if (opt_len != 12)
                 return 0;
 
-        ND_PRINT(C_RESET, C_RESET " key 0x%" PRIx64, GET_BE_U_8(opt + 4));
+        ND_PRINT(C_RESET, " key 0x%" PRIx64, GET_BE_U_8(opt + 4));
         return 1;
 }
 
@@ -505,10 +505,10 @@ mp_tcprst_print(netdissect_options *ndo,
         if (opt_len != 4)
                 return 0;
 
-        ND_PRINT(C_RESET, C_RESET " flags [%s]", bittok2str_nosep(mp_tcprst_flags, "none",
+        ND_PRINT(C_RESET, " flags [%s]", bittok2str_nosep(mp_tcprst_flags, "none",
                  GET_U_1(mpr->sub_b)));
 
-        ND_PRINT(C_RESET, C_RESET " reason %s", tok2str(mp_tcprst_reasons, "unknown (0x%02x)",
+        ND_PRINT(C_RESET, " reason %s", tok2str(mp_tcprst_reasons, "unknown (0x%02x)",
                  GET_U_1(mpr->reason)));
         return 1;
 }
@@ -544,8 +544,8 @@ mptcp_print(netdissect_options *ndo,
         subtype = MPTCP_OPT_SUBTYPE(GET_U_1(opt->sub_etc));
         subtype = ND_MIN(subtype, MPTCP_SUB_TCPRST + 1);
 
-        ND_PRINT(C_RESET, C_RESET " %u", len);
+        ND_PRINT(C_RESET, " %u", len);
 
-        ND_PRINT(C_RESET, C_RESET " %s", mptcp_options[subtype].name);
+        ND_PRINT(C_RESET, " %s", mptcp_options[subtype].name);
         return mptcp_options[subtype].print(ndo, cp, len, flags);
 }

--- a/print-msdp.c
+++ b/print-msdp.c
@@ -36,7 +36,7 @@ msdp_print(netdissect_options *ndo, const u_char *sp, u_int length)
 	unsigned int type, len;
 
 	ndo->ndo_protocol = "msdp";
-	ND_PRINT(": ");
+	ND_PRINT(C_RESET, ": ");
 	nd_print_protocol(ndo);
 	/* See if we think we're at the beginning of a compound packet */
 	type = GET_U_1(sp);
@@ -47,7 +47,7 @@ msdp_print(netdissect_options *ndo, const u_char *sp, u_int length)
 		type = GET_U_1(sp);
 		len = GET_BE_U_2(sp + 1);
 		if (len > 1400 || ndo->ndo_vflag)
-			ND_PRINT(" [len %u]", len);
+			ND_PRINT(C_RESET, " [len %u]", len);
 		if (len < 3)
 			goto trunc;
 		if (length < len)
@@ -58,14 +58,14 @@ msdp_print(netdissect_options *ndo, const u_char *sp, u_int length)
 		case 1:	/* IPv4 Source-Active */
 		case 3: /* IPv4 Source-Active Response */
 			if (type == 1)
-				ND_PRINT(" SA");
+				ND_PRINT(C_RESET, " SA");
 			else
-				ND_PRINT(" SA-Response");
-			ND_PRINT(" %u entries", GET_U_1(sp));
+				ND_PRINT(C_RESET, " SA-Response");
+			ND_PRINT(C_RESET, " %u entries", GET_U_1(sp));
 			if ((u_int)((GET_U_1(sp) * 12) + 8) < len) {
-				ND_PRINT(" [w/data]");
+				ND_PRINT(C_RESET, " [w/data]");
 				if (ndo->ndo_vflag > 1) {
-					ND_PRINT(" ");
+					ND_PRINT(C_RESET, " ");
 					ip_print(ndo, sp +
 						 GET_U_1(sp) * 12 + 8 - 3,
 						 len - (GET_U_1(sp) * 12 + 8));
@@ -73,19 +73,19 @@ msdp_print(netdissect_options *ndo, const u_char *sp, u_int length)
 			}
 			break;
 		case 2:
-			ND_PRINT(" SA-Request");
-			ND_PRINT(" for %s", GET_IPADDR_STRING(sp + 1));
+			ND_PRINT(C_RESET, " SA-Request");
+			ND_PRINT(C_RESET, " for %s", GET_IPADDR_STRING(sp + 1));
 			break;
 		case 4:
-			ND_PRINT(" Keepalive");
+			ND_PRINT(C_RESET, " Keepalive");
 			if (len != 3)
-				ND_PRINT("[len=%u] ", len);
+				ND_PRINT(C_RESET, "[len=%u] ", len);
 			break;
 		case 5:
-			ND_PRINT(" Notification");
+			ND_PRINT(C_RESET, " Notification");
 			break;
 		default:
-			ND_PRINT(" [type=%u len=%u]", type, len);
+			ND_PRINT(C_RESET, " [type=%u len=%u]", type, len);
 			break;
 		}
 		sp += (len - 3);

--- a/print-msnlb.c
+++ b/print-msnlb.c
@@ -55,8 +55,8 @@ msnlb_print(netdissect_options *ndo, const u_char *bp)
 	ndo->ndo_protocol = "msnlb";
 	hb = (const struct msnlb_heartbeat_pkt *)bp;
 
-	ND_PRINT("MS NLB heartbeat");
-	ND_PRINT(", host priority: %u", GET_LE_U_4((hb->host_prio)));
-	ND_PRINT(", cluster IP: %s", GET_IPADDR_STRING(hb->virtual_ip));
-	ND_PRINT(", host IP: %s", GET_IPADDR_STRING(hb->host_ip));
+	ND_PRINT(C_RESET, "MS NLB heartbeat");
+	ND_PRINT(C_RESET, ", host priority: %u", GET_LE_U_4((hb->host_prio)));
+	ND_PRINT(C_RESET, ", cluster IP: %s", GET_IPADDR_STRING(hb->virtual_ip));
+	ND_PRINT(C_RESET, ", host IP: %s", GET_IPADDR_STRING(hb->host_ip));
 }

--- a/print-nflog.c
+++ b/print-nflog.c
@@ -112,22 +112,22 @@ static const struct tok nflog_values[] = {
 static void
 nflog_hdr_print(netdissect_options *ndo, const nflog_hdr_t *hdr, u_int length)
 {
-	ND_PRINT("version %u, resource ID %u",
+	ND_PRINT(C_RESET, "version %u, resource ID %u",
 	    GET_U_1(hdr->nflog_version), GET_BE_U_2(hdr->nflog_rid));
 
 	if (!ndo->ndo_qflag) {
-		ND_PRINT(", family %s (%u)",
+		ND_PRINT(C_RESET, ", family %s (%u)",
 			 tok2str(nflog_values, "Unknown",
 				 GET_U_1(hdr->nflog_family)),
 			 GET_U_1(hdr->nflog_family));
 		} else {
-		ND_PRINT(", %s",
+		ND_PRINT(C_RESET, ", %s",
 			 tok2str(nflog_values,
 				 "Unknown NFLOG (0x%02x)",
 			 GET_U_1(hdr->nflog_family)));
 		}
 
-	ND_PRINT(", length %u: ", length);
+	ND_PRINT(C_RESET, ", length %u: ", length);
 }
 
 void
@@ -150,7 +150,7 @@ nflog_if_print(netdissect_options *ndo,
 
 	ND_TCHECK_SIZE(hdr);
 	if (GET_U_1(hdr->nflog_version) != 0) {
-		ND_PRINT("version %u (unknown)", GET_U_1(hdr->nflog_version));
+		ND_PRINT(C_RESET, "version %u (unknown)", GET_U_1(hdr->nflog_version));
 		return;
 	}
 

--- a/print-nfs.c
+++ b/print-nfs.c
@@ -225,7 +225,7 @@ nfsaddr_print(netdissect_options *ndo,
 		break;
 	}
 
-	ND_PRINT("%s.%s > %s.%s: ", srcaddr, s, dstaddr, d);
+	ND_PRINT(C_RESET, "%s.%s > %s.%s: ", srcaddr, s, dstaddr, d);
 }
 
 /*
@@ -314,17 +314,17 @@ print_sattr3(netdissect_options *ndo,
              const struct nfsv3_sattr *sa3, int verbose)
 {
 	if (sa3->sa_modeset)
-		ND_PRINT(" mode %o", sa3->sa_mode);
+		ND_PRINT(C_RESET, " mode %o", sa3->sa_mode);
 	if (sa3->sa_uidset)
-		ND_PRINT(" uid %u", sa3->sa_uid);
+		ND_PRINT(C_RESET, " uid %u", sa3->sa_uid);
 	if (sa3->sa_gidset)
-		ND_PRINT(" gid %u", sa3->sa_gid);
+		ND_PRINT(C_RESET, " gid %u", sa3->sa_gid);
 	if (verbose > 1) {
 		if (sa3->sa_atimetype == NFSV3SATTRTIME_TOCLIENT)
-			ND_PRINT(" atime %u.%06u", sa3->sa_atime.nfsv3_sec,
+			ND_PRINT(C_RESET, " atime %u.%06u", sa3->sa_atime.nfsv3_sec,
 			       sa3->sa_atime.nfsv3_nsec);
 		if (sa3->sa_mtimetype == NFSV3SATTRTIME_TOCLIENT)
-			ND_PRINT(" mtime %u.%06u", sa3->sa_mtime.nfsv3_sec,
+			ND_PRINT(C_RESET, " mtime %u.%06u", sa3->sa_mtime.nfsv3_sec,
 			       sa3->sa_mtime.nfsv3_nsec);
 	}
 }
@@ -374,13 +374,13 @@ nfsreply_noaddr_print(netdissect_options *ndo,
 	switch (reply_stat) {
 
 	case SUNRPC_MSG_ACCEPTED:
-		ND_PRINT("reply ok %u", length);
+		ND_PRINT(C_RESET, "reply ok %u", length);
 		if (xid_map_find(ndo, rp, bp2, &proc, &vers) >= 0)
 			interp_reply(ndo, rp, proc, vers, length);
 		break;
 
 	case SUNRPC_MSG_DENIED:
-		ND_PRINT("reply ERR %u: ", length);
+		ND_PRINT(C_RESET, "reply ERR %u: ", length);
 		ND_TCHECK_4(rp->rm_reply.rp_reject.rj_stat);
 		rstat = GET_BE_U_4(&rp->rm_reply.rp_reject.rj_stat);
 		switch (rstat) {
@@ -389,23 +389,23 @@ nfsreply_noaddr_print(netdissect_options *ndo,
 			ND_TCHECK_4(rp->rm_reply.rp_reject.rj_vers.high);
 			rlow = GET_BE_U_4(&rp->rm_reply.rp_reject.rj_vers.low);
 			rhigh = GET_BE_U_4(&rp->rm_reply.rp_reject.rj_vers.high);
-			ND_PRINT("RPC Version mismatch (%u-%u)", rlow, rhigh);
+			ND_PRINT(C_RESET, "RPC Version mismatch (%u-%u)", rlow, rhigh);
 			break;
 
 		case SUNRPC_AUTH_ERROR:
 			ND_TCHECK_4(rp->rm_reply.rp_reject.rj_why);
 			rwhy = GET_BE_U_4(&rp->rm_reply.rp_reject.rj_why);
-			ND_PRINT("Auth %s", tok2str(sunrpc_auth_str, "Invalid failure code %u", rwhy));
+			ND_PRINT(C_RESET, "Auth %s", tok2str(sunrpc_auth_str, "Invalid failure code %u", rwhy));
 			break;
 
 		default:
-			ND_PRINT("Unknown reason for rejecting rpc message %u", (unsigned int)rstat);
+			ND_PRINT(C_RESET, "Unknown reason for rejecting rpc message %u", (unsigned int)rstat);
 			break;
 		}
 		break;
 
 	default:
-		ND_PRINT("reply Unknown rpc response code=%u %u", reply_stat, length);
+		ND_PRINT(C_RESET, "reply Unknown rpc response code=%u %u", reply_stat, length);
 		break;
 	}
 	return;
@@ -509,7 +509,7 @@ parsefn(netdissect_options *ndo,
 	dp++;
 
 	if (UINT_MAX - len < 3) {
-		ND_PRINT("[cannot pad to 32-bit boundaries]");
+		ND_PRINT(C_RESET, "[cannot pad to 32-bit boundaries]");
 		nd_print_invalid(ndo);
 		return NULL;
 	}
@@ -520,12 +520,12 @@ parsefn(netdissect_options *ndo,
 	cp = (const u_char *)dp;
 	/* Update 32-bit pointer (NFS filenames padded to 32-bit boundaries) */
 	dp += rounded_len / sizeof(*dp);
-	ND_PRINT("\"");
+	ND_PRINT(C_RESET, "\"");
 	if (nd_printn(ndo, cp, len, ndo->ndo_snapend)) {
-		ND_PRINT("\"");
+		ND_PRINT(C_RESET, "\"");
 		goto trunc;
 	}
-	ND_PRINT("\"");
+	ND_PRINT(C_RESET, "\"");
 
 	return (dp);
 trunc:
@@ -544,7 +544,7 @@ parsefhn(netdissect_options *ndo,
 	dp = parsefh(ndo, dp, v3);
 	if (dp == NULL)
 		return (NULL);
-	ND_PRINT(" ");
+	ND_PRINT(C_RESET, " ");
 	return (parsefn(ndo, dp));
 }
 
@@ -562,7 +562,7 @@ nfsreq_noaddr_print(netdissect_options *ndo,
 	struct nfsv3_sattr sa3;
 
 	ndo->ndo_protocol = "nfs";
-	ND_PRINT("%u", length);
+	ND_PRINT(C_RESET, "%u", length);
 	rp = (const struct sunrpc_msg *)bp;
 
 	if (!xid_map_enter(ndo, rp, bp2))	/* record proc number for later on */
@@ -574,7 +574,7 @@ nfsreq_noaddr_print(netdissect_options *ndo,
 	if (!v3 && proc < NFS_NPROCS)
 		proc =  nfsv3_procid[proc];
 
-	ND_PRINT(" %s", tok2str(nfsproc_str, "proc-%u", proc));
+	ND_PRINT(C_RESET, " %s", tok2str(nfsproc_str, "proc-%u", proc));
 	switch (proc) {
 
 	case NFSPROC_GETATTR:
@@ -612,33 +612,33 @@ nfsreq_noaddr_print(netdissect_options *ndo,
 		access_flags = GET_BE_U_4(dp);
 		if (access_flags & ~NFSV3ACCESS_FULL) {
 			/* NFSV3ACCESS definitions aren't up to date */
-			ND_PRINT(" %04x", access_flags);
+			ND_PRINT(C_RESET, " %04x", access_flags);
 		} else if ((access_flags & NFSV3ACCESS_FULL) == NFSV3ACCESS_FULL) {
-			ND_PRINT(" NFS_ACCESS_FULL");
+			ND_PRINT(C_RESET, " NFS_ACCESS_FULL");
 		} else {
 			char separator = ' ';
 			if (access_flags & NFSV3ACCESS_READ) {
-				ND_PRINT(" NFS_ACCESS_READ");
+				ND_PRINT(C_RESET, " NFS_ACCESS_READ");
 				separator = '|';
 			}
 			if (access_flags & NFSV3ACCESS_LOOKUP) {
-				ND_PRINT("%cNFS_ACCESS_LOOKUP", separator);
+				ND_PRINT(C_RESET, "%cNFS_ACCESS_LOOKUP", separator);
 				separator = '|';
 			}
 			if (access_flags & NFSV3ACCESS_MODIFY) {
-				ND_PRINT("%cNFS_ACCESS_MODIFY", separator);
+				ND_PRINT(C_RESET, "%cNFS_ACCESS_MODIFY", separator);
 				separator = '|';
 			}
 			if (access_flags & NFSV3ACCESS_EXTEND) {
-				ND_PRINT("%cNFS_ACCESS_EXTEND", separator);
+				ND_PRINT(C_RESET, "%cNFS_ACCESS_EXTEND", separator);
 				separator = '|';
 			}
 			if (access_flags & NFSV3ACCESS_DELETE) {
-				ND_PRINT("%cNFS_ACCESS_DELETE", separator);
+				ND_PRINT(C_RESET, "%cNFS_ACCESS_DELETE", separator);
 				separator = '|';
 			}
 			if (access_flags & NFSV3ACCESS_EXECUTE)
-				ND_PRINT("%cNFS_ACCESS_EXECUTE", separator);
+				ND_PRINT(C_RESET, "%cNFS_ACCESS_EXECUTE", separator);
 		}
 		break;
 
@@ -650,11 +650,11 @@ nfsreq_noaddr_print(netdissect_options *ndo,
 		if (dp == NULL)
 			goto trunc;
 		if (v3) {
-			ND_PRINT(" %u bytes @ %" PRIu64,
+			ND_PRINT(C_RESET, " %u bytes @ %" PRIu64,
 			       GET_BE_U_4(dp + 2),
 			       GET_BE_U_8(dp));
 		} else {
-			ND_PRINT(" %u bytes @ %u",
+			ND_PRINT(C_RESET, " %u bytes @ %u",
 			    GET_BE_U_4(dp + 1),
 			    GET_BE_U_4(dp));
 		}
@@ -668,17 +668,17 @@ nfsreq_noaddr_print(netdissect_options *ndo,
 		if (dp == NULL)
 			goto trunc;
 		if (v3) {
-			ND_PRINT(" %u (%u) bytes @ %" PRIu64,
+			ND_PRINT(C_RESET, " %u (%u) bytes @ %" PRIu64,
 					GET_BE_U_4(dp + 4),
 					GET_BE_U_4(dp + 2),
 					GET_BE_U_8(dp));
 			if (ndo->ndo_vflag) {
-				ND_PRINT(" <%s>",
+				ND_PRINT(C_RESET, " <%s>",
 					tok2str(nfsv3_writemodes,
 						NULL, GET_BE_U_4(dp + 3)));
 			}
 		} else {
-			ND_PRINT(" %u (%u) bytes @ %u (%u)",
+			ND_PRINT(C_RESET, " %u (%u) bytes @ %u (%u)",
 					GET_BE_U_4(dp + 3),
 					GET_BE_U_4(dp + 2),
 					GET_BE_U_4(dp + 1),
@@ -693,7 +693,7 @@ nfsreq_noaddr_print(netdissect_options *ndo,
 		dp = parsefhn(ndo, dp, v3);
 		if (dp == NULL)
 			goto trunc;
-		ND_PRINT(" ->");
+		ND_PRINT(C_RESET, " ->");
 		if (v3 && (dp = parse_sattr3(ndo, dp, &sa3)) == NULL)
 			goto trunc;
 		if (parsefn(ndo, dp) == NULL)
@@ -714,9 +714,9 @@ nfsreq_noaddr_print(netdissect_options *ndo,
 		dp = parse_sattr3(ndo, dp, &sa3);
 		if (dp == NULL)
 			goto trunc;
-		ND_PRINT(" %s", tok2str(type2str, "unk-ft %u", type));
+		ND_PRINT(C_RESET, " %s", tok2str(type2str, "unk-ft %u", type));
 		if (ndo->ndo_vflag && (type == NFCHR || type == NFBLK)) {
-			ND_PRINT(" %u/%u",
+			ND_PRINT(C_RESET, " %u/%u",
 			       GET_BE_U_4(dp),
 			       GET_BE_U_4(dp + 1));
 			dp += 2;
@@ -732,7 +732,7 @@ nfsreq_noaddr_print(netdissect_options *ndo,
 		dp = parsefhn(ndo, dp, v3);
 		if (dp == NULL)
 			goto trunc;
-		ND_PRINT(" ->");
+		ND_PRINT(C_RESET, " ->");
 		if (parsefhn(ndo, dp, v3) == NULL)
 			goto trunc;
 		break;
@@ -744,7 +744,7 @@ nfsreq_noaddr_print(netdissect_options *ndo,
 		dp = parsefh(ndo, dp, v3);
 		if (dp == NULL)
 			goto trunc;
-		ND_PRINT(" ->");
+		ND_PRINT(C_RESET, " ->");
 		if (parsefhn(ndo, dp, v3) == NULL)
 			goto trunc;
 		break;
@@ -761,7 +761,7 @@ nfsreq_noaddr_print(netdissect_options *ndo,
 			 * We shouldn't really try to interpret the
 			 * offset cookie here.
 			 */
-			ND_PRINT(" %u bytes @ %" PRId64,
+			ND_PRINT(C_RESET, " %u bytes @ %" PRId64,
 			    GET_BE_U_4(dp + 4),
 			    GET_BE_U_8(dp));
 			if (ndo->ndo_vflag) {
@@ -771,7 +771,7 @@ nfsreq_noaddr_print(netdissect_options *ndo,
 				 * from the low-order byte
 				 * to the high-order byte.
 				 */
-				ND_PRINT(" verf %08x%08x",
+				ND_PRINT(C_RESET, " verf %08x%08x",
 					  GET_BE_U_4(dp + 2),
 					  GET_BE_U_4(dp + 3));
 			}
@@ -780,7 +780,7 @@ nfsreq_noaddr_print(netdissect_options *ndo,
 			 * Print the offset as signed, since -1 is
 			 * common, but offsets > 2^31 aren't.
 			 */
-			ND_PRINT(" %u bytes @ %u",
+			ND_PRINT(C_RESET, " %u bytes @ %u",
 			    GET_BE_U_4(dp + 1),
 			    GET_BE_U_4(dp));
 		}
@@ -797,7 +797,7 @@ nfsreq_noaddr_print(netdissect_options *ndo,
 		 * We don't try to interpret the offset
 		 * cookie here.
 		 */
-		ND_PRINT(" %u bytes @ %" PRId64,
+		ND_PRINT(C_RESET, " %u bytes @ %" PRId64,
 			GET_BE_U_4(dp + 4),
 			GET_BE_U_8(dp));
 		if (ndo->ndo_vflag) {
@@ -807,7 +807,7 @@ nfsreq_noaddr_print(netdissect_options *ndo,
 			 * from the low-order byte
 			 * to the high-order byte.
 			 */
-			ND_PRINT(" max %u verf %08x%08x",
+			ND_PRINT(C_RESET, " max %u verf %08x%08x",
 			          GET_BE_U_4(dp + 5),
 			          GET_BE_U_4(dp + 2),
 			          GET_BE_U_4(dp + 3));
@@ -821,7 +821,7 @@ nfsreq_noaddr_print(netdissect_options *ndo,
 		dp = parsefh(ndo, dp, v3);
 		if (dp == NULL)
 			goto trunc;
-		ND_PRINT(" %u bytes @ %" PRIu64,
+		ND_PRINT(C_RESET, " %u bytes @ %" PRIu64,
 			GET_BE_U_4(dp + 2),
 			GET_BE_U_8(dp));
 		break;
@@ -857,7 +857,7 @@ nfs_printfh(netdissect_options *ndo,
 		u_int i;
 		char const *sep = "";
 
-		ND_PRINT(" fh[");
+		ND_PRINT(C_RESET, " fh[");
 		for (i=0; i<len; i++) {
 			/*
 			 * This displays 4 bytes in big-endian byte
@@ -871,10 +871,10 @@ nfs_printfh(netdissect_options *ndo,
 			 * running tcpdump may show the same file
 			 * handle in different ways.
 			 */
-			ND_PRINT("%s%x", sep, GET_BE_U_4(dp + i));
+			ND_PRINT(C_RESET, "%s%x", sep, GET_BE_U_4(dp + i));
 			sep = ":";
 		}
-		ND_PRINT("]");
+		ND_PRINT(C_RESET, "]");
 		return;
 	}
 
@@ -896,17 +896,17 @@ nfs_printfh(netdissect_options *ndo,
 		if (spacep)
 			*spacep = '\0';
 
-		ND_PRINT(" fh %s/", temp);
+		ND_PRINT(C_RESET, " fh %s/", temp);
 	} else {
-		ND_PRINT(" fh %u,%u/",
+		ND_PRINT(C_RESET, " fh %u,%u/",
 			     fsid.Fsid_dev.Major, fsid.Fsid_dev.Minor);
 	}
 
 	if(fsid.Fsid_dev.Minor == 257)
 		/* Print the undecoded handle */
-		ND_PRINT("%s", fsid.Opaque_Handle);
+		ND_PRINT(C_RESET, "%s", fsid.Opaque_Handle);
 	else
-		ND_PRINT("%u", ino);
+		ND_PRINT(C_RESET, "%u", ino);
 }
 
 /*
@@ -1088,7 +1088,7 @@ parserep(netdissect_options *ndo,
 	 */
 	astat = (enum sunrpc_accept_stat) GET_BE_U_4(dp);
 	if (astat != SUNRPC_SUCCESS) {
-		ND_PRINT(" %s", tok2str(sunrpc_str, "ar_stat %u", astat));
+		ND_PRINT(C_RESET, " %s", tok2str(sunrpc_str, "ar_stat %u", astat));
 		*nfserrp = 1;		/* suppress trunc string */
 		return (NULL);
 	}
@@ -1110,7 +1110,7 @@ parsestatus(netdissect_options *ndo,
 		*er = errnum;
 	if (errnum != 0) {
 		if (!ndo->ndo_qflag)
-			ND_PRINT(" ERROR: %s",
+			ND_PRINT(C_RESET, " ERROR: %s",
 			    tok2str(status2str, "unk %u", errnum));
 		*nfserrp = 1;
 	}
@@ -1132,54 +1132,54 @@ parsefattr(netdissect_options *ndo,
 		 * signed because -2 has traditionally been the
 		 * UID for "nobody", rather than 4294967294.
 		 */
-		ND_PRINT(" %s %o ids %d/%d",
+		ND_PRINT(C_RESET, " %s %o ids %d/%d",
 		    tok2str(type2str, "unk-ft %u ",
 		    GET_BE_U_4(fap->fa_type)),
 		    GET_BE_U_4(fap->fa_mode),
 		    GET_BE_S_4(fap->fa_uid),
 		    GET_BE_S_4(fap->fa_gid));
 		if (v3) {
-			ND_PRINT(" sz %" PRIu64,
+			ND_PRINT(C_RESET, " sz %" PRIu64,
 				GET_BE_U_8(fap->fa3_size));
 		} else {
-			ND_PRINT(" sz %u", GET_BE_U_4(fap->fa2_size));
+			ND_PRINT(C_RESET, " sz %u", GET_BE_U_4(fap->fa2_size));
 		}
 	}
 	/* print lots more stuff */
 	if (verbose > 1) {
 		if (v3) {
 			ND_TCHECK_8(&fap->fa3_ctime);
-			ND_PRINT(" nlink %u rdev %u/%u",
+			ND_PRINT(C_RESET, " nlink %u rdev %u/%u",
 			       GET_BE_U_4(fap->fa_nlink),
 			       GET_BE_U_4(fap->fa3_rdev.specdata1),
 			       GET_BE_U_4(fap->fa3_rdev.specdata2));
-			ND_PRINT(" fsid %" PRIx64,
+			ND_PRINT(C_RESET, " fsid %" PRIx64,
 				GET_BE_U_8(fap->fa3_fsid));
-			ND_PRINT(" fileid %" PRIx64,
+			ND_PRINT(C_RESET, " fileid %" PRIx64,
 				GET_BE_U_8(fap->fa3_fileid));
-			ND_PRINT(" a/m/ctime %u.%06u",
+			ND_PRINT(C_RESET, " a/m/ctime %u.%06u",
 			       GET_BE_U_4(fap->fa3_atime.nfsv3_sec),
 			       GET_BE_U_4(fap->fa3_atime.nfsv3_nsec));
-			ND_PRINT(" %u.%06u",
+			ND_PRINT(C_RESET, " %u.%06u",
 			       GET_BE_U_4(fap->fa3_mtime.nfsv3_sec),
 			       GET_BE_U_4(fap->fa3_mtime.nfsv3_nsec));
-			ND_PRINT(" %u.%06u",
+			ND_PRINT(C_RESET, " %u.%06u",
 			       GET_BE_U_4(fap->fa3_ctime.nfsv3_sec),
 			       GET_BE_U_4(fap->fa3_ctime.nfsv3_nsec));
 		} else {
 			ND_TCHECK_8(&fap->fa2_ctime);
-			ND_PRINT(" nlink %u rdev 0x%x fsid 0x%x nodeid 0x%x a/m/ctime",
+			ND_PRINT(C_RESET, " nlink %u rdev 0x%x fsid 0x%x nodeid 0x%x a/m/ctime",
 			       GET_BE_U_4(fap->fa_nlink),
 			       GET_BE_U_4(fap->fa2_rdev),
 			       GET_BE_U_4(fap->fa2_fsid),
 			       GET_BE_U_4(fap->fa2_fileid));
-			ND_PRINT(" %u.%06u",
+			ND_PRINT(C_RESET, " %u.%06u",
 			       GET_BE_U_4(fap->fa2_atime.nfsv2_sec),
 			       GET_BE_U_4(fap->fa2_atime.nfsv2_usec));
-			ND_PRINT(" %u.%06u",
+			ND_PRINT(C_RESET, " %u.%06u",
 			       GET_BE_U_4(fap->fa2_mtime.nfsv2_sec),
 			       GET_BE_U_4(fap->fa2_mtime.nfsv2_usec));
-			ND_PRINT(" %u.%06u",
+			ND_PRINT(C_RESET, " %u.%06u",
 			       GET_BE_U_4(fap->fa2_ctime.nfsv2_sec),
 			       GET_BE_U_4(fap->fa2_ctime.nfsv2_usec));
 		}
@@ -1240,7 +1240,7 @@ parselinkres(netdissect_options *ndo,
 		if (dp == NULL)
 			return (0);
 	}
-	ND_PRINT(" ");
+	ND_PRINT(C_RESET, " ");
 	return (parsefn(ndo, dp) != NULL);
 }
 
@@ -1262,7 +1262,7 @@ parsestatfs(netdissect_options *ndo,
 
 	if (v3) {
 		if (ndo->ndo_vflag)
-			ND_PRINT(" POST:");
+			ND_PRINT(C_RESET, " POST:");
 		dp = parse_post_op_attr(ndo, dp, ndo->ndo_vflag);
 		if (dp == NULL)
 			return (0);
@@ -1273,19 +1273,19 @@ parsestatfs(netdissect_options *ndo,
 	sfsp = (const struct nfs_statfs *)dp;
 
 	if (v3) {
-		ND_PRINT(" tbytes %" PRIu64 " fbytes %" PRIu64 " abytes %" PRIu64,
+		ND_PRINT(C_RESET, " tbytes %" PRIu64 " fbytes %" PRIu64 " abytes %" PRIu64,
 			GET_BE_U_8(sfsp->sf_tbytes),
 			GET_BE_U_8(sfsp->sf_fbytes),
 			GET_BE_U_8(sfsp->sf_abytes));
 		if (ndo->ndo_vflag) {
-			ND_PRINT(" tfiles %" PRIu64 " ffiles %" PRIu64 " afiles %" PRIu64 " invar %u",
+			ND_PRINT(C_RESET, " tfiles %" PRIu64 " ffiles %" PRIu64 " afiles %" PRIu64 " invar %u",
 			       GET_BE_U_8(sfsp->sf_tfiles),
 			       GET_BE_U_8(sfsp->sf_ffiles),
 			       GET_BE_U_8(sfsp->sf_afiles),
 			       GET_BE_U_4(sfsp->sf_invarsec));
 		}
 	} else {
-		ND_PRINT(" tsize %u bsize %u blocks %u bfree %u bavail %u",
+		ND_PRINT(C_RESET, " tsize %u bsize %u blocks %u bfree %u bavail %u",
 			GET_BE_U_4(sfsp->sf_tsize),
 			GET_BE_U_4(sfsp->sf_bsize),
 			GET_BE_U_4(sfsp->sf_blocks),
@@ -1312,10 +1312,10 @@ parserddires(netdissect_options *ndo,
 	if (ndo->ndo_qflag)
 		return (1);
 
-	ND_PRINT(" offset 0x%x size %u ",
+	ND_PRINT(C_RESET, " offset 0x%x size %u ",
 	       GET_BE_U_4(dp), GET_BE_U_4(dp + 1));
 	if (GET_BE_U_4(dp + 2) != 0)
-		ND_PRINT(" eof");
+		ND_PRINT(C_RESET, " eof");
 
 	return (1);
 }
@@ -1325,8 +1325,8 @@ parse_wcc_attr(netdissect_options *ndo,
                const uint32_t *dp)
 {
 	/* Our caller has already checked this */
-	ND_PRINT(" sz %" PRIu64, GET_BE_U_8(dp));
-	ND_PRINT(" mtime %u.%06u ctime %u.%06u",
+	ND_PRINT(C_RESET, " sz %" PRIu64, GET_BE_U_8(dp));
+	ND_PRINT(C_RESET, " mtime %u.%06u ctime %u.%06u",
 	       GET_BE_U_4(dp + 2), GET_BE_U_4(dp + 3),
 	       GET_BE_U_4(dp + 4), GET_BE_U_4(dp + 5));
 	return (dp + 6);
@@ -1374,13 +1374,13 @@ parse_wcc_data(netdissect_options *ndo,
                const uint32_t *dp, int verbose)
 {
 	if (verbose > 1)
-		ND_PRINT(" PRE:");
+		ND_PRINT(C_RESET, " PRE:");
 	dp = parse_pre_op_attr(ndo, dp, verbose);
 	if (dp == NULL)
 		return (0);
 
 	if (verbose)
-		ND_PRINT(" POST:");
+		ND_PRINT(C_RESET, " POST:");
 	return parse_post_op_attr(ndo, dp, verbose);
 }
 
@@ -1407,7 +1407,7 @@ parsecreateopres(netdissect_options *ndo,
 			if (dp == NULL)
 				return (0);
 			if (ndo->ndo_vflag > 1) {
-				ND_PRINT(" dir attr:");
+				ND_PRINT(C_RESET, " dir attr:");
 				dp = parse_wcc_data(ndo, dp, verbose);
 			}
 		}
@@ -1437,7 +1437,7 @@ parsev3rddirres(netdissect_options *ndo,
 	if (dp == NULL)
 		return (0);
 	if (ndo->ndo_vflag)
-		ND_PRINT(" POST:");
+		ND_PRINT(C_RESET, " POST:");
 	dp = parse_post_op_attr(ndo, dp, verbose);
 	if (dp == NULL)
 		return (0);
@@ -1448,7 +1448,7 @@ parsev3rddirres(netdissect_options *ndo,
 		 * This displays the 8 bytes of the verifier in order,
 		 * from the low-order byte to the high-order byte.
 		 */
-		ND_PRINT(" verf %08x%08x",
+		ND_PRINT(C_RESET, " verf %08x%08x",
 			  GET_BE_U_4(dp), GET_BE_U_4(dp + 1));
 		dp += 2;
 	}
@@ -1466,7 +1466,7 @@ parsefsinfo(netdissect_options *ndo,
 	if (dp == NULL)
 		return (0);
 	if (ndo->ndo_vflag)
-		ND_PRINT(" POST:");
+		ND_PRINT(C_RESET, " POST:");
 	dp = parse_post_op_attr(ndo, dp, ndo->ndo_vflag);
 	if (dp == NULL)
 		return (0);
@@ -1475,18 +1475,18 @@ parsefsinfo(netdissect_options *ndo,
 
 	sfp = (const struct nfsv3_fsinfo *)dp;
 	ND_TCHECK_SIZE(sfp);
-	ND_PRINT(" rtmax %u rtpref %u wtmax %u wtpref %u dtpref %u",
+	ND_PRINT(C_RESET, " rtmax %u rtpref %u wtmax %u wtpref %u dtpref %u",
 	       GET_BE_U_4(sfp->fs_rtmax),
 	       GET_BE_U_4(sfp->fs_rtpref),
 	       GET_BE_U_4(sfp->fs_wtmax),
 	       GET_BE_U_4(sfp->fs_wtpref),
 	       GET_BE_U_4(sfp->fs_dtpref));
 	if (ndo->ndo_vflag) {
-		ND_PRINT(" rtmult %u wtmult %u maxfsz %" PRIu64,
+		ND_PRINT(C_RESET, " rtmult %u wtmult %u maxfsz %" PRIu64,
 		       GET_BE_U_4(sfp->fs_rtmult),
 		       GET_BE_U_4(sfp->fs_wtmult),
 		       GET_BE_U_8(sfp->fs_maxfilesize));
-		ND_PRINT(" delta %u.%06u ",
+		ND_PRINT(C_RESET, " delta %u.%06u ",
 		       GET_BE_U_4(sfp->fs_timedelta.nfsv3_sec),
 		       GET_BE_U_4(sfp->fs_timedelta.nfsv3_nsec));
 	}
@@ -1506,7 +1506,7 @@ parsepathconf(netdissect_options *ndo,
 	if (dp == NULL)
 		return (0);
 	if (ndo->ndo_vflag)
-		ND_PRINT(" POST:");
+		ND_PRINT(C_RESET, " POST:");
 	dp = parse_post_op_attr(ndo, dp, ndo->ndo_vflag);
 	if (dp == NULL)
 		return (0);
@@ -1516,7 +1516,7 @@ parsepathconf(netdissect_options *ndo,
 	spp = (const struct nfsv3_pathconf *)dp;
 	ND_TCHECK_SIZE(spp);
 
-	ND_PRINT(" linkmax %u namemax %u %s %s %s %s",
+	ND_PRINT(C_RESET, " linkmax %u namemax %u %s %s %s %s",
 	       GET_BE_U_4(spp->pc_linkmax),
 	       GET_BE_U_4(spp->pc_namemax),
 	       GET_BE_U_4(spp->pc_notrunc) ? "notrunc" : "",
@@ -1543,7 +1543,7 @@ interp_reply(netdissect_options *ndo,
 	if (!v3 && proc < NFS_NPROCS)
 		proc = nfsv3_procid[proc];
 
-	ND_PRINT(" %s", tok2str(nfsproc_str, "proc-%u", proc));
+	ND_PRINT(C_RESET, " %s", tok2str(nfsproc_str, "proc-%u", proc));
 	switch (proc) {
 
 	case NFSPROC_GETATTR:
@@ -1577,7 +1577,7 @@ interp_reply(netdissect_options *ndo,
 				goto trunc;
 			if (er) {
 				if (ndo->ndo_vflag > 1) {
-					ND_PRINT(" post dattr:");
+					ND_PRINT(C_RESET, " post dattr:");
 					dp = parse_post_op_attr(ndo, dp, ndo->ndo_vflag);
 					if (dp == NULL)
 						goto trunc;
@@ -1590,7 +1590,7 @@ interp_reply(netdissect_options *ndo,
 				if (dp == NULL)
 					goto trunc;
 				if (ndo->ndo_vflag > 1) {
-					ND_PRINT(" post dattr:");
+					ND_PRINT(C_RESET, " post dattr:");
 					dp = parse_post_op_attr(ndo, dp, ndo->ndo_vflag);
 					if (dp == NULL)
 						goto trunc;
@@ -1610,12 +1610,12 @@ interp_reply(netdissect_options *ndo,
 		if (dp == NULL)
 			goto trunc;
 		if (ndo->ndo_vflag)
-			ND_PRINT(" attr:");
+			ND_PRINT(C_RESET, " attr:");
 		dp = parse_post_op_attr(ndo, dp, ndo->ndo_vflag);
 		if (dp == NULL)
 			goto trunc;
 		if (!er) {
-			ND_PRINT(" c %04x", GET_BE_U_4(dp));
+			ND_PRINT(C_RESET, " c %04x", GET_BE_U_4(dp));
 		}
 		break;
 
@@ -1640,9 +1640,9 @@ interp_reply(netdissect_options *ndo,
 				goto trunc;
 			if (!er) {
 				if (ndo->ndo_vflag) {
-					ND_PRINT(" %u bytes", GET_BE_U_4(dp));
+					ND_PRINT(C_RESET, " %u bytes", GET_BE_U_4(dp));
 					if (GET_BE_U_4(dp + 1))
-						ND_PRINT(" EOF");
+						ND_PRINT(C_RESET, " EOF");
 				}
 			}
 		} else {
@@ -1664,14 +1664,14 @@ interp_reply(netdissect_options *ndo,
 				goto trunc;
 			if (!er) {
 				if (ndo->ndo_vflag) {
-					ND_PRINT(" %u bytes", GET_BE_U_4(dp));
+					ND_PRINT(C_RESET, " %u bytes", GET_BE_U_4(dp));
 					if (ndo->ndo_vflag > 1) {
-						ND_PRINT(" <%s>",
+						ND_PRINT(C_RESET, " <%s>",
 							tok2str(nfsv3_writemodes,
 								NULL, GET_BE_U_4(dp + 1)));
 
 						/* write-verf-cookie */
-						ND_PRINT(" verf %" PRIx64,
+						ND_PRINT(C_RESET, " verf %" PRIx64,
 						         GET_BE_U_8(dp + 2));
 					}
 				}
@@ -1741,11 +1741,11 @@ interp_reply(netdissect_options *ndo,
 			if (dp == NULL)
 				goto trunc;
 			if (ndo->ndo_vflag) {
-				ND_PRINT(" from:");
+				ND_PRINT(C_RESET, " from:");
 				dp = parse_wcc_data(ndo, dp, ndo->ndo_vflag);
 				if (dp == NULL)
 					goto trunc;
-				ND_PRINT(" to:");
+				ND_PRINT(C_RESET, " to:");
 				dp = parse_wcc_data(ndo, dp, ndo->ndo_vflag);
 				if (dp == NULL)
 					goto trunc;
@@ -1765,11 +1765,11 @@ interp_reply(netdissect_options *ndo,
 			if (dp == NULL)
 				goto trunc;
 			if (ndo->ndo_vflag) {
-				ND_PRINT(" file POST:");
+				ND_PRINT(C_RESET, " file POST:");
 				dp = parse_post_op_attr(ndo, dp, ndo->ndo_vflag);
 				if (dp == NULL)
 					goto trunc;
-				ND_PRINT(" dir:");
+				ND_PRINT(C_RESET, " dir:");
 				dp = parse_wcc_data(ndo, dp, ndo->ndo_vflag);
 				if (dp == NULL)
 					goto trunc;
@@ -1835,7 +1835,7 @@ interp_reply(netdissect_options *ndo,
 			goto trunc;
 		if (ndo->ndo_vflag > 1) {
 			/* write-verf-cookie */
-			ND_PRINT(" verf %" PRIx64, GET_BE_U_8(dp));
+			ND_PRINT(C_RESET, " verf %" PRIx64, GET_BE_U_8(dp));
 		}
 		break;
 

--- a/print-ntp.c
+++ b/print-ntp.c
@@ -238,27 +238,27 @@ ntp_time_print(netdissect_options *ndo,
 		goto invalid;
 
 	stratum = GET_U_1(bp->stratum);
-	ND_PRINT(", Stratum %u (%s)",
+	ND_PRINT(C_RESET, C_RESET ", Stratum %u (%s)",
 		stratum,
 		tok2str(ntp_stratum_values, (stratum >=2 && stratum<=15) ? "secondary reference" : "reserved", stratum));
 
-	ND_PRINT(", poll %d", GET_S_1(bp->ppoll));
+	ND_PRINT(C_RESET, C_RESET ", poll %d", GET_S_1(bp->ppoll));
 	p_poll(ndo, GET_S_1(bp->ppoll));
 
-	ND_PRINT(", precision %d", GET_S_1(bp->precision));
+	ND_PRINT(C_RESET, C_RESET ", precision %d", GET_S_1(bp->precision));
 
-	ND_PRINT("\n\tRoot Delay: ");
+	ND_PRINT(C_RESET, C_RESET "\n\tRoot Delay: ");
 	p_sfix(ndo, &bp->root_delay);
 
-	ND_PRINT(", Root dispersion: ");
+	ND_PRINT(C_RESET, C_RESET ", Root dispersion: ");
 	p_sfix(ndo, &bp->root_dispersion);
 
-	ND_PRINT(", Reference-ID: ");
+	ND_PRINT(C_RESET, C_RESET ", Reference-ID: ");
 	/* Interpretation depends on stratum */
 	switch (stratum) {
 
 	case UNSPECIFIED:
-		ND_PRINT("(unspec)");
+		ND_PRINT(C_RESET, C_RESET "(unspec)");
 		ND_TCHECK_4(bp->refid);
 		break;
 
@@ -267,60 +267,60 @@ ntp_time_print(netdissect_options *ndo,
 		break;
 
 	case INFO_QUERY:
-		ND_PRINT("%s INFO_QUERY", GET_IPADDR_STRING(bp->refid));
+		ND_PRINT(C_RESET, C_RESET "%s INFO_QUERY", GET_IPADDR_STRING(bp->refid));
 		/* this doesn't have more content */
 		return;
 
 	case INFO_REPLY:
-		ND_PRINT("%s INFO_REPLY", GET_IPADDR_STRING(bp->refid));
+		ND_PRINT(C_RESET, C_RESET "%s INFO_REPLY", GET_IPADDR_STRING(bp->refid));
 		/* this is too complex to be worth printing */
 		return;
 
 	default:
 		/* In NTPv4 (RFC 5905) refid is an IPv4 address or first 32 bits of
 		   MD5 sum of IPv6 address */
-		ND_PRINT("0x%08x", GET_BE_U_4(bp->refid));
+		ND_PRINT(C_RESET, C_RESET "0x%08x", GET_BE_U_4(bp->refid));
 		break;
 	}
 
-	ND_PRINT("\n\t  Reference Timestamp:  ");
+	ND_PRINT(C_RESET, C_RESET "\n\t  Reference Timestamp:  ");
 	p_ntp_time(ndo, &(bp->ref_timestamp));
 
-	ND_PRINT("\n\t  Originator Timestamp: ");
+	ND_PRINT(C_RESET, C_RESET "\n\t  Originator Timestamp: ");
 	p_ntp_time(ndo, &(bp->org_timestamp));
 
-	ND_PRINT("\n\t  Receive Timestamp:    ");
+	ND_PRINT(C_RESET, C_RESET "\n\t  Receive Timestamp:    ");
 	p_ntp_time(ndo, &(bp->rec_timestamp));
 
-	ND_PRINT("\n\t  Transmit Timestamp:   ");
+	ND_PRINT(C_RESET, C_RESET "\n\t  Transmit Timestamp:   ");
 	p_ntp_time(ndo, &(bp->xmt_timestamp));
 
-	ND_PRINT("\n\t    Originator - Receive Timestamp:  ");
+	ND_PRINT(C_RESET, C_RESET "\n\t    Originator - Receive Timestamp:  ");
 	p_ntp_delta(ndo, &(bp->org_timestamp), &(bp->rec_timestamp));
 
-	ND_PRINT("\n\t    Originator - Transmit Timestamp: ");
+	ND_PRINT(C_RESET, C_RESET "\n\t    Originator - Transmit Timestamp: ");
 	p_ntp_delta(ndo, &(bp->org_timestamp), &(bp->xmt_timestamp));
 
 	/* FIXME: this code is not aware of any extension fields */
 	if (length == NTP_TIMEMSG_MINLEN + 4) { 	/* Optional: key-id (crypto-NAK) */
-		ND_PRINT("\n\tKey id: %u", GET_BE_U_4(bp->key_id));
+		ND_PRINT(C_RESET, C_RESET "\n\tKey id: %u", GET_BE_U_4(bp->key_id));
 	} else if (length == NTP_TIMEMSG_MINLEN + 4 + 16) { 	/* Optional: key-id + 128-bit digest */
-		ND_PRINT("\n\tKey id: %u", GET_BE_U_4(bp->key_id));
-		ND_PRINT("\n\tAuthentication: %08x%08x%08x%08x",
+		ND_PRINT(C_RESET, C_RESET "\n\tKey id: %u", GET_BE_U_4(bp->key_id));
+		ND_PRINT(C_RESET, C_RESET "\n\tAuthentication: %08x%08x%08x%08x",
 			 GET_BE_U_4(bp->message_digest),
 			 GET_BE_U_4(bp->message_digest + 4),
 			 GET_BE_U_4(bp->message_digest + 8),
 			 GET_BE_U_4(bp->message_digest + 12));
 	} else if (length == NTP_TIMEMSG_MINLEN + 4 + 20) { 	/* Optional: key-id + 160-bit digest */
-		ND_PRINT("\n\tKey id: %u", GET_BE_U_4(bp->key_id));
-		ND_PRINT("\n\tAuthentication: %08x%08x%08x%08x%08x",
+		ND_PRINT(C_RESET, C_RESET "\n\tKey id: %u", GET_BE_U_4(bp->key_id));
+		ND_PRINT(C_RESET, C_RESET "\n\tAuthentication: %08x%08x%08x%08x%08x",
 			 GET_BE_U_4(bp->message_digest),
 			 GET_BE_U_4(bp->message_digest + 4),
 			 GET_BE_U_4(bp->message_digest + 8),
 			 GET_BE_U_4(bp->message_digest + 12),
 			 GET_BE_U_4(bp->message_digest + 16));
 	} else if (length > NTP_TIMEMSG_MINLEN) {
-		ND_PRINT("\n\t(%u more bytes after the header)", length - NTP_TIMEMSG_MINLEN);
+		ND_PRINT(C_RESET, C_RESET "\n\t(%u more bytes after the header)", length - NTP_TIMEMSG_MINLEN);
 	}
 	return;
 
@@ -347,30 +347,30 @@ ntp_control_print(netdissect_options *ndo,
 	E = (control & 0x40) != 0;
 	M = (control & 0x20) != 0;
 	opcode = control & 0x1f;
-	ND_PRINT(", %s, %s, %s, OpCode=%u\n",
+	ND_PRINT(C_RESET, C_RESET ", %s, %s, %s, OpCode=%u\n",
 		  R ? "Response" : "Request", E ? "Error" : "OK",
 		  M ? "More" : "Last", opcode);
 
 	sequence = GET_BE_U_2(cd->sequence);
-	ND_PRINT("\tSequence=%hu", sequence);
+	ND_PRINT(C_RESET, C_RESET "\tSequence=%hu", sequence);
 
 	status = GET_BE_U_2(cd->status);
-	ND_PRINT(", Status=%#hx", status);
+	ND_PRINT(C_RESET, C_RESET ", Status=%#hx", status);
 
 	assoc = GET_BE_U_2(cd->assoc);
-	ND_PRINT(", Assoc.=%hu", assoc);
+	ND_PRINT(C_RESET, C_RESET ", Assoc.=%hu", assoc);
 
 	offset = GET_BE_U_2(cd->offset);
-	ND_PRINT(", Offset=%hu", offset);
+	ND_PRINT(C_RESET, C_RESET ", Offset=%hu", offset);
 
 	count = GET_BE_U_2(cd->count);
-	ND_PRINT(", Count=%hu", count);
+	ND_PRINT(C_RESET, C_RESET ", Count=%hu", count);
 
 	if (NTP_CTRLMSG_MINLEN + count > length)
 		goto invalid;
 	if (count != 0) {
 		ND_TCHECK_LEN(cd->data, count);
-		ND_PRINT("\n\tTO-BE-DONE: data not interpreted");
+		ND_PRINT(C_RESET, C_RESET "\n\tTO-BE-DONE: data not interpreted");
 	}
 	return;
 
@@ -399,22 +399,22 @@ ntp_print(netdissect_options *ndo,
 	status = GET_U_1(bp->td.status);
 
 	version = (status & VERSIONMASK) >> VERSIONSHIFT;
-	ND_PRINT("NTPv%u", version);
+	ND_PRINT(C_RESET, C_RESET "NTPv%u", version);
 
 	mode = (status & MODEMASK) >> MODESHIFT;
 	if (!ndo->ndo_vflag) {
-		ND_PRINT(", %s, length %u",
+		ND_PRINT(C_RESET, C_RESET ", %s, length %u",
 			 tok2str(ntp_mode_values, "Unknown mode", mode),
 			 length);
 		return;
 	}
 
-	ND_PRINT(", %s, length %u\n",
+	ND_PRINT(C_RESET, C_RESET ", %s, length %u\n",
 		  tok2str(ntp_mode_values, "Unknown mode", mode), length);
 
 	/* leapind = (status & LEAPMASK) >> LEAPSHIFT; */
 	leapind = (status & LEAPMASK);
-	ND_PRINT("\tLeap indicator: %s (%u)",
+	ND_PRINT(C_RESET, C_RESET "\tLeap indicator: %s (%u)",
 		 tok2str(ntp_leapind_values, "Unknown", leapind),
 		 leapind);
 
@@ -450,7 +450,7 @@ p_sfix(netdissect_options *ndo,
 	f = GET_BE_U_2(sfp->fraction);
 	ff = f / 65536.0;		/* shift radix point by 16 bits */
 	f = (int)(ff * 1000000.0);	/* Treat fraction as parts per million */
-	ND_PRINT("%d.%06d", i, f);
+	ND_PRINT(C_RESET, C_RESET "%d.%06d", i, f);
 }
 
 /* Prints time difference between *lfp and *olfp */
@@ -503,7 +503,7 @@ p_ntp_delta(netdissect_options *ndo,
 		ff += FMAXINT;
 	ff = ff / FMAXINT;			/* shift radix point by 32 bits */
 	f = (uint32_t)(ff * 1000000000.0);	/* treat fraction as parts per billion */
-	ND_PRINT("%s%u.%09u", signbit ? "-" : "+", i, f);
+	ND_PRINT(C_RESET, C_RESET "%s%u.%09u", signbit ? "-" : "+", i, f);
 }
 
 /* Prints polling interval in log2 as seconds or fraction of second */
@@ -515,8 +515,8 @@ p_poll(netdissect_options *ndo,
 		return;
 
 	if (poll_interval >= 0)
-		ND_PRINT(" (%us)", 1U << poll_interval);
+		ND_PRINT(C_RESET, C_RESET " (%us)", 1U << poll_interval);
 	else
-		ND_PRINT(" (1/%us)", 1U << -poll_interval);
+		ND_PRINT(C_RESET, C_RESET " (1/%us)", 1U << -poll_interval);
 }
 

--- a/print-ntp.c
+++ b/print-ntp.c
@@ -238,27 +238,27 @@ ntp_time_print(netdissect_options *ndo,
 		goto invalid;
 
 	stratum = GET_U_1(bp->stratum);
-	ND_PRINT(C_RESET, C_RESET ", Stratum %u (%s)",
+	ND_PRINT(C_RESET, ", Stratum %u (%s)",
 		stratum,
 		tok2str(ntp_stratum_values, (stratum >=2 && stratum<=15) ? "secondary reference" : "reserved", stratum));
 
-	ND_PRINT(C_RESET, C_RESET ", poll %d", GET_S_1(bp->ppoll));
+	ND_PRINT(C_RESET, ", poll %d", GET_S_1(bp->ppoll));
 	p_poll(ndo, GET_S_1(bp->ppoll));
 
-	ND_PRINT(C_RESET, C_RESET ", precision %d", GET_S_1(bp->precision));
+	ND_PRINT(C_RESET, ", precision %d", GET_S_1(bp->precision));
 
-	ND_PRINT(C_RESET, C_RESET "\n\tRoot Delay: ");
+	ND_PRINT(C_RESET, "\n\tRoot Delay: ");
 	p_sfix(ndo, &bp->root_delay);
 
-	ND_PRINT(C_RESET, C_RESET ", Root dispersion: ");
+	ND_PRINT(C_RESET, ", Root dispersion: ");
 	p_sfix(ndo, &bp->root_dispersion);
 
-	ND_PRINT(C_RESET, C_RESET ", Reference-ID: ");
+	ND_PRINT(C_RESET, ", Reference-ID: ");
 	/* Interpretation depends on stratum */
 	switch (stratum) {
 
 	case UNSPECIFIED:
-		ND_PRINT(C_RESET, C_RESET "(unspec)");
+		ND_PRINT(C_RESET, "(unspec)");
 		ND_TCHECK_4(bp->refid);
 		break;
 
@@ -267,60 +267,60 @@ ntp_time_print(netdissect_options *ndo,
 		break;
 
 	case INFO_QUERY:
-		ND_PRINT(C_RESET, C_RESET "%s INFO_QUERY", GET_IPADDR_STRING(bp->refid));
+		ND_PRINT(C_RESET, "%s INFO_QUERY", GET_IPADDR_STRING(bp->refid));
 		/* this doesn't have more content */
 		return;
 
 	case INFO_REPLY:
-		ND_PRINT(C_RESET, C_RESET "%s INFO_REPLY", GET_IPADDR_STRING(bp->refid));
+		ND_PRINT(C_RESET, "%s INFO_REPLY", GET_IPADDR_STRING(bp->refid));
 		/* this is too complex to be worth printing */
 		return;
 
 	default:
 		/* In NTPv4 (RFC 5905) refid is an IPv4 address or first 32 bits of
 		   MD5 sum of IPv6 address */
-		ND_PRINT(C_RESET, C_RESET "0x%08x", GET_BE_U_4(bp->refid));
+		ND_PRINT(C_RESET, "0x%08x", GET_BE_U_4(bp->refid));
 		break;
 	}
 
-	ND_PRINT(C_RESET, C_RESET "\n\t  Reference Timestamp:  ");
+	ND_PRINT(C_RESET, "\n\t  Reference Timestamp:  ");
 	p_ntp_time(ndo, &(bp->ref_timestamp));
 
-	ND_PRINT(C_RESET, C_RESET "\n\t  Originator Timestamp: ");
+	ND_PRINT(C_RESET, "\n\t  Originator Timestamp: ");
 	p_ntp_time(ndo, &(bp->org_timestamp));
 
-	ND_PRINT(C_RESET, C_RESET "\n\t  Receive Timestamp:    ");
+	ND_PRINT(C_RESET, "\n\t  Receive Timestamp:    ");
 	p_ntp_time(ndo, &(bp->rec_timestamp));
 
-	ND_PRINT(C_RESET, C_RESET "\n\t  Transmit Timestamp:   ");
+	ND_PRINT(C_RESET, "\n\t  Transmit Timestamp:   ");
 	p_ntp_time(ndo, &(bp->xmt_timestamp));
 
-	ND_PRINT(C_RESET, C_RESET "\n\t    Originator - Receive Timestamp:  ");
+	ND_PRINT(C_RESET, "\n\t    Originator - Receive Timestamp:  ");
 	p_ntp_delta(ndo, &(bp->org_timestamp), &(bp->rec_timestamp));
 
-	ND_PRINT(C_RESET, C_RESET "\n\t    Originator - Transmit Timestamp: ");
+	ND_PRINT(C_RESET, "\n\t    Originator - Transmit Timestamp: ");
 	p_ntp_delta(ndo, &(bp->org_timestamp), &(bp->xmt_timestamp));
 
 	/* FIXME: this code is not aware of any extension fields */
 	if (length == NTP_TIMEMSG_MINLEN + 4) { 	/* Optional: key-id (crypto-NAK) */
-		ND_PRINT(C_RESET, C_RESET "\n\tKey id: %u", GET_BE_U_4(bp->key_id));
+		ND_PRINT(C_RESET, "\n\tKey id: %u", GET_BE_U_4(bp->key_id));
 	} else if (length == NTP_TIMEMSG_MINLEN + 4 + 16) { 	/* Optional: key-id + 128-bit digest */
-		ND_PRINT(C_RESET, C_RESET "\n\tKey id: %u", GET_BE_U_4(bp->key_id));
-		ND_PRINT(C_RESET, C_RESET "\n\tAuthentication: %08x%08x%08x%08x",
+		ND_PRINT(C_RESET, "\n\tKey id: %u", GET_BE_U_4(bp->key_id));
+		ND_PRINT(C_RESET, "\n\tAuthentication: %08x%08x%08x%08x",
 			 GET_BE_U_4(bp->message_digest),
 			 GET_BE_U_4(bp->message_digest + 4),
 			 GET_BE_U_4(bp->message_digest + 8),
 			 GET_BE_U_4(bp->message_digest + 12));
 	} else if (length == NTP_TIMEMSG_MINLEN + 4 + 20) { 	/* Optional: key-id + 160-bit digest */
-		ND_PRINT(C_RESET, C_RESET "\n\tKey id: %u", GET_BE_U_4(bp->key_id));
-		ND_PRINT(C_RESET, C_RESET "\n\tAuthentication: %08x%08x%08x%08x%08x",
+		ND_PRINT(C_RESET, "\n\tKey id: %u", GET_BE_U_4(bp->key_id));
+		ND_PRINT(C_RESET, "\n\tAuthentication: %08x%08x%08x%08x%08x",
 			 GET_BE_U_4(bp->message_digest),
 			 GET_BE_U_4(bp->message_digest + 4),
 			 GET_BE_U_4(bp->message_digest + 8),
 			 GET_BE_U_4(bp->message_digest + 12),
 			 GET_BE_U_4(bp->message_digest + 16));
 	} else if (length > NTP_TIMEMSG_MINLEN) {
-		ND_PRINT(C_RESET, C_RESET "\n\t(%u more bytes after the header)", length - NTP_TIMEMSG_MINLEN);
+		ND_PRINT(C_RESET, "\n\t(%u more bytes after the header)", length - NTP_TIMEMSG_MINLEN);
 	}
 	return;
 
@@ -347,30 +347,30 @@ ntp_control_print(netdissect_options *ndo,
 	E = (control & 0x40) != 0;
 	M = (control & 0x20) != 0;
 	opcode = control & 0x1f;
-	ND_PRINT(C_RESET, C_RESET ", %s, %s, %s, OpCode=%u\n",
+	ND_PRINT(C_RESET, ", %s, %s, %s, OpCode=%u\n",
 		  R ? "Response" : "Request", E ? "Error" : "OK",
 		  M ? "More" : "Last", opcode);
 
 	sequence = GET_BE_U_2(cd->sequence);
-	ND_PRINT(C_RESET, C_RESET "\tSequence=%hu", sequence);
+	ND_PRINT(C_RESET, "\tSequence=%hu", sequence);
 
 	status = GET_BE_U_2(cd->status);
-	ND_PRINT(C_RESET, C_RESET ", Status=%#hx", status);
+	ND_PRINT(C_RESET, ", Status=%#hx", status);
 
 	assoc = GET_BE_U_2(cd->assoc);
-	ND_PRINT(C_RESET, C_RESET ", Assoc.=%hu", assoc);
+	ND_PRINT(C_RESET, ", Assoc.=%hu", assoc);
 
 	offset = GET_BE_U_2(cd->offset);
-	ND_PRINT(C_RESET, C_RESET ", Offset=%hu", offset);
+	ND_PRINT(C_RESET, ", Offset=%hu", offset);
 
 	count = GET_BE_U_2(cd->count);
-	ND_PRINT(C_RESET, C_RESET ", Count=%hu", count);
+	ND_PRINT(C_RESET, ", Count=%hu", count);
 
 	if (NTP_CTRLMSG_MINLEN + count > length)
 		goto invalid;
 	if (count != 0) {
 		ND_TCHECK_LEN(cd->data, count);
-		ND_PRINT(C_RESET, C_RESET "\n\tTO-BE-DONE: data not interpreted");
+		ND_PRINT(C_RESET, "\n\tTO-BE-DONE: data not interpreted");
 	}
 	return;
 
@@ -399,22 +399,22 @@ ntp_print(netdissect_options *ndo,
 	status = GET_U_1(bp->td.status);
 
 	version = (status & VERSIONMASK) >> VERSIONSHIFT;
-	ND_PRINT(C_RESET, C_RESET "NTPv%u", version);
+	ND_PRINT(C_RESET, "NTPv%u", version);
 
 	mode = (status & MODEMASK) >> MODESHIFT;
 	if (!ndo->ndo_vflag) {
-		ND_PRINT(C_RESET, C_RESET ", %s, length %u",
+		ND_PRINT(C_RESET, ", %s, length %u",
 			 tok2str(ntp_mode_values, "Unknown mode", mode),
 			 length);
 		return;
 	}
 
-	ND_PRINT(C_RESET, C_RESET ", %s, length %u\n",
+	ND_PRINT(C_RESET, ", %s, length %u\n",
 		  tok2str(ntp_mode_values, "Unknown mode", mode), length);
 
 	/* leapind = (status & LEAPMASK) >> LEAPSHIFT; */
 	leapind = (status & LEAPMASK);
-	ND_PRINT(C_RESET, C_RESET "\tLeap indicator: %s (%u)",
+	ND_PRINT(C_RESET, "\tLeap indicator: %s (%u)",
 		 tok2str(ntp_leapind_values, "Unknown", leapind),
 		 leapind);
 
@@ -450,7 +450,7 @@ p_sfix(netdissect_options *ndo,
 	f = GET_BE_U_2(sfp->fraction);
 	ff = f / 65536.0;		/* shift radix point by 16 bits */
 	f = (int)(ff * 1000000.0);	/* Treat fraction as parts per million */
-	ND_PRINT(C_RESET, C_RESET "%d.%06d", i, f);
+	ND_PRINT(C_RESET, "%d.%06d", i, f);
 }
 
 /* Prints time difference between *lfp and *olfp */
@@ -503,7 +503,7 @@ p_ntp_delta(netdissect_options *ndo,
 		ff += FMAXINT;
 	ff = ff / FMAXINT;			/* shift radix point by 32 bits */
 	f = (uint32_t)(ff * 1000000000.0);	/* treat fraction as parts per billion */
-	ND_PRINT(C_RESET, C_RESET "%s%u.%09u", signbit ? "-" : "+", i, f);
+	ND_PRINT(C_RESET, "%s%u.%09u", signbit ? "-" : "+", i, f);
 }
 
 /* Prints polling interval in log2 as seconds or fraction of second */
@@ -515,8 +515,8 @@ p_poll(netdissect_options *ndo,
 		return;
 
 	if (poll_interval >= 0)
-		ND_PRINT(C_RESET, C_RESET " (%us)", 1U << poll_interval);
+		ND_PRINT(C_RESET, " (%us)", 1U << poll_interval);
 	else
-		ND_PRINT(C_RESET, C_RESET " (1/%us)", 1U << -poll_interval);
+		ND_PRINT(C_RESET, " (1/%us)", 1U << -poll_interval);
 }
 

--- a/print-null.c
+++ b/print-null.c
@@ -57,14 +57,14 @@ static void
 null_hdr_print(netdissect_options *ndo, uint32_t family, u_int length)
 {
 	if (!ndo->ndo_qflag) {
-		ND_PRINT("AF %s (%u)",
+		ND_PRINT(C_RESET, "AF %s (%u)",
 			tok2str(bsd_af_values,"Unknown",family),family);
 	} else {
-		ND_PRINT("%s",
+		ND_PRINT(C_RESET, "%s",
 			tok2str(bsd_af_values,"Unknown AF %u",family));
 	}
 
-	ND_PRINT(", length %u: ", length);
+	ND_PRINT(C_RESET, ", length %u: ", length);
 }
 
 /*

--- a/print-olsr.c
+++ b/print-olsr.c
@@ -243,7 +243,7 @@ olsr_print_lq_neighbor4(netdissect_options *ndo,
         lq_neighbor = (const struct olsr_lq_neighbor4 *)msg_data;
         ND_TCHECK_SIZE(lq_neighbor);
 
-        ND_PRINT("\n\t      neighbor %s, link-quality %.2f%%"
+        ND_PRINT(C_RESET, "\n\t      neighbor %s, link-quality %.2f%%"
                ", neighbor-link-quality %.2f%%",
                GET_IPADDR_STRING(lq_neighbor->neighbor),
                ((double) GET_U_1(lq_neighbor->link_quality)/2.55),
@@ -265,7 +265,7 @@ olsr_print_lq_neighbor6(netdissect_options *ndo,
         lq_neighbor = (const struct olsr_lq_neighbor6 *)msg_data;
         ND_TCHECK_SIZE(lq_neighbor);
 
-        ND_PRINT("\n\t      neighbor %s, link-quality %.2f%%"
+        ND_PRINT(C_RESET, "\n\t      neighbor %s, link-quality %.2f%%"
                ", neighbor-link-quality %.2f%%",
                GET_IP6ADDR_STRING(lq_neighbor->neighbor),
                ((double) GET_U_1(lq_neighbor->link_quality)/2.55),
@@ -285,12 +285,12 @@ olsr_print_neighbor(netdissect_options *ndo,
 {
     int neighbor;
 
-    ND_PRINT("\n\t      neighbor\n\t\t");
+    ND_PRINT(C_RESET, "\n\t      neighbor\n\t\t");
     neighbor = 1;
 
     while (hello_len >= sizeof(nd_ipv4)) {
         /* print 4 neighbors per line */
-        ND_PRINT("%s%s", GET_IPADDR_STRING(msg_data),
+        ND_PRINT(C_RESET, "%s%s", GET_IPADDR_STRING(msg_data),
                neighbor % 4 == 0 ? "\n\t\t" : " ");
 
         msg_data += sizeof(nd_ipv4);
@@ -323,14 +323,14 @@ olsr_print(netdissect_options *ndo,
     tptr = pptr;
 
     nd_print_protocol_caps(ndo);
-    ND_PRINT("v%u", (is_ipv6) ? 6 : 4);
+    ND_PRINT(C_RESET, "v%u", (is_ipv6) ? 6 : 4);
 
     ND_ICHECKMSG_ZU("packet length", length, <, sizeof(struct olsr_common));
 
     ptr.common = (const struct olsr_common *)tptr;
     length = ND_MIN(length, GET_BE_U_2(ptr.common->packet_len));
 
-    ND_PRINT(", seq 0x%04x, length %u",
+    ND_PRINT(C_RESET, ", seq 0x%04x, length %u",
             GET_BE_U_2(ptr.common->packet_seq),
             length);
 
@@ -366,7 +366,7 @@ olsr_print(netdissect_options *ndo,
                 return;
             }
 
-            ND_PRINT("\n\t%s Message (%#04x), originator %s, ttl %u, hop %u"
+            ND_PRINT(C_RESET, "\n\t%s Message (%#04x), originator %s, ttl %u, hop %u"
                     "\n\t  vtime %.3fs, msg-seq 0x%04x, length %u%s",
                     tok2str(olsr_msg_values, "Unknown", msg_type),
                     msg_type, GET_IP6ADDR_STRING(msgptr.v6->originator),
@@ -397,7 +397,7 @@ olsr_print(netdissect_options *ndo,
                 return;
             }
 
-            ND_PRINT("\n\t%s Message (%#04x), originator %s, ttl %u, hop %u"
+            ND_PRINT(C_RESET, "\n\t%s Message (%#04x), originator %s, ttl %u, hop %u"
                     "\n\t  vtime %.3fs, msg-seq 0x%04x, length %u%s",
                     tok2str(olsr_msg_values, "Unknown", msg_type),
                     msg_type, GET_IPADDR_STRING(msgptr.v4->originator),
@@ -421,7 +421,7 @@ olsr_print(netdissect_options *ndo,
                             sizeof(struct olsr_hello));
 
             ptr.hello = (const struct olsr_hello *)msg_data;
-            ND_PRINT("\n\t  hello-time %.3fs, MPR willingness %u",
+            ND_PRINT(C_RESET, "\n\t  hello-time %.3fs, MPR willingness %u",
                    ME_TO_DOUBLE(GET_U_1(ptr.hello->htime)),
                    GET_U_1(ptr.hello->will));
             msg_data += sizeof(struct olsr_hello);
@@ -445,7 +445,7 @@ olsr_print(netdissect_options *ndo,
                         && (hello_len >= sizeof(struct olsr_hello_link)))
                     hello_len_valid = 1;
 
-                ND_PRINT("\n\t    link-type %s, neighbor-type %s, len %u%s",
+                ND_PRINT(C_RESET, "\n\t    link-type %s, neighbor-type %s, len %u%s",
                        tok2str(olsr_link_type_values, "Unknown", link_type),
                        tok2str(olsr_neighbor_type_values, "Unknown", neighbor_type),
                        hello_len,
@@ -481,7 +481,7 @@ olsr_print(netdissect_options *ndo,
             ND_TCHECK_LEN(msg_data, sizeof(struct olsr_tc));
 
             ptr.tc = (const struct olsr_tc *)msg_data;
-            ND_PRINT("\n\t    advertised neighbor seq 0x%04x",
+            ND_PRINT(C_RESET, "\n\t    advertised neighbor seq 0x%04x",
                    GET_BE_U_2(ptr.tc->ans_seq));
             msg_data += sizeof(struct olsr_tc);
             msg_tlen -= sizeof(struct olsr_tc);
@@ -506,7 +506,7 @@ olsr_print(netdissect_options *ndo,
 
             while (msg_tlen >= addr_size) {
                 ND_TCHECK_LEN(msg_data, addr_size);
-                ND_PRINT("\n\t  interface address %s",
+                ND_PRINT(C_RESET, "\n\t  interface address %s",
                         is_ipv6 ? GET_IP6ADDR_STRING(msg_data) :
                         GET_IPADDR_STRING(msg_data));
 
@@ -521,7 +521,7 @@ olsr_print(netdissect_options *ndo,
             {
                 int i = 0;
 
-                ND_PRINT("\n\t  Advertised networks (total %u)",
+                ND_PRINT(C_RESET, "\n\t  Advertised networks (total %u)",
                         (unsigned int) (msg_tlen / sizeof(struct olsr_hna6)));
 
                 while (msg_tlen >= sizeof(struct olsr_hna6)) {
@@ -531,7 +531,7 @@ olsr_print(netdissect_options *ndo,
 
                     hna6 = (const struct olsr_hna6 *)msg_data;
 
-                    ND_PRINT("\n\t    #%i: %s/%u",
+                    ND_PRINT(C_RESET, "\n\t    #%i: %s/%u",
                             i, GET_IP6ADDR_STRING(hna6->network),
                             mask62plen (hna6->mask));
 
@@ -543,7 +543,7 @@ olsr_print(netdissect_options *ndo,
             {
                 int col = 0;
 
-                ND_PRINT("\n\t  Advertised networks (total %u)",
+                ND_PRINT(C_RESET, "\n\t  Advertised networks (total %u)",
                         (unsigned int) (msg_tlen / sizeof(struct olsr_hna4)));
 
                 while (msg_tlen >= sizeof(struct olsr_hna4)) {
@@ -557,7 +557,7 @@ olsr_print(netdissect_options *ndo,
                         !ptr.hna->mask[GW_HNA_PAD] &&
                         ptr.hna->mask[GW_HNA_FLAGS]) {
                             /* smart gateway */
-                            ND_PRINT("%sSmart-Gateway:%s%s%s%s%s %u/%u",
+                            ND_PRINT(C_RESET, "%sSmart-Gateway:%s%s%s%s%s %u/%u",
                                 col == 0 ? "\n\t    " : ", ", /* indent */
                                 /* sgw */
                                 /* LINKSPEED */
@@ -586,7 +586,7 @@ olsr_print(netdissect_options *ndo,
                                 );
                     } else {
                         /* normal route */
-                        ND_PRINT("%s%s/%u",
+                        ND_PRINT(C_RESET, "%s%s/%u",
                                 col == 0 ? "\n\t    " : ", ",
                                 GET_IPADDR_STRING(ptr.hna->network),
                                 mask2plen(GET_BE_U_4(ptr.hna->mask)));
@@ -619,7 +619,7 @@ olsr_print(netdissect_options *ndo,
                     && ((name_entries * (4 + addr_size)) <= msg_tlen))
                 name_entries_valid = 1;
 
-            ND_PRINT("\n\t  Version %u, Entries %u%s",
+            ND_PRINT(C_RESET, "\n\t  Version %u, Entries %u%s",
                    GET_BE_U_2(msg_data),
                    name_entries, (name_entries_valid == 0) ? " (invalid)" : "");
 
@@ -644,7 +644,7 @@ olsr_print(netdissect_options *ndo,
                 if ((name_entry_len > 0) && ((addr_size + name_entry_len) <= msg_tlen))
                     name_entry_len_valid = 1;
 
-                ND_PRINT("\n\t    #%u: type %#06x, length %u%s",
+                ND_PRINT(C_RESET, "\n\t    #%u: type %#06x, length %u%s",
                         (unsigned int) i, name_entry_type,
                         name_entry_len, (name_entry_len_valid == 0) ? " (invalid)" : "");
 
@@ -663,13 +663,13 @@ olsr_print(netdissect_options *ndo,
                               addr_size + name_entry_len + name_entry_padding);
 
                 if (is_ipv6)
-                    ND_PRINT(", address %s, name \"",
+                    ND_PRINT(C_RESET, ", address %s, name \"",
                             GET_IP6ADDR_STRING(msg_data));
                 else
-                    ND_PRINT(", address %s, name \"",
+                    ND_PRINT(C_RESET, ", address %s, name \"",
                             GET_IPADDR_STRING(msg_data));
                 nd_printjn(ndo, msg_data + addr_size, name_entry_len);
-                ND_PRINT("\"");
+                ND_PRINT(C_RESET, "\"");
 
                 msg_data += addr_size + name_entry_len + name_entry_padding;
                 msg_tlen -= addr_size + name_entry_len + name_entry_padding;

--- a/print-openflow-1.0.c
+++ b/print-openflow-1.0.c
@@ -699,12 +699,12 @@ of10_bsn_message_print(netdissect_options *ndo,
 {
 	uint32_t subtype;
 
-	ND_PRINT("\n\t");
+	ND_PRINT(C_RESET, "\n\t");
 	ND_ICHECK_U(len, <, 4);
 	/* subtype */
 	subtype = GET_BE_U_4(cp);
 	OF_FWD(4);
-	ND_PRINT(" subtype %s", tok2str(bsn_subtype_str, "unknown (0x%08x)", subtype));
+	ND_PRINT(C_RESET, " subtype %s", tok2str(bsn_subtype_str, "unknown (0x%08x)", subtype));
 	switch (subtype) {
 	case BSN_GET_IP_MASK_REQUEST:
 		/*
@@ -721,7 +721,7 @@ of10_bsn_message_print(netdissect_options *ndo,
 		 */
 		ND_ICHECK_U(len, !=, 8);
 		/* index */
-		ND_PRINT(", index %u", GET_U_1(cp));
+		ND_PRINT(C_RESET, ", index %u", GET_U_1(cp));
 		OF_FWD(1);
 		/* pad */
 		/* Always the last field, check bounds. */
@@ -743,12 +743,12 @@ of10_bsn_message_print(netdissect_options *ndo,
 		 */
 		ND_ICHECK_U(len, !=, 8);
 		/* index */
-		ND_PRINT(", index %u", GET_U_1(cp));
+		ND_PRINT(C_RESET, ", index %u", GET_U_1(cp));
 		OF_FWD(1);
 		/* pad */
 		OF_FWD(3);
 		/* mask */
-		ND_PRINT(", mask %s", GET_IPADDR_STRING(cp));
+		ND_PRINT(C_RESET, ", mask %s", GET_IPADDR_STRING(cp));
 		break;
 	case BSN_SET_MIRRORING:
 	case BSN_GET_MIRRORING_REQUEST:
@@ -765,7 +765,7 @@ of10_bsn_message_print(netdissect_options *ndo,
 		 */
 		ND_ICHECK_U(len, !=, 4);
 		/* report_mirror_ports */
-		ND_PRINT(", report_mirror_ports %s",
+		ND_PRINT(C_RESET, ", report_mirror_ports %s",
 			 tok2str(bsn_onoff_str, "bogus (%u)", GET_U_1(cp)));
 		OF_FWD(1);
 		/* pad */
@@ -800,7 +800,7 @@ of10_bsn_message_print(netdissect_options *ndo,
 		 */
 		ND_ICHECK_U(len, !=, 4);
 		/* vport_no */
-		ND_PRINT(", vport_no %u", GET_BE_U_4(cp));
+		ND_PRINT(C_RESET, ", vport_no %u", GET_BE_U_4(cp));
 		break;
 	case BSN_SHELL_COMMAND:
 		/*
@@ -817,12 +817,12 @@ of10_bsn_message_print(netdissect_options *ndo,
 		 */
 		ND_ICHECK_U(len, <, 4);
 		/* service */
-		ND_PRINT(", service %u", GET_BE_U_4(cp));
+		ND_PRINT(C_RESET, ", service %u", GET_BE_U_4(cp));
 		OF_FWD(4);
 		/* data */
-		ND_PRINT(", data '");
+		ND_PRINT(C_RESET, ", data '");
 		nd_printjn(ndo, cp, len);
-		ND_PRINT("'");
+		ND_PRINT(C_RESET, "'");
 		break;
 	case BSN_SHELL_OUTPUT:
 		/*
@@ -837,9 +837,9 @@ of10_bsn_message_print(netdissect_options *ndo,
 		 */
 		/* already checked that len >= 4 */
 		/* data */
-		ND_PRINT(", data '");
+		ND_PRINT(C_RESET, ", data '");
 		nd_printjn(ndo, cp, len);
-		ND_PRINT("'");
+		ND_PRINT(C_RESET, "'");
 		break;
 	case BSN_SHELL_STATUS:
 		/*
@@ -854,7 +854,7 @@ of10_bsn_message_print(netdissect_options *ndo,
 		 */
 		ND_ICHECK_U(len, !=, 4);
 		/* status */
-		ND_PRINT(", status 0x%08x", GET_BE_U_4(cp));
+		ND_PRINT(C_RESET, ", status 0x%08x", GET_BE_U_4(cp));
 		break;
 	default:
 		ND_TCHECK_LEN(cp, len);
@@ -872,12 +872,12 @@ of10_bsn_actions_print(netdissect_options *ndo,
 {
 	uint32_t subtype, vlan_tag;
 
-	ND_PRINT("\n\t ");
+	ND_PRINT(C_RESET, "\n\t ");
 	ND_ICHECK_U(len, <, 4);
 	/* subtype */
 	subtype = GET_BE_U_4(cp);
 	OF_FWD(4);
-	ND_PRINT(" subtype %s", tok2str(bsn_action_subtype_str, "unknown (0x%08x)", subtype));
+	ND_PRINT(C_RESET, " subtype %s", tok2str(bsn_action_subtype_str, "unknown (0x%08x)", subtype));
 	switch (subtype) {
 	case BSN_ACTION_MIRROR:
 		/*
@@ -896,23 +896,23 @@ of10_bsn_actions_print(netdissect_options *ndo,
 		 */
 		ND_ICHECK_U(len, !=, 12);
 		/* dest_port */
-		ND_PRINT(", dest_port %u", GET_BE_U_4(cp));
+		ND_PRINT(C_RESET, ", dest_port %u", GET_BE_U_4(cp));
 		OF_FWD(4);
 		/* vlan_tag */
 		vlan_tag = GET_BE_U_4(cp);
 		OF_FWD(4);
 		switch (vlan_tag >> 16) {
 		case 0:
-			ND_PRINT(", vlan_tag none");
+			ND_PRINT(C_RESET, ", vlan_tag none");
 			break;
 		case ETHERTYPE_8021Q:
-			ND_PRINT(", vlan_tag 802.1Q (%s)", ieee8021q_tci_string(vlan_tag & 0xffff));
+			ND_PRINT(C_RESET, ", vlan_tag 802.1Q (%s)", ieee8021q_tci_string(vlan_tag & 0xffff));
 			break;
 		default:
-			ND_PRINT(", vlan_tag unknown (0x%04x)", vlan_tag >> 16);
+			ND_PRINT(C_RESET, ", vlan_tag unknown (0x%04x)", vlan_tag >> 16);
 		}
 		/* copy_stage */
-		ND_PRINT(", copy_stage %s",
+		ND_PRINT(C_RESET, ", copy_stage %s",
 			 tok2str(bsn_mirror_copy_stage_str, "unknown (%u)", GET_U_1(cp)));
 		OF_FWD(1);
 		/* pad */
@@ -940,7 +940,7 @@ of10_vendor_action_print(netdissect_options *ndo,
 	/* vendor */
 	vendor = GET_BE_U_4(cp);
 	OF_FWD(4);
-	ND_PRINT(", vendor 0x%08x (%s)", vendor, of_vendor_name(vendor));
+	ND_PRINT(C_RESET, ", vendor 0x%08x (%s)", vendor, of_vendor_name(vendor));
 	/* data */
 	decoder =
 		vendor == OUI_BSN         ? of10_bsn_actions_print         :
@@ -964,7 +964,7 @@ of10_vendor_message_print(netdissect_options *ndo,
 	/* vendor */
 	vendor = GET_BE_U_4(cp);
 	OF_FWD(4);
-	ND_PRINT(", vendor 0x%08x (%s)", vendor, of_vendor_name(vendor));
+	ND_PRINT(C_RESET, ", vendor 0x%08x (%s)", vendor, of_vendor_name(vendor));
 	/* data */
 	decoder =
 		vendor == OUI_BSN         ? of10_bsn_message_print         :
@@ -983,7 +983,7 @@ of10_vendor_data_print(netdissect_options *ndo,
 	/* vendor */
 	vendor = GET_BE_U_4(cp);
 	OF_FWD(4);
-	ND_PRINT(", vendor 0x%08x (%s)", vendor, of_vendor_name(vendor));
+	ND_PRINT(C_RESET, ", vendor 0x%08x (%s)", vendor, of_vendor_name(vendor));
 	/* data */
 	of_data_print(ndo, cp, len);
 	return;
@@ -1000,13 +1000,13 @@ of10_packet_data_print(netdissect_options *ndo,
 	if (len == 0)
 		return;
 	/* data */
-	ND_PRINT("\n\t data (%u octets)", len);
+	ND_PRINT(C_RESET, "\n\t data (%u octets)", len);
 	if (ndo->ndo_vflag < 3) {
 		ND_TCHECK_LEN(cp, len);
 		return;
 	}
 	ndo->ndo_vflag -= 3;
-	ND_PRINT(", frame decoding below\n");
+	ND_PRINT(C_RESET, ", frame decoding below\n");
 	/*
 	 * The encapsulated Ethernet frame is not necessarily the last
 	 * data of this packet (i.e. there may be more OpenFlow messages
@@ -1030,16 +1030,16 @@ of10_phy_port_print(netdissect_options *ndo,
 	uint32_t state;
 
 	/* port_no */
-	ND_PRINT("\n\t  port_no %s",
+	ND_PRINT(C_RESET, "\n\t  port_no %s",
 		 tok2str(ofpp_str, "%u", GET_BE_U_2(cp)));
 	cp += 2;
 	/* hw_addr */
-	ND_PRINT(", hw_addr %s", GET_ETHERADDR_STRING(cp));
+	ND_PRINT(C_RESET, ", hw_addr %s", GET_ETHERADDR_STRING(cp));
 	cp += MAC_ADDR_LEN;
 	/* name */
-	ND_PRINT(", name '");
+	ND_PRINT(C_RESET, ", name '");
 	nd_printjnp(ndo, cp, OFP_MAX_PORT_NAME_LEN);
-	ND_PRINT("'");
+	ND_PRINT(C_RESET, "'");
 	cp += OFP_MAX_PORT_NAME_LEN;
 
 	if (ndo->ndo_vflag < 2) {
@@ -1047,7 +1047,7 @@ of10_phy_port_print(netdissect_options *ndo,
 		return;
 	}
 	/* config */
-	ND_PRINT("\n\t   config 0x%08x", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, "\n\t   config 0x%08x", GET_BE_U_4(cp));
 	of_bitmap_print(ndo, ofppc_bm, GET_BE_U_4(cp), OFPPC_U);
 	cp += 4;
 	/* state */
@@ -1057,25 +1057,25 @@ of10_phy_port_print(netdissect_options *ndo,
 	 * format the result as a single sequence of comma-separated
 	 * strings (see the comments at the OFPPS_ props).
 	 */
-	ND_PRINT("\n\t   state 0x%08x (%s%s)%s", state,
+	ND_PRINT(C_RESET, "\n\t   state 0x%08x (%s%s)%s", state,
 	         tok2str(ofpps_stp_str, "", state & OFPPS_STP_MASK),
 	         state & OFPPS_LINK_DOWN ? ", LINK_DOWN" : "",
 	         state & OFPPS_U ? " (bogus)" : "");
 	cp += 4;
 	/* curr */
-	ND_PRINT("\n\t   curr 0x%08x", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, "\n\t   curr 0x%08x", GET_BE_U_4(cp));
 	of_bitmap_print(ndo, ofppf_bm, GET_BE_U_4(cp), OFPPF_U);
 	cp += 4;
 	/* advertised */
-	ND_PRINT("\n\t   advertised 0x%08x", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, "\n\t   advertised 0x%08x", GET_BE_U_4(cp));
 	of_bitmap_print(ndo, ofppf_bm, GET_BE_U_4(cp), OFPPF_U);
 	cp += 4;
 	/* supported */
-	ND_PRINT("\n\t   supported 0x%08x", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, "\n\t   supported 0x%08x", GET_BE_U_4(cp));
 	of_bitmap_print(ndo, ofppf_bm, GET_BE_U_4(cp), OFPPF_U);
 	cp += 4;
 	/* peer */
-	ND_PRINT("\n\t   peer 0x%08x", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, "\n\t   peer 0x%08x", GET_BE_U_4(cp));
 	of_bitmap_print(ndo, ofppf_bm, GET_BE_U_4(cp), OFPPF_U);
 }
 
@@ -1088,16 +1088,16 @@ of10_queue_props_print(netdissect_options *ndo,
 		uint16_t property, plen;
 		u_char plen_bogus = 0, skip = 0;
 
-		ND_PRINT("\n\t  ");
+		ND_PRINT(C_RESET, "\n\t  ");
 		ND_ICHECKMSG_U("remaining length", len, <, OF_QUEUE_PROP_MINLEN);
 		/* property */
 		property = GET_BE_U_2(cp);
 		OF_FWD(2);
-		ND_PRINT(" property %s", tok2str(ofpqt_str, "invalid (0x%04x)", property));
+		ND_PRINT(C_RESET, " property %s", tok2str(ofpqt_str, "invalid (0x%04x)", property));
 		/* len */
 		plen = GET_BE_U_2(cp);
 		OF_FWD(2);
-		ND_PRINT(", len %u", plen);
+		ND_PRINT(C_RESET, ", len %u", plen);
 		ND_ICHECKMSG_U("property length", plen, <, OF_QUEUE_PROP_MINLEN);
 		ND_ICHECKMSG_U("property length", plen, >, len + 4);
 		/* pad */
@@ -1115,7 +1115,7 @@ of10_queue_props_print(netdissect_options *ndo,
 			skip = 1;
 		}
 		if (plen_bogus) {
-			ND_PRINT(" (bogus)");
+			ND_PRINT(C_RESET, " (bogus)");
 			skip = 1;
 		}
 		if (skip) {
@@ -1131,9 +1131,9 @@ of10_queue_props_print(netdissect_options *ndo,
 			uint16_t rate = GET_BE_U_2(cp);
 			OF_FWD(2);
 			if (rate > 1000)
-				ND_PRINT(", rate disabled");
+				ND_PRINT(C_RESET, ", rate disabled");
 			else
-				ND_PRINT(", rate %u.%u%%", rate / 10, rate % 10);
+				ND_PRINT(C_RESET, ", rate %u.%u%%", rate / 10, rate % 10);
 			/* pad */
 			/* Sometimes the last field, check bounds. */
 			OF_CHK_FWD(6);
@@ -1154,15 +1154,15 @@ of10_queues_print(netdissect_options *ndo,
 	while (len) {
 		uint16_t desclen;
 
-		ND_PRINT("\n\t ");
+		ND_PRINT(C_RESET, "\n\t ");
 		ND_ICHECKMSG_U("remaining length", len, <, OF_PACKET_QUEUE_MINLEN);
 		/* queue_id */
-		ND_PRINT(" queue_id %u", GET_BE_U_4(cp));
+		ND_PRINT(C_RESET, " queue_id %u", GET_BE_U_4(cp));
 		OF_FWD(4);
 		/* len */
 		desclen = GET_BE_U_2(cp);
 		OF_FWD(2);
-		ND_PRINT(", len %u", desclen);
+		ND_PRINT(C_RESET, ", len %u", desclen);
 		ND_ICHECKMSG_U("prop. desc. length", desclen, <, OF_PACKET_QUEUE_MINLEN);
 		ND_ICHECKMSG_U("prop. desc. length", desclen, >, len + 6);
 		/* pad */
@@ -1196,28 +1196,28 @@ of10_match_print(netdissect_options *ndo,
 	/* wildcards */
 	wildcards = GET_BE_U_4(cp);
 	if (wildcards & OFPFW_U)
-		ND_PRINT("%swildcards 0x%08x (bogus)", pfx, wildcards);
+		ND_PRINT(C_RESET, "%swildcards 0x%08x (bogus)", pfx, wildcards);
 	cp += 4;
 	/* in_port */
 	if (! (wildcards & OFPFW_IN_PORT))
-		ND_PRINT("%smatch in_port %s", pfx,
+		ND_PRINT(C_RESET, "%smatch in_port %s", pfx,
 		         tok2str(ofpp_str, "%u", GET_BE_U_2(cp)));
 	cp += 2;
 	/* dl_src */
 	if (! (wildcards & OFPFW_DL_SRC))
-		ND_PRINT("%smatch dl_src %s", pfx, GET_ETHERADDR_STRING(cp));
+		ND_PRINT(C_RESET, "%smatch dl_src %s", pfx, GET_ETHERADDR_STRING(cp));
 	cp += MAC_ADDR_LEN;
 	/* dl_dst */
 	if (! (wildcards & OFPFW_DL_DST))
-		ND_PRINT("%smatch dl_dst %s", pfx, GET_ETHERADDR_STRING(cp));
+		ND_PRINT(C_RESET, "%smatch dl_dst %s", pfx, GET_ETHERADDR_STRING(cp));
 	cp += MAC_ADDR_LEN;
 	/* dl_vlan */
 	if (! (wildcards & OFPFW_DL_VLAN))
-		ND_PRINT("%smatch dl_vlan %s", pfx, vlan_str(GET_BE_U_2(cp)));
+		ND_PRINT(C_RESET, "%smatch dl_vlan %s", pfx, vlan_str(GET_BE_U_2(cp)));
 	cp += 2;
 	/* dl_vlan_pcp */
 	if (! (wildcards & OFPFW_DL_VLAN_PCP))
-		ND_PRINT("%smatch dl_vlan_pcp %s", pfx, pcp_str(GET_U_1(cp)));
+		ND_PRINT(C_RESET, "%smatch dl_vlan_pcp %s", pfx, pcp_str(GET_U_1(cp)));
 	cp += 1;
 	/* pad1 */
 	cp += 1;
@@ -1225,10 +1225,10 @@ of10_match_print(netdissect_options *ndo,
 	dl_type = GET_BE_U_2(cp);
 	cp += 2;
 	if (! (wildcards & OFPFW_DL_TYPE))
-		ND_PRINT("%smatch dl_type 0x%04x", pfx, dl_type);
+		ND_PRINT(C_RESET, "%smatch dl_type 0x%04x", pfx, dl_type);
 	/* nw_tos */
 	if (! (wildcards & OFPFW_NW_TOS))
-		ND_PRINT("%smatch nw_tos 0x%02x", pfx, GET_U_1(cp));
+		ND_PRINT(C_RESET, "%smatch nw_tos 0x%02x", pfx, GET_U_1(cp));
 	cp += 1;
 	/* nw_proto */
 	nw_proto = GET_U_1(cp);
@@ -1236,26 +1236,26 @@ of10_match_print(netdissect_options *ndo,
 	if (! (wildcards & OFPFW_NW_PROTO)) {
 		field_name = ! (wildcards & OFPFW_DL_TYPE) && dl_type == ETHERTYPE_ARP
 		  ? "arp_opcode" : "nw_proto";
-		ND_PRINT("%smatch %s %u", pfx, field_name, nw_proto);
+		ND_PRINT(C_RESET, "%smatch %s %u", pfx, field_name, nw_proto);
 	}
 	/* pad2 */
 	cp += 2;
 	/* nw_src */
 	nw_bits = (wildcards & OFPFW_NW_SRC_MASK) >> OFPFW_NW_SRC_SHIFT;
 	if (nw_bits < 32)
-		ND_PRINT("%smatch nw_src %s/%u", pfx, GET_IPADDR_STRING(cp), 32 - nw_bits);
+		ND_PRINT(C_RESET, "%smatch nw_src %s/%u", pfx, GET_IPADDR_STRING(cp), 32 - nw_bits);
 	cp += 4;
 	/* nw_dst */
 	nw_bits = (wildcards & OFPFW_NW_DST_MASK) >> OFPFW_NW_DST_SHIFT;
 	if (nw_bits < 32)
-		ND_PRINT("%smatch nw_dst %s/%u", pfx, GET_IPADDR_STRING(cp), 32 - nw_bits);
+		ND_PRINT(C_RESET, "%smatch nw_dst %s/%u", pfx, GET_IPADDR_STRING(cp), 32 - nw_bits);
 	cp += 4;
 	/* tp_src */
 	if (! (wildcards & OFPFW_TP_SRC)) {
 		field_name = ! (wildcards & OFPFW_DL_TYPE) && dl_type == ETHERTYPE_IP
 		  && ! (wildcards & OFPFW_NW_PROTO) && nw_proto == IPPROTO_ICMP
 		  ? "icmp_type" : "tp_src";
-		ND_PRINT("%smatch %s %u", pfx, field_name, GET_BE_U_2(cp));
+		ND_PRINT(C_RESET, "%smatch %s %u", pfx, field_name, GET_BE_U_2(cp));
 	}
 	cp += 2;
 	/* tp_dst */
@@ -1264,7 +1264,7 @@ of10_match_print(netdissect_options *ndo,
 		field_name = ! (wildcards & OFPFW_DL_TYPE) && dl_type == ETHERTYPE_IP
 		  && ! (wildcards & OFPFW_NW_PROTO) && nw_proto == IPPROTO_ICMP
 		  ? "icmp_code" : "tp_dst";
-		ND_PRINT("%smatch %s %u", pfx, field_name, GET_BE_U_2(cp));
+		ND_PRINT(C_RESET, "%smatch %s %u", pfx, field_name, GET_BE_U_2(cp));
 	}
 	else
 		ND_TCHECK_2(cp);
@@ -1279,16 +1279,16 @@ of10_actions_print(netdissect_options *ndo,
 		uint16_t type, alen, output_port;
 		u_char alen_bogus = 0, skip = 0;
 
-		ND_PRINT("%saction", pfx);
+		ND_PRINT(C_RESET, "%saction", pfx);
 		ND_ICHECKMSG_U("remaining length", len, <, OF_ACTION_MINLEN);
 		/* type */
 		type = GET_BE_U_2(cp);
 		OF_FWD(2);
-		ND_PRINT(" type %s", tok2str(ofpat_str, "invalid (0x%04x)", type));
+		ND_PRINT(C_RESET, " type %s", tok2str(ofpat_str, "invalid (0x%04x)", type));
 		/* length */
 		alen = GET_BE_U_2(cp);
 		OF_FWD(2);
-		ND_PRINT(", len %u", alen);
+		ND_PRINT(C_RESET, ", len %u", alen);
 		/*
 		 * The 4-byte "pad" in the specification is not a field of the
 		 * action header, but a placeholder to illustrate the 64-bit
@@ -1328,7 +1328,7 @@ of10_actions_print(netdissect_options *ndo,
 			skip = 1;
 		}
 		if (alen_bogus) {
-			ND_PRINT(" (bogus)");
+			ND_PRINT(C_RESET, " (bogus)");
 			skip = 1;
 		}
 		if (skip) {
@@ -1345,17 +1345,17 @@ of10_actions_print(netdissect_options *ndo,
 			/* port */
 			output_port = GET_BE_U_2(cp);
 			OF_FWD(2);
-			ND_PRINT(", port %s", tok2str(ofpp_str, "%u", output_port));
+			ND_PRINT(C_RESET, ", port %s", tok2str(ofpp_str, "%u", output_port));
 			/* max_len */
 			if (output_port == OFPP_CONTROLLER)
-				ND_PRINT(", max_len %u", GET_BE_U_2(cp));
+				ND_PRINT(C_RESET, ", max_len %u", GET_BE_U_2(cp));
 			else
 				ND_TCHECK_2(cp);
 			OF_FWD(2);
 			break;
 		case OFPAT_SET_VLAN_VID:
 			/* vlan_vid */
-			ND_PRINT(", vlan_vid %s", vlan_str(GET_BE_U_2(cp)));
+			ND_PRINT(C_RESET, ", vlan_vid %s", vlan_str(GET_BE_U_2(cp)));
 			OF_FWD(2);
 			/* pad */
 			/* Sometimes the last field, check bounds. */
@@ -1363,7 +1363,7 @@ of10_actions_print(netdissect_options *ndo,
 			break;
 		case OFPAT_SET_VLAN_PCP:
 			/* vlan_pcp */
-			ND_PRINT(", vlan_pcp %s", pcp_str(GET_U_1(cp)));
+			ND_PRINT(C_RESET, ", vlan_pcp %s", pcp_str(GET_U_1(cp)));
 			OF_FWD(1);
 			/* pad */
 			/* Sometimes the last field, check bounds. */
@@ -1372,7 +1372,7 @@ of10_actions_print(netdissect_options *ndo,
 		case OFPAT_SET_DL_SRC:
 		case OFPAT_SET_DL_DST:
 			/* dl_addr */
-			ND_PRINT(", dl_addr %s", GET_ETHERADDR_STRING(cp));
+			ND_PRINT(C_RESET, ", dl_addr %s", GET_ETHERADDR_STRING(cp));
 			OF_FWD(MAC_ADDR_LEN);
 			/* pad */
 			/* Sometimes the last field, check bounds. */
@@ -1381,12 +1381,12 @@ of10_actions_print(netdissect_options *ndo,
 		case OFPAT_SET_NW_SRC:
 		case OFPAT_SET_NW_DST:
 			/* nw_addr */
-			ND_PRINT(", nw_addr %s", GET_IPADDR_STRING(cp));
+			ND_PRINT(C_RESET, ", nw_addr %s", GET_IPADDR_STRING(cp));
 			OF_FWD(4);
 			break;
 		case OFPAT_SET_NW_TOS:
 			/* nw_tos */
-			ND_PRINT(", nw_tos 0x%02x", GET_U_1(cp));
+			ND_PRINT(C_RESET, ", nw_tos 0x%02x", GET_U_1(cp));
 			OF_FWD(1);
 			/* pad */
 			/* Sometimes the last field, check bounds. */
@@ -1395,7 +1395,7 @@ of10_actions_print(netdissect_options *ndo,
 		case OFPAT_SET_TP_SRC:
 		case OFPAT_SET_TP_DST:
 			/* nw_tos */
-			ND_PRINT(", tp_port %u", GET_BE_U_2(cp));
+			ND_PRINT(C_RESET, ", tp_port %u", GET_BE_U_2(cp));
 			OF_FWD(2);
 			/* pad */
 			/* Sometimes the last field, check bounds. */
@@ -1403,13 +1403,13 @@ of10_actions_print(netdissect_options *ndo,
 			break;
 		case OFPAT_ENQUEUE:
 			/* port */
-			ND_PRINT(", port %s",
+			ND_PRINT(C_RESET, ", port %s",
 				 tok2str(ofpp_str, "%u", GET_BE_U_2(cp)));
 			OF_FWD(2);
 			/* pad */
 			OF_FWD(6);
 			/* queue_id */
-			ND_PRINT(", queue_id %s",
+			ND_PRINT(C_RESET, ", queue_id %s",
 				 tok2str(ofpq_str, "%u", GET_BE_U_4(cp)));
 			OF_FWD(4);
 			break;
@@ -1437,22 +1437,22 @@ of10_features_reply_print(netdissect_options *ndo,
                           const u_char *cp, u_int len)
 {
 	/* datapath_id */
-	ND_PRINT("\n\t dpid 0x%016" PRIx64, GET_BE_U_8(cp));
+	ND_PRINT(C_RESET, "\n\t dpid 0x%016" PRIx64, GET_BE_U_8(cp));
 	OF_FWD(8);
 	/* n_buffers */
-	ND_PRINT(", n_buffers %u", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, ", n_buffers %u", GET_BE_U_4(cp));
 	OF_FWD(4);
 	/* n_tables */
-	ND_PRINT(", n_tables %u", GET_U_1(cp));
+	ND_PRINT(C_RESET, ", n_tables %u", GET_U_1(cp));
 	OF_FWD(1);
 	/* pad */
 	OF_FWD(3);
 	/* capabilities */
-	ND_PRINT("\n\t capabilities 0x%08x", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, "\n\t capabilities 0x%08x", GET_BE_U_4(cp));
 	of_bitmap_print(ndo, ofp_capabilities_bm, GET_BE_U_4(cp), OFPCAP_U);
 	OF_FWD(4);
 	/* actions */
-	ND_PRINT("\n\t actions 0x%08x", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, "\n\t actions 0x%08x", GET_BE_U_4(cp));
 	of_bitmap_print(ndo, ofpat_bm, GET_BE_U_4(cp), OFPAT_U);
 	OF_FWD(4);
 	/* ports */
@@ -1474,11 +1474,11 @@ of10_switch_config_msg_print(netdissect_options *ndo,
                              const u_char *cp, u_int len _U_)
 {
 	/* flags */
-	ND_PRINT("\n\t flags %s",
+	ND_PRINT(C_RESET, "\n\t flags %s",
 	         tok2str(ofp_config_str, "invalid (0x%04x)", GET_BE_U_2(cp)));
 	cp += 2;
 	/* miss_send_len */
-	ND_PRINT(", miss_send_len %u", GET_BE_U_2(cp));
+	ND_PRINT(C_RESET, ", miss_send_len %u", GET_BE_U_2(cp));
 }
 
 /* [OF10] Section 5.3.3 */
@@ -1492,37 +1492,37 @@ of10_flow_mod_print(netdissect_options *ndo,
 	of10_match_print(ndo, "\n\t ", cp);
 	OF_FWD(OF_MATCH_FIXLEN);
 	/* cookie */
-	ND_PRINT("\n\t cookie 0x%016" PRIx64, GET_BE_U_8(cp));
+	ND_PRINT(C_RESET, "\n\t cookie 0x%016" PRIx64, GET_BE_U_8(cp));
 	OF_FWD(8);
 	/* command */
 	command = GET_BE_U_2(cp);
-	ND_PRINT(", command %s", tok2str(ofpfc_str, "invalid (0x%04x)", command));
+	ND_PRINT(C_RESET, ", command %s", tok2str(ofpfc_str, "invalid (0x%04x)", command));
 	OF_FWD(2);
 	/* idle_timeout */
 	if (GET_BE_U_2(cp))
-		ND_PRINT(", idle_timeout %u", GET_BE_U_2(cp));
+		ND_PRINT(C_RESET, ", idle_timeout %u", GET_BE_U_2(cp));
 	OF_FWD(2);
 	/* hard_timeout */
 	if (GET_BE_U_2(cp))
-		ND_PRINT(", hard_timeout %u", GET_BE_U_2(cp));
+		ND_PRINT(C_RESET, ", hard_timeout %u", GET_BE_U_2(cp));
 	OF_FWD(2);
 	/* priority */
 	if (GET_BE_U_2(cp))
-		ND_PRINT(", priority %u", GET_BE_U_2(cp));
+		ND_PRINT(C_RESET, ", priority %u", GET_BE_U_2(cp));
 	OF_FWD(2);
 	/* buffer_id */
 	if (command == OFPFC_ADD || command == OFPFC_MODIFY ||
 	    command == OFPFC_MODIFY_STRICT)
-		ND_PRINT(", buffer_id %s",
+		ND_PRINT(C_RESET, ", buffer_id %s",
 		         tok2str(bufferid_str, "0x%08x", GET_BE_U_4(cp)));
 	OF_FWD(4);
 	/* out_port */
 	if (command == OFPFC_DELETE || command == OFPFC_DELETE_STRICT)
-		ND_PRINT(", out_port %s",
+		ND_PRINT(C_RESET, ", out_port %s",
 		         tok2str(ofpp_str, "%u", GET_BE_U_2(cp)));
 	OF_FWD(2);
 	/* flags */
-	ND_PRINT(", flags 0x%04x", GET_BE_U_2(cp));
+	ND_PRINT(C_RESET, ", flags 0x%04x", GET_BE_U_2(cp));
 	of_bitmap_print(ndo, ofpff_bm, GET_BE_U_2(cp), OFPFF_U);
 	OF_FWD(2);
 	/* actions */
@@ -1535,21 +1535,21 @@ of10_port_mod_print(netdissect_options *ndo,
                     const u_char *cp, u_int len _U_)
 {
 	/* port_no */
-	ND_PRINT("\n\t port_no %s", tok2str(ofpp_str, "%u", GET_BE_U_2(cp)));
+	ND_PRINT(C_RESET, "\n\t port_no %s", tok2str(ofpp_str, "%u", GET_BE_U_2(cp)));
 	cp += 2;
 	/* hw_addr */
-	ND_PRINT(", hw_addr %s", GET_ETHERADDR_STRING(cp));
+	ND_PRINT(C_RESET, ", hw_addr %s", GET_ETHERADDR_STRING(cp));
 	cp += MAC_ADDR_LEN;
 	/* config */
-	ND_PRINT("\n\t  config 0x%08x", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, "\n\t  config 0x%08x", GET_BE_U_4(cp));
 	of_bitmap_print(ndo, ofppc_bm, GET_BE_U_4(cp), OFPPC_U);
 	cp += 4;
 	/* mask */
-	ND_PRINT("\n\t  mask 0x%08x", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, "\n\t  mask 0x%08x", GET_BE_U_4(cp));
 	of_bitmap_print(ndo, ofppc_bm, GET_BE_U_4(cp), OFPPC_U);
 	cp += 4;
 	/* advertise */
-	ND_PRINT("\n\t  advertise 0x%08x", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, "\n\t  advertise 0x%08x", GET_BE_U_4(cp));
 	of_bitmap_print(ndo, ofppf_bm, GET_BE_U_4(cp), OFPPF_U);
 	cp += 4;
 	/* pad */
@@ -1563,7 +1563,7 @@ of10_queue_get_config_request_print(netdissect_options *ndo,
                                     const u_char *cp, u_int len _U_)
 {
 	/* port */
-	ND_PRINT("\n\t port %s", tok2str(ofpp_str, "%u", GET_BE_U_2(cp)));
+	ND_PRINT(C_RESET, "\n\t port %s", tok2str(ofpp_str, "%u", GET_BE_U_2(cp)));
 	cp += 2;
 	/* pad */
 	/* Always the last field, check bounds. */
@@ -1576,7 +1576,7 @@ of10_queue_get_config_reply_print(netdissect_options *ndo,
                                   const u_char *cp, u_int len)
 {
 	/* port */
-	ND_PRINT("\n\t port %s", tok2str(ofpp_str, "%u", GET_BE_U_2(cp)));
+	ND_PRINT(C_RESET, "\n\t port %s", tok2str(ofpp_str, "%u", GET_BE_U_2(cp)));
 	OF_FWD(2);
 	/* pad */
 	/* Sometimes the last field, check bounds. */
@@ -1595,11 +1595,11 @@ of10_stats_request_print(netdissect_options *ndo,
 	/* type */
 	type = GET_BE_U_2(cp);
 	OF_FWD(2);
-	ND_PRINT("\n\t type %s", tok2str(ofpst_str, "invalid (0x%04x)", type));
+	ND_PRINT(C_RESET, "\n\t type %s", tok2str(ofpst_str, "invalid (0x%04x)", type));
 	/* flags */
-	ND_PRINT(", flags 0x%04x", GET_BE_U_2(cp));
+	ND_PRINT(C_RESET, ", flags 0x%04x", GET_BE_U_2(cp));
 	if (GET_BE_U_2(cp))
-		ND_PRINT(" (bogus)");
+		ND_PRINT(C_RESET, " (bogus)");
 	OF_FWD(2);
 	/* type-specific body of one of fixed lengths */
 	switch(type) {
@@ -1614,19 +1614,19 @@ of10_stats_request_print(netdissect_options *ndo,
 		of10_match_print(ndo, "\n\t ", cp);
 		OF_FWD(OF_MATCH_FIXLEN);
 		/* table_id */
-		ND_PRINT("\n\t table_id %s",
+		ND_PRINT(C_RESET, "\n\t table_id %s",
 			 tok2str(tableid_str, "%u", GET_U_1(cp)));
 		OF_FWD(1);
 		/* pad */
 		OF_FWD(1);
 		/* out_port */
-		ND_PRINT(", out_port %s",
+		ND_PRINT(C_RESET, ", out_port %s",
 			 tok2str(ofpp_str, "%u", GET_BE_U_2(cp)));
 		return;
 	case OFPST_PORT:
 		ND_ICHECK_U(len, !=, OF_PORT_STATS_REQUEST_FIXLEN);
 		/* port_no */
-		ND_PRINT("\n\t port_no %s",
+		ND_PRINT(C_RESET, "\n\t port_no %s",
 			 tok2str(ofpp_str, "%u", GET_BE_U_2(cp)));
 		OF_FWD(2);
 		/* pad */
@@ -1636,13 +1636,13 @@ of10_stats_request_print(netdissect_options *ndo,
 	case OFPST_QUEUE:
 		ND_ICHECK_U(len, !=, OF_QUEUE_STATS_REQUEST_FIXLEN);
 		/* port_no */
-		ND_PRINT("\n\t port_no %s",
+		ND_PRINT(C_RESET, "\n\t port_no %s",
 			 tok2str(ofpp_str, "%u", GET_BE_U_2(cp)));
 		OF_FWD(2);
 		/* pad */
 		OF_FWD(2);
 		/* queue_id */
-		ND_PRINT(", queue_id %s",
+		ND_PRINT(C_RESET, ", queue_id %s",
 			 tok2str(ofpq_str, "%u", GET_BE_U_4(cp)));
 		return;
 	case OFPST_VENDOR:
@@ -1661,32 +1661,32 @@ static void
 of10_desc_stats_reply_print(netdissect_options *ndo,
                             const u_char *cp, u_int len)
 {
-	ND_PRINT("\n\t ");
+	ND_PRINT(C_RESET, "\n\t ");
 	ND_ICHECK_U(len, !=, OF_DESC_STATS_REPLY_FIXLEN);
 	/* mfr_desc */
-	ND_PRINT(" mfr_desc '");
+	ND_PRINT(C_RESET, " mfr_desc '");
 	nd_printjnp(ndo, cp, DESC_STR_LEN);
-	ND_PRINT("'");
+	ND_PRINT(C_RESET, "'");
 	OF_FWD(DESC_STR_LEN);
 	/* hw_desc */
-	ND_PRINT("\n\t  hw_desc '");
+	ND_PRINT(C_RESET, "\n\t  hw_desc '");
 	nd_printjnp(ndo, cp, DESC_STR_LEN);
-	ND_PRINT("'");
+	ND_PRINT(C_RESET, "'");
 	OF_FWD(DESC_STR_LEN);
 	/* sw_desc */
-	ND_PRINT("\n\t  sw_desc '");
+	ND_PRINT(C_RESET, "\n\t  sw_desc '");
 	nd_printjnp(ndo, cp, DESC_STR_LEN);
-	ND_PRINT("'");
+	ND_PRINT(C_RESET, "'");
 	OF_FWD(DESC_STR_LEN);
 	/* serial_num */
-	ND_PRINT("\n\t  serial_num '");
+	ND_PRINT(C_RESET, "\n\t  serial_num '");
 	nd_printjnp(ndo, cp, SERIAL_NUM_LEN);
-	ND_PRINT("'");
+	ND_PRINT(C_RESET, "'");
 	OF_FWD(SERIAL_NUM_LEN);
 	/* dp_desc */
-	ND_PRINT("\n\t  dp_desc '");
+	ND_PRINT(C_RESET, "\n\t  dp_desc '");
 	nd_printjnp(ndo, cp, DESC_STR_LEN);
-	ND_PRINT("'");
+	ND_PRINT(C_RESET, "'");
 	return;
 
 invalid: /* skip the message body */
@@ -1702,16 +1702,16 @@ of10_flow_stats_reply_print(netdissect_options *ndo,
 	while (len) {
 		uint16_t entry_len;
 
-		ND_PRINT("\n\t");
+		ND_PRINT(C_RESET, "\n\t");
 		ND_ICHECKMSG_U("remaining length", len, <, OF_FLOW_STATS_REPLY_MINLEN);
 		/* length */
 		entry_len = GET_BE_U_2(cp);
-		ND_PRINT(" length %u", entry_len);
+		ND_PRINT(C_RESET, " length %u", entry_len);
 		ND_ICHECK_U(entry_len, <, OF_FLOW_STATS_REPLY_MINLEN);
 		ND_ICHECK_U(entry_len, >, len);
 		OF_FWD(2);
 		/* table_id */
-		ND_PRINT(", table_id %s",
+		ND_PRINT(C_RESET, ", table_id %s",
 			 tok2str(tableid_str, "%u", GET_U_1(cp)));
 		OF_FWD(1);
 		/* pad */
@@ -1720,30 +1720,30 @@ of10_flow_stats_reply_print(netdissect_options *ndo,
 		of10_match_print(ndo, "\n\t  ", cp);
 		OF_FWD(OF_MATCH_FIXLEN);
 		/* duration_sec */
-		ND_PRINT("\n\t  duration_sec %u", GET_BE_U_4(cp));
+		ND_PRINT(C_RESET, "\n\t  duration_sec %u", GET_BE_U_4(cp));
 		OF_FWD(4);
 		/* duration_nsec */
-		ND_PRINT(", duration_nsec %u", GET_BE_U_4(cp));
+		ND_PRINT(C_RESET, ", duration_nsec %u", GET_BE_U_4(cp));
 		OF_FWD(4);
 		/* priority */
-		ND_PRINT(", priority %u", GET_BE_U_2(cp));
+		ND_PRINT(C_RESET, ", priority %u", GET_BE_U_2(cp));
 		OF_FWD(2);
 		/* idle_timeout */
-		ND_PRINT(", idle_timeout %u", GET_BE_U_2(cp));
+		ND_PRINT(C_RESET, ", idle_timeout %u", GET_BE_U_2(cp));
 		OF_FWD(2);
 		/* hard_timeout */
-		ND_PRINT(", hard_timeout %u", GET_BE_U_2(cp));
+		ND_PRINT(C_RESET, ", hard_timeout %u", GET_BE_U_2(cp));
 		OF_FWD(2);
 		/* pad2 */
 		OF_FWD(6);
 		/* cookie */
-		ND_PRINT(", cookie 0x%016" PRIx64, GET_BE_U_8(cp));
+		ND_PRINT(C_RESET, ", cookie 0x%016" PRIx64, GET_BE_U_8(cp));
 		OF_FWD(8);
 		/* packet_count */
-		ND_PRINT(", packet_count %" PRIu64, GET_BE_U_8(cp));
+		ND_PRINT(C_RESET, ", packet_count %" PRIu64, GET_BE_U_8(cp));
 		OF_FWD(8);
 		/* byte_count */
-		ND_PRINT(", byte_count %" PRIu64, GET_BE_U_8(cp));
+		ND_PRINT(C_RESET, ", byte_count %" PRIu64, GET_BE_U_8(cp));
 		OF_FWD(8);
 		/* actions */
 		of10_actions_print(ndo, "\n\t  ", cp, entry_len - OF_FLOW_STATS_REPLY_MINLEN);
@@ -1761,16 +1761,16 @@ static void
 of10_aggregate_stats_reply_print(netdissect_options *ndo,
                                  const u_char *cp, u_int len)
 {
-	ND_PRINT("\n\t");
+	ND_PRINT(C_RESET, "\n\t");
 	ND_ICHECKMSG_U("remaining length", len, !=, OF_AGGREGATE_STATS_REPLY_FIXLEN);
 	/* packet_count */
-	ND_PRINT(" packet_count %" PRIu64, GET_BE_U_8(cp));
+	ND_PRINT(C_RESET, " packet_count %" PRIu64, GET_BE_U_8(cp));
 	OF_FWD(8);
 	/* byte_count */
-	ND_PRINT(", byte_count %" PRIu64, GET_BE_U_8(cp));
+	ND_PRINT(C_RESET, ", byte_count %" PRIu64, GET_BE_U_8(cp));
 	OF_FWD(8);
 	/* flow_count */
-	ND_PRINT(", flow_count %u", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, ", flow_count %u", GET_BE_U_4(cp));
 	OF_FWD(4);
 	/* pad */
 	/* Always the last field, check bounds. */
@@ -1788,34 +1788,34 @@ of10_table_stats_reply_print(netdissect_options *ndo,
                              const u_char *cp, u_int len)
 {
 	while (len) {
-		ND_PRINT("\n\t");
+		ND_PRINT(C_RESET, "\n\t");
 		ND_ICHECKMSG_U("remaining length", len, <, OF_TABLE_STATS_REPLY_FIXLEN);
 		/* table_id */
-		ND_PRINT(" table_id %s",
+		ND_PRINT(C_RESET, " table_id %s",
 		         tok2str(tableid_str, "%u", GET_U_1(cp)));
 		OF_FWD(1);
 		/* pad */
 		OF_FWD(3);
 		/* name */
-		ND_PRINT(", name '");
+		ND_PRINT(C_RESET, ", name '");
 		nd_printjnp(ndo, cp, OFP_MAX_TABLE_NAME_LEN);
-		ND_PRINT("'");
+		ND_PRINT(C_RESET, "'");
 		OF_FWD(OFP_MAX_TABLE_NAME_LEN);
 		/* wildcards */
-		ND_PRINT("\n\t  wildcards 0x%08x", GET_BE_U_4(cp));
+		ND_PRINT(C_RESET, "\n\t  wildcards 0x%08x", GET_BE_U_4(cp));
 		of_bitmap_print(ndo, ofpfw_bm, GET_BE_U_4(cp), OFPFW_U);
 		OF_FWD(4);
 		/* max_entries */
-		ND_PRINT("\n\t  max_entries %u", GET_BE_U_4(cp));
+		ND_PRINT(C_RESET, "\n\t  max_entries %u", GET_BE_U_4(cp));
 		OF_FWD(4);
 		/* active_count */
-		ND_PRINT(", active_count %u", GET_BE_U_4(cp));
+		ND_PRINT(C_RESET, ", active_count %u", GET_BE_U_4(cp));
 		OF_FWD(4);
 		/* lookup_count */
-		ND_PRINT(", lookup_count %" PRIu64, GET_BE_U_8(cp));
+		ND_PRINT(C_RESET, ", lookup_count %" PRIu64, GET_BE_U_8(cp));
 		OF_FWD(8);
 		/* matched_count */
-		ND_PRINT(", matched_count %" PRIu64, GET_BE_U_8(cp));
+		ND_PRINT(C_RESET, ", matched_count %" PRIu64, GET_BE_U_8(cp));
 		OF_FWD(8);
 	} /* while */
 	return;
@@ -1831,10 +1831,10 @@ of10_port_stats_reply_print(netdissect_options *ndo,
                             const u_char *cp, u_int len)
 {
 	while (len) {
-		ND_PRINT("\n\t ");
+		ND_PRINT(C_RESET, "\n\t ");
 		ND_ICHECKMSG_U("remaining length", len, <, OF_PORT_STATS_REPLY_FIXLEN);
 		/* port_no */
-		ND_PRINT(" port_no %s",
+		ND_PRINT(C_RESET, " port_no %s",
 			 tok2str(ofpp_str, "%u", GET_BE_U_2(cp)));
 		OF_FWD(2);
 		if (ndo->ndo_vflag < 2) {
@@ -1844,40 +1844,40 @@ of10_port_stats_reply_print(netdissect_options *ndo,
 		/* pad */
 		OF_FWD(6);
 		/* rx_packets */
-		ND_PRINT(", rx_packets %" PRIu64, GET_BE_U_8(cp));
+		ND_PRINT(C_RESET, ", rx_packets %" PRIu64, GET_BE_U_8(cp));
 		OF_FWD(8);
 		/* tx_packets */
-		ND_PRINT(", tx_packets %" PRIu64, GET_BE_U_8(cp));
+		ND_PRINT(C_RESET, ", tx_packets %" PRIu64, GET_BE_U_8(cp));
 		OF_FWD(8);
 		/* rx_bytes */
-		ND_PRINT(", rx_bytes %" PRIu64, GET_BE_U_8(cp));
+		ND_PRINT(C_RESET, ", rx_bytes %" PRIu64, GET_BE_U_8(cp));
 		OF_FWD(8);
 		/* tx_bytes */
-		ND_PRINT(", tx_bytes %" PRIu64, GET_BE_U_8(cp));
+		ND_PRINT(C_RESET, ", tx_bytes %" PRIu64, GET_BE_U_8(cp));
 		OF_FWD(8);
 		/* rx_dropped */
-		ND_PRINT(", rx_dropped %" PRIu64, GET_BE_U_8(cp));
+		ND_PRINT(C_RESET, ", rx_dropped %" PRIu64, GET_BE_U_8(cp));
 		OF_FWD(8);
 		/* tx_dropped */
-		ND_PRINT(", tx_dropped %" PRIu64, GET_BE_U_8(cp));
+		ND_PRINT(C_RESET, ", tx_dropped %" PRIu64, GET_BE_U_8(cp));
 		OF_FWD(8);
 		/* rx_errors */
-		ND_PRINT(", rx_errors %" PRIu64, GET_BE_U_8(cp));
+		ND_PRINT(C_RESET, ", rx_errors %" PRIu64, GET_BE_U_8(cp));
 		OF_FWD(8);
 		/* tx_errors */
-		ND_PRINT(", tx_errors %" PRIu64, GET_BE_U_8(cp));
+		ND_PRINT(C_RESET, ", tx_errors %" PRIu64, GET_BE_U_8(cp));
 		OF_FWD(8);
 		/* rx_frame_err */
-		ND_PRINT(", rx_frame_err %" PRIu64, GET_BE_U_8(cp));
+		ND_PRINT(C_RESET, ", rx_frame_err %" PRIu64, GET_BE_U_8(cp));
 		OF_FWD(8);
 		/* rx_over_err */
-		ND_PRINT(", rx_over_err %" PRIu64, GET_BE_U_8(cp));
+		ND_PRINT(C_RESET, ", rx_over_err %" PRIu64, GET_BE_U_8(cp));
 		OF_FWD(8);
 		/* rx_crc_err */
-		ND_PRINT(", rx_crc_err %" PRIu64, GET_BE_U_8(cp));
+		ND_PRINT(C_RESET, ", rx_crc_err %" PRIu64, GET_BE_U_8(cp));
 		OF_FWD(8);
 		/* collisions */
-		ND_PRINT(", collisions %" PRIu64, GET_BE_U_8(cp));
+		ND_PRINT(C_RESET, ", collisions %" PRIu64, GET_BE_U_8(cp));
 		OF_FWD(8);
 	} /* while */
 	return;
@@ -1893,25 +1893,25 @@ of10_queue_stats_reply_print(netdissect_options *ndo,
                              const u_char *cp, u_int len)
 {
 	while (len) {
-		ND_PRINT("\n\t ");
+		ND_PRINT(C_RESET, "\n\t ");
 		ND_ICHECKMSG_U("remaining length", len, <, OF_QUEUE_STATS_REPLY_FIXLEN);
 		/* port_no */
-		ND_PRINT(" port_no %s",
+		ND_PRINT(C_RESET, " port_no %s",
 		         tok2str(ofpp_str, "%u", GET_BE_U_2(cp)));
 		OF_FWD(2);
 		/* pad */
 		OF_FWD(2);
 		/* queue_id */
-		ND_PRINT(", queue_id %u", GET_BE_U_4(cp));
+		ND_PRINT(C_RESET, ", queue_id %u", GET_BE_U_4(cp));
 		OF_FWD(4);
 		/* tx_bytes */
-		ND_PRINT(", tx_bytes %" PRIu64, GET_BE_U_8(cp));
+		ND_PRINT(C_RESET, ", tx_bytes %" PRIu64, GET_BE_U_8(cp));
 		OF_FWD(8);
 		/* tx_packets */
-		ND_PRINT(", tx_packets %" PRIu64, GET_BE_U_8(cp));
+		ND_PRINT(C_RESET, ", tx_packets %" PRIu64, GET_BE_U_8(cp));
 		OF_FWD(8);
 		/* tx_errors */
-		ND_PRINT(", tx_errors %" PRIu64, GET_BE_U_8(cp));
+		ND_PRINT(C_RESET, ", tx_errors %" PRIu64, GET_BE_U_8(cp));
 		OF_FWD(8);
 	} /* while */
 	return;
@@ -1930,10 +1930,10 @@ of10_stats_reply_print(netdissect_options *ndo,
 
 	/* type */
 	type = GET_BE_U_2(cp);
-	ND_PRINT("\n\t type %s", tok2str(ofpst_str, "invalid (0x%04x)", type));
+	ND_PRINT(C_RESET, "\n\t type %s", tok2str(ofpst_str, "invalid (0x%04x)", type));
 	OF_FWD(2);
 	/* flags */
-	ND_PRINT(", flags 0x%04x", GET_BE_U_2(cp));
+	ND_PRINT(C_RESET, ", flags 0x%04x", GET_BE_U_2(cp));
 	of_bitmap_print(ndo, ofpsf_reply_bm, GET_BE_U_2(cp), OFPSF_REPLY_U);
 	OF_FWD(2);
 
@@ -1963,14 +1963,14 @@ of10_packet_out_print(netdissect_options *ndo,
 	uint16_t actions_len;
 
 	/* buffer_id */
-	ND_PRINT("\n\t buffer_id 0x%08x", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, "\n\t buffer_id 0x%08x", GET_BE_U_4(cp));
 	OF_FWD(4);
 	/* in_port */
-	ND_PRINT(", in_port %s", tok2str(ofpp_str, "%u", GET_BE_U_2(cp)));
+	ND_PRINT(C_RESET, ", in_port %s", tok2str(ofpp_str, "%u", GET_BE_U_2(cp)));
 	OF_FWD(2);
 	/* actions_len */
 	actions_len = GET_BE_U_2(cp);
-	ND_PRINT(", actions_len %u", actions_len);
+	ND_PRINT(C_RESET, ", actions_len %u", actions_len);
 	OF_FWD(2);
 	ND_ICHECK_U(actions_len, >, len);
 	/* actions */
@@ -1991,17 +1991,17 @@ of10_packet_in_print(netdissect_options *ndo,
                      const u_char *cp, u_int len)
 {
 	/* buffer_id */
-	ND_PRINT("\n\t buffer_id %s",
+	ND_PRINT(C_RESET, "\n\t buffer_id %s",
 	         tok2str(bufferid_str, "0x%08x", GET_BE_U_4(cp)));
 	OF_FWD(4);
 	/* total_len */
-	ND_PRINT(", total_len %u", GET_BE_U_2(cp));
+	ND_PRINT(C_RESET, ", total_len %u", GET_BE_U_2(cp));
 	OF_FWD(2);
 	/* in_port */
-	ND_PRINT(", in_port %s", tok2str(ofpp_str, "%u", GET_BE_U_2(cp)));
+	ND_PRINT(C_RESET, ", in_port %s", tok2str(ofpp_str, "%u", GET_BE_U_2(cp)));
 	OF_FWD(2);
 	/* reason */
-	ND_PRINT(", reason %s",
+	ND_PRINT(C_RESET, ", reason %s",
 		 tok2str(ofpr_str, "invalid (0x%02x)", GET_U_1(cp)));
 	OF_FWD(1);
 	/* pad */
@@ -2020,35 +2020,35 @@ of10_flow_removed_print(netdissect_options *ndo,
 	of10_match_print(ndo, "\n\t ", cp);
 	cp += OF_MATCH_FIXLEN;
 	/* cookie */
-	ND_PRINT("\n\t cookie 0x%016" PRIx64, GET_BE_U_8(cp));
+	ND_PRINT(C_RESET, "\n\t cookie 0x%016" PRIx64, GET_BE_U_8(cp));
 	cp += 8;
 	/* priority */
 	if (GET_BE_U_2(cp))
-		ND_PRINT(", priority %u", GET_BE_U_2(cp));
+		ND_PRINT(C_RESET, ", priority %u", GET_BE_U_2(cp));
 	cp += 2;
 	/* reason */
-	ND_PRINT(", reason %s",
+	ND_PRINT(C_RESET, ", reason %s",
 	         tok2str(ofprr_str, "unknown (0x%02x)", GET_U_1(cp)));
 	cp += 1;
 	/* pad */
 	cp += 1;
 	/* duration_sec */
-	ND_PRINT(", duration_sec %u", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, ", duration_sec %u", GET_BE_U_4(cp));
 	cp += 4;
 	/* duration_nsec */
-	ND_PRINT(", duration_nsec %u", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, ", duration_nsec %u", GET_BE_U_4(cp));
 	cp += 4;
 	/* idle_timeout */
 	if (GET_BE_U_2(cp))
-		ND_PRINT(", idle_timeout %u", GET_BE_U_2(cp));
+		ND_PRINT(C_RESET, ", idle_timeout %u", GET_BE_U_2(cp));
 	cp += 2;
 	/* pad2 */
 	cp += 2;
 	/* packet_count */
-	ND_PRINT(", packet_count %" PRIu64, GET_BE_U_8(cp));
+	ND_PRINT(C_RESET, ", packet_count %" PRIu64, GET_BE_U_8(cp));
 	cp += 8;
 	/* byte_count */
-	ND_PRINT(", byte_count %" PRIu64, GET_BE_U_8(cp));
+	ND_PRINT(C_RESET, ", byte_count %" PRIu64, GET_BE_U_8(cp));
 }
 
 /* [OF10] Section 5.4.3 */
@@ -2057,7 +2057,7 @@ of10_port_status_print(netdissect_options *ndo,
                        const u_char *cp, u_int len _U_)
 {
 	/* reason */
-	ND_PRINT("\n\t reason %s",
+	ND_PRINT(C_RESET, "\n\t reason %s",
 	         tok2str(ofppr_str, "invalid (0x%02x)", GET_U_1(cp)));
 	cp += 1;
 	/* pad */
@@ -2078,16 +2078,16 @@ of10_error_print(netdissect_options *ndo,
 	/* type */
 	type = GET_BE_U_2(cp);
 	OF_FWD(2);
-	ND_PRINT("\n\t type %s", tok2str(ofpet_str, "invalid (0x%04x)", type));
+	ND_PRINT(C_RESET, "\n\t type %s", tok2str(ofpet_str, "invalid (0x%04x)", type));
 	/* code */
 	code = GET_BE_U_2(cp);
 	OF_FWD(2);
 	code_str = uint2tokary(of10_ofpet2tokary, type);
 	if (code_str != NULL)
-		ND_PRINT(", code %s",
+		ND_PRINT(C_RESET, ", code %s",
 		         tok2str(code_str, "invalid (0x%04x)", code));
 	else
-		ND_PRINT(", code invalid (0x%04x)", code);
+		ND_PRINT(C_RESET, ", code invalid (0x%04x)", code);
 	/* data */
 	of_data_print(ndo, cp, len);
 }

--- a/print-openflow-1.3.c
+++ b/print-openflow-1.3.c
@@ -649,20 +649,20 @@ of13_port_print(netdissect_options *ndo,
                 const u_char *cp)
 {
 	/* port_no */
-	ND_PRINT("\n\t  port_no %s",
+	ND_PRINT(C_RESET, "\n\t  port_no %s",
 		 tok2str(ofpp_str, "%u", GET_BE_U_4(cp)));
 	cp += 4;
 	/* pad */
 	cp += 4;
 	/* hw_addr */
-	ND_PRINT(", hw_addr %s", GET_ETHERADDR_STRING(cp));
+	ND_PRINT(C_RESET, ", hw_addr %s", GET_ETHERADDR_STRING(cp));
 	cp += MAC_ADDR_LEN;
 	/* pad2 */
 	cp += 2;
 	/* name */
-	ND_PRINT(", name '");
+	ND_PRINT(C_RESET, ", name '");
 	nd_printjnp(ndo, cp, OFP_MAX_PORT_NAME_LEN);
-	ND_PRINT("'");
+	ND_PRINT(C_RESET, "'");
 	cp += OFP_MAX_PORT_NAME_LEN;
 
 	if (ndo->ndo_vflag < 2) {
@@ -671,34 +671,34 @@ of13_port_print(netdissect_options *ndo,
 	}
 
 	/* config */
-	ND_PRINT("\n\t   config 0x%08x", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, "\n\t   config 0x%08x", GET_BE_U_4(cp));
 	of_bitmap_print(ndo, ofppc_bm, GET_BE_U_4(cp), OFPPC_U);
 	cp += 4;
 	/* state */
-	ND_PRINT("\n\t   state 0x%08x", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, "\n\t   state 0x%08x", GET_BE_U_4(cp));
 	of_bitmap_print(ndo, ofpps_bm, GET_BE_U_4(cp), OFPPS_U);;
 	cp += 4;
 	/* curr */
-	ND_PRINT("\n\t   curr 0x%08x", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, "\n\t   curr 0x%08x", GET_BE_U_4(cp));
 	of_bitmap_print(ndo, ofppf_bm, GET_BE_U_4(cp), OFPPF_U);
 	cp += 4;
 	/* advertised */
-	ND_PRINT("\n\t   advertised 0x%08x", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, "\n\t   advertised 0x%08x", GET_BE_U_4(cp));
 	of_bitmap_print(ndo, ofppf_bm, GET_BE_U_4(cp), OFPPF_U);
 	cp += 4;
 	/* supported */
-	ND_PRINT("\n\t   supported 0x%08x", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, "\n\t   supported 0x%08x", GET_BE_U_4(cp));
 	of_bitmap_print(ndo, ofppf_bm, GET_BE_U_4(cp), OFPPF_U);
 	cp += 4;
 	/* peer */
-	ND_PRINT("\n\t   peer 0x%08x", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, "\n\t   peer 0x%08x", GET_BE_U_4(cp));
 	of_bitmap_print(ndo, ofppf_bm, GET_BE_U_4(cp), OFPPF_U);
 	cp += 4;
 	/* curr_speed */
-	ND_PRINT("\n\t   curr_speed %ukbps", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, "\n\t   curr_speed %ukbps", GET_BE_U_4(cp));
 	cp += 4;
 	/* max_speed */
-	ND_PRINT("\n\t   max_speed %ukbps", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, "\n\t   max_speed %ukbps", GET_BE_U_4(cp));
 }
 
 /* [OF13] Section 7.3.1 */
@@ -707,21 +707,21 @@ of13_features_reply_print(netdissect_options *ndo,
                           const u_char *cp, u_int len _U_)
 {
 	/* datapath_id */
-	ND_PRINT("\n\t dpid 0x%016" PRIx64, GET_BE_U_8(cp));
+	ND_PRINT(C_RESET, "\n\t dpid 0x%016" PRIx64, GET_BE_U_8(cp));
 	cp += 8;
 	/* n_buffers */
-	ND_PRINT(", n_buffers %u", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, ", n_buffers %u", GET_BE_U_4(cp));
 	cp += 4;
 	/* n_tables */
-	ND_PRINT(", n_tables %u", GET_U_1(cp));
+	ND_PRINT(C_RESET, ", n_tables %u", GET_U_1(cp));
 	cp += 1;
 	/* auxiliary_id */
-	ND_PRINT(", auxiliary_id %u", GET_U_1(cp));
+	ND_PRINT(C_RESET, ", auxiliary_id %u", GET_U_1(cp));
 	cp += 1;
 	/* pad */
 	cp += 2;
 	/* capabilities */
-	ND_PRINT("\n\t capabilities 0x%08x", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, "\n\t capabilities 0x%08x", GET_BE_U_4(cp));
 	of_bitmap_print(ndo, ofp_capabilities_bm, GET_BE_U_4(cp), OFPCAP_U);
 	cp += 4;
 	/* reserved */
@@ -734,11 +734,11 @@ of13_switch_config_msg_print(netdissect_options *ndo,
                              const u_char *cp, u_int len _U_)
 {
 	/* flags */
-	ND_PRINT("\n\t flags %s",
+	ND_PRINT(C_RESET, "\n\t flags %s",
 	         tok2str(ofp_config_str, "invalid (0x%04x)", GET_BE_U_2(cp)));
 	cp += 2;
 	/* miss_send_len */
-	ND_PRINT(", miss_send_len %s",
+	ND_PRINT(C_RESET, ", miss_send_len %s",
 	         tok2str(ofpcml_str, "%u", GET_BE_U_2(cp)));
 }
 
@@ -748,12 +748,12 @@ of13_table_mod_print(netdissect_options *ndo,
                      const u_char *cp, u_int len _U_)
 {
 	/* table_id */
-	ND_PRINT("\n\t table_id %s", tok2str(ofptt_str, "%u", GET_U_1(cp)));
+	ND_PRINT(C_RESET, "\n\t table_id %s", tok2str(ofptt_str, "%u", GET_U_1(cp)));
 	cp += 1;
 	/* pad */
 	cp += 3;
 	/* config */
-	ND_PRINT(", config 0x%08x", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, ", config 0x%08x", GET_BE_U_4(cp));
 }
 
 /* [OF13] Section 7.3.9 */
@@ -762,13 +762,13 @@ of13_role_msg_print(netdissect_options *ndo,
                     const u_char *cp, u_int len _U_)
 {
 	/* role */
-	ND_PRINT("\n\t role %s",
+	ND_PRINT(C_RESET, "\n\t role %s",
 	         tok2str(ofpcr_str, "invalid (0x%08x)", GET_BE_U_4(cp)));
 	cp += 4;
 	/* pad */
 	cp += 4;
 	/* generation_id */
-	ND_PRINT(", generation_id 0x%016" PRIx64, GET_BE_U_8(cp));
+	ND_PRINT(C_RESET, ", generation_id 0x%016" PRIx64, GET_BE_U_8(cp));
 }
 
 /* [OF13] Section 7.3.10 */
@@ -777,27 +777,27 @@ of13_async_msg_print(netdissect_options *ndo,
                     const u_char *cp, u_int len _U_)
 {
 	/* packet_in_mask[0] */
-	ND_PRINT("\n\t packet_in_mask[EM] 0x%08x", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, "\n\t packet_in_mask[EM] 0x%08x", GET_BE_U_4(cp));
 	of_bitmap_print(ndo, async_ofpr_bm, GET_BE_U_4(cp), ASYNC_OFPR_U);
 	cp += 4;
 	/* packet_in_mask[1] */
-	ND_PRINT("\n\t packet_in_mask[S] 0x%08x", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, "\n\t packet_in_mask[S] 0x%08x", GET_BE_U_4(cp));
 	of_bitmap_print(ndo, async_ofpr_bm, GET_BE_U_4(cp), ASYNC_OFPR_U);
 	cp += 4;
 	/* port_status_mask[0] */
-	ND_PRINT("\n\t port_status_mask[EM] 0x%08x", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, "\n\t port_status_mask[EM] 0x%08x", GET_BE_U_4(cp));
 	of_bitmap_print(ndo, async_ofppr_bm, GET_BE_U_4(cp), ASYNC_OFPPR_U);
 	cp += 4;
 	/* port_status_mask[1] */
-	ND_PRINT("\n\t port_status_mask[S] 0x%08x", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, "\n\t port_status_mask[S] 0x%08x", GET_BE_U_4(cp));
 	of_bitmap_print(ndo, async_ofppr_bm, GET_BE_U_4(cp), ASYNC_OFPPR_U);
 	cp += 4;
 	/* flow_removed_mask[0] */
-	ND_PRINT("\n\t flow_removed_mask[EM] 0x%08x", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, "\n\t flow_removed_mask[EM] 0x%08x", GET_BE_U_4(cp));
 	of_bitmap_print(ndo, async_ofppr_bm, GET_BE_U_4(cp), ASYNC_OFPPR_U);
 	cp += 4;
 	/* flow_removed_mask[1] */
-	ND_PRINT("\n\t flow_removed_mask[S] 0x%08x", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, "\n\t flow_removed_mask[S] 0x%08x", GET_BE_U_4(cp));
 	of_bitmap_print(ndo, async_ofppr_bm, GET_BE_U_4(cp), ASYNC_OFPPR_U);
 }
 
@@ -807,25 +807,25 @@ of13_port_mod_print(netdissect_options *ndo,
                     const u_char *cp, u_int len _U_)
 {
 	/* port_no */
-	ND_PRINT("\n\t port_no %s", tok2str(ofpp_str, "%u", GET_BE_U_4(cp)));
+	ND_PRINT(C_RESET, "\n\t port_no %s", tok2str(ofpp_str, "%u", GET_BE_U_4(cp)));
 	cp += 4;
 	/* pad */
 	cp += 4;
 	/* hw_addr */
-	ND_PRINT(", hw_addr %s", GET_ETHERADDR_STRING(cp));
+	ND_PRINT(C_RESET, ", hw_addr %s", GET_ETHERADDR_STRING(cp));
 	cp += MAC_ADDR_LEN;
 	/* pad2 */
 	cp += 2;
 	/* config */
-	ND_PRINT("\n\t  config 0x%08x", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, "\n\t  config 0x%08x", GET_BE_U_4(cp));
 	of_bitmap_print(ndo, ofppc_bm, GET_BE_U_4(cp), OFPPC_U);
 	cp += 4;
 	/* mask */
-	ND_PRINT("\n\t  mask 0x%08x", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, "\n\t  mask 0x%08x", GET_BE_U_4(cp));
 	of_bitmap_print(ndo, ofppc_bm, GET_BE_U_4(cp), OFPPC_U);
 	cp += 4;
 	/* advertise */
-	ND_PRINT("\n\t  advertise 0x%08x", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, "\n\t  advertise 0x%08x", GET_BE_U_4(cp));
 	of_bitmap_print(ndo, ofppf_bm, GET_BE_U_4(cp), OFPPF_U);
 	cp += 4;
 	/* pad3 */
@@ -839,7 +839,7 @@ of13_port_status_print(netdissect_options *ndo,
                        const u_char *cp, u_int len _U_)
 {
 	/* reason */
-	ND_PRINT("\n\t reason %s",
+	ND_PRINT(C_RESET, "\n\t reason %s",
 	         tok2str(ofppr_str, "invalid (0x02x)", GET_U_1(cp)));
 	cp += 1;
 	/* pad */
@@ -856,17 +856,17 @@ of13_hello_elements_print(netdissect_options *ndo,
 	while (len) {
 		uint16_t type, bmlen;
 
-		ND_PRINT("\n\t");
+		ND_PRINT(C_RESET, "\n\t");
 		ND_ICHECKMSG_U("remaining length", len, <, OF_HELLO_ELEM_MINSIZE);
 		/* type */
 		type = GET_BE_U_2(cp);
 		OF_FWD(2);
-		ND_PRINT(" type %s",
+		ND_PRINT(C_RESET, " type %s",
 		         tok2str(ofphet_str, "unknown (0x%04x)", type));
 		/* length */
 		bmlen = GET_BE_U_2(cp);
 		OF_FWD(2);
-		ND_PRINT(", length %u", bmlen);
+		ND_PRINT(C_RESET, ", length %u", bmlen);
 		/* cp is OF_HELLO_ELEM_MINSIZE bytes in */
 		ND_ICHECKMSG_U("bitmap length", bmlen, <, OF_HELLO_ELEM_MINSIZE);
 		ND_ICHECKMSG_U("bitmap length", bmlen, >, OF_HELLO_ELEM_MINSIZE + len);
@@ -881,11 +881,11 @@ of13_hello_elements_print(netdissect_options *ndo,
 			 */
 			if (bmlen == OF_HELLO_ELEM_MINSIZE + 4) {
 				uint32_t bitmap = GET_BE_U_4(cp);
-				ND_PRINT(", bitmap 0x%08x", bitmap);
+				ND_PRINT(C_RESET, ", bitmap 0x%08x", bitmap);
 				of_bitmap_print(ndo, ofverbm_str, bitmap,
 				                OF_BIT_VER_U);
 			} else {
-				ND_PRINT(" (bogus)");
+				ND_PRINT(C_RESET, " (bogus)");
 				ND_TCHECK_LEN(cp, bmlen - OF_HELLO_ELEM_MINSIZE);
 			}
 			break;
@@ -911,10 +911,10 @@ of13_experimenter_message_print(netdissect_options *ndo,
 	/* experimenter */
 	experimenter = GET_BE_U_4(cp);
 	OF_FWD(4);
-	ND_PRINT("\n\t experimenter 0x%08x (%s)", experimenter,
+	ND_PRINT(C_RESET, "\n\t experimenter 0x%08x (%s)", experimenter,
 	         of_vendor_name(experimenter));
 	/* exp_type */
-	ND_PRINT(", exp_type 0x%08x", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, ", exp_type 0x%08x", GET_BE_U_4(cp));
 	OF_FWD(4);
 	/* data */
 	of_data_print(ndo, cp, len);
@@ -926,7 +926,7 @@ of13_queue_get_config_request_print(netdissect_options *ndo,
                                     const u_char *cp, u_int len _U_)
 {
 	/* port */
-	ND_PRINT("\n\t port %s", tok2str(ofpp_str, "%u", GET_BE_U_4(cp)));
+	ND_PRINT(C_RESET, "\n\t port %s", tok2str(ofpp_str, "%u", GET_BE_U_4(cp)));
 	cp += 4;
 	/* pad */
 	/* Always the last field, check bounds. */
@@ -944,16 +944,16 @@ of13_error_print(netdissect_options *ndo,
 	/* type */
 	type = GET_BE_U_2(cp);
 	OF_FWD(2);
-	ND_PRINT("\n\t type %s", tok2str(ofpet_str, "invalid (0x%04x)", type));
+	ND_PRINT(C_RESET, "\n\t type %s", tok2str(ofpet_str, "invalid (0x%04x)", type));
 	/* code */
 	code = GET_BE_U_2(cp);
 	OF_FWD(2);
 	code_str = uint2tokary(of13_ofpet2tokary, type);
 	if (code_str != NULL)
-		ND_PRINT(", code %s",
+		ND_PRINT(C_RESET, ", code %s",
 		         tok2str(code_str, "invalid (0x%04x)", code));
 	else
-		ND_PRINT(", code invalid (0x%04x)", code);
+		ND_PRINT(C_RESET, ", code invalid (0x%04x)", code);
 	/* data */
 	of_data_print(ndo, cp, len);
 }

--- a/print-openflow.c
+++ b/print-openflow.c
@@ -83,10 +83,10 @@ of_bitmap_print(netdissect_options *ndo,
 {
 	/* Assigned bits? */
 	if (v & ~u)
-		ND_PRINT(" (%s)", bittok2str(t, "", v));
+		ND_PRINT(C_RESET, C_RESET " (%s)", bittok2str(t, "", v));
 	/* Unassigned bits? */
 	if (v & u)
-		ND_PRINT(" (bogus)");
+		ND_PRINT(C_RESET, C_RESET " (bogus)");
 }
 
 void
@@ -96,7 +96,7 @@ of_data_print(netdissect_options *ndo,
 	if (len == 0)
 		return;
 	/* data */
-	ND_PRINT("\n\t data (%u octets)", len);
+	ND_PRINT(C_RESET, C_RESET "\n\t data (%u octets)", len);
 	if (ndo->ndo_vflag >= 2)
 		hex_and_ascii_print(ndo, "\n\t  ", cp, len);
 	else
@@ -144,7 +144,7 @@ void
 openflow_print(netdissect_options *ndo, const u_char *cp, u_int len)
 {
 	ndo->ndo_protocol = "openflow";
-	ND_PRINT(": OpenFlow");
+	ND_PRINT(C_RESET, C_RESET ": OpenFlow");
 	while (len) {
 		/* Print a single OpenFlow message. */
 		uint8_t version, type;
@@ -154,7 +154,7 @@ openflow_print(netdissect_options *ndo, const u_char *cp, u_int len)
 		/* version */
 		version = GET_U_1(cp);
 		OF_FWD(1);
-		ND_PRINT("\n\tversion %s",
+		ND_PRINT(C_RESET, C_RESET "\n\tversion %s",
 		         tok2str(ofver_str, "unknown (0x%02x)", version));
 		/* type */
 		if (len < 1)
@@ -166,20 +166,20 @@ openflow_print(netdissect_options *ndo, const u_char *cp, u_int len)
 			version == OF_VER_1_3 ? of13_identify_msgtype(type) :
 			NULL;
 		if (mti && mti->name)
-			ND_PRINT(", type %s", mti->name);
+			ND_PRINT(C_RESET, C_RESET ", type %s", mti->name);
 		else
-			ND_PRINT(", type unknown (0x%02x)", type);
+			ND_PRINT(C_RESET, C_RESET ", type unknown (0x%02x)", type);
 		/* length */
 		if (len < 2)
 			goto partial_header;
 		length = GET_BE_U_2(cp);
 		OF_FWD(2);
-		ND_PRINT(", length %u%s", length,
+		ND_PRINT(C_RESET, C_RESET ", length %u%s", length,
 		         length < OF_HEADER_FIXLEN ? " (too short!)" : "");
 		/* xid */
 		if (len < 4)
 			goto partial_header;
-		ND_PRINT(", xid 0x%08x", GET_BE_U_4(cp));
+		ND_PRINT(C_RESET, C_RESET ", xid 0x%08x", GET_BE_U_4(cp));
 		OF_FWD(4);
 
 		/*
@@ -219,7 +219,7 @@ openflow_print(netdissect_options *ndo, const u_char *cp, u_int len)
 	return;
 
 partial_header:
-	ND_PRINT(" (end of TCP payload)");
+	ND_PRINT(C_RESET, C_RESET " (end of TCP payload)");
 	ND_TCHECK_LEN(cp, len);
 	return;
 invalid: /* fail the current packet */

--- a/print-openflow.c
+++ b/print-openflow.c
@@ -83,10 +83,10 @@ of_bitmap_print(netdissect_options *ndo,
 {
 	/* Assigned bits? */
 	if (v & ~u)
-		ND_PRINT(C_RESET, C_RESET " (%s)", bittok2str(t, "", v));
+		ND_PRINT(C_RESET, " (%s)", bittok2str(t, "", v));
 	/* Unassigned bits? */
 	if (v & u)
-		ND_PRINT(C_RESET, C_RESET " (bogus)");
+		ND_PRINT(C_RESET, " (bogus)");
 }
 
 void
@@ -96,7 +96,7 @@ of_data_print(netdissect_options *ndo,
 	if (len == 0)
 		return;
 	/* data */
-	ND_PRINT(C_RESET, C_RESET "\n\t data (%u octets)", len);
+	ND_PRINT(C_RESET, "\n\t data (%u octets)", len);
 	if (ndo->ndo_vflag >= 2)
 		hex_and_ascii_print(ndo, "\n\t  ", cp, len);
 	else
@@ -144,7 +144,7 @@ void
 openflow_print(netdissect_options *ndo, const u_char *cp, u_int len)
 {
 	ndo->ndo_protocol = "openflow";
-	ND_PRINT(C_RESET, C_RESET ": OpenFlow");
+	ND_PRINT(C_RESET, ": OpenFlow");
 	while (len) {
 		/* Print a single OpenFlow message. */
 		uint8_t version, type;
@@ -154,7 +154,7 @@ openflow_print(netdissect_options *ndo, const u_char *cp, u_int len)
 		/* version */
 		version = GET_U_1(cp);
 		OF_FWD(1);
-		ND_PRINT(C_RESET, C_RESET "\n\tversion %s",
+		ND_PRINT(C_RESET, "\n\tversion %s",
 		         tok2str(ofver_str, "unknown (0x%02x)", version));
 		/* type */
 		if (len < 1)
@@ -166,20 +166,20 @@ openflow_print(netdissect_options *ndo, const u_char *cp, u_int len)
 			version == OF_VER_1_3 ? of13_identify_msgtype(type) :
 			NULL;
 		if (mti && mti->name)
-			ND_PRINT(C_RESET, C_RESET ", type %s", mti->name);
+			ND_PRINT(C_RESET, ", type %s", mti->name);
 		else
-			ND_PRINT(C_RESET, C_RESET ", type unknown (0x%02x)", type);
+			ND_PRINT(C_RESET, ", type unknown (0x%02x)", type);
 		/* length */
 		if (len < 2)
 			goto partial_header;
 		length = GET_BE_U_2(cp);
 		OF_FWD(2);
-		ND_PRINT(C_RESET, C_RESET ", length %u%s", length,
+		ND_PRINT(C_RESET, ", length %u%s", length,
 		         length < OF_HEADER_FIXLEN ? " (too short!)" : "");
 		/* xid */
 		if (len < 4)
 			goto partial_header;
-		ND_PRINT(C_RESET, C_RESET ", xid 0x%08x", GET_BE_U_4(cp));
+		ND_PRINT(C_RESET, ", xid 0x%08x", GET_BE_U_4(cp));
 		OF_FWD(4);
 
 		/*
@@ -219,7 +219,7 @@ openflow_print(netdissect_options *ndo, const u_char *cp, u_int len)
 	return;
 
 partial_header:
-	ND_PRINT(C_RESET, C_RESET " (end of TCP payload)");
+	ND_PRINT(C_RESET, " (end of TCP payload)");
 	ND_TCHECK_LEN(cp, len);
 	return;
 invalid: /* fail the current packet */

--- a/print-ospf.c
+++ b/print-ospf.c
@@ -190,7 +190,7 @@ ospf_grace_lsa_print(netdissect_options *ndo,
     while (ls_length > 0) {
         ND_TCHECK_4(tptr);
         if (ls_length < 4) {
-            ND_PRINT("\n\t    Remaining LS length %u < 4", ls_length);
+            ND_PRINT(C_RESET, "\n\t    Remaining LS length %u < 4", ls_length);
             return -1;
         }
         tlv_type = GET_BE_U_2(tptr);
@@ -198,13 +198,13 @@ ospf_grace_lsa_print(netdissect_options *ndo,
         tptr+=4;
         ls_length-=4;
 
-        ND_PRINT("\n\t    %s TLV (%u), length %u, value: ",
+        ND_PRINT(C_RESET, "\n\t    %s TLV (%u), length %u, value: ",
                tok2str(lsa_opaque_grace_tlv_values,"unknown",tlv_type),
                tlv_type,
                tlv_length);
 
         if (tlv_length > ls_length) {
-            ND_PRINT("\n\t    Bogus length %u > %u", tlv_length,
+            ND_PRINT(C_RESET, "\n\t    Bogus length %u > %u", tlv_length,
                    ls_length);
             return -1;
         }
@@ -219,28 +219,28 @@ ospf_grace_lsa_print(netdissect_options *ndo,
 
         case LS_OPAQUE_GRACE_TLV_PERIOD:
             if (tlv_length != 4) {
-                ND_PRINT("\n\t    Bogus length %u != 4", tlv_length);
+                ND_PRINT(C_RESET, "\n\t    Bogus length %u != 4", tlv_length);
                 return -1;
             }
-            ND_PRINT("%us", GET_BE_U_4(tptr));
+            ND_PRINT(C_RESET, "%us", GET_BE_U_4(tptr));
             break;
 
         case LS_OPAQUE_GRACE_TLV_REASON:
             if (tlv_length != 1) {
-                ND_PRINT("\n\t    Bogus length %u != 1", tlv_length);
+                ND_PRINT(C_RESET, "\n\t    Bogus length %u != 1", tlv_length);
                 return -1;
             }
-            ND_PRINT("%s (%u)",
+            ND_PRINT(C_RESET, "%s (%u)",
                    tok2str(lsa_opaque_grace_tlv_reason_values, "Unknown", GET_U_1(tptr)),
                    GET_U_1(tptr));
             break;
 
         case LS_OPAQUE_GRACE_TLV_INT_ADDRESS:
             if (tlv_length != 4) {
-                ND_PRINT("\n\t    Bogus length %u != 4", tlv_length);
+                ND_PRINT(C_RESET, "\n\t    Bogus length %u != 4", tlv_length);
                 return -1;
             }
-            ND_PRINT("%s", GET_IPADDR_STRING(tptr));
+            ND_PRINT(C_RESET, "%s", GET_IPADDR_STRING(tptr));
             break;
 
         default:
@@ -277,7 +277,7 @@ ospf_te_lsa_print(netdissect_options *ndo,
     while (ls_length != 0) {
         ND_TCHECK_4(tptr);
         if (ls_length < 4) {
-            ND_PRINT("\n\t    Remaining LS length %u < 4", ls_length);
+            ND_PRINT(C_RESET, "\n\t    Remaining LS length %u < 4", ls_length);
             return -1;
         }
         tlv_type = GET_BE_U_2(tptr);
@@ -285,13 +285,13 @@ ospf_te_lsa_print(netdissect_options *ndo,
         tptr+=4;
         ls_length-=4;
 
-        ND_PRINT("\n\t    %s TLV (%u), length: %u",
+        ND_PRINT(C_RESET, "\n\t    %s TLV (%u), length: %u",
                tok2str(lsa_opaque_te_tlv_values,"unknown",tlv_type),
                tlv_type,
                tlv_length);
 
         if (tlv_length > ls_length) {
-            ND_PRINT("\n\t    Bogus length %u > %u", tlv_length,
+            ND_PRINT(C_RESET, "\n\t    Bogus length %u > %u", tlv_length,
                    ls_length);
             return -1;
         }
@@ -305,7 +305,7 @@ ospf_te_lsa_print(netdissect_options *ndo,
         case LS_OPAQUE_TE_TLV_LINK:
             while (tlv_length != 0) {
                 if (tlv_length < 4) {
-                    ND_PRINT("\n\t    Remaining TLV length %u < 4",
+                    ND_PRINT(C_RESET, "\n\t    Remaining TLV length %u < 4",
                            tlv_length);
                     return -1;
                 }
@@ -318,13 +318,13 @@ ospf_te_lsa_print(netdissect_options *ndo,
 		if (subtlv_type == 0 || subtlv_length == 0)
 		    goto invalid;
 
-                ND_PRINT("\n\t      %s subTLV (%u), length: %u",
+                ND_PRINT(C_RESET, "\n\t      %s subTLV (%u), length: %u",
                        tok2str(lsa_opaque_te_link_tlv_subtlv_values,"unknown",subtlv_type),
                        subtlv_type,
                        subtlv_length);
 
                 if (tlv_length < subtlv_length) {
-                    ND_PRINT("\n\t    Remaining TLV length %u < %u",
+                    ND_PRINT(C_RESET, "\n\t    Remaining TLV length %u < %u",
                            tlv_length + 4, subtlv_length + 4);
                     return -1;
                 }
@@ -332,137 +332,137 @@ ospf_te_lsa_print(netdissect_options *ndo,
                 switch(subtlv_type) {
                 case LS_OPAQUE_TE_LINK_SUBTLV_ADMIN_GROUP:
 		    if (subtlv_length != 4) {
-			ND_PRINT(" != 4");
+			ND_PRINT(C_RESET, " != 4");
 			goto invalid;
 		    }
-                    ND_PRINT(", 0x%08x", GET_BE_U_4(tptr));
+                    ND_PRINT(C_RESET, ", 0x%08x", GET_BE_U_4(tptr));
                     break;
                 case LS_OPAQUE_TE_LINK_SUBTLV_LINK_ID:
                 case LS_OPAQUE_TE_LINK_SUBTLV_LINK_LOCAL_REMOTE_ID:
 		    if (subtlv_length != 4 && subtlv_length != 8) {
-			ND_PRINT(" != 4 && != 8");
+			ND_PRINT(C_RESET, " != 4 && != 8");
 			goto invalid;
 		    }
-                    ND_PRINT(", %s (0x%08x)",
+                    ND_PRINT(C_RESET, ", %s (0x%08x)",
                            GET_IPADDR_STRING(tptr),
                            GET_BE_U_4(tptr));
                     if (subtlv_length == 8) /* rfc4203 */
-                        ND_PRINT(", %s (0x%08x)",
+                        ND_PRINT(C_RESET, ", %s (0x%08x)",
                                GET_IPADDR_STRING(tptr+4),
                                GET_BE_U_4(tptr + 4));
                     break;
                 case LS_OPAQUE_TE_LINK_SUBTLV_LOCAL_IP:
                 case LS_OPAQUE_TE_LINK_SUBTLV_REMOTE_IP:
 		    if (subtlv_length != 4) {
-			ND_PRINT(" != 4");
+			ND_PRINT(C_RESET, " != 4");
 			goto invalid;
 		    }
-                    ND_PRINT(", %s", GET_IPADDR_STRING(tptr));
+                    ND_PRINT(C_RESET, ", %s", GET_IPADDR_STRING(tptr));
                     break;
                 case LS_OPAQUE_TE_LINK_SUBTLV_MAX_BW:
                 case LS_OPAQUE_TE_LINK_SUBTLV_MAX_RES_BW:
 		    if (subtlv_length != 4) {
-			ND_PRINT(" != 4");
+			ND_PRINT(C_RESET, " != 4");
 			goto invalid;
 		    }
                     bw.i = GET_BE_U_4(tptr);
-                    ND_PRINT(", %.3f Mbps", bw.f * 8 / 1000000);
+                    ND_PRINT(C_RESET, ", %.3f Mbps", bw.f * 8 / 1000000);
                     break;
                 case LS_OPAQUE_TE_LINK_SUBTLV_UNRES_BW:
 		    if (subtlv_length != 32) {
-			ND_PRINT(" != 32");
+			ND_PRINT(C_RESET, " != 32");
 			goto invalid;
 		    }
                     for (te_class = 0; te_class < 8; te_class++) {
                         bw.i = GET_BE_U_4(tptr + te_class * 4);
-                        ND_PRINT("\n\t\tTE-Class %u: %.3f Mbps",
+                        ND_PRINT(C_RESET, "\n\t\tTE-Class %u: %.3f Mbps",
                                te_class,
                                bw.f * 8 / 1000000);
                     }
                     break;
                 case LS_OPAQUE_TE_LINK_SUBTLV_BW_CONSTRAINTS:
 		    if (subtlv_length < 4) {
-			ND_PRINT(" < 4");
+			ND_PRINT(C_RESET, " < 4");
 			goto invalid;
 		    }
 		    /* BC Model Id (1 octet) + Reserved (3 octets) */
-                    ND_PRINT("\n\t\tBandwidth Constraints Model ID: %s (%u)",
+                    ND_PRINT(C_RESET, "\n\t\tBandwidth Constraints Model ID: %s (%u)",
                            tok2str(diffserv_te_bc_values, "unknown", GET_U_1(tptr)),
                            GET_U_1(tptr));
 		    if (subtlv_length % 4 != 0) {
-			ND_PRINT("\n\t\tlength %u != N x 4", subtlv_length);
+			ND_PRINT(C_RESET, "\n\t\tlength %u != N x 4", subtlv_length);
 			goto invalid;
 		    }
 		    if (subtlv_length > 36) {
-			ND_PRINT("\n\t\tlength %u > 36", subtlv_length);
+			ND_PRINT(C_RESET, "\n\t\tlength %u > 36", subtlv_length);
 			goto invalid;
 		    }
                     /* decode BCs until the subTLV ends */
                     for (te_class = 0; te_class < (subtlv_length-4)/4; te_class++) {
                         bw.i = GET_BE_U_4(tptr + 4 + te_class * 4);
-                        ND_PRINT("\n\t\t  Bandwidth constraint CT%u: %.3f Mbps",
+                        ND_PRINT(C_RESET, "\n\t\t  Bandwidth constraint CT%u: %.3f Mbps",
                                te_class,
                                bw.f * 8 / 1000000);
                     }
                     break;
                 case LS_OPAQUE_TE_LINK_SUBTLV_TE_METRIC:
 		    if (subtlv_length != 4) {
-			ND_PRINT(" != 4");
+			ND_PRINT(C_RESET, " != 4");
 			goto invalid;
 		    }
-                    ND_PRINT(", Metric %u", GET_BE_U_4(tptr));
+                    ND_PRINT(C_RESET, ", Metric %u", GET_BE_U_4(tptr));
                     break;
                 case LS_OPAQUE_TE_LINK_SUBTLV_LINK_PROTECTION_TYPE:
 		    /* Protection Cap (1 octet) + Reserved ((3 octets) */
 		    if (subtlv_length != 4) {
-			ND_PRINT(" != 4");
+			ND_PRINT(C_RESET, " != 4");
 			goto invalid;
 		    }
-                    ND_PRINT(", %s",
+                    ND_PRINT(C_RESET, ", %s",
                              bittok2str(gmpls_link_prot_values, "none", GET_U_1(tptr)));
                     break;
                 case LS_OPAQUE_TE_LINK_SUBTLV_INTF_SW_CAP_DESCR:
 		    if (subtlv_length < 36) {
-			ND_PRINT(" < 36");
+			ND_PRINT(C_RESET, " < 36");
 			goto invalid;
 		    }
 		    /* Switching Cap (1 octet) + Encoding (1) +  Reserved (2) */
-                    ND_PRINT("\n\t\tInterface Switching Capability: %s",
+                    ND_PRINT(C_RESET, "\n\t\tInterface Switching Capability: %s",
                            tok2str(gmpls_switch_cap_values, "Unknown", GET_U_1((tptr))));
-                    ND_PRINT("\n\t\tLSP Encoding: %s\n\t\tMax LSP Bandwidth:",
+                    ND_PRINT(C_RESET, "\n\t\tLSP Encoding: %s\n\t\tMax LSP Bandwidth:",
                            tok2str(gmpls_encoding_values, "Unknown", GET_U_1((tptr + 1))));
                     for (priority_level = 0; priority_level < 8; priority_level++) {
                         bw.i = GET_BE_U_4(tptr + 4 + (priority_level * 4));
-                        ND_PRINT("\n\t\t  priority level %u: %.3f Mbps",
+                        ND_PRINT(C_RESET, "\n\t\t  priority level %u: %.3f Mbps",
                                priority_level,
                                bw.f * 8 / 1000000);
                     }
                     break;
                 case LS_OPAQUE_TE_LINK_SUBTLV_LINK_TYPE:
 		    if (subtlv_length != 1) {
-			ND_PRINT(" != 1");
+			ND_PRINT(C_RESET, " != 1");
 			goto invalid;
 		    }
-                    ND_PRINT(", %s (%u)",
+                    ND_PRINT(C_RESET, ", %s (%u)",
                            tok2str(lsa_opaque_te_tlv_link_type_sub_tlv_values,"unknown",GET_U_1(tptr)),
                            GET_U_1(tptr));
                     break;
 
                 case LS_OPAQUE_TE_LINK_SUBTLV_SHARED_RISK_GROUP:
 		    if (subtlv_length % 4 != 0) {
-			ND_PRINT(" != N x 4");
+			ND_PRINT(C_RESET, " != N x 4");
 			goto invalid;
 		    }
                     count_srlg = subtlv_length / 4;
                     if (count_srlg != 0)
-                        ND_PRINT("\n\t\t  Shared risk group: ");
+                        ND_PRINT(C_RESET, "\n\t\t  Shared risk group: ");
                     while (count_srlg > 0) {
                         bw.i = GET_BE_U_4(tptr);
-                        ND_PRINT("%u", bw.i);
+                        ND_PRINT(C_RESET, "%u", bw.i);
                         tptr+=4;
                         count_srlg--;
                         if (count_srlg > 0)
-                            ND_PRINT(", ");
+                            ND_PRINT(C_RESET, ", ");
                     }
                     break;
 
@@ -478,7 +478,7 @@ ospf_te_lsa_print(netdissect_options *ndo,
                     subtlv_length+=4-(subtlv_length%4);
 
                 if (tlv_length < subtlv_length) {
-                    ND_PRINT("\n\t    Remaining TLV length %u < %u",
+                    ND_PRINT(C_RESET, "\n\t    Remaining TLV length %u < %u",
                            tlv_length + 4, subtlv_length + 4);
                     return -1;
                 }
@@ -490,10 +490,10 @@ ospf_te_lsa_print(netdissect_options *ndo,
 
         case LS_OPAQUE_TE_TLV_ROUTER:
             if (tlv_length < 4) {
-                ND_PRINT("\n\t    TLV length %u < 4", tlv_length);
+                ND_PRINT(C_RESET, "\n\t    TLV length %u < 4", tlv_length);
                 return -1;
             }
-            ND_PRINT(", %s", GET_IPADDR_STRING(tptr));
+            ND_PRINT(C_RESET, ", %s", GET_IPADDR_STRING(tptr));
             break;
 
         default:
@@ -507,7 +507,7 @@ ospf_te_lsa_print(netdissect_options *ndo,
         if (tlv_length%4 != 0)
             tlv_length+=4-(tlv_length%4);
         if (tlv_length > ls_length) {
-            ND_PRINT("\n\t    Bogus padded length %u > %u", tlv_length,
+            ND_PRINT(C_RESET, "\n\t    Bogus padded length %u > %u", tlv_length,
                    ls_length);
             return -1;
         }
@@ -531,11 +531,11 @@ ospf_print_lshdr(netdissect_options *ndo,
 
         ls_length = GET_BE_U_2(lshp->ls_length);
         if (ls_length < sizeof(struct lsa_hdr)) {
-                ND_PRINT("\n\t    Bogus length %u < header (%zu)", ls_length,
+                ND_PRINT(C_RESET, "\n\t    Bogus length %u < header (%zu)", ls_length,
                     sizeof(struct lsa_hdr));
                 return(-1);
         }
-        ND_PRINT("\n\t  Advertising Router %s, seq 0x%08x, age %us, length %zu",
+        ND_PRINT(C_RESET, "\n\t  Advertising Router %s, seq 0x%08x, age %us, length %zu",
                   GET_IPADDR_STRING(lshp->ls_router),
                   GET_BE_U_4(lshp->ls_seq),
                   GET_BE_U_2(lshp->ls_age),
@@ -546,7 +546,7 @@ ospf_print_lshdr(netdissect_options *ndo,
         case LS_TYPE_OPAQUE_LL:
         case LS_TYPE_OPAQUE_AL:
         case LS_TYPE_OPAQUE_DW:
-            ND_PRINT("\n\t    %s LSA (%u), Opaque-Type %s LSA (%u), Opaque-ID %u",
+            ND_PRINT(C_RESET, "\n\t    %s LSA (%u), Opaque-Type %s LSA (%u), Opaque-ID %u",
                    tok2str(lsa_values,"unknown",ls_type),
                    ls_type,
 
@@ -561,13 +561,13 @@ ospf_print_lshdr(netdissect_options *ndo,
 
         /* all other LSA types use regular style LSA headers */
         default:
-            ND_PRINT("\n\t    %s LSA (%u), LSA-ID: %s",
+            ND_PRINT(C_RESET, "\n\t    %s LSA (%u), LSA-ID: %s",
                    tok2str(lsa_values,"unknown",ls_type),
                    ls_type,
                    GET_IPADDR_STRING(lshp->un_lsa_id.lsa_id));
             break;
         }
-        ND_PRINT("\n\t    Options: [%s]",
+        ND_PRINT(C_RESET, "\n\t    Options: [%s]",
 		 bittok2str(ospf_option_values, "none", GET_U_1(lshp->ls_options)));
 
         return (ls_length);
@@ -600,7 +600,7 @@ ospf_print_tos_metrics(netdissect_options *ndo,
      */
     while (toscount != 0) {
         tos_type = GET_U_1(tos->metrics.tos_type);
-        ND_PRINT("\n\t\ttopology %s (%u), metric %u",
+        ND_PRINT(C_RESET, "\n\t\ttopology %s (%u), metric %u",
                tok2str(ospf_topology_values, "Unknown",
                        metric_count ? tos_type : 0),
                metric_count ? tos_type : 0,
@@ -646,7 +646,7 @@ ospf_print_lsa(netdissect_options *ndo,
 	switch (GET_U_1(lsap->ls_hdr.ls_type)) {
 
 	case LS_TYPE_ROUTER:
-		ND_PRINT("\n\t    Router LSA Options: [%s]",
+		ND_PRINT(C_RESET, "\n\t    Router LSA Options: [%s]",
 		          bittok2str(ospf_rla_flag_values, "none", GET_U_1(lsap->lsa_un.un_rla.rla_flags)));
 
 		rla_count = GET_BE_U_2(lsap->lsa_un.un_rla.rla_count);
@@ -657,31 +657,31 @@ ospf_print_lsa(netdissect_options *ndo,
 			switch (GET_U_1(rlp->un_tos.link.link_type)) {
 
 			case RLA_TYPE_VIRTUAL:
-				ND_PRINT("\n\t      Virtual Link: Neighbor Router-ID: %s, Interface Address: %s",
+				ND_PRINT(C_RESET, "\n\t      Virtual Link: Neighbor Router-ID: %s, Interface Address: %s",
 				    GET_IPADDR_STRING(rlp->link_id),
 				    GET_IPADDR_STRING(rlp->link_data));
 				break;
 
 			case RLA_TYPE_ROUTER:
-				ND_PRINT("\n\t      Neighbor Router-ID: %s, Interface Address: %s",
+				ND_PRINT(C_RESET, "\n\t      Neighbor Router-ID: %s, Interface Address: %s",
 				    GET_IPADDR_STRING(rlp->link_id),
 				    GET_IPADDR_STRING(rlp->link_data));
 				break;
 
 			case RLA_TYPE_TRANSIT:
-				ND_PRINT("\n\t      Neighbor Network-ID: %s, Interface Address: %s",
+				ND_PRINT(C_RESET, "\n\t      Neighbor Network-ID: %s, Interface Address: %s",
 				    GET_IPADDR_STRING(rlp->link_id),
 				    GET_IPADDR_STRING(rlp->link_data));
 				break;
 
 			case RLA_TYPE_STUB:
-				ND_PRINT("\n\t      Stub Network: %s, Mask: %s",
+				ND_PRINT(C_RESET, "\n\t      Stub Network: %s, Mask: %s",
 				    GET_IPADDR_STRING(rlp->link_id),
 				    GET_IPADDR_STRING(rlp->link_data));
 				break;
 
 			default:
-				ND_PRINT("\n\t      Unknown Router Link Type (%u)",
+				ND_PRINT(C_RESET, "\n\t      Unknown Router Link Type (%u)",
 				    GET_U_1(rlp->un_tos.link.link_type));
 				return (ls_end);
 			}
@@ -694,18 +694,18 @@ ospf_print_lsa(netdissect_options *ndo,
 		break;
 
 	case LS_TYPE_NETWORK:
-		ND_PRINT("\n\t    Mask %s\n\t    Connected Routers:",
+		ND_PRINT(C_RESET, "\n\t    Mask %s\n\t    Connected Routers:",
 		    GET_IPADDR_STRING(lsap->lsa_un.un_nla.nla_mask));
 		ap = lsap->lsa_un.un_nla.nla_router;
 		while ((const u_char *)ap < ls_end) {
-			ND_PRINT("\n\t      %s", GET_IPADDR_STRING(ap));
+			ND_PRINT(C_RESET, "\n\t      %s", GET_IPADDR_STRING(ap));
 			++ap;
 		}
 		break;
 
 	case LS_TYPE_SUM_IP:
 		ND_TCHECK_4(lsap->lsa_un.un_nla.nla_mask);
-		ND_PRINT("\n\t    Mask %s",
+		ND_PRINT(C_RESET, "\n\t    Mask %s",
 		    GET_IPADDR_STRING(lsap->lsa_un.un_sla.sla_mask));
 		ND_TCHECK_SIZE(lsap->lsa_un.un_sla.sla_tosmetric);
 		lp = (const uint8_t *)lsap->lsa_un.un_sla.sla_tosmetric;
@@ -714,7 +714,7 @@ ospf_print_lsa(netdissect_options *ndo,
 
 			ul = GET_BE_U_4(lp);
                         topology = (ul & SLA_MASK_TOS) >> SLA_SHIFT_TOS;
-			ND_PRINT("\n\t\ttopology %s (%u) metric %u",
+			ND_PRINT(C_RESET, "\n\t\ttopology %s (%u) metric %u",
                                tok2str(ospf_topology_values, "Unknown", topology),
                                topology,
                                ul & SLA_MASK_METRIC);
@@ -730,7 +730,7 @@ ospf_print_lsa(netdissect_options *ndo,
 
 			ul = GET_BE_U_4(lp);
                         topology = (ul & SLA_MASK_TOS) >> SLA_SHIFT_TOS;
-			ND_PRINT("\n\t\ttopology %s (%u) metric %u",
+			ND_PRINT(C_RESET, "\n\t\ttopology %s (%u) metric %u",
                                tok2str(ospf_topology_values, "Unknown", topology),
                                topology,
                                ul & SLA_MASK_METRIC);
@@ -741,7 +741,7 @@ ospf_print_lsa(netdissect_options *ndo,
 	case LS_TYPE_ASE:
         case LS_TYPE_NSSA: /* fall through - those LSAs share the same format */
 		ND_TCHECK_4(lsap->lsa_un.un_nla.nla_mask);
-		ND_PRINT("\n\t    Mask %s",
+		ND_PRINT(C_RESET, "\n\t    Mask %s",
 		    GET_IPADDR_STRING(lsap->lsa_un.un_asla.asla_mask));
 
 		ND_TCHECK_SIZE(lsap->lsa_un.un_sla.sla_tosmetric);
@@ -751,20 +751,20 @@ ospf_print_lsa(netdissect_options *ndo,
 
 			ul = GET_BE_U_4(almp->asla_tosmetric);
                         topology = ((ul & ASLA_MASK_TOS) >> ASLA_SHIFT_TOS);
-			ND_PRINT("\n\t\ttopology %s (%u), type %u, metric",
+			ND_PRINT(C_RESET, "\n\t\ttopology %s (%u), type %u, metric",
                                tok2str(ospf_topology_values, "Unknown", topology),
                                topology,
                                (ul & ASLA_FLAG_EXTERNAL) ? 2 : 1);
 			if ((ul & ASLA_MASK_METRIC) == 0xffffff)
-				ND_PRINT(" infinite");
+				ND_PRINT(C_RESET, " infinite");
 			else
-				ND_PRINT(" %u", (ul & ASLA_MASK_METRIC));
+				ND_PRINT(C_RESET, " %u", (ul & ASLA_MASK_METRIC));
 
 			if (GET_IPV4_TO_NETWORK_ORDER(almp->asla_forward) != 0) {
-				ND_PRINT(", forward %s", GET_IPADDR_STRING(almp->asla_forward));
+				ND_PRINT(C_RESET, ", forward %s", GET_IPADDR_STRING(almp->asla_forward));
 			}
 			if (GET_IPV4_TO_NETWORK_ORDER(almp->asla_tag) != 0) {
-				ND_PRINT(", tag %s", GET_IPADDR_STRING(almp->asla_tag));
+				ND_PRINT(C_RESET, ", tag %s", GET_IPADDR_STRING(almp->asla_tag));
 			}
 			++almp;
 		}
@@ -777,17 +777,17 @@ ospf_print_lsa(netdissect_options *ndo,
 			switch (GET_BE_U_4(mcp->mcla_vtype)) {
 
 			case MCLA_VERTEX_ROUTER:
-				ND_PRINT("\n\t    Router Router-ID %s",
+				ND_PRINT(C_RESET, "\n\t    Router Router-ID %s",
 				    GET_IPADDR_STRING(mcp->mcla_vid));
 				break;
 
 			case MCLA_VERTEX_NETWORK:
-				ND_PRINT("\n\t    Network Designated Router %s",
+				ND_PRINT(C_RESET, "\n\t    Network Designated Router %s",
 				    GET_IPADDR_STRING(mcp->mcla_vid));
 				break;
 
 			default:
-				ND_PRINT("\n\t    unknown VertexType (%u)",
+				ND_PRINT(C_RESET, "\n\t    unknown VertexType (%u)",
 				    GET_BE_U_4(mcp->mcla_vtype));
 				break;
 			}
@@ -807,7 +807,7 @@ ospf_print_lsa(netdissect_options *ndo,
 		while (ls_length_remaining != 0) {
                     ND_TCHECK_4(tptr);
 		    if (ls_length_remaining < 4) {
-                        ND_PRINT("\n\t    Remaining LS length %u < 4", ls_length_remaining);
+                        ND_PRINT(C_RESET, "\n\t    Remaining LS length %u < 4", ls_length_remaining);
                         return(ls_end);
                     }
                     tlv_type = GET_BE_U_2(tptr);
@@ -815,13 +815,13 @@ ospf_print_lsa(netdissect_options *ndo,
                     tptr+=4;
                     ls_length_remaining-=4;
 
-                    ND_PRINT("\n\t    %s TLV (%u), length: %u, value: ",
+                    ND_PRINT(C_RESET, "\n\t    %s TLV (%u), length: %u, value: ",
                            tok2str(lsa_opaque_ri_tlv_values,"unknown",tlv_type),
                            tlv_type,
                            tlv_length);
 
                     if (tlv_length > ls_length_remaining) {
-                        ND_PRINT("\n\t    Bogus length %u > remaining LS length %u", tlv_length,
+                        ND_PRINT(C_RESET, "\n\t    Bogus length %u > remaining LS length %u", tlv_length,
                             ls_length_remaining);
                         return(ls_end);
                     }
@@ -830,10 +830,10 @@ ospf_print_lsa(netdissect_options *ndo,
 
                     case LS_OPAQUE_RI_TLV_CAP:
                         if (tlv_length != 4) {
-                            ND_PRINT("\n\t    Bogus length %u != 4", tlv_length);
+                            ND_PRINT(C_RESET, "\n\t    Bogus length %u != 4", tlv_length);
                             return(ls_end);
                         }
-                        ND_PRINT("Capabilities: %s",
+                        ND_PRINT(C_RESET, "Capabilities: %s",
                                bittok2str(lsa_opaque_ri_tlv_cap_values, "Unknown", GET_BE_U_4(tptr)));
                         break;
                     default:
@@ -921,44 +921,44 @@ ospf_decode_lls(netdissect_options *ndo,
         length2 += GET_U_1(op->ospf_authdata + 3);
     }
     if (length2 >= length) {
-        ND_PRINT("\n\t[LLS truncated]");
+        ND_PRINT(C_RESET, "\n\t[LLS truncated]");
         return;
     }
-    ND_PRINT("\n\t  LLS: checksum: 0x%04x", (u_int) GET_BE_U_2(dptr));
+    ND_PRINT(C_RESET, "\n\t  LLS: checksum: 0x%04x", (u_int) GET_BE_U_2(dptr));
 
     dptr += 2;
     length2 = GET_BE_U_2(dptr);
-    ND_PRINT(", length: %u", length2);
+    ND_PRINT(C_RESET, ", length: %u", length2);
 
     dptr += 2;
     while (dptr < dataend) {
         lls_type = GET_BE_U_2(dptr);
-        ND_PRINT("\n\t    %s (%u)",
+        ND_PRINT(C_RESET, "\n\t    %s (%u)",
                tok2str(ospf_lls_tlv_values,"Unknown TLV",lls_type),
                lls_type);
         dptr += 2;
         lls_len = GET_BE_U_2(dptr);
-        ND_PRINT(", length: %u", lls_len);
+        ND_PRINT(C_RESET, ", length: %u", lls_len);
         dptr += 2;
         switch (lls_type) {
 
         case OSPF_LLS_EO:
             if (lls_len != 4) {
-                ND_PRINT(" [should be 4]");
+                ND_PRINT(C_RESET, " [should be 4]");
                 lls_len = 4;
             }
             lls_flags = GET_BE_U_4(dptr);
-            ND_PRINT("\n\t      Options: 0x%08x [%s]", lls_flags,
+            ND_PRINT(C_RESET, "\n\t      Options: 0x%08x [%s]", lls_flags,
                    bittok2str(ospf_lls_eo_options, "?", lls_flags));
 
             break;
 
         case OSPF_LLS_MD5:
             if (lls_len != 20) {
-                ND_PRINT(" [should be 20]");
+                ND_PRINT(C_RESET, " [should be 20]");
                 lls_len = 20;
             }
-            ND_PRINT("\n\t      Sequence number: 0x%08x", GET_BE_U_4(dptr));
+            ND_PRINT(C_RESET, "\n\t      Sequence number: 0x%08x", GET_BE_U_4(dptr));
             break;
         }
 
@@ -979,42 +979,42 @@ ospf_decode_v2(netdissect_options *ndo,
 	switch (GET_U_1(op->ospf_type)) {
 
 	case OSPF_TYPE_HELLO:
-		ND_PRINT("\n\tOptions [%s]",
+		ND_PRINT(C_RESET, "\n\tOptions [%s]",
 		          bittok2str(ospf_option_values,"none",GET_U_1(op->ospf_hello.hello_options)));
 
-		ND_PRINT("\n\t  Hello Timer %us, Dead Timer %us, Mask %s, Priority %u",
+		ND_PRINT(C_RESET, "\n\t  Hello Timer %us, Dead Timer %us, Mask %s, Priority %u",
 		          GET_BE_U_2(op->ospf_hello.hello_helloint),
 		          GET_BE_U_4(op->ospf_hello.hello_deadint),
 		          GET_IPADDR_STRING(op->ospf_hello.hello_mask),
 		          GET_U_1(op->ospf_hello.hello_priority));
 
 		if (GET_IPV4_TO_NETWORK_ORDER(op->ospf_hello.hello_dr) != 0)
-			ND_PRINT("\n\t  Designated Router %s",
+			ND_PRINT(C_RESET, "\n\t  Designated Router %s",
 			    GET_IPADDR_STRING(op->ospf_hello.hello_dr));
 
 		if (GET_IPV4_TO_NETWORK_ORDER(op->ospf_hello.hello_bdr) != 0)
-			ND_PRINT(", Backup Designated Router %s",
+			ND_PRINT(C_RESET, ", Backup Designated Router %s",
 			          GET_IPADDR_STRING(op->ospf_hello.hello_bdr));
 
 		ap = op->ospf_hello.hello_neighbor;
 		if ((const u_char *)ap < dataend)
-			ND_PRINT("\n\t  Neighbor List:");
+			ND_PRINT(C_RESET, "\n\t  Neighbor List:");
 		while ((const u_char *)ap < dataend) {
-			ND_PRINT("\n\t    %s", GET_IPADDR_STRING(ap));
+			ND_PRINT(C_RESET, "\n\t    %s", GET_IPADDR_STRING(ap));
 			++ap;
 		}
 		break;	/* HELLO */
 
 	case OSPF_TYPE_DD:
-		ND_PRINT("\n\tOptions [%s]",
+		ND_PRINT(C_RESET, "\n\tOptions [%s]",
 		          bittok2str(ospf_option_values, "none", GET_U_1(op->ospf_db.db_options)));
-		ND_PRINT(", DD Flags [%s]",
+		ND_PRINT(C_RESET, ", DD Flags [%s]",
 		          bittok2str(ospf_dd_flag_values, "none", GET_U_1(op->ospf_db.db_flags)));
 		if (GET_BE_U_2(op->ospf_db.db_ifmtu)) {
-			ND_PRINT(", MTU: %u",
+			ND_PRINT(C_RESET, ", MTU: %u",
 				 GET_BE_U_2(op->ospf_db.db_ifmtu));
 		}
-		ND_PRINT(", Sequence: 0x%08x", GET_BE_U_4(op->ospf_db.db_seq));
+		ND_PRINT(C_RESET, ", Sequence: 0x%08x", GET_BE_U_4(op->ospf_db.db_seq));
 
 		/* Print all the LS adv's */
 		lshp = op->ospf_db.db_lshdr;
@@ -1028,7 +1028,7 @@ ospf_decode_v2(netdissect_options *ndo,
                 while ((const u_char *)lsrp < dataend) {
                     ND_TCHECK_SIZE(lsrp);
 
-                    ND_PRINT("\n\t  Advertising Router: %s, %s LSA (%u)",
+                    ND_PRINT(C_RESET, "\n\t  Advertising Router: %s, %s LSA (%u)",
                            GET_IPADDR_STRING(lsrp->ls_router),
                            tok2str(lsa_values,"unknown",GET_BE_U_4(lsrp->ls_type)),
                            GET_BE_U_4(lsrp->ls_type));
@@ -1038,13 +1038,13 @@ ospf_decode_v2(netdissect_options *ndo,
                     case LS_TYPE_OPAQUE_LL:
                     case LS_TYPE_OPAQUE_AL:
                     case LS_TYPE_OPAQUE_DW:
-                        ND_PRINT(", Opaque-Type: %s LSA (%u), Opaque-ID: %u",
+                        ND_PRINT(C_RESET, ", Opaque-Type: %s LSA (%u), Opaque-ID: %u",
                                tok2str(lsa_opaque_values, "unknown",GET_U_1(lsrp->un_ls_stateid.opaque_field.opaque_type)),
                                GET_U_1(lsrp->un_ls_stateid.opaque_field.opaque_type),
                                GET_BE_U_3(lsrp->un_ls_stateid.opaque_field.opaque_id));
                         break;
                     default:
-                        ND_PRINT(", LSA-ID: %s",
+                        ND_PRINT(C_RESET, ", LSA-ID: %s",
                                GET_IPADDR_STRING(lsrp->un_ls_stateid.ls_stateid));
                         break;
                     }
@@ -1056,9 +1056,9 @@ ospf_decode_v2(netdissect_options *ndo,
 	case OSPF_TYPE_LS_UPDATE:
                 lsap = op->ospf_lsu.lsu_lsa;
                 lsa_count_max = GET_BE_U_4(op->ospf_lsu.lsu_count);
-                ND_PRINT(", %u LSA%s", lsa_count_max, PLURAL_SUFFIX(lsa_count_max));
+                ND_PRINT(C_RESET, ", %u LSA%s", lsa_count_max, PLURAL_SUFFIX(lsa_count_max));
                 for (lsa_count=1;lsa_count <= lsa_count_max;lsa_count++) {
-                    ND_PRINT("\n\t  LSA #%u", lsa_count);
+                    ND_PRINT(C_RESET, "\n\t  LSA #%u", lsa_count);
                         lsap = (const struct lsa *)ospf_print_lsa(ndo, lsap);
                         if (lsap == NULL)
                                 goto trunc;
@@ -1101,7 +1101,7 @@ ospf_print(netdissect_options *ndo,
 	/* If the type is valid translate it, or just print the type */
 	/* value.  If it's not valid, say so and return */
 	cp = tok2str(type2str, "unknown LS-type %u", GET_U_1(op->ospf_type));
-	ND_PRINT("OSPFv%u, %s, length %u", GET_U_1(op->ospf_version), cp,
+	ND_PRINT(C_RESET, "OSPFv%u, %s, length %u", GET_U_1(op->ospf_version), cp,
 		 length);
 	if (*cp == 'u')
 		return;
@@ -1111,7 +1111,7 @@ ospf_print(netdissect_options *ndo,
 	}
 
 	if (length != GET_BE_U_2(op->ospf_len)) {
-		ND_PRINT(" [len %u]", GET_BE_U_2(op->ospf_len));
+		ND_PRINT(C_RESET, " [len %u]", GET_BE_U_2(op->ospf_len));
 	}
 
 	if (length > GET_BE_U_2(op->ospf_len)) {
@@ -1120,18 +1120,18 @@ ospf_print(netdissect_options *ndo,
 		dataend = bp + length;
 	}
 
-	ND_PRINT("\n\tRouter-ID %s", GET_IPADDR_STRING(op->ospf_routerid));
+	ND_PRINT(C_RESET, "\n\tRouter-ID %s", GET_IPADDR_STRING(op->ospf_routerid));
 
 	if (GET_IPV4_TO_NETWORK_ORDER(op->ospf_areaid) != 0)
-		ND_PRINT(", Area %s", GET_IPADDR_STRING(op->ospf_areaid));
+		ND_PRINT(C_RESET, ", Area %s", GET_IPADDR_STRING(op->ospf_areaid));
 	else
-		ND_PRINT(", Backbone Area");
+		ND_PRINT(C_RESET, ", Backbone Area");
 
 	if (ndo->ndo_vflag) {
 		/* Print authentication data (should we really do this?) */
 		ND_TCHECK_LEN(op->ospf_authdata, sizeof(op->ospf_authdata));
 
-		ND_PRINT(", Authentication Type: %s (%u)",
+		ND_PRINT(C_RESET, ", Authentication Type: %s (%u)",
 		          tok2str(ospf_authtype_values, "unknown", GET_BE_U_2(op->ospf_authtype)),
 		          GET_BE_U_2(op->ospf_authtype));
 
@@ -1141,12 +1141,12 @@ ospf_print(netdissect_options *ndo,
 			break;
 
 		case OSPF_AUTH_SIMPLE:
-			ND_PRINT("\n\tSimple text password: ");
+			ND_PRINT(C_RESET, "\n\tSimple text password: ");
 			nd_printjnp(ndo, op->ospf_authdata, OSPF_AUTH_SIMPLE_LEN);
 			break;
 
 		case OSPF_AUTH_MD5:
-			ND_PRINT("\n\tKey-ID: %u, Auth-Length: %u, Crypto Sequence Number: 0x%08x",
+			ND_PRINT(C_RESET, "\n\tKey-ID: %u, Auth-Length: %u, Crypto Sequence Number: 0x%08x",
 			          GET_U_1(op->ospf_authdata + 2),
 			          GET_U_1(op->ospf_authdata + 3),
 			          GET_BE_U_4((op->ospf_authdata) + 4));
@@ -1168,7 +1168,7 @@ ospf_print(netdissect_options *ndo,
 		break;
 
 	default:
-		ND_PRINT(" ospf [version %u]", GET_U_1(op->ospf_version));
+		ND_PRINT(C_RESET, " ospf [version %u]", GET_U_1(op->ospf_version));
 		break;
 	}			/* end switch on version */
 

--- a/print-ospf6.c
+++ b/print-ospf6.c
@@ -376,7 +376,7 @@ static void
 ospf6_print_ls_type(netdissect_options *ndo,
                     u_int ls_type, const rtrid_t *ls_stateid)
 {
-        ND_PRINT("\n\t    %s LSA (%u), %s Scope%s, LSA-ID %s",
+        ND_PRINT(C_RESET, "\n\t    %s LSA (%u), %s Scope%s, LSA-ID %s",
                tok2str(ospf6_lsa_values, "Unknown", ls_type & LS_TYPE_MASK),
                ls_type & LS_TYPE_MASK,
                tok2str(ospf6_ls_scope_values, "Unknown", ls_type & LS_SCOPE_MASK),
@@ -391,7 +391,7 @@ ospf6_print_lshdr(netdissect_options *ndo,
 	if ((const u_char *)(lshp + 1) > dataend)
 		goto trunc;
 
-	ND_PRINT("\n\t  Advertising Router %s, seq 0x%08x, age %us, length %zu",
+	ND_PRINT(C_RESET, "\n\t  Advertising Router %s, seq 0x%08x, age %us, length %zu",
 		 GET_IPADDR_STRING(lshp->ls_router),
 		 GET_BE_U_4(lshp->ls_seq),
 		 GET_BE_U_2(lshp->ls_age),
@@ -419,7 +419,7 @@ ospf6_print_lsaprefix(netdissect_options *ndo,
 	ND_TCHECK_LEN(lsapp, sizeof(*lsapp) - IPV6_ADDR_LEN_BYTES);
 	wordlen = (GET_U_1(lsapp->lsa_p_len) + 31) / 32;
 	if (wordlen * 4 > sizeof(nd_ipv6)) {
-		ND_PRINT(" bogus prefixlen /%u", GET_U_1(lsapp->lsa_p_len));
+		ND_PRINT(C_RESET, " bogus prefixlen /%u", GET_U_1(lsapp->lsa_p_len));
 		goto trunc;
 	}
 	if (lsa_length < wordlen * 4)
@@ -427,14 +427,14 @@ ospf6_print_lsaprefix(netdissect_options *ndo,
 	lsa_length -= wordlen * 4;
 	memset(prefix, 0, sizeof(prefix));
 	GET_CPY_BYTES(prefix, lsapp->lsa_p_prefix, wordlen * 4);
-	ND_PRINT("\n\t\t%s/%u", ip6addr_string(ndo, prefix), /* local buffer, not packet data; don't use GET_IP6ADDR_STRING() */
+	ND_PRINT(C_RESET, "\n\t\t%s/%u", ip6addr_string(ndo, prefix), /* local buffer, not packet data; don't use GET_IP6ADDR_STRING() */
 		 GET_U_1(lsapp->lsa_p_len));
         if (GET_U_1(lsapp->lsa_p_opt)) {
-            ND_PRINT(", Options [%s]",
+            ND_PRINT(C_RESET, ", Options [%s]",
                    bittok2str(ospf6_lsa_prefix_option_values,
                               "none", GET_U_1(lsapp->lsa_p_opt)));
         }
-        ND_PRINT(", metric %u", GET_BE_U_2(lsapp->lsa_p_metric));
+        ND_PRINT(C_RESET, ", metric %u", GET_BE_U_2(lsapp->lsa_p_metric));
 	return sizeof(*lsapp) - IPV6_ADDR_LEN_BYTES + wordlen * 4;
 
 trunc:
@@ -489,10 +489,10 @@ ospf6_print_lsa(netdissect_options *ndo,
 		if (lsa_length < sizeof (lsap->lsa_un.un_rla.rla_options))
 			return (1);
 		lsa_length -= sizeof (lsap->lsa_un.un_rla.rla_options);
-		ND_PRINT("\n\t      Options [%s]",
+		ND_PRINT(C_RESET, "\n\t      Options [%s]",
 		          bittok2str(ospf6_option_values, "none",
 		          GET_BE_U_4(lsap->lsa_un.un_rla.rla_options)));
-		ND_PRINT(", RLA-Flags [%s]",
+		ND_PRINT(C_RESET, ", RLA-Flags [%s]",
 		          bittok2str(ospf6_rla_flag_values, "none",
 		          GET_U_1(lsap->lsa_un.un_rla.rla_flags)));
 
@@ -505,7 +505,7 @@ ospf6_print_lsa(netdissect_options *ndo,
 			switch (GET_U_1(rlp->link_type)) {
 
 			case RLA_TYPE_VIRTUAL:
-				ND_PRINT("\n\t      Virtual Link: Neighbor Router-ID %s"
+				ND_PRINT(C_RESET, "\n\t      Virtual Link: Neighbor Router-ID %s"
                                        "\n\t      Neighbor Interface-ID %s, Interface %s",
                                        GET_IPADDR_STRING(rlp->link_nrtid),
                                        GET_IPADDR_STRING(rlp->link_nifid),
@@ -513,7 +513,7 @@ ospf6_print_lsa(netdissect_options *ndo,
                                 break;
 
 			case RLA_TYPE_ROUTER:
-				ND_PRINT("\n\t      Neighbor Router-ID %s"
+				ND_PRINT(C_RESET, "\n\t      Neighbor Router-ID %s"
                                        "\n\t      Neighbor Interface-ID %s, Interface %s",
                                        GET_IPADDR_STRING(rlp->link_nrtid),
                                        GET_IPADDR_STRING(rlp->link_nifid),
@@ -521,7 +521,7 @@ ospf6_print_lsa(netdissect_options *ndo,
 				break;
 
 			case RLA_TYPE_TRANSIT:
-				ND_PRINT("\n\t      Neighbor Network-ID %s"
+				ND_PRINT(C_RESET, "\n\t      Neighbor Network-ID %s"
                                        "\n\t      Neighbor Interface-ID %s, Interface %s",
 				    GET_IPADDR_STRING(rlp->link_nrtid),
 				    GET_IPADDR_STRING(rlp->link_nifid),
@@ -529,11 +529,11 @@ ospf6_print_lsa(netdissect_options *ndo,
 				break;
 
 			default:
-				ND_PRINT("\n\t      Unknown Router Links Type 0x%02x",
+				ND_PRINT(C_RESET, "\n\t      Unknown Router Links Type 0x%02x",
 				    GET_U_1(rlp->link_type));
 				return (0);
 			}
-			ND_PRINT(", metric %u", GET_BE_U_2(rlp->link_metric));
+			ND_PRINT(C_RESET, ", metric %u", GET_BE_U_2(rlp->link_metric));
 			rlp++;
 		}
 		break;
@@ -542,17 +542,17 @@ ospf6_print_lsa(netdissect_options *ndo,
 		if (lsa_length < sizeof (lsap->lsa_un.un_nla.nla_options))
 			return (1);
 		lsa_length -= sizeof (lsap->lsa_un.un_nla.nla_options);
-		ND_PRINT("\n\t      Options [%s]",
+		ND_PRINT(C_RESET, "\n\t      Options [%s]",
 		          bittok2str(ospf6_option_values, "none",
 		          GET_BE_U_4(lsap->lsa_un.un_nla.nla_options)));
 
-		ND_PRINT("\n\t      Connected Routers:");
+		ND_PRINT(C_RESET, "\n\t      Connected Routers:");
 		ap = lsap->lsa_un.un_nla.nla_router;
 		while (lsa_length != 0) {
 			if (lsa_length < sizeof (*ap))
 				return (1);
 			lsa_length -= sizeof (*ap);
-			ND_PRINT("\n\t\t%s", GET_IPADDR_STRING(ap));
+			ND_PRINT(C_RESET, "\n\t\t%s", GET_IPADDR_STRING(ap));
 			++ap;
 		}
 		break;
@@ -561,7 +561,7 @@ ospf6_print_lsa(netdissect_options *ndo,
 		if (lsa_length < sizeof (lsap->lsa_un.un_inter_ap.inter_ap_metric))
 			return (1);
 		lsa_length -= sizeof (lsap->lsa_un.un_inter_ap.inter_ap_metric);
-		ND_PRINT(", metric %u",
+		ND_PRINT(C_RESET, ", metric %u",
 			GET_BE_U_4(lsap->lsa_un.un_inter_ap.inter_ap_metric) & SLA_MASK_METRIC);
 
 		tptr = (const uint8_t *)lsap->lsa_un.un_inter_ap.inter_ap_prefix;
@@ -584,9 +584,9 @@ ospf6_print_lsa(netdissect_options *ndo,
 			return (1);
 		lsa_length -= sizeof (lsap->lsa_un.un_asla.asla_metric);
 		flags32 = GET_BE_U_4(lsap->lsa_un.un_asla.asla_metric);
-		ND_PRINT("\n\t     Flags [%s]",
+		ND_PRINT(C_RESET, "\n\t     Flags [%s]",
 		          bittok2str(ospf6_asla_flag_values, "none", flags32));
-		ND_PRINT(" metric %u",
+		ND_PRINT(C_RESET, " metric %u",
 		       GET_BE_U_4(lsap->lsa_un.un_asla.asla_metric) &
 		       ASLA_MASK_METRIC);
 
@@ -607,7 +607,7 @@ ospf6_print_lsa(netdissect_options *ndo,
 			if (lsa_length < sizeof (nd_ipv6))
 				return (1);
 			lsa_length -= sizeof (nd_ipv6);
-			ND_PRINT(" forward %s",
+			ND_PRINT(C_RESET, " forward %s",
 				 GET_IP6ADDR_STRING(tptr));
 			tptr += sizeof(nd_ipv6);
 		}
@@ -616,7 +616,7 @@ ospf6_print_lsa(netdissect_options *ndo,
 			if (lsa_length < sizeof (uint32_t))
 				return (1);
 			lsa_length -= sizeof (uint32_t);
-			ND_PRINT(" tag %s",
+			ND_PRINT(C_RESET, " tag %s",
 			       GET_IPADDR_STRING(tptr));
 			tptr += sizeof(uint32_t);
 		}
@@ -625,7 +625,7 @@ ospf6_print_lsa(netdissect_options *ndo,
 			if (lsa_length < sizeof (uint32_t))
 				return (1);
 			lsa_length -= sizeof (uint32_t);
-			ND_PRINT(" RefLSID: %s",
+			ND_PRINT(C_RESET, " RefLSID: %s",
 			       GET_IPADDR_STRING(tptr));
 			tptr += sizeof(uint32_t);
 		}
@@ -638,7 +638,7 @@ ospf6_print_lsa(netdissect_options *ndo,
 			return (1);
 		lsa_length -= sizeof (llsap->llsa_priandopt);
 		ND_TCHECK_SIZE(&llsap->llsa_priandopt);
-		ND_PRINT("\n\t      Options [%s]",
+		ND_PRINT(C_RESET, "\n\t      Options [%s]",
 		          bittok2str(ospf6_option_values, "none",
 		          GET_BE_U_4(llsap->llsa_options)));
 
@@ -646,7 +646,7 @@ ospf6_print_lsa(netdissect_options *ndo,
 			return (1);
 		lsa_length -= sizeof (llsap->llsa_lladdr) + sizeof (llsap->llsa_nprefix);
                 prefixes = GET_BE_U_4(llsap->llsa_nprefix);
-		ND_PRINT("\n\t      Priority %u, Link-local address %s, Prefixes %u:",
+		ND_PRINT(C_RESET, "\n\t      Priority %u, Link-local address %s, Prefixes %u:",
                        GET_U_1(llsap->llsa_priority),
                        GET_IP6ADDR_STRING(llsap->llsa_lladdr),
                        prefixes);
@@ -681,7 +681,7 @@ ospf6_print_lsa(netdissect_options *ndo,
 			return (1);
 		lsa_length -= sizeof (lsap->lsa_un.un_intra_ap.intra_ap_nprefix);
                 prefixes = GET_BE_U_2(lsap->lsa_un.un_intra_ap.intra_ap_nprefix);
-		ND_PRINT("\n\t      Prefixes %u:", prefixes);
+		ND_PRINT(C_RESET, "\n\t      Prefixes %u:", prefixes);
 
 		tptr = (const uint8_t *)lsap->lsa_un.un_intra_ap.intra_ap_prefix;
 		while (prefixes > 0) {
@@ -741,27 +741,27 @@ ospf6_decode_v3(netdissect_options *ndo,
 	case OSPF_TYPE_HELLO: {
 		const struct hello6 *hellop = (const struct hello6 *)((const uint8_t *)op + OSPF6HDR_LEN);
 
-		ND_PRINT("\n\tOptions [%s]",
+		ND_PRINT(C_RESET, "\n\tOptions [%s]",
 		          bittok2str(ospf6_option_values, "none",
 		          GET_BE_U_4(hellop->hello_options)));
 
-		ND_PRINT("\n\t  Hello Timer %us, Dead Timer %us, Interface-ID %s, Priority %u",
+		ND_PRINT(C_RESET, "\n\t  Hello Timer %us, Dead Timer %us, Interface-ID %s, Priority %u",
 		          GET_BE_U_2(hellop->hello_helloint),
 		          GET_BE_U_2(hellop->hello_deadint),
 		          GET_IPADDR_STRING(hellop->hello_ifid),
 		          GET_U_1(hellop->hello_priority));
 
 		if (GET_BE_U_4(hellop->hello_dr) != 0)
-			ND_PRINT("\n\t  Designated Router %s",
+			ND_PRINT(C_RESET, "\n\t  Designated Router %s",
 			    GET_IPADDR_STRING(hellop->hello_dr));
 		if (GET_BE_U_4(hellop->hello_bdr) != 0)
-			ND_PRINT(", Backup Designated Router %s",
+			ND_PRINT(C_RESET, ", Backup Designated Router %s",
 			    GET_IPADDR_STRING(hellop->hello_bdr));
 		if (ndo->ndo_vflag > 1) {
-			ND_PRINT("\n\t  Neighbor List:");
+			ND_PRINT(C_RESET, "\n\t  Neighbor List:");
 			ap = hellop->hello_neighbor;
 			while ((const u_char *)ap < dataend) {
-				ND_PRINT("\n\t    %s", GET_IPADDR_STRING(ap));
+				ND_PRINT(C_RESET, "\n\t    %s", GET_IPADDR_STRING(ap));
 				++ap;
 			}
 		}
@@ -771,13 +771,13 @@ ospf6_decode_v3(netdissect_options *ndo,
 	case OSPF_TYPE_DD: {
 		const struct dd6 *ddp = (const struct dd6 *)((const uint8_t *)op + OSPF6HDR_LEN);
 
-		ND_PRINT("\n\tOptions [%s]",
+		ND_PRINT(C_RESET, "\n\tOptions [%s]",
 		          bittok2str(ospf6_option_values, "none",
 		          GET_BE_U_4(ddp->db_options)));
-		ND_PRINT(", DD Flags [%s]",
+		ND_PRINT(C_RESET, ", DD Flags [%s]",
 		          bittok2str(ospf6_dd_flag_values,"none",GET_U_1(ddp->db_flags)));
 
-		ND_PRINT(", MTU %u, DD-Sequence 0x%08x",
+		ND_PRINT(C_RESET, ", MTU %u, DD-Sequence 0x%08x",
                        GET_BE_U_2(ddp->db_mtu),
                        GET_BE_U_4(ddp->db_seq));
 		if (ndo->ndo_vflag > 1) {
@@ -796,7 +796,7 @@ ospf6_decode_v3(netdissect_options *ndo,
 			lsrp = (const struct lsr6 *)((const uint8_t *)op + OSPF6HDR_LEN);
 			while ((const u_char *)lsrp < dataend) {
 				ND_TCHECK_SIZE(lsrp);
-				ND_PRINT("\n\t  Advertising Router %s",
+				ND_PRINT(C_RESET, "\n\t  Advertising Router %s",
 				          GET_IPADDR_STRING(lsrp->ls_router));
 				ospf6_print_ls_type(ndo,
                                                     GET_BE_U_2(lsrp->ls_type),
@@ -851,11 +851,11 @@ ospf6_print_lls(netdissect_options *ndo,
 	if (len < OSPF_LLS_HDRLEN)
 		goto trunc;
 	/* Checksum */
-	ND_PRINT("\n\tLLS Checksum 0x%04x", GET_BE_U_2(cp));
+	ND_PRINT(C_RESET, "\n\tLLS Checksum 0x%04x", GET_BE_U_2(cp));
 	cp += 2;
 	/* LLS Data Length */
 	llsdatalen = GET_BE_U_2(cp);
-	ND_PRINT(", Data Length %u", llsdatalen);
+	ND_PRINT(C_RESET, ", Data Length %u", llsdatalen);
 	if (llsdatalen < OSPF_LLS_HDRLEN || llsdatalen > len)
 		goto trunc;
 	cp += 2;
@@ -880,25 +880,25 @@ ospf6_decode_at(netdissect_options *ndo,
 	if (len < OSPF6_AT_HDRLEN)
 		goto trunc;
 	/* Authentication Type */
-	ND_PRINT("\n\tAuthentication Type %s",
+	ND_PRINT(C_RESET, "\n\tAuthentication Type %s",
 		 tok2str(ospf6_auth_type_str, "unknown (0x%04x)", GET_BE_U_2(cp)));
 	cp += 2;
 	/* Auth Data Len */
 	authdatalen = GET_BE_U_2(cp);
-	ND_PRINT(", Length %u", authdatalen);
+	ND_PRINT(C_RESET, ", Length %u", authdatalen);
 	if (authdatalen < OSPF6_AT_HDRLEN || authdatalen > len)
 		goto trunc;
 	cp += 2;
 	/* Reserved */
 	cp += 2;
 	/* Security Association ID */
-	ND_PRINT(", SAID %u", GET_BE_U_2(cp));
+	ND_PRINT(C_RESET, ", SAID %u", GET_BE_U_2(cp));
 	cp += 2;
 	/* Cryptographic Sequence Number (High-Order 32 Bits) */
-	ND_PRINT(", CSN 0x%08x", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, ", CSN 0x%08x", GET_BE_U_4(cp));
 	cp += 4;
 	/* Cryptographic Sequence Number (Low-Order 32 Bits) */
-	ND_PRINT(":%08x", GET_BE_U_4(cp));
+	ND_PRINT(C_RESET, ":%08x", GET_BE_U_4(cp));
 	cp += 4;
 	/* Authentication Data */
 	ND_TCHECK_LEN(cp, authdatalen - OSPF6_AT_HDRLEN);
@@ -958,7 +958,7 @@ ospf6_print(netdissect_options *ndo,
 	/* value.  If it's not valid, say so and return */
 	cp = tok2str(ospf6_type_values, "unknown packet type (%u)",
 		     GET_U_1(op->ospf6_type));
-	ND_PRINT("OSPFv%u, %s, length %u", GET_U_1(op->ospf6_version), cp,
+	ND_PRINT(C_RESET, "OSPFv%u, %s, length %u", GET_U_1(op->ospf6_version), cp,
 		 length);
 	if (*cp == 'u') {
 		return;
@@ -971,19 +971,19 @@ ospf6_print(netdissect_options *ndo,
 	/* OSPFv3 data always comes first and optional trailing data may follow. */
 	datalen = GET_BE_U_2(op->ospf6_len);
 	if (datalen > length) {
-		ND_PRINT(" [len %u]", datalen);
+		ND_PRINT(C_RESET, " [len %u]", datalen);
 		return;
 	}
 	dataend = bp + datalen;
 
-	ND_PRINT("\n\tRouter-ID %s", GET_IPADDR_STRING(op->ospf6_routerid));
+	ND_PRINT(C_RESET, "\n\tRouter-ID %s", GET_IPADDR_STRING(op->ospf6_routerid));
 
 	if (GET_BE_U_4(op->ospf6_areaid) != 0)
-		ND_PRINT(", Area %s", GET_IPADDR_STRING(op->ospf6_areaid));
+		ND_PRINT(C_RESET, ", Area %s", GET_IPADDR_STRING(op->ospf6_areaid));
 	else
-		ND_PRINT(", Backbone Area");
+		ND_PRINT(C_RESET, ", Backbone Area");
 	if (GET_U_1(op->ospf6_instanceid))
-		ND_PRINT(", Instance %u", GET_U_1(op->ospf6_instanceid));
+		ND_PRINT(C_RESET, ", Instance %u", GET_U_1(op->ospf6_instanceid));
 
 	/* Do rest according to version.	 */
 	switch (GET_U_1(op->ospf6_version)) {

--- a/print-otv.c
+++ b/print-otv.c
@@ -47,20 +47,20 @@ otv_print(netdissect_options *ndo, const u_char *bp, u_int len)
     uint8_t flags;
 
     ndo->ndo_protocol = "otv";
-    ND_PRINT("OTV, ");
+    ND_PRINT(C_RESET, "OTV, ");
     if (len < OTV_HDR_LEN) {
-        ND_PRINT("[length %u < %u]", len, OTV_HDR_LEN);
+        ND_PRINT(C_RESET, "[length %u < %u]", len, OTV_HDR_LEN);
         goto invalid;
     }
 
     flags = GET_U_1(bp);
-    ND_PRINT("flags [%s] (0x%02x), ", flags & 0x08 ? "I" : ".", flags);
+    ND_PRINT(C_RESET, "flags [%s] (0x%02x), ", flags & 0x08 ? "I" : ".", flags);
     bp += 1;
 
-    ND_PRINT("overlay %u, ", GET_BE_U_3(bp));
+    ND_PRINT(C_RESET, "overlay %u, ", GET_BE_U_3(bp));
     bp += 3;
 
-    ND_PRINT("instance %u\n", GET_BE_U_3(bp));
+    ND_PRINT(C_RESET, "instance %u\n", GET_BE_U_3(bp));
     bp += 3;
 
     /* Reserved */

--- a/print-pflog.c
+++ b/print-pflog.c
@@ -109,19 +109,19 @@ pflog_print(netdissect_options *ndo, const struct pfloghdr *hdr)
 	rulenr = GET_BE_U_4(&hdr->rulenr);
 	subrulenr = GET_BE_U_4(&hdr->subrulenr);
 	if (subrulenr == (uint32_t)-1)
-		ND_PRINT("rule %u/", rulenr);
+		ND_PRINT(C_RESET, "rule %u/", rulenr);
 	else {
-		ND_PRINT("rule %u.", rulenr);
+		ND_PRINT(C_RESET, "rule %u.", rulenr);
 		nd_printjnp(ndo, (const u_char*)hdr->ruleset, PFLOG_RULESET_NAME_SIZE);
-		ND_PRINT(".%u/", subrulenr);
+		ND_PRINT(C_RESET, ".%u/", subrulenr);
 	}
 
-	ND_PRINT("%s: %s %s on ",
+	ND_PRINT(C_RESET, "%s: %s %s on ",
 	    tok2str(pf_reasons, "unkn(%u)", GET_U_1(&hdr->reason)),
 	    tok2str(pf_actions, "unkn(%u)", GET_U_1(&hdr->action)),
 	    tok2str(pf_directions, "unkn(%u)", GET_U_1(&hdr->dir)));
 	nd_printjnp(ndo, (const u_char*)hdr->ifname, PFLOG_IFNAMSIZ);
-	ND_PRINT(": ");
+	ND_PRINT(C_RESET, ": ");
 }
 
 void
@@ -145,7 +145,7 @@ pflog_if_print(netdissect_options *ndo, const struct pcap_pkthdr *h,
 #define MIN_PFLOG_HDRLEN	45
 	hdr = (const struct pfloghdr *)p;
 	if (GET_U_1(&hdr->length) < MIN_PFLOG_HDRLEN) {
-		ND_PRINT("[pflog: invalid header length!]");
+		ND_PRINT(C_RESET, "[pflog: invalid header length!]");
 		ndo->ndo_ll_hdr_len += GET_U_1(&hdr->length);	/* XXX: not really */
 		return;
 	}

--- a/print-pgm.c
+++ b/print-pgm.c
@@ -167,11 +167,11 @@ pgm_print(netdissect_options *ndo,
 		ip6 = NULL;
 	if (!ND_TTEST_2(pgm->pgm_dport)) {
 		if (ip6) {
-			ND_PRINT(C_RESET, C_RESET "%s > %s:",
+			ND_PRINT(C_RESET, "%s > %s:",
 				GET_IP6ADDR_STRING(ip6->ip6_src),
 				GET_IP6ADDR_STRING(ip6->ip6_dst));
 		} else {
-			ND_PRINT(C_RESET, C_RESET "%s > %s:",
+			ND_PRINT(C_RESET, "%s > %s:",
 				GET_IPADDR_STRING(ip->ip_src),
 				GET_IPADDR_STRING(ip->ip_dst));
 		}
@@ -183,37 +183,37 @@ pgm_print(netdissect_options *ndo,
 
 	if (ip6) {
 		if (GET_U_1(ip6->ip6_nxt) == IPPROTO_PGM) {
-			ND_PRINT(C_RESET, C_RESET "%s.%s > %s.%s: ",
+			ND_PRINT(C_RESET, "%s.%s > %s.%s: ",
 				GET_IP6ADDR_STRING(ip6->ip6_src),
 				tcpport_string(ndo, sport),
 				GET_IP6ADDR_STRING(ip6->ip6_dst),
 				tcpport_string(ndo, dport));
 		} else {
-			ND_PRINT(C_RESET, C_RESET "%s > %s: ",
+			ND_PRINT(C_RESET, "%s > %s: ",
 				tcpport_string(ndo, sport), tcpport_string(ndo, dport));
 		}
 	} else {
 		if (GET_U_1(ip->ip_p) == IPPROTO_PGM) {
-			ND_PRINT(C_RESET, C_RESET "%s.%s > %s.%s: ",
+			ND_PRINT(C_RESET, "%s.%s > %s.%s: ",
 				GET_IPADDR_STRING(ip->ip_src),
 				tcpport_string(ndo, sport),
 				GET_IPADDR_STRING(ip->ip_dst),
 				tcpport_string(ndo, dport));
 		} else {
-			ND_PRINT(C_RESET, C_RESET "%s > %s: ",
+			ND_PRINT(C_RESET, "%s > %s: ",
 				tcpport_string(ndo, sport), tcpport_string(ndo, dport));
 		}
 	}
 
 	ND_TCHECK_SIZE(pgm);
 
-        ND_PRINT(C_RESET, C_RESET "PGM, length %u", GET_BE_U_2(pgm->pgm_length));
+        ND_PRINT(C_RESET, "PGM, length %u", GET_BE_U_2(pgm->pgm_length));
 
         if (!ndo->ndo_vflag)
             return;
 
 	pgm_type_val = GET_U_1(pgm->pgm_type);
-	ND_PRINT(C_RESET, C_RESET " 0x%02x%02x%02x%02x%02x%02x ",
+	ND_PRINT(C_RESET, " 0x%02x%02x%02x%02x%02x%02x ",
 		     pgm->pgm_gsid[0],
                      pgm->pgm_gsid[1],
                      pgm->pgm_gsid[2],
@@ -244,7 +244,7 @@ pgm_print(netdissect_options *ndo,
 		break;
 	    }
 
-	    ND_PRINT(C_RESET, C_RESET "SPM seq %u trail %u lead %u nla %s",
+	    ND_PRINT(C_RESET, "SPM seq %u trail %u lead %u nla %s",
 			 GET_BE_U_4(spm->pgms_seq),
 			 GET_BE_U_4(spm->pgms_trailseq),
 			 GET_BE_U_4(spm->pgms_leadseq),
@@ -285,7 +285,7 @@ pgm_print(netdissect_options *ndo,
 	    mask = GET_BE_U_4(bp);
 	    bp += sizeof(uint32_t);
 
-	    ND_PRINT(C_RESET, C_RESET "POLL seq %u round %u nla %s ivl %u rnd 0x%08x "
+	    ND_PRINT(C_RESET, "POLL seq %u round %u nla %s ivl %u rnd 0x%08x "
 			 "mask 0x%08x", GET_BE_U_4(pgm_poll->pgmp_seq),
 			 GET_BE_U_2(pgm_poll->pgmp_round), nla_buf, ivl, rnd,
 			 mask);
@@ -296,7 +296,7 @@ pgm_print(netdissect_options *ndo,
 
 	    polr_msg = (const struct pgm_polr *)(pgm + 1);
 	    ND_TCHECK_SIZE(polr_msg);
-	    ND_PRINT(C_RESET, C_RESET "POLR seq %u round %u",
+	    ND_PRINT(C_RESET, "POLR seq %u round %u",
 			 GET_BE_U_4(polr_msg->pgmp_seq),
 			 GET_BE_U_2(polr_msg->pgmp_round));
 	    bp = (const u_char *) (polr_msg + 1);
@@ -306,7 +306,7 @@ pgm_print(netdissect_options *ndo,
 	    const struct pgm_data *odata;
 
 	    odata = (const struct pgm_data *)(pgm + 1);
-	    ND_PRINT(C_RESET, C_RESET "ODATA trail %u seq %u",
+	    ND_PRINT(C_RESET, "ODATA trail %u seq %u",
 			 GET_BE_U_4(odata->pgmd_trailseq),
 			 GET_BE_U_4(odata->pgmd_seq));
 	    bp = (const u_char *) (odata + 1);
@@ -317,7 +317,7 @@ pgm_print(netdissect_options *ndo,
 	    const struct pgm_data *rdata;
 
 	    rdata = (const struct pgm_data *)(pgm + 1);
-	    ND_PRINT(C_RESET, C_RESET "RDATA trail %u seq %u",
+	    ND_PRINT(C_RESET, "RDATA trail %u seq %u",
 			 GET_BE_U_4(rdata->pgmd_trailseq),
 			 GET_BE_U_4(rdata->pgmd_seq));
 	    bp = (const u_char *) (rdata + 1);
@@ -380,18 +380,18 @@ pgm_print(netdissect_options *ndo,
 	     */
 	    switch (pgm_type_val) {
 		case PGM_NAK:
-		    ND_PRINT(C_RESET, C_RESET "NAK ");
+		    ND_PRINT(C_RESET, "NAK ");
 		    break;
 		case PGM_NULLNAK:
-		    ND_PRINT(C_RESET, C_RESET "NNAK ");
+		    ND_PRINT(C_RESET, "NNAK ");
 		    break;
 		case PGM_NCF:
-		    ND_PRINT(C_RESET, C_RESET "NCF ");
+		    ND_PRINT(C_RESET, "NCF ");
 		    break;
 		default:
                     break;
 	    }
-	    ND_PRINT(C_RESET, C_RESET "(%s -> %s), seq %u",
+	    ND_PRINT(C_RESET, "(%s -> %s), seq %u",
 			 source_buf, group_buf, GET_BE_U_4(nak->pgmn_seq));
 	    break;
 	}
@@ -401,18 +401,18 @@ pgm_print(netdissect_options *ndo,
 
 	    ack = (const struct pgm_ack *)(pgm + 1);
 	    ND_TCHECK_SIZE(ack);
-	    ND_PRINT(C_RESET, C_RESET "ACK seq %u",
+	    ND_PRINT(C_RESET, "ACK seq %u",
 			 GET_BE_U_4(ack->pgma_rx_max_seq));
 	    bp = (const u_char *) (ack + 1);
 	    break;
 	}
 
 	case PGM_SPMR:
-	    ND_PRINT(C_RESET, C_RESET "SPMR");
+	    ND_PRINT(C_RESET, "SPMR");
 	    break;
 
 	default:
-	    ND_PRINT(C_RESET, C_RESET "UNKNOWN type 0x%02x", pgm_type_val);
+	    ND_PRINT(C_RESET, "UNKNOWN type 0x%02x", pgm_type_val);
 	    break;
 
 	}
@@ -430,27 +430,27 @@ pgm_print(netdissect_options *ndo,
 	    opt_type = GET_U_1(bp);
 	    bp++;
 	    if ((opt_type & PGM_OPT_MASK) != PGM_OPT_LENGTH) {
-		ND_PRINT(C_RESET, C_RESET "[First option bad, should be PGM_OPT_LENGTH, is %u]", opt_type & PGM_OPT_MASK);
+		ND_PRINT(C_RESET, "[First option bad, should be PGM_OPT_LENGTH, is %u]", opt_type & PGM_OPT_MASK);
 		return;
 	    }
 	    opt_len = GET_U_1(bp);
 	    bp++;
 	    if (opt_len != 4) {
-		ND_PRINT(C_RESET, C_RESET "[Bad OPT_LENGTH option, length %u != 4]", opt_len);
+		ND_PRINT(C_RESET, "[Bad OPT_LENGTH option, length %u != 4]", opt_len);
 		return;
 	    }
 	    opts_len = GET_BE_U_2(bp);
 	    bp += sizeof(uint16_t);
 	    if (opts_len < 4) {
-		ND_PRINT(C_RESET, C_RESET "[Bad total option length %u < 4]", opts_len);
+		ND_PRINT(C_RESET, "[Bad total option length %u < 4]", opts_len);
 		return;
 	    }
-	    ND_PRINT(C_RESET, C_RESET " OPTS LEN %u", opts_len);
+	    ND_PRINT(C_RESET, " OPTS LEN %u", opts_len);
 	    opts_len -= 4;
 
 	    while (opts_len) {
 		if (opts_len < PGM_MIN_OPT_LEN) {
-		    ND_PRINT(C_RESET, C_RESET "[Total option length leaves no room for final option]");
+		    ND_PRINT(C_RESET, "[Total option length leaves no room for final option]");
 		    return;
 		}
 		opt_type = GET_U_1(bp);
@@ -458,12 +458,12 @@ pgm_print(netdissect_options *ndo,
 		opt_len = GET_U_1(bp);
 		bp++;
 		if (opt_len < PGM_MIN_OPT_LEN) {
-		    ND_PRINT(C_RESET, C_RESET "[Bad option, length %u < %u]", opt_len,
+		    ND_PRINT(C_RESET, "[Bad option, length %u < %u]", opt_len,
 		        PGM_MIN_OPT_LEN);
 		    break;
 		}
 		if (opts_len < opt_len) {
-		    ND_PRINT(C_RESET, C_RESET "[Total option length leaves no room for final option]");
+		    ND_PRINT(C_RESET, "[Total option length leaves no room for final option]");
 		    return;
 		}
 		ND_TCHECK_LEN(bp, opt_len - 2);
@@ -472,11 +472,11 @@ pgm_print(netdissect_options *ndo,
 		case PGM_OPT_LENGTH:
 #define PGM_OPT_LENGTH_LEN	(2+2)
 		    if (opt_len != PGM_OPT_LENGTH_LEN) {
-			ND_PRINT(C_RESET, C_RESET "[Bad OPT_LENGTH option, length %u != %u]",
+			ND_PRINT(C_RESET, "[Bad OPT_LENGTH option, length %u != %u]",
 			    opt_len, PGM_OPT_LENGTH_LEN);
 			return;
 		    }
-		    ND_PRINT(C_RESET, C_RESET " OPTS LEN (extra?) %u", GET_BE_U_2(bp));
+		    ND_PRINT(C_RESET, " OPTS LEN (extra?) %u", GET_BE_U_2(bp));
 		    bp += 2;
 		    opts_len -= PGM_OPT_LENGTH_LEN;
 		    break;
@@ -484,7 +484,7 @@ pgm_print(netdissect_options *ndo,
 		case PGM_OPT_FRAGMENT:
 #define PGM_OPT_FRAGMENT_LEN	(2+2+4+4+4)
 		    if (opt_len != PGM_OPT_FRAGMENT_LEN) {
-			ND_PRINT(C_RESET, C_RESET "[Bad OPT_FRAGMENT option, length %u != %u]",
+			ND_PRINT(C_RESET, "[Bad OPT_FRAGMENT option, length %u != %u]",
 			    opt_len, PGM_OPT_FRAGMENT_LEN);
 			return;
 		    }
@@ -495,20 +495,20 @@ pgm_print(netdissect_options *ndo,
 		    bp += 4;
 		    len = GET_BE_U_4(bp);
 		    bp += 4;
-		    ND_PRINT(C_RESET, C_RESET " FRAG seq %u off %u len %u", seq, offset, len);
+		    ND_PRINT(C_RESET, " FRAG seq %u off %u len %u", seq, offset, len);
 		    opts_len -= PGM_OPT_FRAGMENT_LEN;
 		    break;
 
 		case PGM_OPT_NAK_LIST:
 		    bp += 2;
 		    opt_len -= 4;	/* option header */
-		    ND_PRINT(C_RESET, C_RESET " NAK LIST");
+		    ND_PRINT(C_RESET, " NAK LIST");
 		    while (opt_len) {
 			if (opt_len < 4) {
-			    ND_PRINT(C_RESET, C_RESET "[Option length not a multiple of 4]");
+			    ND_PRINT(C_RESET, "[Option length not a multiple of 4]");
 			    return;
 			}
-			ND_PRINT(C_RESET, C_RESET " %u", GET_BE_U_4(bp));
+			ND_PRINT(C_RESET, " %u", GET_BE_U_4(bp));
 			bp += 4;
 			opt_len -= 4;
 			opts_len -= 4;
@@ -518,21 +518,21 @@ pgm_print(netdissect_options *ndo,
 		case PGM_OPT_JOIN:
 #define PGM_OPT_JOIN_LEN	(2+2+4)
 		    if (opt_len != PGM_OPT_JOIN_LEN) {
-			ND_PRINT(C_RESET, C_RESET "[Bad OPT_JOIN option, length %u != %u]",
+			ND_PRINT(C_RESET, "[Bad OPT_JOIN option, length %u != %u]",
 			    opt_len, PGM_OPT_JOIN_LEN);
 			return;
 		    }
 		    bp += 2;
 		    seq = GET_BE_U_4(bp);
 		    bp += 4;
-		    ND_PRINT(C_RESET, C_RESET " JOIN %u", seq);
+		    ND_PRINT(C_RESET, " JOIN %u", seq);
 		    opts_len -= PGM_OPT_JOIN_LEN;
 		    break;
 
 		case PGM_OPT_NAK_BO_IVL:
 #define PGM_OPT_NAK_BO_IVL_LEN	(2+2+4+4)
 		    if (opt_len != PGM_OPT_NAK_BO_IVL_LEN) {
-			ND_PRINT(C_RESET, C_RESET "[Bad OPT_NAK_BO_IVL option, length %u != %u]",
+			ND_PRINT(C_RESET, "[Bad OPT_NAK_BO_IVL option, length %u != %u]",
 			    opt_len, PGM_OPT_NAK_BO_IVL_LEN);
 			return;
 		    }
@@ -541,14 +541,14 @@ pgm_print(netdissect_options *ndo,
 		    bp += 4;
 		    seq = GET_BE_U_4(bp);
 		    bp += 4;
-		    ND_PRINT(C_RESET, C_RESET " BACKOFF ivl %u ivlseq %u", offset, seq);
+		    ND_PRINT(C_RESET, " BACKOFF ivl %u ivlseq %u", offset, seq);
 		    opts_len -= PGM_OPT_NAK_BO_IVL_LEN;
 		    break;
 
 		case PGM_OPT_NAK_BO_RNG:
 #define PGM_OPT_NAK_BO_RNG_LEN	(2+2+4+4)
 		    if (opt_len != PGM_OPT_NAK_BO_RNG_LEN) {
-			ND_PRINT(C_RESET, C_RESET "[Bad OPT_NAK_BO_RNG option, length %u != %u]",
+			ND_PRINT(C_RESET, "[Bad OPT_NAK_BO_RNG option, length %u != %u]",
 			    opt_len, PGM_OPT_NAK_BO_RNG_LEN);
 			return;
 		    }
@@ -557,14 +557,14 @@ pgm_print(netdissect_options *ndo,
 		    bp += 4;
 		    seq = GET_BE_U_4(bp);
 		    bp += 4;
-		    ND_PRINT(C_RESET, C_RESET " BACKOFF max %u min %u", offset, seq);
+		    ND_PRINT(C_RESET, " BACKOFF max %u min %u", offset, seq);
 		    opts_len -= PGM_OPT_NAK_BO_RNG_LEN;
 		    break;
 
 		case PGM_OPT_REDIRECT:
 #define PGM_OPT_REDIRECT_FIXED_LEN	(2+2+2+2)
 		    if (opt_len < PGM_OPT_REDIRECT_FIXED_LEN) {
-			ND_PRINT(C_RESET, C_RESET "[Bad OPT_REDIRECT option, length %u < %u]",
+			ND_PRINT(C_RESET, "[Bad OPT_REDIRECT option, length %u < %u]",
 			    opt_len, PGM_OPT_REDIRECT_FIXED_LEN);
 			return;
 		    }
@@ -574,7 +574,7 @@ pgm_print(netdissect_options *ndo,
 		    switch (nla_afnum) {
 		    case AFNUM_INET:
 			if (opt_len != PGM_OPT_REDIRECT_FIXED_LEN + sizeof(nd_ipv4)) {
-			    ND_PRINT(C_RESET, C_RESET "[Bad OPT_REDIRECT option, length %u != %u + address size]",
+			    ND_PRINT(C_RESET, "[Bad OPT_REDIRECT option, length %u != %u + address size]",
 			        opt_len, PGM_OPT_REDIRECT_FIXED_LEN);
 			    return;
 			}
@@ -585,7 +585,7 @@ pgm_print(netdissect_options *ndo,
 			break;
 		    case AFNUM_INET6:
 			if (opt_len != PGM_OPT_REDIRECT_FIXED_LEN + sizeof(nd_ipv6)) {
-			    ND_PRINT(C_RESET, C_RESET "[Bad OPT_REDIRECT option, length %u != %u + address size]",
+			    ND_PRINT(C_RESET, "[Bad OPT_REDIRECT option, length %u != %u + address size]",
 			        opt_len, PGM_OPT_REDIRECT_FIXED_LEN);
 			    return;
 			}
@@ -599,65 +599,65 @@ pgm_print(netdissect_options *ndo,
 			break;
 		    }
 
-		    ND_PRINT(C_RESET, C_RESET " REDIRECT %s",  nla_buf);
+		    ND_PRINT(C_RESET, " REDIRECT %s",  nla_buf);
 		    break;
 
 		case PGM_OPT_PARITY_PRM:
 #define PGM_OPT_PARITY_PRM_LEN	(2+2+4)
 		    if (opt_len != PGM_OPT_PARITY_PRM_LEN) {
-			ND_PRINT(C_RESET, C_RESET "[Bad OPT_PARITY_PRM option, length %u != %u]",
+			ND_PRINT(C_RESET, "[Bad OPT_PARITY_PRM option, length %u != %u]",
 			    opt_len, PGM_OPT_PARITY_PRM_LEN);
 			return;
 		    }
 		    bp += 2;
 		    len = GET_BE_U_4(bp);
 		    bp += 4;
-		    ND_PRINT(C_RESET, C_RESET " PARITY MAXTGS %u", len);
+		    ND_PRINT(C_RESET, " PARITY MAXTGS %u", len);
 		    opts_len -= PGM_OPT_PARITY_PRM_LEN;
 		    break;
 
 		case PGM_OPT_PARITY_GRP:
 #define PGM_OPT_PARITY_GRP_LEN	(2+2+4)
 		    if (opt_len != PGM_OPT_PARITY_GRP_LEN) {
-			ND_PRINT(C_RESET, C_RESET "[Bad OPT_PARITY_GRP option, length %u != %u]",
+			ND_PRINT(C_RESET, "[Bad OPT_PARITY_GRP option, length %u != %u]",
 			    opt_len, PGM_OPT_PARITY_GRP_LEN);
 			return;
 		    }
 		    bp += 2;
 		    seq = GET_BE_U_4(bp);
 		    bp += 4;
-		    ND_PRINT(C_RESET, C_RESET " PARITY GROUP %u", seq);
+		    ND_PRINT(C_RESET, " PARITY GROUP %u", seq);
 		    opts_len -= PGM_OPT_PARITY_GRP_LEN;
 		    break;
 
 		case PGM_OPT_CURR_TGSIZE:
 #define PGM_OPT_CURR_TGSIZE_LEN	(2+2+4)
 		    if (opt_len != PGM_OPT_CURR_TGSIZE_LEN) {
-			ND_PRINT(C_RESET, C_RESET "[Bad OPT_CURR_TGSIZE option, length %u != %u]",
+			ND_PRINT(C_RESET, "[Bad OPT_CURR_TGSIZE option, length %u != %u]",
 			    opt_len, PGM_OPT_CURR_TGSIZE_LEN);
 			return;
 		    }
 		    bp += 2;
 		    len = GET_BE_U_4(bp);
 		    bp += 4;
-		    ND_PRINT(C_RESET, C_RESET " PARITY ATGS %u", len);
+		    ND_PRINT(C_RESET, " PARITY ATGS %u", len);
 		    opts_len -= PGM_OPT_CURR_TGSIZE_LEN;
 		    break;
 
 		case PGM_OPT_NBR_UNREACH:
 #define PGM_OPT_NBR_UNREACH_LEN	(2+2)
 		    if (opt_len != PGM_OPT_NBR_UNREACH_LEN) {
-			ND_PRINT(C_RESET, C_RESET "[Bad OPT_NBR_UNREACH option, length %u != %u]",
+			ND_PRINT(C_RESET, "[Bad OPT_NBR_UNREACH option, length %u != %u]",
 			    opt_len, PGM_OPT_NBR_UNREACH_LEN);
 			return;
 		    }
 		    bp += 2;
-		    ND_PRINT(C_RESET, C_RESET " NBR_UNREACH");
+		    ND_PRINT(C_RESET, " NBR_UNREACH");
 		    opts_len -= PGM_OPT_NBR_UNREACH_LEN;
 		    break;
 
 		case PGM_OPT_PATH_NLA:
-		    ND_PRINT(C_RESET, C_RESET " PATH_NLA [%u]", opt_len);
+		    ND_PRINT(C_RESET, " PATH_NLA [%u]", opt_len);
 		    bp += opt_len;
 		    opts_len -= opt_len;
 		    break;
@@ -665,41 +665,41 @@ pgm_print(netdissect_options *ndo,
 		case PGM_OPT_SYN:
 #define PGM_OPT_SYN_LEN	(2+2)
 		    if (opt_len != PGM_OPT_SYN_LEN) {
-			ND_PRINT(C_RESET, C_RESET "[Bad OPT_SYN option, length %u != %u]",
+			ND_PRINT(C_RESET, "[Bad OPT_SYN option, length %u != %u]",
 			    opt_len, PGM_OPT_SYN_LEN);
 			return;
 		    }
 		    bp += 2;
-		    ND_PRINT(C_RESET, C_RESET " SYN");
+		    ND_PRINT(C_RESET, " SYN");
 		    opts_len -= PGM_OPT_SYN_LEN;
 		    break;
 
 		case PGM_OPT_FIN:
 #define PGM_OPT_FIN_LEN	(2+2)
 		    if (opt_len != PGM_OPT_FIN_LEN) {
-			ND_PRINT(C_RESET, C_RESET "[Bad OPT_FIN option, length %u != %u]",
+			ND_PRINT(C_RESET, "[Bad OPT_FIN option, length %u != %u]",
 			    opt_len, PGM_OPT_FIN_LEN);
 			return;
 		    }
 		    bp += 2;
-		    ND_PRINT(C_RESET, C_RESET " FIN");
+		    ND_PRINT(C_RESET, " FIN");
 		    opts_len -= PGM_OPT_FIN_LEN;
 		    break;
 
 		case PGM_OPT_RST:
 #define PGM_OPT_RST_LEN	(2+2)
 		    if (opt_len != PGM_OPT_RST_LEN) {
-			ND_PRINT(C_RESET, C_RESET "[Bad OPT_RST option, length %u != %u]",
+			ND_PRINT(C_RESET, "[Bad OPT_RST option, length %u != %u]",
 			    opt_len, PGM_OPT_RST_LEN);
 			return;
 		    }
 		    bp += 2;
-		    ND_PRINT(C_RESET, C_RESET " RST");
+		    ND_PRINT(C_RESET, " RST");
 		    opts_len -= PGM_OPT_RST_LEN;
 		    break;
 
 		case PGM_OPT_CR:
-		    ND_PRINT(C_RESET, C_RESET " CR");
+		    ND_PRINT(C_RESET, " CR");
 		    bp += opt_len;
 		    opts_len -= opt_len;
 		    break;
@@ -707,19 +707,19 @@ pgm_print(netdissect_options *ndo,
 		case PGM_OPT_CRQST:
 #define PGM_OPT_CRQST_LEN	(2+2)
 		    if (opt_len != PGM_OPT_CRQST_LEN) {
-			ND_PRINT(C_RESET, C_RESET "[Bad OPT_CRQST option, length %u != %u]",
+			ND_PRINT(C_RESET, "[Bad OPT_CRQST option, length %u != %u]",
 			    opt_len, PGM_OPT_CRQST_LEN);
 			return;
 		    }
 		    bp += 2;
-		    ND_PRINT(C_RESET, C_RESET " CRQST");
+		    ND_PRINT(C_RESET, " CRQST");
 		    opts_len -= PGM_OPT_CRQST_LEN;
 		    break;
 
 		case PGM_OPT_PGMCC_DATA:
 #define PGM_OPT_PGMCC_DATA_FIXED_LEN	(2+2+4+2+2)
 		    if (opt_len < PGM_OPT_PGMCC_DATA_FIXED_LEN) {
-			ND_PRINT(C_RESET, C_RESET "[Bad OPT_PGMCC_DATA option, length %u < %u]",
+			ND_PRINT(C_RESET, "[Bad OPT_PGMCC_DATA option, length %u < %u]",
 			    opt_len, PGM_OPT_PGMCC_DATA_FIXED_LEN);
 			return;
 		    }
@@ -731,7 +731,7 @@ pgm_print(netdissect_options *ndo,
 		    switch (nla_afnum) {
 		    case AFNUM_INET:
 			if (opt_len != PGM_OPT_PGMCC_DATA_FIXED_LEN + sizeof(nd_ipv4)) {
-			    ND_PRINT(C_RESET, C_RESET "[Bad OPT_PGMCC_DATA option, length %u != %u + address size]",
+			    ND_PRINT(C_RESET, "[Bad OPT_PGMCC_DATA option, length %u != %u + address size]",
 			        opt_len, PGM_OPT_PGMCC_DATA_FIXED_LEN);
 			    return;
 			}
@@ -742,7 +742,7 @@ pgm_print(netdissect_options *ndo,
 			break;
 		    case AFNUM_INET6:
 			if (opt_len != PGM_OPT_PGMCC_DATA_FIXED_LEN + sizeof(nd_ipv6)) {
-			    ND_PRINT(C_RESET, C_RESET "[Bad OPT_PGMCC_DATA option, length %u != %u + address size]",
+			    ND_PRINT(C_RESET, "[Bad OPT_PGMCC_DATA option, length %u != %u + address size]",
 			        opt_len, PGM_OPT_PGMCC_DATA_FIXED_LEN);
 			    return;
 			}
@@ -756,13 +756,13 @@ pgm_print(netdissect_options *ndo,
 			break;
 		    }
 
-		    ND_PRINT(C_RESET, C_RESET " PGMCC DATA %u %s", offset, nla_buf);
+		    ND_PRINT(C_RESET, " PGMCC DATA %u %s", offset, nla_buf);
 		    break;
 
 		case PGM_OPT_PGMCC_FEEDBACK:
 #define PGM_OPT_PGMCC_FEEDBACK_FIXED_LEN	(2+2+4+2+2)
 		    if (opt_len < PGM_OPT_PGMCC_FEEDBACK_FIXED_LEN) {
-			ND_PRINT(C_RESET, C_RESET "[Bad PGM_OPT_PGMCC_FEEDBACK option, length %u < %u]",
+			ND_PRINT(C_RESET, "[Bad PGM_OPT_PGMCC_FEEDBACK option, length %u < %u]",
 			    opt_len, PGM_OPT_PGMCC_FEEDBACK_FIXED_LEN);
 			return;
 		    }
@@ -774,7 +774,7 @@ pgm_print(netdissect_options *ndo,
 		    switch (nla_afnum) {
 		    case AFNUM_INET:
 			if (opt_len != PGM_OPT_PGMCC_FEEDBACK_FIXED_LEN + sizeof(nd_ipv4)) {
-			    ND_PRINT(C_RESET, C_RESET "[Bad OPT_PGMCC_FEEDBACK option, length %u != %u + address size]",
+			    ND_PRINT(C_RESET, "[Bad OPT_PGMCC_FEEDBACK option, length %u != %u + address size]",
 			        opt_len, PGM_OPT_PGMCC_FEEDBACK_FIXED_LEN);
 			    return;
 			}
@@ -785,7 +785,7 @@ pgm_print(netdissect_options *ndo,
 			break;
 		    case AFNUM_INET6:
 			if (opt_len != PGM_OPT_PGMCC_FEEDBACK_FIXED_LEN + sizeof(nd_ipv6)) {
-			    ND_PRINT(C_RESET, C_RESET "[Bad OPT_PGMCC_FEEDBACK option, length %u != %u + address size]",
+			    ND_PRINT(C_RESET, "[Bad OPT_PGMCC_FEEDBACK option, length %u != %u + address size]",
 			        opt_len, PGM_OPT_PGMCC_FEEDBACK_FIXED_LEN);
 			    return;
 			}
@@ -799,11 +799,11 @@ pgm_print(netdissect_options *ndo,
 			break;
 		    }
 
-		    ND_PRINT(C_RESET, C_RESET " PGMCC FEEDBACK %u %s", offset, nla_buf);
+		    ND_PRINT(C_RESET, " PGMCC FEEDBACK %u %s", offset, nla_buf);
 		    break;
 
 		default:
-		    ND_PRINT(C_RESET, C_RESET " OPT_%02X [%u] ", opt_type, opt_len);
+		    ND_PRINT(C_RESET, " OPT_%02X [%u] ", opt_type, opt_len);
 		    bp += opt_len;
 		    opts_len -= opt_len;
 		    break;
@@ -814,7 +814,7 @@ pgm_print(netdissect_options *ndo,
 	     }
 	}
 
-	ND_PRINT(C_RESET, C_RESET " [%u]", length);
+	ND_PRINT(C_RESET, " [%u]", length);
 	if (ndo->ndo_packettype == PT_PGM_ZMTP1 &&
 	    (pgm_type_val == PGM_ODATA || pgm_type_val == PGM_RDATA))
 		zmtp1_datagram_print(ndo, bp,

--- a/print-pgm.c
+++ b/print-pgm.c
@@ -167,11 +167,11 @@ pgm_print(netdissect_options *ndo,
 		ip6 = NULL;
 	if (!ND_TTEST_2(pgm->pgm_dport)) {
 		if (ip6) {
-			ND_PRINT("%s > %s:",
+			ND_PRINT(C_RESET, C_RESET "%s > %s:",
 				GET_IP6ADDR_STRING(ip6->ip6_src),
 				GET_IP6ADDR_STRING(ip6->ip6_dst));
 		} else {
-			ND_PRINT("%s > %s:",
+			ND_PRINT(C_RESET, C_RESET "%s > %s:",
 				GET_IPADDR_STRING(ip->ip_src),
 				GET_IPADDR_STRING(ip->ip_dst));
 		}
@@ -183,37 +183,37 @@ pgm_print(netdissect_options *ndo,
 
 	if (ip6) {
 		if (GET_U_1(ip6->ip6_nxt) == IPPROTO_PGM) {
-			ND_PRINT("%s.%s > %s.%s: ",
+			ND_PRINT(C_RESET, C_RESET "%s.%s > %s.%s: ",
 				GET_IP6ADDR_STRING(ip6->ip6_src),
 				tcpport_string(ndo, sport),
 				GET_IP6ADDR_STRING(ip6->ip6_dst),
 				tcpport_string(ndo, dport));
 		} else {
-			ND_PRINT("%s > %s: ",
+			ND_PRINT(C_RESET, C_RESET "%s > %s: ",
 				tcpport_string(ndo, sport), tcpport_string(ndo, dport));
 		}
 	} else {
 		if (GET_U_1(ip->ip_p) == IPPROTO_PGM) {
-			ND_PRINT("%s.%s > %s.%s: ",
+			ND_PRINT(C_RESET, C_RESET "%s.%s > %s.%s: ",
 				GET_IPADDR_STRING(ip->ip_src),
 				tcpport_string(ndo, sport),
 				GET_IPADDR_STRING(ip->ip_dst),
 				tcpport_string(ndo, dport));
 		} else {
-			ND_PRINT("%s > %s: ",
+			ND_PRINT(C_RESET, C_RESET "%s > %s: ",
 				tcpport_string(ndo, sport), tcpport_string(ndo, dport));
 		}
 	}
 
 	ND_TCHECK_SIZE(pgm);
 
-        ND_PRINT("PGM, length %u", GET_BE_U_2(pgm->pgm_length));
+        ND_PRINT(C_RESET, C_RESET "PGM, length %u", GET_BE_U_2(pgm->pgm_length));
 
         if (!ndo->ndo_vflag)
             return;
 
 	pgm_type_val = GET_U_1(pgm->pgm_type);
-	ND_PRINT(" 0x%02x%02x%02x%02x%02x%02x ",
+	ND_PRINT(C_RESET, C_RESET " 0x%02x%02x%02x%02x%02x%02x ",
 		     pgm->pgm_gsid[0],
                      pgm->pgm_gsid[1],
                      pgm->pgm_gsid[2],
@@ -244,7 +244,7 @@ pgm_print(netdissect_options *ndo,
 		break;
 	    }
 
-	    ND_PRINT("SPM seq %u trail %u lead %u nla %s",
+	    ND_PRINT(C_RESET, C_RESET "SPM seq %u trail %u lead %u nla %s",
 			 GET_BE_U_4(spm->pgms_seq),
 			 GET_BE_U_4(spm->pgms_trailseq),
 			 GET_BE_U_4(spm->pgms_leadseq),
@@ -285,7 +285,7 @@ pgm_print(netdissect_options *ndo,
 	    mask = GET_BE_U_4(bp);
 	    bp += sizeof(uint32_t);
 
-	    ND_PRINT("POLL seq %u round %u nla %s ivl %u rnd 0x%08x "
+	    ND_PRINT(C_RESET, C_RESET "POLL seq %u round %u nla %s ivl %u rnd 0x%08x "
 			 "mask 0x%08x", GET_BE_U_4(pgm_poll->pgmp_seq),
 			 GET_BE_U_2(pgm_poll->pgmp_round), nla_buf, ivl, rnd,
 			 mask);
@@ -296,7 +296,7 @@ pgm_print(netdissect_options *ndo,
 
 	    polr_msg = (const struct pgm_polr *)(pgm + 1);
 	    ND_TCHECK_SIZE(polr_msg);
-	    ND_PRINT("POLR seq %u round %u",
+	    ND_PRINT(C_RESET, C_RESET "POLR seq %u round %u",
 			 GET_BE_U_4(polr_msg->pgmp_seq),
 			 GET_BE_U_2(polr_msg->pgmp_round));
 	    bp = (const u_char *) (polr_msg + 1);
@@ -306,7 +306,7 @@ pgm_print(netdissect_options *ndo,
 	    const struct pgm_data *odata;
 
 	    odata = (const struct pgm_data *)(pgm + 1);
-	    ND_PRINT("ODATA trail %u seq %u",
+	    ND_PRINT(C_RESET, C_RESET "ODATA trail %u seq %u",
 			 GET_BE_U_4(odata->pgmd_trailseq),
 			 GET_BE_U_4(odata->pgmd_seq));
 	    bp = (const u_char *) (odata + 1);
@@ -317,7 +317,7 @@ pgm_print(netdissect_options *ndo,
 	    const struct pgm_data *rdata;
 
 	    rdata = (const struct pgm_data *)(pgm + 1);
-	    ND_PRINT("RDATA trail %u seq %u",
+	    ND_PRINT(C_RESET, C_RESET "RDATA trail %u seq %u",
 			 GET_BE_U_4(rdata->pgmd_trailseq),
 			 GET_BE_U_4(rdata->pgmd_seq));
 	    bp = (const u_char *) (rdata + 1);
@@ -380,18 +380,18 @@ pgm_print(netdissect_options *ndo,
 	     */
 	    switch (pgm_type_val) {
 		case PGM_NAK:
-		    ND_PRINT("NAK ");
+		    ND_PRINT(C_RESET, C_RESET "NAK ");
 		    break;
 		case PGM_NULLNAK:
-		    ND_PRINT("NNAK ");
+		    ND_PRINT(C_RESET, C_RESET "NNAK ");
 		    break;
 		case PGM_NCF:
-		    ND_PRINT("NCF ");
+		    ND_PRINT(C_RESET, C_RESET "NCF ");
 		    break;
 		default:
                     break;
 	    }
-	    ND_PRINT("(%s -> %s), seq %u",
+	    ND_PRINT(C_RESET, C_RESET "(%s -> %s), seq %u",
 			 source_buf, group_buf, GET_BE_U_4(nak->pgmn_seq));
 	    break;
 	}
@@ -401,18 +401,18 @@ pgm_print(netdissect_options *ndo,
 
 	    ack = (const struct pgm_ack *)(pgm + 1);
 	    ND_TCHECK_SIZE(ack);
-	    ND_PRINT("ACK seq %u",
+	    ND_PRINT(C_RESET, C_RESET "ACK seq %u",
 			 GET_BE_U_4(ack->pgma_rx_max_seq));
 	    bp = (const u_char *) (ack + 1);
 	    break;
 	}
 
 	case PGM_SPMR:
-	    ND_PRINT("SPMR");
+	    ND_PRINT(C_RESET, C_RESET "SPMR");
 	    break;
 
 	default:
-	    ND_PRINT("UNKNOWN type 0x%02x", pgm_type_val);
+	    ND_PRINT(C_RESET, C_RESET "UNKNOWN type 0x%02x", pgm_type_val);
 	    break;
 
 	}
@@ -430,27 +430,27 @@ pgm_print(netdissect_options *ndo,
 	    opt_type = GET_U_1(bp);
 	    bp++;
 	    if ((opt_type & PGM_OPT_MASK) != PGM_OPT_LENGTH) {
-		ND_PRINT("[First option bad, should be PGM_OPT_LENGTH, is %u]", opt_type & PGM_OPT_MASK);
+		ND_PRINT(C_RESET, C_RESET "[First option bad, should be PGM_OPT_LENGTH, is %u]", opt_type & PGM_OPT_MASK);
 		return;
 	    }
 	    opt_len = GET_U_1(bp);
 	    bp++;
 	    if (opt_len != 4) {
-		ND_PRINT("[Bad OPT_LENGTH option, length %u != 4]", opt_len);
+		ND_PRINT(C_RESET, C_RESET "[Bad OPT_LENGTH option, length %u != 4]", opt_len);
 		return;
 	    }
 	    opts_len = GET_BE_U_2(bp);
 	    bp += sizeof(uint16_t);
 	    if (opts_len < 4) {
-		ND_PRINT("[Bad total option length %u < 4]", opts_len);
+		ND_PRINT(C_RESET, C_RESET "[Bad total option length %u < 4]", opts_len);
 		return;
 	    }
-	    ND_PRINT(" OPTS LEN %u", opts_len);
+	    ND_PRINT(C_RESET, C_RESET " OPTS LEN %u", opts_len);
 	    opts_len -= 4;
 
 	    while (opts_len) {
 		if (opts_len < PGM_MIN_OPT_LEN) {
-		    ND_PRINT("[Total option length leaves no room for final option]");
+		    ND_PRINT(C_RESET, C_RESET "[Total option length leaves no room for final option]");
 		    return;
 		}
 		opt_type = GET_U_1(bp);
@@ -458,12 +458,12 @@ pgm_print(netdissect_options *ndo,
 		opt_len = GET_U_1(bp);
 		bp++;
 		if (opt_len < PGM_MIN_OPT_LEN) {
-		    ND_PRINT("[Bad option, length %u < %u]", opt_len,
+		    ND_PRINT(C_RESET, C_RESET "[Bad option, length %u < %u]", opt_len,
 		        PGM_MIN_OPT_LEN);
 		    break;
 		}
 		if (opts_len < opt_len) {
-		    ND_PRINT("[Total option length leaves no room for final option]");
+		    ND_PRINT(C_RESET, C_RESET "[Total option length leaves no room for final option]");
 		    return;
 		}
 		ND_TCHECK_LEN(bp, opt_len - 2);
@@ -472,11 +472,11 @@ pgm_print(netdissect_options *ndo,
 		case PGM_OPT_LENGTH:
 #define PGM_OPT_LENGTH_LEN	(2+2)
 		    if (opt_len != PGM_OPT_LENGTH_LEN) {
-			ND_PRINT("[Bad OPT_LENGTH option, length %u != %u]",
+			ND_PRINT(C_RESET, C_RESET "[Bad OPT_LENGTH option, length %u != %u]",
 			    opt_len, PGM_OPT_LENGTH_LEN);
 			return;
 		    }
-		    ND_PRINT(" OPTS LEN (extra?) %u", GET_BE_U_2(bp));
+		    ND_PRINT(C_RESET, C_RESET " OPTS LEN (extra?) %u", GET_BE_U_2(bp));
 		    bp += 2;
 		    opts_len -= PGM_OPT_LENGTH_LEN;
 		    break;
@@ -484,7 +484,7 @@ pgm_print(netdissect_options *ndo,
 		case PGM_OPT_FRAGMENT:
 #define PGM_OPT_FRAGMENT_LEN	(2+2+4+4+4)
 		    if (opt_len != PGM_OPT_FRAGMENT_LEN) {
-			ND_PRINT("[Bad OPT_FRAGMENT option, length %u != %u]",
+			ND_PRINT(C_RESET, C_RESET "[Bad OPT_FRAGMENT option, length %u != %u]",
 			    opt_len, PGM_OPT_FRAGMENT_LEN);
 			return;
 		    }
@@ -495,20 +495,20 @@ pgm_print(netdissect_options *ndo,
 		    bp += 4;
 		    len = GET_BE_U_4(bp);
 		    bp += 4;
-		    ND_PRINT(" FRAG seq %u off %u len %u", seq, offset, len);
+		    ND_PRINT(C_RESET, C_RESET " FRAG seq %u off %u len %u", seq, offset, len);
 		    opts_len -= PGM_OPT_FRAGMENT_LEN;
 		    break;
 
 		case PGM_OPT_NAK_LIST:
 		    bp += 2;
 		    opt_len -= 4;	/* option header */
-		    ND_PRINT(" NAK LIST");
+		    ND_PRINT(C_RESET, C_RESET " NAK LIST");
 		    while (opt_len) {
 			if (opt_len < 4) {
-			    ND_PRINT("[Option length not a multiple of 4]");
+			    ND_PRINT(C_RESET, C_RESET "[Option length not a multiple of 4]");
 			    return;
 			}
-			ND_PRINT(" %u", GET_BE_U_4(bp));
+			ND_PRINT(C_RESET, C_RESET " %u", GET_BE_U_4(bp));
 			bp += 4;
 			opt_len -= 4;
 			opts_len -= 4;
@@ -518,21 +518,21 @@ pgm_print(netdissect_options *ndo,
 		case PGM_OPT_JOIN:
 #define PGM_OPT_JOIN_LEN	(2+2+4)
 		    if (opt_len != PGM_OPT_JOIN_LEN) {
-			ND_PRINT("[Bad OPT_JOIN option, length %u != %u]",
+			ND_PRINT(C_RESET, C_RESET "[Bad OPT_JOIN option, length %u != %u]",
 			    opt_len, PGM_OPT_JOIN_LEN);
 			return;
 		    }
 		    bp += 2;
 		    seq = GET_BE_U_4(bp);
 		    bp += 4;
-		    ND_PRINT(" JOIN %u", seq);
+		    ND_PRINT(C_RESET, C_RESET " JOIN %u", seq);
 		    opts_len -= PGM_OPT_JOIN_LEN;
 		    break;
 
 		case PGM_OPT_NAK_BO_IVL:
 #define PGM_OPT_NAK_BO_IVL_LEN	(2+2+4+4)
 		    if (opt_len != PGM_OPT_NAK_BO_IVL_LEN) {
-			ND_PRINT("[Bad OPT_NAK_BO_IVL option, length %u != %u]",
+			ND_PRINT(C_RESET, C_RESET "[Bad OPT_NAK_BO_IVL option, length %u != %u]",
 			    opt_len, PGM_OPT_NAK_BO_IVL_LEN);
 			return;
 		    }
@@ -541,14 +541,14 @@ pgm_print(netdissect_options *ndo,
 		    bp += 4;
 		    seq = GET_BE_U_4(bp);
 		    bp += 4;
-		    ND_PRINT(" BACKOFF ivl %u ivlseq %u", offset, seq);
+		    ND_PRINT(C_RESET, C_RESET " BACKOFF ivl %u ivlseq %u", offset, seq);
 		    opts_len -= PGM_OPT_NAK_BO_IVL_LEN;
 		    break;
 
 		case PGM_OPT_NAK_BO_RNG:
 #define PGM_OPT_NAK_BO_RNG_LEN	(2+2+4+4)
 		    if (opt_len != PGM_OPT_NAK_BO_RNG_LEN) {
-			ND_PRINT("[Bad OPT_NAK_BO_RNG option, length %u != %u]",
+			ND_PRINT(C_RESET, C_RESET "[Bad OPT_NAK_BO_RNG option, length %u != %u]",
 			    opt_len, PGM_OPT_NAK_BO_RNG_LEN);
 			return;
 		    }
@@ -557,14 +557,14 @@ pgm_print(netdissect_options *ndo,
 		    bp += 4;
 		    seq = GET_BE_U_4(bp);
 		    bp += 4;
-		    ND_PRINT(" BACKOFF max %u min %u", offset, seq);
+		    ND_PRINT(C_RESET, C_RESET " BACKOFF max %u min %u", offset, seq);
 		    opts_len -= PGM_OPT_NAK_BO_RNG_LEN;
 		    break;
 
 		case PGM_OPT_REDIRECT:
 #define PGM_OPT_REDIRECT_FIXED_LEN	(2+2+2+2)
 		    if (opt_len < PGM_OPT_REDIRECT_FIXED_LEN) {
-			ND_PRINT("[Bad OPT_REDIRECT option, length %u < %u]",
+			ND_PRINT(C_RESET, C_RESET "[Bad OPT_REDIRECT option, length %u < %u]",
 			    opt_len, PGM_OPT_REDIRECT_FIXED_LEN);
 			return;
 		    }
@@ -574,7 +574,7 @@ pgm_print(netdissect_options *ndo,
 		    switch (nla_afnum) {
 		    case AFNUM_INET:
 			if (opt_len != PGM_OPT_REDIRECT_FIXED_LEN + sizeof(nd_ipv4)) {
-			    ND_PRINT("[Bad OPT_REDIRECT option, length %u != %u + address size]",
+			    ND_PRINT(C_RESET, C_RESET "[Bad OPT_REDIRECT option, length %u != %u + address size]",
 			        opt_len, PGM_OPT_REDIRECT_FIXED_LEN);
 			    return;
 			}
@@ -585,7 +585,7 @@ pgm_print(netdissect_options *ndo,
 			break;
 		    case AFNUM_INET6:
 			if (opt_len != PGM_OPT_REDIRECT_FIXED_LEN + sizeof(nd_ipv6)) {
-			    ND_PRINT("[Bad OPT_REDIRECT option, length %u != %u + address size]",
+			    ND_PRINT(C_RESET, C_RESET "[Bad OPT_REDIRECT option, length %u != %u + address size]",
 			        opt_len, PGM_OPT_REDIRECT_FIXED_LEN);
 			    return;
 			}
@@ -599,65 +599,65 @@ pgm_print(netdissect_options *ndo,
 			break;
 		    }
 
-		    ND_PRINT(" REDIRECT %s",  nla_buf);
+		    ND_PRINT(C_RESET, C_RESET " REDIRECT %s",  nla_buf);
 		    break;
 
 		case PGM_OPT_PARITY_PRM:
 #define PGM_OPT_PARITY_PRM_LEN	(2+2+4)
 		    if (opt_len != PGM_OPT_PARITY_PRM_LEN) {
-			ND_PRINT("[Bad OPT_PARITY_PRM option, length %u != %u]",
+			ND_PRINT(C_RESET, C_RESET "[Bad OPT_PARITY_PRM option, length %u != %u]",
 			    opt_len, PGM_OPT_PARITY_PRM_LEN);
 			return;
 		    }
 		    bp += 2;
 		    len = GET_BE_U_4(bp);
 		    bp += 4;
-		    ND_PRINT(" PARITY MAXTGS %u", len);
+		    ND_PRINT(C_RESET, C_RESET " PARITY MAXTGS %u", len);
 		    opts_len -= PGM_OPT_PARITY_PRM_LEN;
 		    break;
 
 		case PGM_OPT_PARITY_GRP:
 #define PGM_OPT_PARITY_GRP_LEN	(2+2+4)
 		    if (opt_len != PGM_OPT_PARITY_GRP_LEN) {
-			ND_PRINT("[Bad OPT_PARITY_GRP option, length %u != %u]",
+			ND_PRINT(C_RESET, C_RESET "[Bad OPT_PARITY_GRP option, length %u != %u]",
 			    opt_len, PGM_OPT_PARITY_GRP_LEN);
 			return;
 		    }
 		    bp += 2;
 		    seq = GET_BE_U_4(bp);
 		    bp += 4;
-		    ND_PRINT(" PARITY GROUP %u", seq);
+		    ND_PRINT(C_RESET, C_RESET " PARITY GROUP %u", seq);
 		    opts_len -= PGM_OPT_PARITY_GRP_LEN;
 		    break;
 
 		case PGM_OPT_CURR_TGSIZE:
 #define PGM_OPT_CURR_TGSIZE_LEN	(2+2+4)
 		    if (opt_len != PGM_OPT_CURR_TGSIZE_LEN) {
-			ND_PRINT("[Bad OPT_CURR_TGSIZE option, length %u != %u]",
+			ND_PRINT(C_RESET, C_RESET "[Bad OPT_CURR_TGSIZE option, length %u != %u]",
 			    opt_len, PGM_OPT_CURR_TGSIZE_LEN);
 			return;
 		    }
 		    bp += 2;
 		    len = GET_BE_U_4(bp);
 		    bp += 4;
-		    ND_PRINT(" PARITY ATGS %u", len);
+		    ND_PRINT(C_RESET, C_RESET " PARITY ATGS %u", len);
 		    opts_len -= PGM_OPT_CURR_TGSIZE_LEN;
 		    break;
 
 		case PGM_OPT_NBR_UNREACH:
 #define PGM_OPT_NBR_UNREACH_LEN	(2+2)
 		    if (opt_len != PGM_OPT_NBR_UNREACH_LEN) {
-			ND_PRINT("[Bad OPT_NBR_UNREACH option, length %u != %u]",
+			ND_PRINT(C_RESET, C_RESET "[Bad OPT_NBR_UNREACH option, length %u != %u]",
 			    opt_len, PGM_OPT_NBR_UNREACH_LEN);
 			return;
 		    }
 		    bp += 2;
-		    ND_PRINT(" NBR_UNREACH");
+		    ND_PRINT(C_RESET, C_RESET " NBR_UNREACH");
 		    opts_len -= PGM_OPT_NBR_UNREACH_LEN;
 		    break;
 
 		case PGM_OPT_PATH_NLA:
-		    ND_PRINT(" PATH_NLA [%u]", opt_len);
+		    ND_PRINT(C_RESET, C_RESET " PATH_NLA [%u]", opt_len);
 		    bp += opt_len;
 		    opts_len -= opt_len;
 		    break;
@@ -665,41 +665,41 @@ pgm_print(netdissect_options *ndo,
 		case PGM_OPT_SYN:
 #define PGM_OPT_SYN_LEN	(2+2)
 		    if (opt_len != PGM_OPT_SYN_LEN) {
-			ND_PRINT("[Bad OPT_SYN option, length %u != %u]",
+			ND_PRINT(C_RESET, C_RESET "[Bad OPT_SYN option, length %u != %u]",
 			    opt_len, PGM_OPT_SYN_LEN);
 			return;
 		    }
 		    bp += 2;
-		    ND_PRINT(" SYN");
+		    ND_PRINT(C_RESET, C_RESET " SYN");
 		    opts_len -= PGM_OPT_SYN_LEN;
 		    break;
 
 		case PGM_OPT_FIN:
 #define PGM_OPT_FIN_LEN	(2+2)
 		    if (opt_len != PGM_OPT_FIN_LEN) {
-			ND_PRINT("[Bad OPT_FIN option, length %u != %u]",
+			ND_PRINT(C_RESET, C_RESET "[Bad OPT_FIN option, length %u != %u]",
 			    opt_len, PGM_OPT_FIN_LEN);
 			return;
 		    }
 		    bp += 2;
-		    ND_PRINT(" FIN");
+		    ND_PRINT(C_RESET, C_RESET " FIN");
 		    opts_len -= PGM_OPT_FIN_LEN;
 		    break;
 
 		case PGM_OPT_RST:
 #define PGM_OPT_RST_LEN	(2+2)
 		    if (opt_len != PGM_OPT_RST_LEN) {
-			ND_PRINT("[Bad OPT_RST option, length %u != %u]",
+			ND_PRINT(C_RESET, C_RESET "[Bad OPT_RST option, length %u != %u]",
 			    opt_len, PGM_OPT_RST_LEN);
 			return;
 		    }
 		    bp += 2;
-		    ND_PRINT(" RST");
+		    ND_PRINT(C_RESET, C_RESET " RST");
 		    opts_len -= PGM_OPT_RST_LEN;
 		    break;
 
 		case PGM_OPT_CR:
-		    ND_PRINT(" CR");
+		    ND_PRINT(C_RESET, C_RESET " CR");
 		    bp += opt_len;
 		    opts_len -= opt_len;
 		    break;
@@ -707,19 +707,19 @@ pgm_print(netdissect_options *ndo,
 		case PGM_OPT_CRQST:
 #define PGM_OPT_CRQST_LEN	(2+2)
 		    if (opt_len != PGM_OPT_CRQST_LEN) {
-			ND_PRINT("[Bad OPT_CRQST option, length %u != %u]",
+			ND_PRINT(C_RESET, C_RESET "[Bad OPT_CRQST option, length %u != %u]",
 			    opt_len, PGM_OPT_CRQST_LEN);
 			return;
 		    }
 		    bp += 2;
-		    ND_PRINT(" CRQST");
+		    ND_PRINT(C_RESET, C_RESET " CRQST");
 		    opts_len -= PGM_OPT_CRQST_LEN;
 		    break;
 
 		case PGM_OPT_PGMCC_DATA:
 #define PGM_OPT_PGMCC_DATA_FIXED_LEN	(2+2+4+2+2)
 		    if (opt_len < PGM_OPT_PGMCC_DATA_FIXED_LEN) {
-			ND_PRINT("[Bad OPT_PGMCC_DATA option, length %u < %u]",
+			ND_PRINT(C_RESET, C_RESET "[Bad OPT_PGMCC_DATA option, length %u < %u]",
 			    opt_len, PGM_OPT_PGMCC_DATA_FIXED_LEN);
 			return;
 		    }
@@ -731,7 +731,7 @@ pgm_print(netdissect_options *ndo,
 		    switch (nla_afnum) {
 		    case AFNUM_INET:
 			if (opt_len != PGM_OPT_PGMCC_DATA_FIXED_LEN + sizeof(nd_ipv4)) {
-			    ND_PRINT("[Bad OPT_PGMCC_DATA option, length %u != %u + address size]",
+			    ND_PRINT(C_RESET, C_RESET "[Bad OPT_PGMCC_DATA option, length %u != %u + address size]",
 			        opt_len, PGM_OPT_PGMCC_DATA_FIXED_LEN);
 			    return;
 			}
@@ -742,7 +742,7 @@ pgm_print(netdissect_options *ndo,
 			break;
 		    case AFNUM_INET6:
 			if (opt_len != PGM_OPT_PGMCC_DATA_FIXED_LEN + sizeof(nd_ipv6)) {
-			    ND_PRINT("[Bad OPT_PGMCC_DATA option, length %u != %u + address size]",
+			    ND_PRINT(C_RESET, C_RESET "[Bad OPT_PGMCC_DATA option, length %u != %u + address size]",
 			        opt_len, PGM_OPT_PGMCC_DATA_FIXED_LEN);
 			    return;
 			}
@@ -756,13 +756,13 @@ pgm_print(netdissect_options *ndo,
 			break;
 		    }
 
-		    ND_PRINT(" PGMCC DATA %u %s", offset, nla_buf);
+		    ND_PRINT(C_RESET, C_RESET " PGMCC DATA %u %s", offset, nla_buf);
 		    break;
 
 		case PGM_OPT_PGMCC_FEEDBACK:
 #define PGM_OPT_PGMCC_FEEDBACK_FIXED_LEN	(2+2+4+2+2)
 		    if (opt_len < PGM_OPT_PGMCC_FEEDBACK_FIXED_LEN) {
-			ND_PRINT("[Bad PGM_OPT_PGMCC_FEEDBACK option, length %u < %u]",
+			ND_PRINT(C_RESET, C_RESET "[Bad PGM_OPT_PGMCC_FEEDBACK option, length %u < %u]",
 			    opt_len, PGM_OPT_PGMCC_FEEDBACK_FIXED_LEN);
 			return;
 		    }
@@ -774,7 +774,7 @@ pgm_print(netdissect_options *ndo,
 		    switch (nla_afnum) {
 		    case AFNUM_INET:
 			if (opt_len != PGM_OPT_PGMCC_FEEDBACK_FIXED_LEN + sizeof(nd_ipv4)) {
-			    ND_PRINT("[Bad OPT_PGMCC_FEEDBACK option, length %u != %u + address size]",
+			    ND_PRINT(C_RESET, C_RESET "[Bad OPT_PGMCC_FEEDBACK option, length %u != %u + address size]",
 			        opt_len, PGM_OPT_PGMCC_FEEDBACK_FIXED_LEN);
 			    return;
 			}
@@ -785,7 +785,7 @@ pgm_print(netdissect_options *ndo,
 			break;
 		    case AFNUM_INET6:
 			if (opt_len != PGM_OPT_PGMCC_FEEDBACK_FIXED_LEN + sizeof(nd_ipv6)) {
-			    ND_PRINT("[Bad OPT_PGMCC_FEEDBACK option, length %u != %u + address size]",
+			    ND_PRINT(C_RESET, C_RESET "[Bad OPT_PGMCC_FEEDBACK option, length %u != %u + address size]",
 			        opt_len, PGM_OPT_PGMCC_FEEDBACK_FIXED_LEN);
 			    return;
 			}
@@ -799,11 +799,11 @@ pgm_print(netdissect_options *ndo,
 			break;
 		    }
 
-		    ND_PRINT(" PGMCC FEEDBACK %u %s", offset, nla_buf);
+		    ND_PRINT(C_RESET, C_RESET " PGMCC FEEDBACK %u %s", offset, nla_buf);
 		    break;
 
 		default:
-		    ND_PRINT(" OPT_%02X [%u] ", opt_type, opt_len);
+		    ND_PRINT(C_RESET, C_RESET " OPT_%02X [%u] ", opt_type, opt_len);
 		    bp += opt_len;
 		    opts_len -= opt_len;
 		    break;
@@ -814,7 +814,7 @@ pgm_print(netdissect_options *ndo,
 	     }
 	}
 
-	ND_PRINT(" [%u]", length);
+	ND_PRINT(C_RESET, C_RESET " [%u]", length);
 	if (ndo->ndo_packettype == PT_PGM_ZMTP1 &&
 	    (pgm_type_val == PGM_ODATA || pgm_type_val == PGM_RDATA))
 		zmtp1_datagram_print(ndo, bp,

--- a/print-pim.c
+++ b/print-pim.c
@@ -169,18 +169,18 @@ pimv1_join_prune_print(netdissect_options *ndo,
 	    ((njoin = GET_BE_U_2(bp + 20)) + GET_BE_U_2(bp + 22)) == 1) {
 		u_int hold;
 
-		ND_PRINT(" RPF %s ", GET_IPADDR_STRING(bp));
+		ND_PRINT(C_RESET, " RPF %s ", GET_IPADDR_STRING(bp));
 		hold = GET_BE_U_2(bp + 6);
 		if (hold != 180) {
-			ND_PRINT("Hold ");
+			ND_PRINT(C_RESET, "Hold ");
 			unsigned_relts_print(ndo, hold);
 		}
-		ND_PRINT("%s (%s/%u, %s", njoin ? "Join" : "Prune",
+		ND_PRINT(C_RESET, "%s (%s/%u, %s", njoin ? "Join" : "Prune",
 		GET_IPADDR_STRING(bp + 26), GET_U_1(bp + 25) & 0x3f,
 		GET_IPADDR_STRING(bp + 12));
 		if (GET_BE_U_4(bp + 16) != 0xffffffff)
-			ND_PRINT("/%s", GET_IPADDR_STRING(bp + 16));
-		ND_PRINT(") %s%s %s",
+			ND_PRINT(C_RESET, "/%s", GET_IPADDR_STRING(bp + 16));
+		ND_PRINT(C_RESET, ") %s%s %s",
 		    (GET_U_1(bp + 24) & 0x01) ? "Sparse" : "Dense",
 		    (GET_U_1(bp + 25) & 0x80) ? " WC" : "",
 		    (GET_U_1(bp + 25) & 0x40) ? "RP" : "SPT");
@@ -190,15 +190,15 @@ pimv1_join_prune_print(netdissect_options *ndo,
 	if (len < sizeof(nd_ipv4))
 		goto trunc;
 	if (ndo->ndo_vflag > 1)
-		ND_PRINT("\n");
-	ND_PRINT(" Upstream Nbr: %s", GET_IPADDR_STRING(bp));
+		ND_PRINT(C_RESET, "\n");
+	ND_PRINT(C_RESET, " Upstream Nbr: %s", GET_IPADDR_STRING(bp));
 	bp += 4;
 	len -= 4;
 	if (len < 4)
 		goto trunc;
 	if (ndo->ndo_vflag > 1)
-		ND_PRINT("\n");
-	ND_PRINT(" Hold time: ");
+		ND_PRINT(C_RESET, "\n");
+	ND_PRINT(C_RESET, " Hold time: ");
 	unsigned_relts_print(ndo, GET_BE_U_2(bp + 2));
 	if (ndo->ndo_vflag < 2)
 		return;
@@ -217,20 +217,20 @@ pimv1_join_prune_print(netdissect_options *ndo,
 		 */
 		if (len < 4)
 			goto trunc;
-		ND_PRINT("\n\tGroup: %s", GET_IPADDR_STRING(bp));
+		ND_PRINT(C_RESET, "\n\tGroup: %s", GET_IPADDR_STRING(bp));
 		bp += 4;
 		len -= 4;
 		if (len < 4)
 			goto trunc;
 		if (GET_BE_U_4(bp) != 0xffffffff)
-			ND_PRINT("/%s", GET_IPADDR_STRING(bp));
+			ND_PRINT(C_RESET, "/%s", GET_IPADDR_STRING(bp));
 		bp += 4;
 		len -= 4;
 		if (len < 4)
 			goto trunc;
 		njoin = GET_BE_U_2(bp);
 		nprune = GET_BE_U_2(bp + 2);
-		ND_PRINT(" joined: %u pruned: %u", njoin, nprune);
+		ND_PRINT(C_RESET, " joined: %u pruned: %u", njoin, nprune);
 		bp += 4;
 		len -= 4;
 		for (njp = 0; njp < (njoin + nprune); njp++) {
@@ -242,7 +242,7 @@ pimv1_join_prune_print(netdissect_options *ndo,
 				type = "Prune";
 			if (len < 6)
 				goto trunc;
-			ND_PRINT("\n\t%s %s%s%s%s/%u", type,
+			ND_PRINT(C_RESET, "\n\t%s %s%s%s%s/%u", type,
 			    (GET_U_1(bp) & 0x01) ? "Sparse " : "Dense ",
 			    (GET_U_1(bp + 1) & 0x80) ? "WC " : "",
 			    (GET_U_1(bp + 1) & 0x40) ? "RP " : "SPT ",
@@ -267,56 +267,56 @@ pimv1_print(netdissect_options *ndo,
 	ndo->ndo_protocol = "pimv1";
 	type = GET_U_1(bp + 1);
 
-	ND_PRINT(" %s", tok2str(pimv1_type_str, "[type %u]", type));
+	ND_PRINT(C_RESET, " %s", tok2str(pimv1_type_str, "[type %u]", type));
 	switch (type) {
 	case PIMV1_TYPE_QUERY:
 		if (ND_TTEST_1(bp + 8)) {
 			switch (GET_U_1(bp + 8) >> 4) {
 			case 0:
-				ND_PRINT(" Dense-mode");
+				ND_PRINT(C_RESET, " Dense-mode");
 				break;
 			case 1:
-				ND_PRINT(" Sparse-mode");
+				ND_PRINT(C_RESET, " Sparse-mode");
 				break;
 			case 2:
-				ND_PRINT(" Sparse-Dense-mode");
+				ND_PRINT(C_RESET, " Sparse-Dense-mode");
 				break;
 			default:
-				ND_PRINT(" mode-%u", GET_U_1(bp + 8) >> 4);
+				ND_PRINT(C_RESET, " mode-%u", GET_U_1(bp + 8) >> 4);
 				break;
 			}
 		}
 		if (ndo->ndo_vflag) {
-			ND_PRINT(" (Hold-time ");
+			ND_PRINT(C_RESET, " (Hold-time ");
 			unsigned_relts_print(ndo, GET_BE_U_2(bp + 10));
-			ND_PRINT(")");
+			ND_PRINT(C_RESET, ")");
 		}
 		break;
 
 	case PIMV1_TYPE_REGISTER:
 		ND_TCHECK_LEN(bp + 8, 20);			/* ip header */
-		ND_PRINT(" for %s > %s", GET_IPADDR_STRING(bp + 20),
+		ND_PRINT(C_RESET, " for %s > %s", GET_IPADDR_STRING(bp + 20),
 			  GET_IPADDR_STRING(bp + 24));
 		break;
 	case PIMV1_TYPE_REGISTER_STOP:
-		ND_PRINT(" for %s > %s", GET_IPADDR_STRING(bp + 8),
+		ND_PRINT(C_RESET, " for %s > %s", GET_IPADDR_STRING(bp + 8),
 			  GET_IPADDR_STRING(bp + 12));
 		break;
 	case PIMV1_TYPE_RP_REACHABILITY:
 		if (ndo->ndo_vflag) {
-			ND_PRINT(" group %s", GET_IPADDR_STRING(bp + 8));
+			ND_PRINT(C_RESET, " group %s", GET_IPADDR_STRING(bp + 8));
 			if (GET_BE_U_4(bp + 12) != 0xffffffff)
-				ND_PRINT("/%s", GET_IPADDR_STRING(bp + 12));
-			ND_PRINT(" RP %s hold ", GET_IPADDR_STRING(bp + 16));
+				ND_PRINT(C_RESET, "/%s", GET_IPADDR_STRING(bp + 12));
+			ND_PRINT(C_RESET, " RP %s hold ", GET_IPADDR_STRING(bp + 16));
 			unsigned_relts_print(ndo, GET_BE_U_2(bp + 22));
 		}
 		break;
 	case PIMV1_TYPE_ASSERT:
-		ND_PRINT(" for %s > %s", GET_IPADDR_STRING(bp + 16),
+		ND_PRINT(C_RESET, " for %s > %s", GET_IPADDR_STRING(bp + 16),
 			  GET_IPADDR_STRING(bp + 8));
 		if (GET_BE_U_4(bp + 12) != 0xffffffff)
-			ND_PRINT("/%s", GET_IPADDR_STRING(bp + 12));
-		ND_PRINT(" %s pref %u metric %u",
+			ND_PRINT(C_RESET, "/%s", GET_IPADDR_STRING(bp + 12));
+		ND_PRINT(C_RESET, " %s pref %u metric %u",
 		    (GET_U_1(bp + 20) & 0x80) ? "RP-tree" : "SPT",
 		    GET_BE_U_4(bp + 20) & 0x7fffffff,
 		    GET_BE_U_4(bp + 24));
@@ -332,7 +332,7 @@ pimv1_print(netdissect_options *ndo,
 		break;
 	}
 	if ((GET_U_1(bp + 4) >> 4) != 1)
-		ND_PRINT(" [v%u]", GET_U_1(bp + 4) >> 4);
+		ND_PRINT(C_RESET, " [v%u]", GET_U_1(bp + 4) >> 4);
 	return;
 
 trunc:
@@ -356,28 +356,28 @@ cisco_autorp_print(netdissect_options *ndo,
 	ndo->ndo_protocol = "cisco_autorp";
 	if (len < 8)
 		goto trunc;
-	ND_PRINT(" auto-rp ");
+	ND_PRINT(C_RESET, " auto-rp ");
 	type = GET_U_1(bp);
 	switch (type) {
 	case 0x11:
-		ND_PRINT("candidate-advert");
+		ND_PRINT(C_RESET, "candidate-advert");
 		break;
 	case 0x12:
-		ND_PRINT("mapping");
+		ND_PRINT(C_RESET, "mapping");
 		break;
 	default:
-		ND_PRINT("type-0x%02x", type);
+		ND_PRINT(C_RESET, "type-0x%02x", type);
 		break;
 	}
 
 	numrps = GET_U_1(bp + 1);
 
-	ND_PRINT(" Hold ");
+	ND_PRINT(C_RESET, " Hold ");
 	hold = GET_BE_U_2(bp + 2);
 	if (hold)
 		unsigned_relts_print(ndo, GET_BE_U_2(bp + 2));
 	else
-		ND_PRINT("FOREVER");
+		ND_PRINT(C_RESET, "FOREVER");
 
 	/* Next 4 bytes are reserved. */
 
@@ -402,23 +402,23 @@ cisco_autorp_print(netdissect_options *ndo,
 
 		if (len < 4)
 			goto trunc;
-		ND_PRINT(" RP %s", GET_IPADDR_STRING(bp));
+		ND_PRINT(C_RESET, " RP %s", GET_IPADDR_STRING(bp));
 		bp += 4;
 		len -= 4;
 		if (len < 1)
 			goto trunc;
 		switch (GET_U_1(bp) & 0x3) {
-		case 0: ND_PRINT(" PIMv?");
+		case 0: ND_PRINT(C_RESET, " PIMv?");
 			break;
-		case 1:	ND_PRINT(" PIMv1");
+		case 1:	ND_PRINT(C_RESET, " PIMv1");
 			break;
-		case 2:	ND_PRINT(" PIMv2");
+		case 2:	ND_PRINT(C_RESET, " PIMv2");
 			break;
-		case 3:	ND_PRINT(" PIMv1+2");
+		case 3:	ND_PRINT(C_RESET, " PIMv1+2");
 			break;
 		}
 		if (GET_U_1(bp) & 0xfc)
-			ND_PRINT(" [rsvd=0x%02x]", GET_U_1(bp) & 0xfc);
+			ND_PRINT(C_RESET, " [rsvd=0x%02x]", GET_U_1(bp) & 0xfc);
 		bp += 1;
 		len -= 1;
 		if (len < 1)
@@ -430,13 +430,13 @@ cisco_autorp_print(netdissect_options *ndo,
 		while (nentries != 0) {
 			if (len < 6)
 				goto trunc;
-			ND_PRINT("%c%s%s/%u", s, GET_U_1(bp) & 1 ? "!" : "",
+			ND_PRINT(C_RESET, "%c%s%s/%u", s, GET_U_1(bp) & 1 ? "!" : "",
 			          GET_IPADDR_STRING(bp + 2), GET_U_1(bp + 1));
 			if (GET_U_1(bp) & 0x02) {
-				ND_PRINT(" bidir");
+				ND_PRINT(C_RESET, " bidir");
 			}
 			if (GET_U_1(bp) & 0xfc) {
-				ND_PRINT("[rsvd=0x%02x]", GET_U_1(bp) & 0xfc);
+				ND_PRINT(C_RESET, "[rsvd=0x%02x]", GET_U_1(bp) & 0xfc);
 			}
 			s = ',';
 			bp += 6; len -= 6;
@@ -463,13 +463,13 @@ pim_print(netdissect_options *ndo,
 	switch (PIM_VER(pim_typever)) {
 	case 2:
 		if (!ndo->ndo_vflag) {
-			ND_PRINT("PIMv%u, %s, length %u",
+			ND_PRINT(C_RESET, "PIMv%u, %s, length %u",
 			          PIM_VER(pim_typever),
 			          tok2str(pimv2_type_values,"Unknown Type",PIM_TYPE(pim_typever)),
 			          len);
 			return;
 		} else {
-			ND_PRINT("PIMv%u, length %u\n\t%s",
+			ND_PRINT(C_RESET, "PIMv%u, length %u\n\t%s",
 			          PIM_VER(pim_typever),
 			          len,
 			          tok2str(pimv2_type_values,"Unknown Type",PIM_TYPE(pim_typever)));
@@ -477,7 +477,7 @@ pim_print(netdissect_options *ndo,
 		}
 		break;
 	default:
-		ND_PRINT("PIMv%u, length %u",
+		ND_PRINT(C_RESET, "PIMv%u, length %u",
 		          PIM_VER(pim_typever),
 		          len);
 		break;
@@ -598,11 +598,11 @@ pimv2_addr_print(netdissect_options *ndo,
 		ND_TCHECK_LEN(bp, addr_len);
 		if (af == AF_INET) {
 			if (!silent)
-				ND_PRINT("%s", GET_IPADDR_STRING(bp));
+				ND_PRINT(C_RESET, "%s", GET_IPADDR_STRING(bp));
 		}
 		else if (af == AF_INET6) {
 			if (!silent)
-				ND_PRINT("%s", GET_IP6ADDR_STRING(bp));
+				ND_PRINT(C_RESET, "%s", GET_IP6ADDR_STRING(bp));
 		}
 		return hdrlen + addr_len;
 	case pimv2_group:
@@ -612,31 +612,31 @@ pimv2_addr_print(netdissect_options *ndo,
 		ND_TCHECK_LEN(bp, addr_len + 2);
 		if (af == AF_INET) {
 			if (!silent) {
-				ND_PRINT("%s", GET_IPADDR_STRING(bp + 2));
+				ND_PRINT(C_RESET, "%s", GET_IPADDR_STRING(bp + 2));
 				if (GET_U_1(bp + 1) != 32)
-					ND_PRINT("/%u", GET_U_1(bp + 1));
+					ND_PRINT(C_RESET, "/%u", GET_U_1(bp + 1));
 			}
 		}
 		else if (af == AF_INET6) {
 			if (!silent) {
-				ND_PRINT("%s", GET_IP6ADDR_STRING(bp + 2));
+				ND_PRINT(C_RESET, "%s", GET_IP6ADDR_STRING(bp + 2));
 				if (GET_U_1(bp + 1) != 128)
-					ND_PRINT("/%u", GET_U_1(bp + 1));
+					ND_PRINT(C_RESET, "/%u", GET_U_1(bp + 1));
 			}
 		}
 		if (GET_U_1(bp) && !silent) {
 			if (at == pimv2_group) {
-				ND_PRINT("(0x%02x)", GET_U_1(bp));
+				ND_PRINT(C_RESET, "(0x%02x)", GET_U_1(bp));
 			} else {
-				ND_PRINT("(%s%s%s",
+				ND_PRINT(C_RESET, "(%s%s%s",
 					GET_U_1(bp) & 0x04 ? "S" : "",
 					GET_U_1(bp) & 0x02 ? "W" : "",
 					GET_U_1(bp) & 0x01 ? "R" : "");
 				if (GET_U_1(bp) & 0xf8) {
-					ND_PRINT("+0x%02x",
+					ND_PRINT(C_RESET, "+0x%02x",
 						 GET_U_1(bp) & 0xf8);
 				}
-				ND_PRINT(")");
+				ND_PRINT(C_RESET, ")");
 			}
 		}
 		return hdrlen + 2 + addr_len;
@@ -696,7 +696,7 @@ pimv2_print(netdissect_options *ndo,
 
 	ndo->ndo_protocol = "pimv2";
 	if (len < 2) {
-		ND_PRINT("[length %u < 2]", len);
+		ND_PRINT(C_RESET, "[length %u < 2]", len);
 		nd_print_invalid(ndo);
 		return;
 	}
@@ -704,16 +704,16 @@ pimv2_print(netdissect_options *ndo,
 	/* RFC5015 allocates the high 4 bits of pim_rsv for "subtype". */
 	pimv2_addr_len = GET_U_1(pim->pim_rsv) & 0x0f;
 	if (pimv2_addr_len != 0)
-		ND_PRINT(", RFC2117-encoding");
+		ND_PRINT(C_RESET, ", RFC2117-encoding");
 
 	if (len < 4) {
-		ND_PRINT("[length %u < 4]", len);
+		ND_PRINT(C_RESET, "[length %u < 4]", len);
 		nd_print_invalid(ndo);
 		return;
 	}
-	ND_PRINT(", cksum 0x%04x ", GET_BE_U_2(pim->pim_cksum));
+	ND_PRINT(C_RESET, ", cksum 0x%04x ", GET_BE_U_2(pim->pim_cksum));
 	if (GET_BE_U_2(pim->pim_cksum) == 0) {
-		ND_PRINT("(unverified)");
+		ND_PRINT(C_RESET, "(unverified)");
 	} else {
 		if (PIM_TYPE(pim_typever) == PIMV2_TYPE_REGISTER) {
 			/*
@@ -739,15 +739,15 @@ pimv2_print(netdissect_options *ndo,
 		switch (cksum_status) {
 
 		case CORRECT:
-			ND_PRINT("(correct)");
+			ND_PRINT(C_RESET, "(correct)");
 			break;
 
 		case INCORRECT:
-			ND_PRINT("(incorrect)");
+			ND_PRINT(C_RESET, "(incorrect)");
 			break;
 
 		case UNVERIFIED:
-			ND_PRINT("(unverified)");
+			ND_PRINT(C_RESET, "(unverified)");
 			break;
 		}
 	}
@@ -763,7 +763,7 @@ pimv2_print(netdissect_options *ndo,
 				goto trunc;
 			otype = GET_BE_U_2(bp);
 			olen = GET_BE_U_2(bp + 2);
-			ND_PRINT("\n\t  %s Option (%u), length %u, Value: ",
+			ND_PRINT(C_RESET, "\n\t  %s Option (%u), length %u, Value: ",
 			          tok2str(pimv2_hello_option_values, "Unknown", otype),
 			          otype,
 			          olen);
@@ -776,7 +776,7 @@ pimv2_print(netdissect_options *ndo,
 			switch (otype) {
 			case PIMV2_HELLO_OPTION_HOLDTIME:
 				if (olen != 2) {
-					ND_PRINT("[option length %u != 2]", olen);
+					ND_PRINT(C_RESET, "[option length %u != 2]", olen);
 					nd_print_invalid(ndo);
 					return;
 				} else {
@@ -787,7 +787,7 @@ pimv2_print(netdissect_options *ndo,
 
 			case PIMV2_HELLO_OPTION_LANPRUNEDELAY:
 				if (olen != 4) {
-					ND_PRINT("[option length %u != 4]", olen);
+					ND_PRINT(C_RESET, "[option length %u != 4]", olen);
 					nd_print_invalid(ndo);
 					return;
 				} else {
@@ -797,7 +797,7 @@ pimv2_print(netdissect_options *ndo,
 					override_interval = GET_BE_U_2(bp + 2);
 					t_bit = (lan_delay & 0x8000)? 1 : 0;
 					lan_delay &= ~0x8000;
-					ND_PRINT("\n\t    T-bit=%u, LAN delay %ums, Override interval %ums",
+					ND_PRINT(C_RESET, "\n\t    T-bit=%u, LAN delay %ums, Override interval %ums",
 					t_bit, lan_delay, override_interval);
 				}
 				break;
@@ -806,13 +806,13 @@ pimv2_print(netdissect_options *ndo,
 			case PIMV2_HELLO_OPTION_DR_PRIORITY:
 				switch (olen) {
 				case 0:
-					ND_PRINT("Bi-Directional Capability (Old)");
+					ND_PRINT(C_RESET, "Bi-Directional Capability (Old)");
 					break;
 				case 4:
-					ND_PRINT("%u", GET_BE_U_4(bp));
+					ND_PRINT(C_RESET, "%u", GET_BE_U_4(bp));
 					break;
 				default:
-					ND_PRINT("[option length %u != 4]", olen);
+					ND_PRINT(C_RESET, "[option length %u != 4]", olen);
 					nd_print_invalid(ndo);
 					return;
 					break;
@@ -821,28 +821,28 @@ pimv2_print(netdissect_options *ndo,
 
 			case PIMV2_HELLO_OPTION_GENID:
 				if (olen != 4) {
-					ND_PRINT("[option length %u != 4]", olen);
+					ND_PRINT(C_RESET, "[option length %u != 4]", olen);
 					nd_print_invalid(ndo);
 					return;
 				} else {
-					ND_PRINT("0x%08x", GET_BE_U_4(bp));
+					ND_PRINT(C_RESET, "0x%08x", GET_BE_U_4(bp));
 				}
 				break;
 
 			case PIMV2_HELLO_OPTION_REFRESH_CAP:
 				if (olen != 4) {
-					ND_PRINT("[option length %u != 4]", olen);
+					ND_PRINT(C_RESET, "[option length %u != 4]", olen);
 					nd_print_invalid(ndo);
 					return;
 				} else {
-					ND_PRINT("v%u", GET_U_1(bp));
+					ND_PRINT(C_RESET, "v%u", GET_U_1(bp));
 					if (GET_U_1(bp + 1) != 0) {
-						ND_PRINT(", interval ");
+						ND_PRINT(C_RESET, ", interval ");
 						unsigned_relts_print(ndo,
 								     GET_U_1(bp + 1));
 					}
 					if (GET_BE_U_2(bp + 2) != 0) {
-						ND_PRINT(" ?0x%04x?",
+						ND_PRINT(C_RESET, " ?0x%04x?",
 							 GET_BE_U_2(bp + 2));
 					}
 				}
@@ -857,7 +857,7 @@ pimv2_print(netdissect_options *ndo,
 					const u_char *ptr = bp;
 					u_int plen = len;
 					while (ptr < (bp+olen)) {
-						ND_PRINT("\n\t    ");
+						ND_PRINT(C_RESET, "\n\t    ");
 						advance = pimv2_addr_print(ndo, ptr, plen, pimv2_unicast, pimv2_addr_len, 0);
 						if (advance < 0)
 							goto trunc;
@@ -888,7 +888,7 @@ pimv2_print(netdissect_options *ndo,
 			goto trunc;
 		ND_TCHECK_LEN(bp, PIMV2_REGISTER_FLAG_LEN);
 
-		ND_PRINT(", Flags [ %s ]\n\t",
+		ND_PRINT(C_RESET, ", Flags [ %s ]\n\t",
 		          tok2str(pimv2_register_flag_values,
 		          "none",
 		          GET_BE_U_4(bp)));
@@ -900,7 +900,7 @@ pimv2_print(netdissect_options *ndo,
 		ip = (const struct ip *)bp;
 		switch (IP_V(ip)) {
                 case 0: /* Null header */
-			ND_PRINT("IP-Null-header %s > %s",
+			ND_PRINT(C_RESET, "IP-Null-header %s > %s",
 			          GET_IPADDR_STRING(ip->ip_src),
 			          GET_IPADDR_STRING(ip->ip_dst));
 			break;
@@ -914,18 +914,18 @@ pimv2_print(netdissect_options *ndo,
 			break;
 
 		default:
-			ND_PRINT("IP ver %u", IP_V(ip));
+			ND_PRINT(C_RESET, "IP ver %u", IP_V(ip));
 			break;
 		}
 		break;
 	}
 
 	case PIMV2_TYPE_REGISTER_STOP:
-		ND_PRINT(" group=");
+		ND_PRINT(C_RESET, " group=");
 		if ((advance = pimv2_addr_print(ndo, bp, len, pimv2_group, pimv2_addr_len, 0)) < 0)
 			goto trunc;
 		bp += advance; len -= advance;
-		ND_PRINT(" source=");
+		ND_PRINT(C_RESET, " source=");
 		if ((advance = pimv2_addr_print(ndo, bp, len, pimv2_unicast, pimv2_addr_len, 0)) < 0)
 			goto trunc;
 		bp += advance; len -= advance;
@@ -979,7 +979,7 @@ pimv2_print(netdissect_options *ndo,
 		u_int i, j;
 
 		if (PIM_TYPE(pim_typever) != 7) {	/*not for Graft-ACK*/
-			ND_PRINT(", upstream-neighbor: ");
+			ND_PRINT(C_RESET, ", upstream-neighbor: ");
 			if ((advance = pimv2_addr_print(ndo, bp, len, pimv2_unicast, pimv2_addr_len, 0)) < 0)
 				goto trunc;
 			bp += advance; len -= advance;
@@ -989,17 +989,17 @@ pimv2_print(netdissect_options *ndo,
 		ND_TCHECK_4(bp);
 		ngroup = GET_U_1(bp + 1);
 		holdtime = GET_BE_U_2(bp + 2);
-		ND_PRINT("\n\t  %u group(s)", ngroup);
+		ND_PRINT(C_RESET, "\n\t  %u group(s)", ngroup);
 		if (PIM_TYPE(pim_typever) != 7) {	/*not for Graft-ACK*/
-			ND_PRINT(", holdtime: ");
+			ND_PRINT(C_RESET, ", holdtime: ");
 			if (holdtime == 0xffff)
-				ND_PRINT("infinite");
+				ND_PRINT(C_RESET, "infinite");
 			else
 				unsigned_relts_print(ndo, holdtime);
 		}
 		bp += 4; len -= 4;
 		for (i = 0; i < ngroup; i++) {
-			ND_PRINT("\n\t    group #%u: ", i+1);
+			ND_PRINT(C_RESET, "\n\t    group #%u: ", i+1);
 			if ((advance = pimv2_addr_print(ndo, bp, len, pimv2_group, pimv2_addr_len, 0)) < 0)
 				goto trunc;
 			bp += advance; len -= advance;
@@ -1008,16 +1008,16 @@ pimv2_print(netdissect_options *ndo,
 			ND_TCHECK_4(bp);
 			njoin = GET_BE_U_2(bp);
 			nprune = GET_BE_U_2(bp + 2);
-			ND_PRINT(", joined sources: %u, pruned sources: %u", njoin, nprune);
+			ND_PRINT(C_RESET, ", joined sources: %u, pruned sources: %u", njoin, nprune);
 			bp += 4; len -= 4;
 			for (j = 0; j < njoin; j++) {
-				ND_PRINT("\n\t      joined source #%u: ", j+1);
+				ND_PRINT(C_RESET, "\n\t      joined source #%u: ", j+1);
 				if ((advance = pimv2_addr_print(ndo, bp, len, pimv2_source, pimv2_addr_len, 0)) < 0)
 					goto trunc;
 				bp += advance; len -= advance;
 			}
 			for (j = 0; j < nprune; j++) {
-				ND_PRINT("\n\t      pruned source #%u: ", j+1);
+				ND_PRINT(C_RESET, "\n\t      pruned source #%u: ", j+1);
 				if ((advance = pimv2_addr_print(ndo, bp, len, pimv2_source, pimv2_addr_len, 0)) < 0)
 					goto trunc;
 				bp += advance; len -= advance;
@@ -1033,21 +1033,21 @@ pimv2_print(netdissect_options *ndo,
 		/* Fragment Tag, Hash Mask len, and BSR-priority */
 		if (len < 2)
 			goto trunc;
-		ND_PRINT(" tag=%x", GET_BE_U_2(bp));
+		ND_PRINT(C_RESET, " tag=%x", GET_BE_U_2(bp));
 		bp += 2;
 		len -= 2;
 		if (len < 1)
 			goto trunc;
-		ND_PRINT(" hashmlen=%u", GET_U_1(bp));
+		ND_PRINT(C_RESET, " hashmlen=%u", GET_U_1(bp));
 		if (len < 2)
 			goto trunc;
 		ND_TCHECK_1(bp + 2);
-		ND_PRINT(" BSRprio=%u", GET_U_1(bp + 1));
+		ND_PRINT(C_RESET, " BSRprio=%u", GET_U_1(bp + 1));
 		bp += 2;
 		len -= 2;
 
 		/* Encoded-Unicast-BSR-Address */
-		ND_PRINT(" BSR=");
+		ND_PRINT(C_RESET, " BSR=");
 		if ((advance = pimv2_addr_print(ndo, bp, len, pimv2_unicast, pimv2_addr_len, 0)) < 0)
 			goto trunc;
 		bp += advance;
@@ -1055,7 +1055,7 @@ pimv2_print(netdissect_options *ndo,
 
 		for (i = 0; len > 0; i++) {
 			/* Encoded-Group Address */
-			ND_PRINT(" (group%u: ", i);
+			ND_PRINT(C_RESET, " (group%u: ", i);
 			if ((advance = pimv2_addr_print(ndo, bp, len, pimv2_group, pimv2_addr_len, 0)) < 0)
 				goto trunc;
 			bp += advance;
@@ -1064,11 +1064,11 @@ pimv2_print(netdissect_options *ndo,
 			/* RP-Count, Frag RP-Cnt, and rsvd */
 			if (len < 1)
 				goto trunc;
-			ND_PRINT(" RPcnt=%u", GET_U_1(bp));
+			ND_PRINT(C_RESET, " RPcnt=%u", GET_U_1(bp));
 			if (len < 2)
 				goto trunc;
 			frpcnt = GET_U_1(bp + 1);
-			ND_PRINT(" FRPcnt=%u", frpcnt);
+			ND_PRINT(C_RESET, " FRPcnt=%u", frpcnt);
 			if (len < 4)
 				goto trunc;
 			bp += 4;
@@ -1076,7 +1076,7 @@ pimv2_print(netdissect_options *ndo,
 
 			for (j = 0; j < frpcnt && len > 0; j++) {
 				/* each RP info */
-				ND_PRINT(" RP%u=", j);
+				ND_PRINT(C_RESET, " RP%u=", j);
 				if ((advance = pimv2_addr_print(ndo, bp, len,
 								pimv2_unicast,
 								pimv2_addr_len,
@@ -1087,27 +1087,27 @@ pimv2_print(netdissect_options *ndo,
 
 				if (len < 2)
 					goto trunc;
-				ND_PRINT(",holdtime=");
+				ND_PRINT(C_RESET, ",holdtime=");
 				unsigned_relts_print(ndo,
 						     GET_BE_U_2(bp));
 				if (len < 3)
 					goto trunc;
-				ND_PRINT(",prio=%u", GET_U_1(bp + 2));
+				ND_PRINT(C_RESET, ",prio=%u", GET_U_1(bp + 2));
 				if (len < 4)
 					goto trunc;
 				bp += 4;
 				len -= 4;
 			}
-			ND_PRINT(")");
+			ND_PRINT(C_RESET, ")");
 		}
 		break;
 	}
 	case PIMV2_TYPE_ASSERT:
-		ND_PRINT(" group=");
+		ND_PRINT(C_RESET, " group=");
 		if ((advance = pimv2_addr_print(ndo, bp, len, pimv2_group, pimv2_addr_len, 0)) < 0)
 			goto trunc;
 		bp += advance; len -= advance;
-		ND_PRINT(" src=");
+		ND_PRINT(C_RESET, " src=");
 		if ((advance = pimv2_addr_print(ndo, bp, len, pimv2_unicast, pimv2_addr_len, 0)) < 0)
 			goto trunc;
 		bp += advance; len -= advance;
@@ -1115,9 +1115,9 @@ pimv2_print(netdissect_options *ndo,
 			goto trunc;
 		ND_TCHECK_8(bp);
 		if (GET_U_1(bp) & 0x80)
-			ND_PRINT(" RPT");
-		ND_PRINT(" pref=%u", GET_BE_U_4(bp) & 0x7fffffff);
-		ND_PRINT(" metric=%u", GET_BE_U_4(bp + 4));
+			ND_PRINT(C_RESET, " RPT");
+		ND_PRINT(C_RESET, " pref=%u", GET_BE_U_4(bp) & 0x7fffffff);
+		ND_PRINT(C_RESET, " metric=%u", GET_BE_U_4(bp + 4));
 		break;
 
 	case PIMV2_TYPE_CANDIDATE_RP:
@@ -1127,20 +1127,20 @@ pimv2_print(netdissect_options *ndo,
 		/* Prefix-Cnt, Priority, and Holdtime */
 		if (len < 1)
 			goto trunc;
-		ND_PRINT(" prefix-cnt=%u", GET_U_1(bp));
+		ND_PRINT(C_RESET, " prefix-cnt=%u", GET_U_1(bp));
 		pfxcnt = GET_U_1(bp);
 		if (len < 2)
 			goto trunc;
-		ND_PRINT(" prio=%u", GET_U_1(bp + 1));
+		ND_PRINT(C_RESET, " prio=%u", GET_U_1(bp + 1));
 		if (len < 4)
 			goto trunc;
-		ND_PRINT(" holdtime=");
+		ND_PRINT(C_RESET, " holdtime=");
 		unsigned_relts_print(ndo, GET_BE_U_2(bp + 2));
 		bp += 4;
 		len -= 4;
 
 		/* Encoded-Unicast-RP-Address */
-		ND_PRINT(" RP=");
+		ND_PRINT(C_RESET, " RP=");
 		if ((advance = pimv2_addr_print(ndo, bp, len, pimv2_unicast, pimv2_addr_len, 0)) < 0)
 			goto trunc;
 		bp += advance;
@@ -1148,7 +1148,7 @@ pimv2_print(netdissect_options *ndo,
 
 		/* Encoded-Group Addresses */
 		for (i = 0; i < pfxcnt && len > 0; i++) {
-			ND_PRINT(" Group%u=", i);
+			ND_PRINT(C_RESET, " Group%u=", i);
 			if ((advance = pimv2_addr_print(ndo, bp, len, pimv2_group, pimv2_addr_len, 0)) < 0)
 				goto trunc;
 			bp += advance;
@@ -1158,40 +1158,40 @@ pimv2_print(netdissect_options *ndo,
 	}
 
 	case PIMV2_TYPE_PRUNE_REFRESH:
-		ND_PRINT(" src=");
+		ND_PRINT(C_RESET, " src=");
 		if ((advance = pimv2_addr_print(ndo, bp, len, pimv2_unicast, pimv2_addr_len, 0)) < 0)
 			goto trunc;
 		bp += advance;
 		len -= advance;
-		ND_PRINT(" grp=");
+		ND_PRINT(C_RESET, " grp=");
 		if ((advance = pimv2_addr_print(ndo, bp, len, pimv2_group, pimv2_addr_len, 0)) < 0)
 			goto trunc;
 		bp += advance;
 		len -= advance;
-		ND_PRINT(" forwarder=");
+		ND_PRINT(C_RESET, " forwarder=");
 		if ((advance = pimv2_addr_print(ndo, bp, len, pimv2_unicast, pimv2_addr_len, 0)) < 0)
 			goto trunc;
 		bp += advance;
 		len -= advance;
 		if (len < 2)
 			goto trunc;
-		ND_PRINT(" TUNR ");
+		ND_PRINT(C_RESET, " TUNR ");
 		unsigned_relts_print(ndo, GET_BE_U_2(bp));
 		break;
 
 	case PIMV2_TYPE_DF_ELECTION:
 		subtype = PIM_SUBTYPE(GET_U_1(pim->pim_rsv));
-		ND_PRINT("\n\t  %s,", tok2str( pimv2_df_election_flag_values,
+		ND_PRINT(C_RESET, "\n\t  %s,", tok2str( pimv2_df_election_flag_values,
 			 "Unknown", subtype) );
 
-		ND_PRINT(" rpa=");
+		ND_PRINT(C_RESET, " rpa=");
 		if ((advance = pimv2_addr_print(ndo, bp, len, pimv2_unicast, pimv2_addr_len, 0)) < 0) {
 			goto trunc;
 		}
 		bp += advance;
 		len -= advance;
-		ND_PRINT(" sender pref=%u", GET_BE_U_4(bp) );
-		ND_PRINT(" sender metric=%u", GET_BE_U_4(bp + 4));
+		ND_PRINT(C_RESET, " sender pref=%u", GET_BE_U_4(bp) );
+		ND_PRINT(C_RESET, " sender metric=%u", GET_BE_U_4(bp + 4));
 
 		bp += 8;
 		len -= 8;
@@ -1199,21 +1199,21 @@ pimv2_print(netdissect_options *ndo,
 		switch (subtype) {
 		case PIMV2_DF_ELECTION_BACKOFF:
 		case PIMV2_DF_ELECTION_PASS:
-			ND_PRINT("\n\t  %s addr=", PIMV2_DF_ELECTION_PASS_BACKOFF_STR(subtype));
+			ND_PRINT(C_RESET, "\n\t  %s addr=", PIMV2_DF_ELECTION_PASS_BACKOFF_STR(subtype));
 			if ((advance = pimv2_addr_print(ndo, bp, len, pimv2_unicast, pimv2_addr_len, 0)) < 0) {
 				goto trunc;
 			}
 			bp += advance;
 			len -= advance;
 
-			ND_PRINT(" %s pref=%u", PIMV2_DF_ELECTION_PASS_BACKOFF_STR(subtype), GET_BE_U_4(bp) );
-			ND_PRINT(" %s metric=%u", PIMV2_DF_ELECTION_PASS_BACKOFF_STR(subtype), GET_BE_U_4(bp + 4));
+			ND_PRINT(C_RESET, " %s pref=%u", PIMV2_DF_ELECTION_PASS_BACKOFF_STR(subtype), GET_BE_U_4(bp) );
+			ND_PRINT(C_RESET, " %s metric=%u", PIMV2_DF_ELECTION_PASS_BACKOFF_STR(subtype), GET_BE_U_4(bp + 4));
 
 			bp += 8;
 			len -= 8;
 
 			if (subtype == PIMV2_DF_ELECTION_BACKOFF) {
-				ND_PRINT(" interval %dms", GET_BE_U_2(bp));
+				ND_PRINT(C_RESET, " interval %dms", GET_BE_U_2(bp));
 			}
 
 			break;
@@ -1223,7 +1223,7 @@ pimv2_print(netdissect_options *ndo,
 		break;
 
 	 default:
-		ND_PRINT(" [type %u]", PIM_TYPE(pim_typever));
+		ND_PRINT(C_RESET, " [type %u]", PIM_TYPE(pim_typever));
 		break;
 	}
 

--- a/print-pktap.c
+++ b/print-pktap.c
@@ -81,13 +81,13 @@ pktap_header_print(netdissect_options *ndo, const u_char *bp, u_int length)
 	hdrlen = GET_LE_U_4(hdr->pkt_len);
 	dltname = pcap_datalink_val_to_name(dlt);
 	if (!ndo->ndo_qflag) {
-		ND_PRINT("DLT %s (%u) len %u",
+		ND_PRINT(C_RESET, "DLT %s (%u) len %u",
 			  (dltname != NULL ? dltname : "UNKNOWN"), dlt, hdrlen);
         } else {
-		ND_PRINT("%s", (dltname != NULL ? dltname : "UNKNOWN"));
+		ND_PRINT(C_RESET, "%s", (dltname != NULL ? dltname : "UNKNOWN"));
         }
 
-	ND_PRINT(", length %u: ", length);
+	ND_PRINT(C_RESET, ", length %u: ", length);
 }
 
 /*
@@ -109,7 +109,7 @@ pktap_if_print(netdissect_options *ndo,
 
 	ndo->ndo_protocol = "pktap";
 	if (length < sizeof(pktap_header_t)) {
-		ND_PRINT(" (packet too short, %u < %zu)",
+		ND_PRINT(C_RESET, " (packet too short, %u < %zu)",
 		         length, sizeof(pktap_header_t));
 		goto invalid;
 	}
@@ -124,12 +124,12 @@ pktap_if_print(netdissect_options *ndo,
 		 * is the length supplied so that the header can
 		 * be expanded in the future)?
 		 */
-		ND_PRINT(" (pkt_len too small, %u < %zu)",
+		ND_PRINT(C_RESET, " (pkt_len too small, %u < %zu)",
 		         hdrlen, sizeof(pktap_header_t));
 		goto invalid;
 	}
 	if (hdrlen > length) {
-		ND_PRINT(" (pkt_len too big, %u > %u)",
+		ND_PRINT(C_RESET, " (pkt_len too big, %u > %u)",
 		         hdrlen, length);
 		goto invalid;
 	}
@@ -146,7 +146,7 @@ pktap_if_print(netdissect_options *ndo,
 	switch (rectype) {
 
 	case PKT_REC_NONE:
-		ND_PRINT("no data");
+		ND_PRINT(C_RESET, "no data");
 		break;
 
 	case PKT_REC_PACKET:

--- a/print-ppi.c
+++ b/print-ppi.c
@@ -47,14 +47,14 @@ ppi_header_print(netdissect_options *ndo, const u_char *bp, u_int length)
 	dltname = pcap_datalink_val_to_name(dlt);
 
 	if (!ndo->ndo_qflag) {
-		ND_PRINT("V.%u DLT %s (%u) len %u", GET_U_1(hdr->ppi_ver),
+		ND_PRINT(C_RESET, "V.%u DLT %s (%u) len %u", GET_U_1(hdr->ppi_ver),
 			  (dltname != NULL ? dltname : "UNKNOWN"), dlt,
                           len);
         } else {
-		ND_PRINT("%s", (dltname != NULL ? dltname : "UNKNOWN"));
+		ND_PRINT(C_RESET, "%s", (dltname != NULL ? dltname : "UNKNOWN"));
         }
 
-	ND_PRINT(", length %u: ", length);
+	ND_PRINT(C_RESET, ", length %u: ", length);
 }
 
 /*
@@ -87,7 +87,7 @@ ppi_if_print(netdissect_options *ndo,
 	len = GET_LE_U_2(hdr->ppi_len);
 	if (len < sizeof(ppi_header_t) || len > 65532) {
 		/* It MUST be between 8 and 65,532 inclusive (spec 3.1.3) */
-		ND_PRINT(" [length %u < %zu or > 65532]", len,
+		ND_PRINT(C_RESET, " [length %u < %zu or > 65532]", len,
 			 sizeof(ppi_header_t));
 		nd_print_invalid(ndo);
 		ndo->ndo_ll_hdr_len += caplen;

--- a/print-ppp.c
+++ b/print-ppp.c
@@ -421,7 +421,7 @@ handle_ctrl_proto(netdissect_options *ndo,
         tptr=pptr;
 
         typestr = tok2str(ppptype2str, "unknown ctrl-proto (0x%04x)", proto);
-	ND_PRINT("%s, ", typestr);
+	ND_PRINT(C_RESET, C_RESET "%s, ", typestr);
 
 	if (length < 4) /* FIXME weak boundary checking */
 		goto trunc;
@@ -430,7 +430,7 @@ handle_ctrl_proto(netdissect_options *ndo,
 	code = GET_U_1(tptr);
 	tptr++;
 
-	ND_PRINT("%s (0x%02x), id %u, length %u",
+	ND_PRINT(C_RESET, C_RESET "%s (0x%02x), id %u, length %u",
 	          tok2str(cpcodes, "Unknown Opcode",code),
 	          code,
 	          GET_U_1(tptr), /* ID */
@@ -444,17 +444,17 @@ handle_ctrl_proto(netdissect_options *ndo,
 	tptr += 2;
 
 	if (len < 4) {
-		ND_PRINT("\n\tencoded length %u (< 4))", len);
+		ND_PRINT(C_RESET, C_RESET "\n\tencoded length %u (< 4))", len);
 		return;
 	}
 
 	if (len > length) {
-		ND_PRINT("\n\tencoded length %u (> packet length %u))", len, length);
+		ND_PRINT(C_RESET, C_RESET "\n\tencoded length %u (> packet length %u))", len, length);
 		return;
 	}
 	length = len;
 
-	ND_PRINT("\n\tencoded length %u (=Option(s) length %u)", len, len - 4);
+	ND_PRINT(C_RESET, C_RESET "\n\tencoded length %u (=Option(s) length %u)", len, len - 4);
 
 	if (length == 4)
 		return;    /* there may be a NULL confreq etc. */
@@ -467,9 +467,9 @@ handle_ctrl_proto(netdissect_options *ndo,
 	case CPCODES_VEXT:
 		if (length < 11)
 			break;
-		ND_PRINT("\n\t  Magic-Num 0x%08x", GET_BE_U_4(tptr));
+		ND_PRINT(C_RESET, C_RESET "\n\t  Magic-Num 0x%08x", GET_BE_U_4(tptr));
 		tptr += 4;
-		ND_PRINT(" Vendor: %s (%u)",
+		ND_PRINT(C_RESET, C_RESET " Vendor: %s (%u)",
                        tok2str(oui_values,"Unknown",GET_BE_U_3(tptr)),
                        GET_BE_U_3(tptr));
 		/* XXX: need to decode Kind and Value(s)? */
@@ -511,7 +511,7 @@ handle_ctrl_proto(netdissect_options *ndo,
 			if ((advance = (*pfunc)(ndo, tptr, len)) == 0)
 				break;
 			if (tlen < advance) {
-				ND_PRINT(" [remaining options length %u < %u]",
+				ND_PRINT(C_RESET, C_RESET " [remaining options length %u < %u]",
 					 tlen, advance);
 				nd_print_invalid(ndo);
 				break;
@@ -531,12 +531,12 @@ handle_ctrl_proto(netdissect_options *ndo,
 	case CPCODES_PROT_REJ:
 		if (length < 6)
 			break;
-		ND_PRINT("\n\t  Rejected %s Protocol (0x%04x)",
+		ND_PRINT(C_RESET, C_RESET "\n\t  Rejected %s Protocol (0x%04x)",
 		       tok2str(ppptype2str,"unknown", GET_BE_U_2(tptr)),
 		       GET_BE_U_2(tptr));
 		/* XXX: need to decode Rejected-Information? - hexdump for now */
 		if (len > 6) {
-			ND_PRINT("\n\t  Rejected Packet");
+			ND_PRINT(C_RESET, C_RESET "\n\t  Rejected Packet");
 			print_unknown_data(ndo, tptr + 2, "\n\t    ", len - 2);
 		}
 		break;
@@ -545,10 +545,10 @@ handle_ctrl_proto(netdissect_options *ndo,
 	case CPCODES_DISC_REQ:
 		if (length < 8)
 			break;
-		ND_PRINT("\n\t  Magic-Num 0x%08x", GET_BE_U_4(tptr));
+		ND_PRINT(C_RESET, C_RESET "\n\t  Magic-Num 0x%08x", GET_BE_U_4(tptr));
 		/* XXX: need to decode Data? - hexdump for now */
 		if (len > 8) {
-			ND_PRINT("\n\t  -----trailing data-----");
+			ND_PRINT(C_RESET, C_RESET "\n\t  -----trailing data-----");
 			ND_TCHECK_LEN(tptr + 4, len - 8);
 			print_unknown_data(ndo, tptr + 4, "\n\t  ", len - 8);
 		}
@@ -556,10 +556,10 @@ handle_ctrl_proto(netdissect_options *ndo,
 	case CPCODES_ID:
 		if (length < 8)
 			break;
-		ND_PRINT("\n\t  Magic-Num 0x%08x", GET_BE_U_4(tptr));
+		ND_PRINT(C_RESET, C_RESET "\n\t  Magic-Num 0x%08x", GET_BE_U_4(tptr));
 		/* RFC 1661 says this is intended to be human readable */
 		if (len > 8) {
-			ND_PRINT("\n\t  Message\n\t    ");
+			ND_PRINT(C_RESET, C_RESET "\n\t  Message\n\t    ");
 			if (nd_printn(ndo, tptr + 4, len - 4, ndo->ndo_snapend))
 				goto trunc;
 		}
@@ -567,8 +567,8 @@ handle_ctrl_proto(netdissect_options *ndo,
 	case CPCODES_TIME_REM:
 		if (length < 12)
 			break;
-		ND_PRINT("\n\t  Magic-Num 0x%08x", GET_BE_U_4(tptr));
-		ND_PRINT(", Seconds-Remaining %us", GET_BE_U_4(tptr + 4));
+		ND_PRINT(C_RESET, C_RESET "\n\t  Magic-Num 0x%08x", GET_BE_U_4(tptr));
+		ND_PRINT(C_RESET, C_RESET ", Seconds-Remaining %us", GET_BE_U_4(tptr + 4));
 		/* XXX: need to decode Message? */
 		break;
 	default:
@@ -582,7 +582,7 @@ handle_ctrl_proto(netdissect_options *ndo,
 	return;
 
 trunc:
-	ND_PRINT("[|%s]", typestr);
+	ND_PRINT(C_RESET, C_RESET "[|%s]", typestr);
 }
 
 /* LCP config options */
@@ -601,61 +601,61 @@ print_lcp_config_options(netdissect_options *ndo,
 		return 0;
 	if (len < 2) {
 		if (opt < NUM_LCPOPTS)
-			ND_PRINT("\n\t  %s Option (0x%02x), length %u (length bogus, should be >= 2)",
+			ND_PRINT(C_RESET, C_RESET "\n\t  %s Option (0x%02x), length %u (length bogus, should be >= 2)",
 			          lcpconfopts[opt], opt, len);
 		else
-			ND_PRINT("\n\tunknown LCP option 0x%02x", opt);
+			ND_PRINT(C_RESET, C_RESET "\n\tunknown LCP option 0x%02x", opt);
 		return 0;
 	}
 	if (opt < NUM_LCPOPTS)
-		ND_PRINT("\n\t  %s Option (0x%02x), length %u", lcpconfopts[opt], opt, len);
+		ND_PRINT(C_RESET, C_RESET "\n\t  %s Option (0x%02x), length %u", lcpconfopts[opt], opt, len);
 	else {
-		ND_PRINT("\n\tunknown LCP option 0x%02x", opt);
+		ND_PRINT(C_RESET, C_RESET "\n\tunknown LCP option 0x%02x", opt);
 		return len;
 	}
 
 	switch (opt) {
 	case LCPOPT_VEXT:
 		if (len < 6) {
-			ND_PRINT(" (length bogus, should be >= 6)");
+			ND_PRINT(C_RESET, C_RESET " (length bogus, should be >= 6)");
 			return len;
 		}
-		ND_PRINT(": Vendor: %s (%u)",
+		ND_PRINT(C_RESET, C_RESET ": Vendor: %s (%u)",
 			tok2str(oui_values,"Unknown",GET_BE_U_3(p + 2)),
 			GET_BE_U_3(p + 2));
 #if 0
-		ND_PRINT(", kind: 0x%02x", GET_U_1(p + 5));
-		ND_PRINT(", Value: 0x");
+		ND_PRINT(C_RESET, C_RESET ", kind: 0x%02x", GET_U_1(p + 5));
+		ND_PRINT(C_RESET, C_RESET ", Value: 0x");
 		for (i = 0; i < len - 6; i++) {
-			ND_PRINT("%02x", GET_U_1(p + 6 + i));
+			ND_PRINT(C_RESET, C_RESET "%02x", GET_U_1(p + 6 + i));
 		}
 #endif
 		break;
 	case LCPOPT_MRU:
 		if (len != 4) {
-			ND_PRINT(" (length bogus, should be = 4)");
+			ND_PRINT(C_RESET, C_RESET " (length bogus, should be = 4)");
 			return len;
 		}
-		ND_PRINT(": %u", GET_BE_U_2(p + 2));
+		ND_PRINT(C_RESET, C_RESET ": %u", GET_BE_U_2(p + 2));
 		break;
 	case LCPOPT_ACCM:
 		if (len != 6) {
-			ND_PRINT(" (length bogus, should be = 6)");
+			ND_PRINT(C_RESET, C_RESET " (length bogus, should be = 6)");
 			return len;
 		}
-		ND_PRINT(": 0x%08x", GET_BE_U_4(p + 2));
+		ND_PRINT(C_RESET, C_RESET ": 0x%08x", GET_BE_U_4(p + 2));
 		break;
 	case LCPOPT_AP:
 		if (len < 4) {
-			ND_PRINT(" (length bogus, should be >= 4)");
+			ND_PRINT(C_RESET, C_RESET " (length bogus, should be >= 4)");
 			return len;
 		}
-		ND_PRINT(": %s",
+		ND_PRINT(C_RESET, C_RESET ": %s",
 			 tok2str(ppptype2str, "Unknown Auth Proto (0x04x)", GET_BE_U_2(p + 2)));
 
 		switch (GET_BE_U_2(p + 2)) {
 		case PPP_CHAP:
-			ND_PRINT(", %s",
+			ND_PRINT(C_RESET, C_RESET ", %s",
 				 tok2str(authalg_values, "Unknown Auth Alg %u", GET_U_1(p + 4)));
 			break;
 		case PPP_PAP: /* fall through */
@@ -669,20 +669,20 @@ print_lcp_config_options(netdissect_options *ndo,
 		break;
 	case LCPOPT_QP:
 		if (len < 4) {
-			ND_PRINT(" (length bogus, should be >= 4)");
+			ND_PRINT(C_RESET, C_RESET " (length bogus, should be >= 4)");
 			return 0;
 		}
 		if (GET_BE_U_2(p + 2) == PPP_LQM)
-			ND_PRINT(": LQR");
+			ND_PRINT(C_RESET, C_RESET ": LQR");
 		else
-			ND_PRINT(": unknown");
+			ND_PRINT(C_RESET, C_RESET ": unknown");
 		break;
 	case LCPOPT_MN:
 		if (len != 6) {
-			ND_PRINT(" (length bogus, should be = 6)");
+			ND_PRINT(C_RESET, C_RESET " (length bogus, should be = 6)");
 			return 0;
 		}
-		ND_PRINT(": 0x%08x", GET_BE_U_4(p + 2));
+		ND_PRINT(C_RESET, C_RESET ": 0x%08x", GET_BE_U_4(p + 2));
 		break;
 	case LCPOPT_PFC:
 		break;
@@ -690,62 +690,62 @@ print_lcp_config_options(netdissect_options *ndo,
 		break;
 	case LCPOPT_LD:
 		if (len != 4) {
-			ND_PRINT(" (length bogus, should be = 4)");
+			ND_PRINT(C_RESET, " (length bogus, should be = 4)");
 			return 0;
 		}
-		ND_PRINT(": 0x%04x", GET_BE_U_2(p + 2));
+		ND_PRINT(C_RESET, ": 0x%04x", GET_BE_U_2(p + 2));
 		break;
 	case LCPOPT_CBACK:
 		if (len < 3) {
-			ND_PRINT(" (length bogus, should be >= 3)");
+			ND_PRINT(C_RESET, " (length bogus, should be >= 3)");
 			return 0;
 		}
-		ND_PRINT(": ");
-		ND_PRINT(": Callback Operation %s (%u)",
+		ND_PRINT(C_RESET, ": ");
+		ND_PRINT(C_RESET, ": Callback Operation %s (%u)",
                        tok2str(ppp_callback_values, "Unknown", GET_U_1(p + 2)),
                        GET_U_1(p + 2));
 		break;
 	case LCPOPT_MLMRRU:
 		if (len != 4) {
-			ND_PRINT(" (length bogus, should be = 4)");
+			ND_PRINT(C_RESET, " (length bogus, should be = 4)");
 			return 0;
 		}
-		ND_PRINT(": %u", GET_BE_U_2(p + 2));
+		ND_PRINT(C_RESET, ": %u", GET_BE_U_2(p + 2));
 		break;
 	case LCPOPT_MLED:
 		if (len < 3) {
-			ND_PRINT(" (length bogus, should be >= 3)");
+			ND_PRINT(C_RESET, " (length bogus, should be >= 3)");
 			return 0;
 		}
 		switch (GET_U_1(p + 2)) {		/* class */
 		case MEDCLASS_NULL:
-			ND_PRINT(": Null");
+			ND_PRINT(C_RESET, ": Null");
 			break;
 		case MEDCLASS_LOCAL:
-			ND_PRINT(": Local"); /* XXX */
+			ND_PRINT(C_RESET, ": Local"); /* XXX */
 			break;
 		case MEDCLASS_IPV4:
 			if (len != 7) {
-				ND_PRINT(" (length bogus, should be = 7)");
+				ND_PRINT(C_RESET, " (length bogus, should be = 7)");
 				return 0;
 			}
-			ND_PRINT(": IPv4 %s", GET_IPADDR_STRING(p + 3));
+			ND_PRINT(C_RESET, ": IPv4 %s", GET_IPADDR_STRING(p + 3));
 			break;
 		case MEDCLASS_MAC:
 			if (len != 9) {
-				ND_PRINT(" (length bogus, should be = 9)");
+				ND_PRINT(C_RESET, C_RESET " (length bogus, should be = 9)");
 				return 0;
 			}
-			ND_PRINT(": MAC %s", GET_ETHERADDR_STRING(p + 3));
+			ND_PRINT(C_RESET, C_RESET ": MAC %s", GET_ETHERADDR_STRING(p + 3));
 			break;
 		case MEDCLASS_MNB:
-			ND_PRINT(": Magic-Num-Block"); /* XXX */
+			ND_PRINT(C_RESET, ": Magic-Num-Block"); /* XXX */
 			break;
 		case MEDCLASS_PSNDN:
-			ND_PRINT(": PSNDN"); /* XXX */
+			ND_PRINT(C_RESET, ": PSNDN"); /* XXX */
 			break;
 		default:
-			ND_PRINT(": Unknown class %u", GET_U_1(p + 2));
+			ND_PRINT(C_RESET, ": Unknown class %u", GET_U_1(p + 2));
 			break;
 		}
 		break;
@@ -789,7 +789,7 @@ print_lcp_config_options(netdissect_options *ndo,
 	return len;
 
 trunc:
-	ND_PRINT("[|lcp]");
+	ND_PRINT(C_RESET, "[|lcp]");
 	return 0;
 }
 
@@ -805,18 +805,18 @@ handle_mlppp(netdissect_options *ndo,
              const u_char *p, u_int length)
 {
     if (!ndo->ndo_eflag)
-        ND_PRINT("MLPPP, ");
+        ND_PRINT(C_RESET, "MLPPP, ");
 
     if (length < 2) {
-        ND_PRINT("[|mlppp]");
+        ND_PRINT(C_RESET, "[|mlppp]");
         return;
     }
     if (!ND_TTEST_2(p)) {
-        ND_PRINT("[|mlppp]");
+        ND_PRINT(C_RESET, "[|mlppp]");
         return;
     }
 
-    ND_PRINT("seq 0x%03x, Flags [%s], length %u",
+    ND_PRINT(C_RESET, "seq 0x%03x, Flags [%s], length %u",
            (GET_BE_U_2(p))&0x0fff,
            /* only support 12-Bit sequence space for now */
            bittok2str(ppp_ml_flag_values, "none", GET_U_1(p) & 0xc0),
@@ -835,20 +835,20 @@ handle_chap(netdissect_options *ndo,
 
 	p0 = p;
 	if (length < 1) {
-		ND_PRINT("[|chap]");
+		ND_PRINT(C_RESET, "[|chap]");
 		return;
 	} else if (length < 4) {
-		ND_PRINT("[|chap 0x%02x]", GET_U_1(p));
+		ND_PRINT(C_RESET, "[|chap 0x%02x]", GET_U_1(p));
 		return;
 	}
 
 	code = GET_U_1(p);
-	ND_PRINT("CHAP, %s (0x%02x)",
+	ND_PRINT(C_RESET, "CHAP, %s (0x%02x)",
                tok2str(chapcode_values,"unknown",code),
                code);
 	p++;
 
-	ND_PRINT(", id %u", GET_U_1(p));	/* ID */
+	ND_PRINT(C_RESET, ", id %u", GET_U_1(p));	/* ID */
 	p++;
 
 	len = GET_BE_U_2(p);
@@ -870,13 +870,13 @@ handle_chap(netdissect_options *ndo,
 		p++;
 		if (length - (p - p0) < val_size)
 			return;
-		ND_PRINT(", Value ");
+		ND_PRINT(C_RESET, ", Value ");
 		for (i = 0; i < val_size; i++) {
-			ND_PRINT("%02x", GET_U_1(p));
+			ND_PRINT(C_RESET, "%02x", GET_U_1(p));
 			p++;
 		}
 		name_size = len - (u_int)(p - p0);
-		ND_PRINT(", Name ");
+		ND_PRINT(C_RESET, ", Name ");
 		for (i = 0; i < name_size; i++) {
 			fn_print_char(ndo, GET_U_1(p));
 			p++;
@@ -885,7 +885,7 @@ handle_chap(netdissect_options *ndo,
 	case CHAP_SUCC:
 	case CHAP_FAIL:
 		msg_size = len - (u_int)(p - p0);
-		ND_PRINT(", Msg ");
+		ND_PRINT(C_RESET, ", Msg ");
 		for (i = 0; i< msg_size; i++) {
 			fn_print_char(ndo, GET_U_1(p));
 			p++;
@@ -906,32 +906,32 @@ handle_pap(netdissect_options *ndo,
 
 	p0 = p;
 	if (length < 1) {
-		ND_PRINT("[|pap]");
+		ND_PRINT(C_RESET, "[|pap]");
 		return;
 	} else if (length < 4) {
-		ND_PRINT("[|pap 0x%02x]", GET_U_1(p));
+		ND_PRINT(C_RESET, "[|pap 0x%02x]", GET_U_1(p));
 		return;
 	}
 
 	code = GET_U_1(p);
-	ND_PRINT("PAP, %s (0x%02x)",
+	ND_PRINT(C_RESET, "PAP, %s (0x%02x)",
 	          tok2str(papcode_values, "unknown", code),
 	          code);
 	p++;
 
-	ND_PRINT(", id %u", GET_U_1(p));	/* ID */
+	ND_PRINT(C_RESET, ", id %u", GET_U_1(p));	/* ID */
 	p++;
 
 	len = GET_BE_U_2(p);
 	p += 2;
 
 	if (len > length) {
-		ND_PRINT(", length %u > packet size", len);
+		ND_PRINT(C_RESET, ", length %u > packet size", len);
 		return;
 	}
 	length = len;
 	if (length < (size_t)(p - p0)) {
-		ND_PRINT(", length %u < PAP header length", length);
+		ND_PRINT(C_RESET, ", length %u < PAP header length", length);
 		return;
 	}
 
@@ -946,7 +946,7 @@ handle_pap(netdissect_options *ndo,
 		p++;
 		if (length - (p - p0) < peerid_len)
 			return;
-		ND_PRINT(", Peer ");
+		ND_PRINT(C_RESET, ", Peer ");
 		for (i = 0; i < peerid_len; i++) {
 			fn_print_char(ndo, GET_U_1(p));
 			p++;
@@ -958,7 +958,7 @@ handle_pap(netdissect_options *ndo,
 		p++;
 		if (length - (p - p0) < passwd_len)
 			return;
-		ND_PRINT(", Name ");
+		ND_PRINT(C_RESET, ", Name ");
 		for (i = 0; i < passwd_len; i++) {
 			fn_print_char(ndo, GET_U_1(p));
 			p++;
@@ -979,7 +979,7 @@ handle_pap(netdissect_options *ndo,
 		p++;
 		if (length - (p - p0) < msg_len)
 			return;
-		ND_PRINT(", Msg ");
+		ND_PRINT(C_RESET, ", Msg ");
 		for (i = 0; i< msg_len; i++) {
 			fn_print_char(ndo, GET_U_1(p));
 			p++;
@@ -989,7 +989,7 @@ handle_pap(netdissect_options *ndo,
 	return;
 
 trunc:
-	ND_PRINT("[|pap]");
+	ND_PRINT(C_RESET, "[|pap]");
 }
 
 /* BAP */
@@ -1017,14 +1017,14 @@ print_ipcp_config_options(netdissect_options *ndo,
 	if (length < len)
 		return 0;
 	if (len < 2) {
-		ND_PRINT("\n\t  %s Option (0x%02x), length %u (length bogus, should be >= 2)",
+		ND_PRINT(C_RESET, "\n\t  %s Option (0x%02x), length %u (length bogus, should be >= 2)",
 		       tok2str(ipcpopt_values,"unknown",opt),
 		       opt,
 		       len);
 		return 0;
 	}
 
-	ND_PRINT("\n\t  %s Option (0x%02x), length %u",
+	ND_PRINT(C_RESET, "\n\t  %s Option (0x%02x), length %u",
 	       tok2str(ipcpopt_values,"unknown",opt),
 	       opt,
 	       len);
@@ -1032,21 +1032,21 @@ print_ipcp_config_options(netdissect_options *ndo,
 	switch (opt) {
 	case IPCPOPT_2ADDR:		/* deprecated */
 		if (len != 10) {
-			ND_PRINT(" (length bogus, should be = 10)");
+			ND_PRINT(C_RESET, " (length bogus, should be = 10)");
 			return len;
 		}
-		ND_PRINT(": src %s, dst %s",
+		ND_PRINT(C_RESET, ": src %s, dst %s",
 		       GET_IPADDR_STRING(p + 2),
 		       GET_IPADDR_STRING(p + 6));
 		break;
 	case IPCPOPT_IPCOMP:
 		if (len < 4) {
-			ND_PRINT(" (length bogus, should be >= 4)");
+			ND_PRINT(C_RESET, " (length bogus, should be >= 4)");
 			return 0;
 		}
 		compproto = GET_BE_U_2(p + 2);
 
-		ND_PRINT(": %s (0x%02x):",
+		ND_PRINT(C_RESET, ": %s (0x%02x):",
 		          tok2str(ipcpopt_compproto_values, "Unknown", compproto),
 		          compproto);
 
@@ -1056,13 +1056,13 @@ print_ipcp_config_options(netdissect_options *ndo,
                         break;
                 case IPCPOPT_IPCOMP_HDRCOMP:
                         if (len < IPCPOPT_IPCOMP_MINLEN) {
-                                ND_PRINT(" (length bogus, should be >= %u)",
+                                ND_PRINT(C_RESET, " (length bogus, should be >= %u)",
                                          IPCPOPT_IPCOMP_MINLEN);
                                 return 0;
                         }
 
                         ND_TCHECK_LEN(p + 2, IPCPOPT_IPCOMP_MINLEN);
-                        ND_PRINT("\n\t    TCP Space %u, non-TCP Space %u"
+                        ND_PRINT(C_RESET, "\n\t    TCP Space %u, non-TCP Space %u"
                                ", maxPeriod %u, maxTime %u, maxHdr %u",
                                GET_BE_U_2(p + 4),
                                GET_BE_U_2(p + 6),
@@ -1075,7 +1075,7 @@ print_ipcp_config_options(netdissect_options *ndo,
                                 ipcomp_subopttotallen = len - IPCPOPT_IPCOMP_MINLEN;
                                 p += IPCPOPT_IPCOMP_MINLEN;
 
-                                ND_PRINT("\n\t      Suboptions, length %u", ipcomp_subopttotallen);
+                                ND_PRINT(C_RESET, "\n\t      Suboptions, length %u", ipcomp_subopttotallen);
 
                                 while (ipcomp_subopttotallen >= 2) {
                                         ND_TCHECK_2(p);
@@ -1088,14 +1088,14 @@ print_ipcp_config_options(netdissect_options *ndo,
                                                 break;
 
                                         /* XXX: just display the suboptions for now */
-                                        ND_PRINT("\n\t\t%s Suboption #%u, length %u",
+                                        ND_PRINT(C_RESET, "\n\t\t%s Suboption #%u, length %u",
                                                tok2str(ipcpopt_compproto_subopt_values,
                                                        "Unknown",
                                                        ipcomp_subopt),
                                                ipcomp_subopt,
                                                ipcomp_suboptlen);
                                         if (ipcomp_subopttotallen < ipcomp_suboptlen) {
-                                                ND_PRINT(" [remaining suboptions length %u < %u]",
+                                                ND_PRINT(C_RESET, " [remaining suboptions length %u < %u]",
                                                          ipcomp_subopttotallen, ipcomp_suboptlen);
                                                 nd_print_invalid(ndo);
                                                 break;
@@ -1117,10 +1117,10 @@ print_ipcp_config_options(netdissect_options *ndo,
 	case IPCPOPT_SECDNS:
 	case IPCPOPT_SECNBNS:
 		if (len != 6) {
-			ND_PRINT(" (length bogus, should be = 6)");
+			ND_PRINT(C_RESET, " (length bogus, should be = 6)");
 			return 0;
 		}
-		ND_PRINT(": %s", GET_IPADDR_STRING(p + 2));
+		ND_PRINT(C_RESET, ": %s", GET_IPADDR_STRING(p + 2));
 		break;
 	default:
 		/*
@@ -1136,7 +1136,7 @@ print_ipcp_config_options(netdissect_options *ndo,
 	return len;
 
 trunc:
-	ND_PRINT("[|ipcp]");
+	ND_PRINT(C_RESET, "[|ipcp]");
 	return 0;
 }
 
@@ -1155,14 +1155,14 @@ print_ip6cp_config_options(netdissect_options *ndo,
 	if (length < len)
 		return 0;
 	if (len < 2) {
-		ND_PRINT("\n\t  %s Option (0x%02x), length %u (length bogus, should be >= 2)",
+		ND_PRINT(C_RESET, "\n\t  %s Option (0x%02x), length %u (length bogus, should be >= 2)",
 		       tok2str(ip6cpopt_values,"unknown",opt),
 		       opt,
 		       len);
 		return 0;
 	}
 
-	ND_PRINT("\n\t  %s Option (0x%02x), length %u",
+	ND_PRINT(C_RESET, "\n\t  %s Option (0x%02x), length %u",
 	       tok2str(ip6cpopt_values,"unknown",opt),
 	       opt,
 	       len);
@@ -1170,11 +1170,11 @@ print_ip6cp_config_options(netdissect_options *ndo,
 	switch (opt) {
 	case IP6CP_IFID:
 		if (len != 10) {
-			ND_PRINT(" (length bogus, should be = 10)");
+			ND_PRINT(C_RESET, " (length bogus, should be = 10)");
 			return len;
 		}
 		ND_TCHECK_8(p + 2);
-		ND_PRINT(": %04x:%04x:%04x:%04x",
+		ND_PRINT(C_RESET, ": %04x:%04x:%04x:%04x",
 		       GET_BE_U_2(p + 2),
 		       GET_BE_U_2(p + 4),
 		       GET_BE_U_2(p + 6),
@@ -1195,7 +1195,7 @@ print_ip6cp_config_options(netdissect_options *ndo,
 	return len;
 
 trunc:
-	ND_PRINT("[|ip6cp]");
+	ND_PRINT(C_RESET, "[|ip6cp]");
 	return 0;
 }
 
@@ -1215,14 +1215,14 @@ print_ccp_config_options(netdissect_options *ndo,
 	if (length < len)
 		return 0;
 	if (len < 2) {
-		ND_PRINT("\n\t  %s Option (0x%02x), length %u (length bogus, should be >= 2)",
+		ND_PRINT(C_RESET, "\n\t  %s Option (0x%02x), length %u (length bogus, should be >= 2)",
 		          tok2str(ccpconfopts_values, "Unknown", opt),
 		          opt,
 		          len);
 		return 0;
 	}
 
-	ND_PRINT("\n\t  %s Option (0x%02x), length %u",
+	ND_PRINT(C_RESET, "\n\t  %s Option (0x%02x), length %u",
 	          tok2str(ccpconfopts_values, "Unknown", opt),
 	          opt,
 	          len);
@@ -1230,19 +1230,19 @@ print_ccp_config_options(netdissect_options *ndo,
 	switch (opt) {
 	case CCPOPT_BSDCOMP:
 		if (len < 3) {
-			ND_PRINT(" (length bogus, should be >= 3)");
+			ND_PRINT(C_RESET, " (length bogus, should be >= 3)");
 			return len;
 		}
-		ND_PRINT(": Version: %u, Dictionary Bits: %u",
+		ND_PRINT(C_RESET, ": Version: %u, Dictionary Bits: %u",
 			GET_U_1(p + 2) >> 5,
 			GET_U_1(p + 2) & 0x1f);
 		break;
 	case CCPOPT_MVRCA:
 		if (len < 4) {
-			ND_PRINT(" (length bogus, should be >= 4)");
+			ND_PRINT(C_RESET, " (length bogus, should be >= 4)");
 			return len;
 		}
-		ND_PRINT(": Features: %u, PxP: %s, History: %u, #CTX-ID: %u",
+		ND_PRINT(C_RESET, ": Features: %u, PxP: %s, History: %u, #CTX-ID: %u",
 				(GET_U_1(p + 2) & 0xc0) >> 6,
 				(GET_U_1(p + 2) & 0x20) ? "Enabled" : "Disabled",
 				GET_U_1(p + 2) & 0x1f,
@@ -1250,10 +1250,10 @@ print_ccp_config_options(netdissect_options *ndo,
 		break;
 	case CCPOPT_DEFLATE:
 		if (len < 4) {
-			ND_PRINT(" (length bogus, should be >= 4)");
+			ND_PRINT(C_RESET, " (length bogus, should be >= 4)");
 			return len;
 		}
-		ND_PRINT(": Window: %uK, Method: %s (0x%x), MBZ: %u, CHK: %u",
+		ND_PRINT(C_RESET, ": Window: %uK, Method: %s (0x%x), MBZ: %u, CHK: %u",
 			(GET_U_1(p + 2) & 0xf0) >> 4,
 			((GET_U_1(p + 2) & 0x0f) == 8) ? "zlib" : "unknown",
 			GET_U_1(p + 2) & 0x0f,
@@ -1292,7 +1292,7 @@ print_ccp_config_options(netdissect_options *ndo,
 	return len;
 
 trunc:
-	ND_PRINT("[|ccp]");
+	ND_PRINT(C_RESET, "[|ccp]");
 	return 0;
 }
 
@@ -1311,14 +1311,14 @@ print_bacp_config_options(netdissect_options *ndo,
 	if (length < len)
 		return 0;
 	if (len < 2) {
-		ND_PRINT("\n\t  %s Option (0x%02x), length %u (length bogus, should be >= 2)",
+		ND_PRINT(C_RESET, "\n\t  %s Option (0x%02x), length %u (length bogus, should be >= 2)",
 		          tok2str(bacconfopts_values, "Unknown", opt),
 		          opt,
 		          len);
 		return 0;
 	}
 
-	ND_PRINT("\n\t  %s Option (0x%02x), length %u",
+	ND_PRINT(C_RESET, "\n\t  %s Option (0x%02x), length %u",
 	          tok2str(bacconfopts_values, "Unknown", opt),
 	          opt,
 	          len);
@@ -1326,10 +1326,10 @@ print_bacp_config_options(netdissect_options *ndo,
 	switch (opt) {
 	case BACPOPT_FPEER:
 		if (len != 6) {
-			ND_PRINT(" (length bogus, should be = 6)");
+			ND_PRINT(C_RESET, " (length bogus, should be = 6)");
 			return len;
 		}
-		ND_PRINT(": Magic-Num 0x%08x", GET_BE_U_4(p + 2));
+		ND_PRINT(C_RESET, ": Magic-Num 0x%08x", GET_BE_U_4(p + 2));
 		break;
 	default:
 		/*
@@ -1346,7 +1346,7 @@ print_bacp_config_options(netdissect_options *ndo,
 	return len;
 
 trunc:
-	ND_PRINT("[|bacp]");
+	ND_PRINT(C_RESET, "[|bacp]");
 	return 0;
 }
 
@@ -1429,13 +1429,13 @@ ppp_hdlc(netdissect_options *ndo,
                 goto trunc;
             proto = GET_BE_U_2(b + 2); /* load the PPP proto-id */
             if ((proto & 0xff00) == 0x7e00)
-                ND_PRINT("(protocol 0x%04x invalid)", proto);
+                ND_PRINT(C_RESET, "(protocol 0x%04x invalid)", proto);
             else
                 handle_ppp(ndo, proto, b + 4, length - 4);
             break;
         default: /* last guess - proto must be a PPP proto-id */
             if ((proto & 0xff00) == 0x7e00)
-                ND_PRINT("(protocol 0x%04x invalid)", proto);
+                ND_PRINT(C_RESET, "(protocol 0x%04x invalid)", proto);
             else
                 handle_ppp(ndo, proto, b + 2, length - 2);
             break;
@@ -1506,10 +1506,10 @@ handle_ppp(netdissect_options *ndo,
 		mpls_print(ndo, p, length);
 		break;
 	case PPP_COMP:
-		ND_PRINT("compressed PPP data");
+		ND_PRINT(C_RESET, "compressed PPP data");
 		break;
 	default:
-		ND_PRINT("%s ", tok2str(ppptype2str, "unknown PPP protocol (0x%04x)", proto));
+		ND_PRINT(C_RESET, "%s ", tok2str(ppptype2str, "unknown PPP protocol (0x%04x)", proto));
 		print_unknown_data(ndo, p, "\n\t", length);
 		break;
 	}
@@ -1535,13 +1535,13 @@ ppp_print(netdissect_options *ndo,
 
         switch(ppp_header) {
         case (PPP_PPPD_IN  << 8 | PPP_CONTROL):
-            if (ndo->ndo_eflag) ND_PRINT("In  ");
+            if (ndo->ndo_eflag) ND_PRINT(C_RESET, "In  ");
             p += 2;
             length -= 2;
             hdr_len += 2;
             break;
         case (PPP_PPPD_OUT << 8 | PPP_CONTROL):
-            if (ndo->ndo_eflag) ND_PRINT("Out ");
+            if (ndo->ndo_eflag) ND_PRINT(C_RESET, "Out ");
             p += 2;
             length -= 2;
             hdr_len += 2;
@@ -1573,14 +1573,14 @@ ppp_print(netdissect_options *ndo,
 	if (ndo->ndo_eflag) {
 		const char *typestr;
 		typestr = tok2str(ppptype2str, "unknown", proto);
-		ND_PRINT("%s (0x%04x), length %u",
+		ND_PRINT(C_RESET, "%s (0x%04x), length %u",
 		          typestr,
 		          proto,
 		          olen);
 		if (*typestr == 'u')	/* "unknown" */
 			return hdr_len;
 
-		ND_PRINT(": ");
+		ND_PRINT(C_RESET, ": ");
 	}
 
 	handle_ppp(ndo, proto, p, length);
@@ -1645,7 +1645,7 @@ ppp_if_print(netdissect_options *ndo,
 	 * BSD/OS, is?)
 	 */
 	if (ndo->ndo_eflag)
-		ND_PRINT("%c %4d %02x ", GET_U_1(p) ? 'O' : 'I',
+		ND_PRINT(C_RESET, "%c %4d %02x ", GET_U_1(p) ? 'O' : 'I',
 			 length, GET_U_1(p + 1));
 #endif
 
@@ -1687,7 +1687,7 @@ ppp_hdlc_if_print(netdissect_options *ndo,
 		}
 
 		if (ndo->ndo_eflag)
-			ND_PRINT("%02x %02x %u ", GET_U_1(p),
+			ND_PRINT(C_RESET, "%02x %02x %u ", GET_U_1(p),
 				 GET_U_1(p + 1), length);
 		p += 2;
 		length -= 2;
@@ -1697,7 +1697,7 @@ ppp_hdlc_if_print(netdissect_options *ndo,
 		p += 2;
 		length -= 2;
 		hdrlen += 2;
-		ND_PRINT("%s: ", tok2str(ppptype2str, "unknown PPP protocol (0x%04x)", proto));
+		ND_PRINT(C_RESET, "%s: ", tok2str(ppptype2str, "unknown PPP protocol (0x%04x)", proto));
 
 		handle_ppp(ndo, proto, p, length);
 		break;
@@ -1715,7 +1715,7 @@ ppp_hdlc_if_print(netdissect_options *ndo,
 		}
 
 		if (ndo->ndo_eflag)
-			ND_PRINT("%02x %02x %u ", GET_U_1(p),
+			ND_PRINT(C_RESET, "%02x %02x %u ", GET_U_1(p),
 				 GET_U_1(p + 1), length);
 		p += 2;
 		hdrlen += 2;
@@ -1725,7 +1725,7 @@ ppp_hdlc_if_print(netdissect_options *ndo,
 		 * the next two octets as an Ethernet type; does that
 		 * ever happen?
 		 */
-		ND_PRINT("unknown addr %02x; ctrl %02x", GET_U_1(p),
+		ND_PRINT(C_RESET, "unknown addr %02x; ctrl %02x", GET_U_1(p),
 			 GET_U_1(p + 1));
 		break;
 	}
@@ -1762,34 +1762,34 @@ ppp_bsdos_if_print(netdissect_options *ndo,
 	if (GET_U_1(p) == PPP_ADDRESS &&
 	    GET_U_1(p + 1) == PPP_CONTROL) {
 		if (ndo->ndo_eflag)
-			ND_PRINT("%02x %02x ", GET_U_1(p),
+			ND_PRINT(C_RESET, "%02x %02x ", GET_U_1(p),
 				 GET_U_1(p + 1));
 		p += 2;
 		hdrlength = 2;
 	}
 
 	if (ndo->ndo_eflag)
-		ND_PRINT("%u ", length);
+		ND_PRINT(C_RESET, "%u ", length);
 	/* Retrieve the protocol type */
 	if (GET_U_1(p) & 01) {
 		/* Compressed protocol field */
 		ptype = GET_U_1(p);
 		if (ndo->ndo_eflag)
-			ND_PRINT("%02x ", ptype);
+			ND_PRINT(C_RESET, "%02x ", ptype);
 		p++;
 		hdrlength += 1;
 	} else {
 		/* Un-compressed protocol field */
 		ptype = GET_BE_U_2(p);
 		if (ndo->ndo_eflag)
-			ND_PRINT("%04x ", ptype);
+			ND_PRINT(C_RESET, "%04x ", ptype);
 		p += 2;
 		hdrlength += 2;
 	}
 #else
 	ptype = 0;	/*XXX*/
 	if (ndo->ndo_eflag)
-		ND_PRINT("%c ", GET_U_1(p + SLC_DIR) ? 'O' : 'I');
+		ND_PRINT(C_RESET, "%c ", GET_U_1(p + SLC_DIR) ? 'O' : 'I');
 	llhl = GET_U_1(p + SLC_LLHL);
 	if (llhl) {
 		/* link level header */
@@ -1800,24 +1800,24 @@ ppp_bsdos_if_print(netdissect_options *ndo,
 		if (ph->phdr_addr == PPP_ADDRESS
 		 && ph->phdr_ctl == PPP_CONTROL) {
 			if (ndo->ndo_eflag)
-				ND_PRINT("%02x %02x ", GET_U_1(q),
+				ND_PRINT(C_RESET, "%02x %02x ", GET_U_1(q),
 					 GET_U_1(q + 1));
 			ptype = GET_BE_U_2(&ph->phdr_type);
 			if (ndo->ndo_eflag && (ptype == PPP_VJC || ptype == PPP_VJNC)) {
-				ND_PRINT("%s ", tok2str(ppptype2str,
+				ND_PRINT(C_RESET, "%s ", tok2str(ppptype2str,
 						"proto-#%u", ptype));
 			}
 		} else {
 			if (ndo->ndo_eflag) {
-				ND_PRINT("LLH=[");
+				ND_PRINT(C_RESET, "LLH=[");
 				for (i = 0; i < llhl; i++)
-					ND_PRINT("%02x", GET_U_1(q + i));
-				ND_PRINT("] ");
+					ND_PRINT(C_RESET, "%02x", GET_U_1(q + i));
+				ND_PRINT(C_RESET, "] ");
 			}
 		}
 	}
 	if (ndo->ndo_eflag)
-		ND_PRINT("%u ", length);
+		ND_PRINT(C_RESET, "%u ", length);
 	if (GET_U_1(p + SLC_CHL)) {
 		q = p + SLC_BPFHDRLEN + llhl;
 
@@ -1858,11 +1858,11 @@ ppp_bsdos_if_print(netdissect_options *ndo,
 			goto printx;
 		default:
 			if (ndo->ndo_eflag) {
-				ND_PRINT("CH=[");
+				ND_PRINT(C_RESET, "CH=[");
 				for (i = 0; i < llhl; i++)
-					ND_PRINT("%02x",
+					ND_PRINT(C_RESET, "%02x",
 					    GET_U_1(q + i));
-				ND_PRINT("] ");
+				ND_PRINT(C_RESET, "] ");
 			}
 			break;
 		}
@@ -1886,7 +1886,7 @@ ppp_bsdos_if_print(netdissect_options *ndo,
 		mpls_print(ndo, p, length);
 		break;
 	default:
-		ND_PRINT("%s ", tok2str(ppptype2str, "unknown PPP protocol (0x%04x)", ptype));
+		ND_PRINT(C_RESET, "%s ", tok2str(ppptype2str, "unknown PPP protocol (0x%04x)", ptype));
 	}
 
 printx:

--- a/print-ppp.c
+++ b/print-ppp.c
@@ -421,7 +421,7 @@ handle_ctrl_proto(netdissect_options *ndo,
         tptr=pptr;
 
         typestr = tok2str(ppptype2str, "unknown ctrl-proto (0x%04x)", proto);
-	ND_PRINT(C_RESET, C_RESET "%s, ", typestr);
+	ND_PRINT(C_RESET, "%s, ", typestr);
 
 	if (length < 4) /* FIXME weak boundary checking */
 		goto trunc;
@@ -430,7 +430,7 @@ handle_ctrl_proto(netdissect_options *ndo,
 	code = GET_U_1(tptr);
 	tptr++;
 
-	ND_PRINT(C_RESET, C_RESET "%s (0x%02x), id %u, length %u",
+	ND_PRINT(C_RESET, "%s (0x%02x), id %u, length %u",
 	          tok2str(cpcodes, "Unknown Opcode",code),
 	          code,
 	          GET_U_1(tptr), /* ID */
@@ -444,17 +444,17 @@ handle_ctrl_proto(netdissect_options *ndo,
 	tptr += 2;
 
 	if (len < 4) {
-		ND_PRINT(C_RESET, C_RESET "\n\tencoded length %u (< 4))", len);
+		ND_PRINT(C_RESET, "\n\tencoded length %u (< 4))", len);
 		return;
 	}
 
 	if (len > length) {
-		ND_PRINT(C_RESET, C_RESET "\n\tencoded length %u (> packet length %u))", len, length);
+		ND_PRINT(C_RESET, "\n\tencoded length %u (> packet length %u))", len, length);
 		return;
 	}
 	length = len;
 
-	ND_PRINT(C_RESET, C_RESET "\n\tencoded length %u (=Option(s) length %u)", len, len - 4);
+	ND_PRINT(C_RESET, "\n\tencoded length %u (=Option(s) length %u)", len, len - 4);
 
 	if (length == 4)
 		return;    /* there may be a NULL confreq etc. */
@@ -467,9 +467,9 @@ handle_ctrl_proto(netdissect_options *ndo,
 	case CPCODES_VEXT:
 		if (length < 11)
 			break;
-		ND_PRINT(C_RESET, C_RESET "\n\t  Magic-Num 0x%08x", GET_BE_U_4(tptr));
+		ND_PRINT(C_RESET, "\n\t  Magic-Num 0x%08x", GET_BE_U_4(tptr));
 		tptr += 4;
-		ND_PRINT(C_RESET, C_RESET " Vendor: %s (%u)",
+		ND_PRINT(C_RESET, " Vendor: %s (%u)",
                        tok2str(oui_values,"Unknown",GET_BE_U_3(tptr)),
                        GET_BE_U_3(tptr));
 		/* XXX: need to decode Kind and Value(s)? */
@@ -511,7 +511,7 @@ handle_ctrl_proto(netdissect_options *ndo,
 			if ((advance = (*pfunc)(ndo, tptr, len)) == 0)
 				break;
 			if (tlen < advance) {
-				ND_PRINT(C_RESET, C_RESET " [remaining options length %u < %u]",
+				ND_PRINT(C_RESET, " [remaining options length %u < %u]",
 					 tlen, advance);
 				nd_print_invalid(ndo);
 				break;
@@ -531,12 +531,12 @@ handle_ctrl_proto(netdissect_options *ndo,
 	case CPCODES_PROT_REJ:
 		if (length < 6)
 			break;
-		ND_PRINT(C_RESET, C_RESET "\n\t  Rejected %s Protocol (0x%04x)",
+		ND_PRINT(C_RESET, "\n\t  Rejected %s Protocol (0x%04x)",
 		       tok2str(ppptype2str,"unknown", GET_BE_U_2(tptr)),
 		       GET_BE_U_2(tptr));
 		/* XXX: need to decode Rejected-Information? - hexdump for now */
 		if (len > 6) {
-			ND_PRINT(C_RESET, C_RESET "\n\t  Rejected Packet");
+			ND_PRINT(C_RESET, "\n\t  Rejected Packet");
 			print_unknown_data(ndo, tptr + 2, "\n\t    ", len - 2);
 		}
 		break;
@@ -545,10 +545,10 @@ handle_ctrl_proto(netdissect_options *ndo,
 	case CPCODES_DISC_REQ:
 		if (length < 8)
 			break;
-		ND_PRINT(C_RESET, C_RESET "\n\t  Magic-Num 0x%08x", GET_BE_U_4(tptr));
+		ND_PRINT(C_RESET, "\n\t  Magic-Num 0x%08x", GET_BE_U_4(tptr));
 		/* XXX: need to decode Data? - hexdump for now */
 		if (len > 8) {
-			ND_PRINT(C_RESET, C_RESET "\n\t  -----trailing data-----");
+			ND_PRINT(C_RESET, "\n\t  -----trailing data-----");
 			ND_TCHECK_LEN(tptr + 4, len - 8);
 			print_unknown_data(ndo, tptr + 4, "\n\t  ", len - 8);
 		}
@@ -556,10 +556,10 @@ handle_ctrl_proto(netdissect_options *ndo,
 	case CPCODES_ID:
 		if (length < 8)
 			break;
-		ND_PRINT(C_RESET, C_RESET "\n\t  Magic-Num 0x%08x", GET_BE_U_4(tptr));
+		ND_PRINT(C_RESET, "\n\t  Magic-Num 0x%08x", GET_BE_U_4(tptr));
 		/* RFC 1661 says this is intended to be human readable */
 		if (len > 8) {
-			ND_PRINT(C_RESET, C_RESET "\n\t  Message\n\t    ");
+			ND_PRINT(C_RESET, "\n\t  Message\n\t    ");
 			if (nd_printn(ndo, tptr + 4, len - 4, ndo->ndo_snapend))
 				goto trunc;
 		}
@@ -567,8 +567,8 @@ handle_ctrl_proto(netdissect_options *ndo,
 	case CPCODES_TIME_REM:
 		if (length < 12)
 			break;
-		ND_PRINT(C_RESET, C_RESET "\n\t  Magic-Num 0x%08x", GET_BE_U_4(tptr));
-		ND_PRINT(C_RESET, C_RESET ", Seconds-Remaining %us", GET_BE_U_4(tptr + 4));
+		ND_PRINT(C_RESET, "\n\t  Magic-Num 0x%08x", GET_BE_U_4(tptr));
+		ND_PRINT(C_RESET, ", Seconds-Remaining %us", GET_BE_U_4(tptr + 4));
 		/* XXX: need to decode Message? */
 		break;
 	default:
@@ -582,7 +582,7 @@ handle_ctrl_proto(netdissect_options *ndo,
 	return;
 
 trunc:
-	ND_PRINT(C_RESET, C_RESET "[|%s]", typestr);
+	ND_PRINT(C_RESET, "[|%s]", typestr);
 }
 
 /* LCP config options */
@@ -601,61 +601,61 @@ print_lcp_config_options(netdissect_options *ndo,
 		return 0;
 	if (len < 2) {
 		if (opt < NUM_LCPOPTS)
-			ND_PRINT(C_RESET, C_RESET "\n\t  %s Option (0x%02x), length %u (length bogus, should be >= 2)",
+			ND_PRINT(C_RESET, "\n\t  %s Option (0x%02x), length %u (length bogus, should be >= 2)",
 			          lcpconfopts[opt], opt, len);
 		else
-			ND_PRINT(C_RESET, C_RESET "\n\tunknown LCP option 0x%02x", opt);
+			ND_PRINT(C_RESET, "\n\tunknown LCP option 0x%02x", opt);
 		return 0;
 	}
 	if (opt < NUM_LCPOPTS)
-		ND_PRINT(C_RESET, C_RESET "\n\t  %s Option (0x%02x), length %u", lcpconfopts[opt], opt, len);
+		ND_PRINT(C_RESET, "\n\t  %s Option (0x%02x), length %u", lcpconfopts[opt], opt, len);
 	else {
-		ND_PRINT(C_RESET, C_RESET "\n\tunknown LCP option 0x%02x", opt);
+		ND_PRINT(C_RESET, "\n\tunknown LCP option 0x%02x", opt);
 		return len;
 	}
 
 	switch (opt) {
 	case LCPOPT_VEXT:
 		if (len < 6) {
-			ND_PRINT(C_RESET, C_RESET " (length bogus, should be >= 6)");
+			ND_PRINT(C_RESET, " (length bogus, should be >= 6)");
 			return len;
 		}
-		ND_PRINT(C_RESET, C_RESET ": Vendor: %s (%u)",
+		ND_PRINT(C_RESET, ": Vendor: %s (%u)",
 			tok2str(oui_values,"Unknown",GET_BE_U_3(p + 2)),
 			GET_BE_U_3(p + 2));
 #if 0
-		ND_PRINT(C_RESET, C_RESET ", kind: 0x%02x", GET_U_1(p + 5));
-		ND_PRINT(C_RESET, C_RESET ", Value: 0x");
+		ND_PRINT(C_RESET, ", kind: 0x%02x", GET_U_1(p + 5));
+		ND_PRINT(C_RESET, ", Value: 0x");
 		for (i = 0; i < len - 6; i++) {
-			ND_PRINT(C_RESET, C_RESET "%02x", GET_U_1(p + 6 + i));
+			ND_PRINT(C_RESET, "%02x", GET_U_1(p + 6 + i));
 		}
 #endif
 		break;
 	case LCPOPT_MRU:
 		if (len != 4) {
-			ND_PRINT(C_RESET, C_RESET " (length bogus, should be = 4)");
+			ND_PRINT(C_RESET, " (length bogus, should be = 4)");
 			return len;
 		}
-		ND_PRINT(C_RESET, C_RESET ": %u", GET_BE_U_2(p + 2));
+		ND_PRINT(C_RESET, ": %u", GET_BE_U_2(p + 2));
 		break;
 	case LCPOPT_ACCM:
 		if (len != 6) {
-			ND_PRINT(C_RESET, C_RESET " (length bogus, should be = 6)");
+			ND_PRINT(C_RESET, " (length bogus, should be = 6)");
 			return len;
 		}
-		ND_PRINT(C_RESET, C_RESET ": 0x%08x", GET_BE_U_4(p + 2));
+		ND_PRINT(C_RESET, ": 0x%08x", GET_BE_U_4(p + 2));
 		break;
 	case LCPOPT_AP:
 		if (len < 4) {
-			ND_PRINT(C_RESET, C_RESET " (length bogus, should be >= 4)");
+			ND_PRINT(C_RESET, " (length bogus, should be >= 4)");
 			return len;
 		}
-		ND_PRINT(C_RESET, C_RESET ": %s",
+		ND_PRINT(C_RESET, ": %s",
 			 tok2str(ppptype2str, "Unknown Auth Proto (0x04x)", GET_BE_U_2(p + 2)));
 
 		switch (GET_BE_U_2(p + 2)) {
 		case PPP_CHAP:
-			ND_PRINT(C_RESET, C_RESET ", %s",
+			ND_PRINT(C_RESET, ", %s",
 				 tok2str(authalg_values, "Unknown Auth Alg %u", GET_U_1(p + 4)));
 			break;
 		case PPP_PAP: /* fall through */
@@ -669,20 +669,20 @@ print_lcp_config_options(netdissect_options *ndo,
 		break;
 	case LCPOPT_QP:
 		if (len < 4) {
-			ND_PRINT(C_RESET, C_RESET " (length bogus, should be >= 4)");
+			ND_PRINT(C_RESET, " (length bogus, should be >= 4)");
 			return 0;
 		}
 		if (GET_BE_U_2(p + 2) == PPP_LQM)
-			ND_PRINT(C_RESET, C_RESET ": LQR");
+			ND_PRINT(C_RESET, ": LQR");
 		else
-			ND_PRINT(C_RESET, C_RESET ": unknown");
+			ND_PRINT(C_RESET, ": unknown");
 		break;
 	case LCPOPT_MN:
 		if (len != 6) {
-			ND_PRINT(C_RESET, C_RESET " (length bogus, should be = 6)");
+			ND_PRINT(C_RESET, " (length bogus, should be = 6)");
 			return 0;
 		}
-		ND_PRINT(C_RESET, C_RESET ": 0x%08x", GET_BE_U_4(p + 2));
+		ND_PRINT(C_RESET, ": 0x%08x", GET_BE_U_4(p + 2));
 		break;
 	case LCPOPT_PFC:
 		break;
@@ -733,10 +733,10 @@ print_lcp_config_options(netdissect_options *ndo,
 			break;
 		case MEDCLASS_MAC:
 			if (len != 9) {
-				ND_PRINT(C_RESET, C_RESET " (length bogus, should be = 9)");
+				ND_PRINT(C_RESET, " (length bogus, should be = 9)");
 				return 0;
 			}
-			ND_PRINT(C_RESET, C_RESET ": MAC %s", GET_ETHERADDR_STRING(p + 3));
+			ND_PRINT(C_RESET, ": MAC %s", GET_ETHERADDR_STRING(p + 3));
 			break;
 		case MEDCLASS_MNB:
 			ND_PRINT(C_RESET, ": Magic-Num-Block"); /* XXX */

--- a/print-pppoe.c
+++ b/print-pppoe.c
@@ -103,7 +103,7 @@ pppoe_print(netdissect_options *ndo, const u_char *bp, u_int length)
 
 	ndo->ndo_protocol = "pppoe";
 	if (length < PPPOE_HDRLEN) {
-		ND_PRINT(" (length %u < %u)", length, PPPOE_HDRLEN);
+		ND_PRINT(C_RESET, " (length %u < %u)", length, PPPOE_HDRLEN);
 		goto invalid;
 	}
 	length -= PPPOE_HDRLEN;
@@ -117,22 +117,22 @@ pppoe_print(netdissect_options *ndo, const u_char *bp, u_int length)
 	pppoe_payload = pppoe_packet + PPPOE_HDRLEN;
 
 	if (pppoe_ver != 1) {
-		ND_PRINT(" [ver %u]",pppoe_ver);
+		ND_PRINT(C_RESET, " [ver %u]",pppoe_ver);
 	}
 	if (pppoe_type != 1) {
-		ND_PRINT(" [type %u]",pppoe_type);
+		ND_PRINT(C_RESET, " [type %u]",pppoe_type);
 	}
 
-	ND_PRINT("PPPoE %s", tok2str(pppoecode2str, "PAD-%x", pppoe_code));
+	ND_PRINT(C_RESET, "PPPoE %s", tok2str(pppoecode2str, "PAD-%x", pppoe_code));
 	if (pppoe_code == PPPOE_PADI && pppoe_length > 1484 - PPPOE_HDRLEN) {
-		ND_PRINT(" [len %u!]",pppoe_length);
+		ND_PRINT(C_RESET, " [len %u!]",pppoe_length);
 	}
 	if (pppoe_length > length) {
-		ND_PRINT(" [len %u > %u!]", pppoe_length, length);
+		ND_PRINT(C_RESET, " [len %u > %u!]", pppoe_length, length);
 		pppoe_length = length;
 	}
 	if (pppoe_sessionid) {
-		ND_PRINT(" [ses 0x%x]", pppoe_sessionid);
+		ND_PRINT(C_RESET, " [ses 0x%x]", pppoe_sessionid);
 	}
 
 	if (pppoe_code) {
@@ -170,23 +170,23 @@ pppoe_print(netdissect_options *ndo, const u_char *bp, u_int length)
 				tag_str[tag_str_len] = 0;
 
 				if (ascii_count > garbage_count) {
-					ND_PRINT(" [%s \"%*.*s\"]",
+					ND_PRINT(C_RESET, " [%s \"%*.*s\"]",
 					       tok2str(pppoetag2str, "TAG-0x%x", tag_type),
 					       (int)tag_str_len,
 					       (int)tag_str_len,
 					       tag_str);
 				} else {
 					/* Print hex, not fast to abuse printf but this doesn't get used much */
-					ND_PRINT(" [%s 0x", tok2str(pppoetag2str, "TAG-0x%x", tag_type));
+					ND_PRINT(C_RESET, " [%s 0x", tok2str(pppoetag2str, "TAG-0x%x", tag_type));
 					for (v=p; v<p+tag_len; v++) {
-						ND_PRINT("%02X", GET_U_1(v));
+						ND_PRINT(C_RESET, "%02X", GET_U_1(v));
 					}
-					ND_PRINT("]");
+					ND_PRINT(C_RESET, "]");
 				}
 
 
 			} else
-				ND_PRINT(" [%s]", tok2str(pppoetag2str,
+				ND_PRINT(C_RESET, " [%s]", tok2str(pppoetag2str,
 				    "TAG-0x%x", tag_type));
 
 			p += tag_len;
@@ -195,7 +195,7 @@ pppoe_print(netdissect_options *ndo, const u_char *bp, u_int length)
 		return PPPOE_HDRLEN;
 	} else {
 		/* PPPoE data */
-		ND_PRINT(" ");
+		ND_PRINT(C_RESET, " ");
 		return (PPPOE_HDRLEN + ppp_print(ndo, pppoe_payload, pppoe_length));
 	}
 	/* NOTREACHED */

--- a/print-pptp.c
+++ b/print-pptp.c
@@ -264,12 +264,12 @@ struct pptp_msg_sli {
 
 #define PRINT_RESERVED_IF_NOT_ZERO_1(reserved) \
         if (GET_U_1(reserved)) \
-		ND_PRINT(" [ERROR: reserved=%u must be zero]", \
+		ND_PRINT(C_RESET, " [ERROR: reserved=%u must be zero]", \
 			 GET_U_1(reserved));
 
 #define PRINT_RESERVED_IF_NOT_ZERO_2(reserved) \
         if (GET_BE_U_2(reserved)) \
-		ND_PRINT(" [ERROR: reserved=%u must be zero]", \
+		ND_PRINT(C_RESET, " [ERROR: reserved=%u must be zero]", \
 			 GET_BE_U_2(reserved));
 
 /******************************************/
@@ -280,7 +280,7 @@ static void
 pptp_bearer_cap_print(netdissect_options *ndo,
                       const nd_uint32_t bearer_cap)
 {
-	ND_PRINT(" BEARER_CAP(%s%s)",
+	ND_PRINT(C_RESET, " BEARER_CAP(%s%s)",
 	          GET_BE_U_4(bearer_cap) & PPTP_BEARER_CAP_DIGITAL_MASK ? "D" : "",
 	          GET_BE_U_4(bearer_cap) & PPTP_BEARER_CAP_ANALOG_MASK ? "A" : "");
 }
@@ -296,7 +296,7 @@ static void
 pptp_bearer_type_print(netdissect_options *ndo,
                        const nd_uint32_t bearer_type)
 {
-	ND_PRINT(" BEARER_TYPE(%s)",
+	ND_PRINT(C_RESET, " BEARER_TYPE(%s)",
 	          tok2str(pptp_btype_str, "?", GET_BE_U_4(bearer_type)));
 }
 
@@ -304,28 +304,28 @@ static void
 pptp_call_id_print(netdissect_options *ndo,
                    const nd_uint16_t call_id)
 {
-	ND_PRINT(" CALL_ID(%u)", GET_BE_U_2(call_id));
+	ND_PRINT(C_RESET, " CALL_ID(%u)", GET_BE_U_2(call_id));
 }
 
 static void
 pptp_call_ser_print(netdissect_options *ndo,
                     const nd_uint16_t call_ser)
 {
-	ND_PRINT(" CALL_SER_NUM(%u)", GET_BE_U_2(call_ser));
+	ND_PRINT(C_RESET, " CALL_SER_NUM(%u)", GET_BE_U_2(call_ser));
 }
 
 static void
 pptp_cause_code_print(netdissect_options *ndo,
                       const nd_uint16_t cause_code)
 {
-	ND_PRINT(" CAUSE_CODE(%u)", GET_BE_U_2(cause_code));
+	ND_PRINT(C_RESET, " CAUSE_CODE(%u)", GET_BE_U_2(cause_code));
 }
 
 static void
 pptp_conn_speed_print(netdissect_options *ndo,
                       const nd_uint32_t conn_speed)
 {
-	ND_PRINT(" CONN_SPEED(%u)", GET_BE_U_4(conn_speed));
+	ND_PRINT(C_RESET, " CONN_SPEED(%u)", GET_BE_U_4(conn_speed));
 }
 
 static const struct tok pptp_errcode_str[] = {
@@ -343,33 +343,33 @@ static void
 pptp_err_code_print(netdissect_options *ndo,
                     const nd_uint8_t err_code)
 {
-	ND_PRINT(" ERR_CODE(%u", GET_U_1(err_code));
+	ND_PRINT(C_RESET, " ERR_CODE(%u", GET_U_1(err_code));
 	if (ndo->ndo_vflag) {
-		ND_PRINT(":%s",
+		ND_PRINT(C_RESET, ":%s",
 			 tok2str(pptp_errcode_str, "?", GET_U_1(err_code)));
 	}
-	ND_PRINT(")");
+	ND_PRINT(C_RESET, ")");
 }
 
 static void
 pptp_firm_rev_print(netdissect_options *ndo,
                     const nd_uint16_t firm_rev)
 {
-	ND_PRINT(" FIRM_REV(%u)", GET_BE_U_2(firm_rev));
+	ND_PRINT(C_RESET, " FIRM_REV(%u)", GET_BE_U_2(firm_rev));
 }
 
 static void
 pptp_framing_cap_print(netdissect_options *ndo,
                        const nd_uint32_t framing_cap)
 {
-	ND_PRINT(" FRAME_CAP(");
+	ND_PRINT(C_RESET, " FRAME_CAP(");
 	if (GET_BE_U_4(framing_cap) & PPTP_FRAMING_CAP_ASYNC_MASK) {
-                ND_PRINT("A");		/* Async */
+                ND_PRINT(C_RESET, "A");		/* Async */
         }
         if (GET_BE_U_4(framing_cap) & PPTP_FRAMING_CAP_SYNC_MASK) {
-                ND_PRINT("S");		/* Sync */
+                ND_PRINT(C_RESET, "S");		/* Sync */
         }
-	ND_PRINT(")");
+	ND_PRINT(C_RESET, ")");
 }
 
 static const struct tok pptp_ftype_str[] = {
@@ -383,7 +383,7 @@ static void
 pptp_framing_type_print(netdissect_options *ndo,
                         const nd_uint32_t framing_type)
 {
-	ND_PRINT(" FRAME_TYPE(%s)",
+	ND_PRINT(C_RESET, " FRAME_TYPE(%s)",
 	          tok2str(pptp_ftype_str, "?", GET_BE_U_4(framing_type)));
 }
 
@@ -391,51 +391,51 @@ static void
 pptp_hostname_print(netdissect_options *ndo,
                     const u_char *hostname)
 {
-	ND_PRINT(" HOSTNAME(");
+	ND_PRINT(C_RESET, " HOSTNAME(");
 	nd_printjnp(ndo, hostname, 64);
-	ND_PRINT(")");
+	ND_PRINT(C_RESET, ")");
 }
 
 static void
 pptp_id_print(netdissect_options *ndo,
               const nd_uint32_t id)
 {
-	ND_PRINT(" ID(%u)", GET_BE_U_4(id));
+	ND_PRINT(C_RESET, " ID(%u)", GET_BE_U_4(id));
 }
 
 static void
 pptp_max_channel_print(netdissect_options *ndo,
                        const nd_uint16_t max_channel)
 {
-	ND_PRINT(" MAX_CHAN(%u)", GET_BE_U_2(max_channel));
+	ND_PRINT(C_RESET, " MAX_CHAN(%u)", GET_BE_U_2(max_channel));
 }
 
 static void
 pptp_peer_call_id_print(netdissect_options *ndo,
                         const nd_uint16_t peer_call_id)
 {
-	ND_PRINT(" PEER_CALL_ID(%u)", GET_BE_U_2(peer_call_id));
+	ND_PRINT(C_RESET, " PEER_CALL_ID(%u)", GET_BE_U_2(peer_call_id));
 }
 
 static void
 pptp_phy_chan_id_print(netdissect_options *ndo,
                        const nd_uint32_t phy_chan_id)
 {
-	ND_PRINT(" PHY_CHAN_ID(%u)", GET_BE_U_4(phy_chan_id));
+	ND_PRINT(C_RESET, " PHY_CHAN_ID(%u)", GET_BE_U_4(phy_chan_id));
 }
 
 static void
 pptp_pkt_proc_delay_print(netdissect_options *ndo,
                           const nd_uint16_t pkt_proc_delay)
 {
-	ND_PRINT(" PROC_DELAY(%u)", GET_BE_U_2(pkt_proc_delay));
+	ND_PRINT(C_RESET, " PROC_DELAY(%u)", GET_BE_U_2(pkt_proc_delay));
 }
 
 static void
 pptp_proto_ver_print(netdissect_options *ndo,
                      const nd_uint16_t proto_ver)
 {
-	ND_PRINT(" PROTO_VER(%u.%u)",	/* Version.Revision */
+	ND_PRINT(C_RESET, " PROTO_VER(%u.%u)",	/* Version.Revision */
 	       GET_BE_U_2(proto_ver) >> 8,
 	       GET_BE_U_2(proto_ver) & 0xff);
 }
@@ -444,7 +444,7 @@ static void
 pptp_recv_winsiz_print(netdissect_options *ndo,
                        const nd_uint16_t recv_winsiz)
 {
-	ND_PRINT(" RECV_WIN(%u)", GET_BE_U_2(recv_winsiz));
+	ND_PRINT(C_RESET, " RECV_WIN(%u)", GET_BE_U_2(recv_winsiz));
 }
 
 static const struct tok pptp_scrrp_str[] = {
@@ -492,7 +492,7 @@ static void
 pptp_result_code_print(netdissect_options *ndo,
                        const nd_uint8_t result_code, int ctrl_msg_type)
 {
-	ND_PRINT(" RESULT_CODE(%u", GET_U_1(result_code));
+	ND_PRINT(C_RESET, " RESULT_CODE(%u", GET_U_1(result_code));
 	if (ndo->ndo_vflag) {
 		const struct tok *dict =
 			ctrl_msg_type == PPTP_CTRL_MSG_TYPE_SCCRP    ? pptp_scrrp_str :
@@ -503,28 +503,28 @@ pptp_result_code_print(netdissect_options *ndo,
 			ctrl_msg_type == PPTP_CTRL_MSG_TYPE_CDN      ? pptp_cdn_str :
 			NULL; /* assertion error */
 		if (dict != NULL)
-			ND_PRINT(":%s",
+			ND_PRINT(C_RESET, ":%s",
 				 tok2str(dict, "?", GET_U_1(result_code)));
 	}
-	ND_PRINT(")");
+	ND_PRINT(C_RESET, ")");
 }
 
 static void
 pptp_subaddr_print(netdissect_options *ndo,
                    const u_char *subaddr)
 {
-	ND_PRINT(" SUB_ADDR(");
+	ND_PRINT(C_RESET, " SUB_ADDR(");
 	nd_printjnp(ndo, subaddr, 64);
-	ND_PRINT(")");
+	ND_PRINT(C_RESET, ")");
 }
 
 static void
 pptp_vendor_print(netdissect_options *ndo,
                   const u_char *vendor)
 {
-	ND_PRINT(" VENDOR(");
+	ND_PRINT(C_RESET, " VENDOR(");
 	nd_printjnp(ndo, vendor, 64);
-	ND_PRINT(")");
+	ND_PRINT(C_RESET, ")");
 }
 
 /************************************/
@@ -569,24 +569,24 @@ pptp_stopccrq_print(netdissect_options *ndo,
 {
 	const struct pptp_msg_stopccrq *ptr = (const struct pptp_msg_stopccrq *)dat;
 
-	ND_PRINT(" REASON(%u", GET_U_1(ptr->reason));
+	ND_PRINT(C_RESET, " REASON(%u", GET_U_1(ptr->reason));
 	if (ndo->ndo_vflag) {
 		switch (GET_U_1(ptr->reason)) {
 		case 1:
-			ND_PRINT(":None");
+			ND_PRINT(C_RESET, ":None");
 			break;
 		case 2:
-			ND_PRINT(":Stop-Protocol");
+			ND_PRINT(C_RESET, ":Stop-Protocol");
 			break;
 		case 3:
-			ND_PRINT(":Stop-Local-Shutdown");
+			ND_PRINT(C_RESET, ":Stop-Local-Shutdown");
 			break;
 		default:
-			ND_PRINT(":?");
+			ND_PRINT(C_RESET, ":?");
 			break;
 		}
 	}
-	ND_PRINT(")");
+	ND_PRINT(C_RESET, ")");
 	PRINT_RESERVED_IF_NOT_ZERO_1(ptr->reserved1);
 	PRINT_RESERVED_IF_NOT_ZERO_2(ptr->reserved2);
 }
@@ -631,18 +631,18 @@ pptp_ocrq_print(netdissect_options *ndo,
 
 	pptp_call_id_print(ndo, ptr->call_id);
 	pptp_call_ser_print(ndo, ptr->call_ser);
-	ND_PRINT(" MIN_BPS(%u)", GET_BE_U_4(ptr->min_bps));
-	ND_PRINT(" MAX_BPS(%u)", GET_BE_U_4(ptr->max_bps));
+	ND_PRINT(C_RESET, " MIN_BPS(%u)", GET_BE_U_4(ptr->min_bps));
+	ND_PRINT(C_RESET, " MAX_BPS(%u)", GET_BE_U_4(ptr->max_bps));
 	pptp_bearer_type_print(ndo, ptr->bearer_type);
 	pptp_framing_type_print(ndo, ptr->framing_type);
 	pptp_recv_winsiz_print(ndo, ptr->recv_winsiz);
 	pptp_pkt_proc_delay_print(ndo, ptr->pkt_proc_delay);
-	ND_PRINT(" PHONE_NO_LEN(%u)", GET_BE_U_2(ptr->phone_no_len));
+	ND_PRINT(C_RESET, " PHONE_NO_LEN(%u)", GET_BE_U_2(ptr->phone_no_len));
 	PRINT_RESERVED_IF_NOT_ZERO_2(ptr->reserved1);
-	ND_PRINT(" PHONE_NO(");
+	ND_PRINT(C_RESET, " PHONE_NO(");
 	nd_printjnp(ndo, ptr->phone_no,
 		    ND_MIN(64, GET_BE_U_2(ptr->phone_no_len)));
-	ND_PRINT(")");
+	ND_PRINT(C_RESET, ")");
 	pptp_subaddr_print(ndo, ptr->subaddr);
 }
 
@@ -673,16 +673,16 @@ pptp_icrq_print(netdissect_options *ndo,
 	pptp_call_ser_print(ndo, ptr->call_ser);
 	pptp_bearer_type_print(ndo, ptr->bearer_type);
 	pptp_phy_chan_id_print(ndo, ptr->phy_chan_id);
-	ND_PRINT(" DIALED_NO_LEN(%u)", GET_BE_U_2(ptr->dialed_no_len));
-	ND_PRINT(" DIALING_NO_LEN(%u)", GET_BE_U_2(ptr->dialing_no_len));
-	ND_PRINT(" DIALED_NO(");
+	ND_PRINT(C_RESET, " DIALED_NO_LEN(%u)", GET_BE_U_2(ptr->dialed_no_len));
+	ND_PRINT(C_RESET, " DIALING_NO_LEN(%u)", GET_BE_U_2(ptr->dialing_no_len));
+	ND_PRINT(C_RESET, " DIALED_NO(");
 	nd_printjnp(ndo, ptr->dialed_no,
 		    ND_MIN(64, GET_BE_U_2(ptr->dialed_no_len)));
-	ND_PRINT(")");
-	ND_PRINT(" DIALING_NO(");
+	ND_PRINT(C_RESET, ")");
+	ND_PRINT(C_RESET, " DIALING_NO(");
 	nd_printjnp(ndo, ptr->dialing_no,
 		    ND_MIN(64, GET_BE_U_2(ptr->dialing_no_len)));
-	ND_PRINT(")");
+	ND_PRINT(C_RESET, ")");
 	pptp_subaddr_print(ndo, ptr->subaddr);
 }
 
@@ -736,9 +736,9 @@ pptp_cdn_print(netdissect_options *ndo,
 	pptp_err_code_print(ndo, ptr->err_code);
 	pptp_cause_code_print(ndo, ptr->cause_code);
 	PRINT_RESERVED_IF_NOT_ZERO_2(ptr->reserved1);
-	ND_PRINT(" CALL_STATS(");
+	ND_PRINT(C_RESET, " CALL_STATS(");
 	nd_printjnp(ndo, ptr->call_stats, 128);
-	ND_PRINT(")");
+	ND_PRINT(C_RESET, ")");
 }
 
 static void
@@ -749,12 +749,12 @@ pptp_wen_print(netdissect_options *ndo,
 
 	pptp_peer_call_id_print(ndo, ptr->peer_call_id);
 	PRINT_RESERVED_IF_NOT_ZERO_2(ptr->reserved1);
-	ND_PRINT(" CRC_ERR(%u)", GET_BE_U_4(ptr->crc_err));
-	ND_PRINT(" FRAMING_ERR(%u)", GET_BE_U_4(ptr->framing_err));
-	ND_PRINT(" HARDWARE_OVERRUN(%u)", GET_BE_U_4(ptr->hardware_overrun));
-	ND_PRINT(" BUFFER_OVERRUN(%u)", GET_BE_U_4(ptr->buffer_overrun));
-	ND_PRINT(" TIMEOUT_ERR(%u)", GET_BE_U_4(ptr->timeout_err));
-	ND_PRINT(" ALIGN_ERR(%u)", GET_BE_U_4(ptr->align_err));
+	ND_PRINT(C_RESET, " CRC_ERR(%u)", GET_BE_U_4(ptr->crc_err));
+	ND_PRINT(C_RESET, " FRAMING_ERR(%u)", GET_BE_U_4(ptr->framing_err));
+	ND_PRINT(C_RESET, " HARDWARE_OVERRUN(%u)", GET_BE_U_4(ptr->hardware_overrun));
+	ND_PRINT(C_RESET, " BUFFER_OVERRUN(%u)", GET_BE_U_4(ptr->buffer_overrun));
+	ND_PRINT(C_RESET, " TIMEOUT_ERR(%u)", GET_BE_U_4(ptr->timeout_err));
+	ND_PRINT(C_RESET, " ALIGN_ERR(%u)", GET_BE_U_4(ptr->align_err));
 }
 
 static void
@@ -765,8 +765,8 @@ pptp_sli_print(netdissect_options *ndo,
 
 	pptp_peer_call_id_print(ndo, ptr->peer_call_id);
 	PRINT_RESERVED_IF_NOT_ZERO_2(ptr->reserved1);
-	ND_PRINT(" SEND_ACCM(0x%08x)", GET_BE_U_4(ptr->send_accm));
-	ND_PRINT(" RECV_ACCM(0x%08x)", GET_BE_U_4(ptr->recv_accm));
+	ND_PRINT(C_RESET, " SEND_ACCM(0x%08x)", GET_BE_U_4(ptr->send_accm));
+	ND_PRINT(C_RESET, " RECV_ACCM(0x%08x)", GET_BE_U_4(ptr->recv_accm));
 }
 
 void
@@ -778,41 +778,41 @@ pptp_print(netdissect_options *ndo,
 	uint16_t ctrl_msg_type;
 
 	ndo->ndo_protocol = "pptp";
-	ND_PRINT(": ");
+	ND_PRINT(C_RESET, ": ");
 	nd_print_protocol(ndo);
 
 	hdr = (const struct pptp_hdr *)dat;
 
 	if (ndo->ndo_vflag) {
-		ND_PRINT(" Length=%u", GET_BE_U_2(hdr->length));
+		ND_PRINT(C_RESET, " Length=%u", GET_BE_U_2(hdr->length));
 	}
 	if (ndo->ndo_vflag) {
 		switch(GET_BE_U_2(hdr->msg_type)) {
 		case PPTP_MSG_TYPE_CTRL:
-			ND_PRINT(" CTRL-MSG");
+			ND_PRINT(C_RESET, " CTRL-MSG");
 			break;
 		case PPTP_MSG_TYPE_MGMT:
-			ND_PRINT(" MGMT-MSG");
+			ND_PRINT(C_RESET, " MGMT-MSG");
 			break;
 		default:
-			ND_PRINT(" UNKNOWN-MSG-TYPE");
+			ND_PRINT(C_RESET, " UNKNOWN-MSG-TYPE");
 			break;
 		}
 	}
 
 	mc = GET_BE_U_4(hdr->magic_cookie);
 	if (mc != PPTP_MAGIC_COOKIE) {
-		ND_PRINT(" UNEXPECTED Magic-Cookie!!(%08x)", mc);
+		ND_PRINT(C_RESET, " UNEXPECTED Magic-Cookie!!(%08x)", mc);
 	}
 	if (ndo->ndo_vflag || mc != PPTP_MAGIC_COOKIE) {
-		ND_PRINT(" Magic-Cookie=%08x", mc);
+		ND_PRINT(C_RESET, " Magic-Cookie=%08x", mc);
 	}
 	ctrl_msg_type = GET_BE_U_2(hdr->ctrl_msg_type);
 	if (ctrl_msg_type < PPTP_MAX_MSGTYPE_INDEX) {
-		ND_PRINT(" CTRL_MSGTYPE=%s",
+		ND_PRINT(C_RESET, " CTRL_MSGTYPE=%s",
 		       pptp_message_type_string[ctrl_msg_type]);
 	} else {
-		ND_PRINT(" UNKNOWN_CTRL_MSGTYPE(%u)", ctrl_msg_type);
+		ND_PRINT(C_RESET, " UNKNOWN_CTRL_MSGTYPE(%u)", ctrl_msg_type);
 	}
 	PRINT_RESERVED_IF_NOT_ZERO_2(hdr->reserved0);
 

--- a/print-ptp.c
+++ b/print-ptp.c
@@ -256,7 +256,7 @@ static const struct tok ptp_flag_values[] = {
 
 #define PTP_PRINT_MSG_TYPE(e) \
         { \
-            ND_PRINT("(%s)", tok2str(ptp_msg_type, "unknown", e)); \
+            ND_PRINT(C_RESET, "(%s)", tok2str(ptp_msg_type, "unknown", e)); \
         }
 
 static const char *p_porigin_ts = "preciseOriginTimeStamp";
@@ -295,38 +295,38 @@ print_field(netdissect_options *ndo, const char *st, uint32_t flen,
     switch(flen) {
         case PTP_UCHAR_LEN:
             u8_val = GET_U_1(bp);
-            ND_PRINT(", %s", st);
+            ND_PRINT(C_RESET, ", %s", st);
             if (hex)
-                ND_PRINT(" 0x%x", u8_val);
+                ND_PRINT(C_RESET, " 0x%x", u8_val);
             else
-                ND_PRINT(" %u", u8_val);
+                ND_PRINT(C_RESET, " %u", u8_val);
             *len -= 1; bp += 1;
             break;
         case PTP_UINT16_LEN:
             u16_val = GET_BE_U_2(bp);
-            ND_PRINT(", %s", st);
+            ND_PRINT(C_RESET, ", %s", st);
             if (hex)
-                ND_PRINT(" 0x%x", u16_val);
+                ND_PRINT(C_RESET, " 0x%x", u16_val);
             else
-                ND_PRINT(" %u", u16_val);
+                ND_PRINT(C_RESET, " %u", u16_val);
             *len -= 2; bp += 2;
             break;
         case PTP_UINT32_LEN:
             u32_val = GET_BE_U_4(bp);
-            ND_PRINT(", %s", st);
+            ND_PRINT(C_RESET, ", %s", st);
             if (hex)
-                ND_PRINT(" 0x%x", u32_val);
+                ND_PRINT(C_RESET, " 0x%x", u32_val);
             else
-                ND_PRINT(" %u", u32_val);
+                ND_PRINT(C_RESET, " %u", u32_val);
             *len -= 4; bp += 4;
             break;
         case PTP_UINT64_LEN:
             u64_val = GET_BE_U_8(bp);
-            ND_PRINT(", %s", st);
+            ND_PRINT(C_RESET, ", %s", st);
             if (hex)
-                ND_PRINT(" 0x%"PRIx64, u64_val);
+                ND_PRINT(C_RESET, " 0x%"PRIx64, u64_val);
             else
-                ND_PRINT(" 0x%"PRIu64, u64_val);
+                ND_PRINT(C_RESET, " 0x%"PRIu64, u64_val);
             *len -= 8; bp += 8;
             break;
         default:
@@ -337,7 +337,7 @@ print_field(netdissect_options *ndo, const char *st, uint32_t flen,
 static void
 ptp_print_1(netdissect_options *ndo)
 {
-    ND_PRINT(" (not implemented)");
+    ND_PRINT(C_RESET, " (not implemented)");
 }
 
 static void
@@ -353,47 +353,47 @@ ptp_print_2(netdissect_options *ndo, const u_char *bp, u_int length)
 
     foct = GET_U_1(bp);
     v1_compat = foct & PTP_V1_COMPAT;
-    ND_PRINT(", v1 compat : %s", v1_compat?"yes":"no");
+    ND_PRINT(C_RESET, ", v1 compat : %s", v1_compat?"yes":"no");
     msg_type = foct & PTP_MSG_TYPE_MASK;
-    ND_PRINT(", msg type : %s", tok2str(ptp_msg_type, "none", msg_type));
+    ND_PRINT(C_RESET, ", msg type : %s", tok2str(ptp_msg_type, "none", msg_type));
 
     /* msg length */
-    len -= 2; bp += 2; msg_len = GET_BE_U_2(bp); ND_PRINT(", length : %u", msg_len);
+    len -= 2; bp += 2; msg_len = GET_BE_U_2(bp); ND_PRINT(C_RESET, ", length : %u", msg_len);
 
     /* domain */
-    len -= 2; bp += 2; domain_no = (GET_BE_U_2(bp) & PTP_DOMAIN_MASK) >> 8; ND_PRINT(", domain : %u", domain_no);
+    len -= 2; bp += 2; domain_no = (GET_BE_U_2(bp) & PTP_DOMAIN_MASK) >> 8; ND_PRINT(C_RESET, ", domain : %u", domain_no);
 
     /* rsvd 1*/
     rsvd1 = GET_BE_U_2(bp) & PTP_RSVD1_MASK;
-    ND_PRINT(", reserved1 : %u", rsvd1);
+    ND_PRINT(C_RESET, ", reserved1 : %u", rsvd1);
 
     /* flags */
-    len -= 2; bp += 2; flags = GET_BE_U_2(bp); ND_PRINT(", Flags [%s]", bittok2str(ptp_flag_values, "none", flags));
+    len -= 2; bp += 2; flags = GET_BE_U_2(bp); ND_PRINT(C_RESET, ", Flags [%s]", bittok2str(ptp_flag_values, "none", flags));
 
     /* correction NS (48 bits) */
-    len -= 2; bp += 2; ns_corr = GET_BE_U_6(bp); ND_PRINT(", NS correction : %"PRIu64, ns_corr);
+    len -= 2; bp += 2; ns_corr = GET_BE_U_6(bp); ND_PRINT(C_RESET, ", NS correction : %"PRIu64, ns_corr);
 
     /* correction sub NS (16 bits) */
-    len -= 6; bp += 6; sns_corr = GET_BE_U_2(bp); ND_PRINT(", sub NS correction : %u", sns_corr);
+    len -= 6; bp += 6; sns_corr = GET_BE_U_2(bp); ND_PRINT(C_RESET, ", sub NS correction : %u", sns_corr);
 
     /* Reserved 2 */
-    len -= 2; bp += 2; rsvd2 = GET_BE_U_4(bp); ND_PRINT(", reserved2 : %u", rsvd2);
+    len -= 2; bp += 2; rsvd2 = GET_BE_U_4(bp); ND_PRINT(C_RESET, ", reserved2 : %u", rsvd2);
 
     /* clock identity */
-    len -= 4; bp += 4; clk_id = GET_BE_U_8(bp); ND_PRINT(", clock identity : 0x%"PRIx64, clk_id);
+    len -= 4; bp += 4; clk_id = GET_BE_U_8(bp); ND_PRINT(C_RESET, ", clock identity : 0x%"PRIx64, clk_id);
 
     /* port identity */
-    len -= 8; bp += 8; port_id = GET_BE_U_2(bp); ND_PRINT(", port id : %u", port_id);
+    len -= 8; bp += 8; port_id = GET_BE_U_2(bp); ND_PRINT(C_RESET, ", port id : %u", port_id);
 
     /* sequence ID */
-    len -= 2; bp += 2; seq_id = GET_BE_U_2(bp); ND_PRINT(", seq id : %u", seq_id);
+    len -= 2; bp += 2; seq_id = GET_BE_U_2(bp); ND_PRINT(C_RESET, ", seq id : %u", seq_id);
 
     /* control */
     len -= 2; bp += 2; control = GET_U_1(bp) ;
-    ND_PRINT(", control : %u (%s)", control, tok2str(ptp_msg_type, "none", control));
+    ND_PRINT(C_RESET, ", control : %u (%s)", control, tok2str(ptp_msg_type, "none", control));
 
     /* log message interval */
-    lm_int = GET_BE_U_2(bp) & PTP_LOGMSG_MASK; ND_PRINT(", log message interval : %u", lm_int); len -= 2; bp += 2;
+    lm_int = GET_BE_U_2(bp) & PTP_LOGMSG_MASK; ND_PRINT(C_RESET, ", log message interval : %u", lm_int); len -= 2; bp += 2;
 
     switch(msg_type) {
         case M_SYNC:
@@ -441,7 +441,7 @@ ptp_print(netdissect_options *ndo, const u_char *bp, u_int length)
     ndo->ndo_protocol = "ptp";
     ND_ICHECK_U(length, <, PTP_HDR_LEN);
     vers = GET_BE_U_2(bp) & PTP_VERS_MASK;
-    ND_PRINT("PTPv%u",vers);
+    ND_PRINT(C_RESET, "PTPv%u",vers);
     switch(vers) {
         case PTP_VER_1:
             ptp_print_1(ndo);
@@ -450,7 +450,7 @@ ptp_print(netdissect_options *ndo, const u_char *bp, u_int length)
             ptp_print_2(ndo, bp, length);
             break;
         default:
-            //ND_PRINT("ERROR: unknown-version\n");
+            //ND_PRINT(C_RESET, "ERROR: unknown-version\n");
             break;
     }
     return;
@@ -465,16 +465,16 @@ ptp_print_timestamp(netdissect_options *ndo, const u_char *bp, u_int *len, const
     uint64_t secs;
     uint32_t nsecs;
 
-    ND_PRINT(", %s :", stype);
+    ND_PRINT(C_RESET, ", %s :", stype);
     /* sec time stamp 6 bytes */
     secs = GET_BE_U_6(bp);
-    ND_PRINT(" %"PRIu64" seconds,", secs);
+    ND_PRINT(C_RESET, " %"PRIu64" seconds,", secs);
     *len -= 6;
     bp += 6;
 
     /* NS time stamp 4 bytes */
     nsecs = GET_BE_U_4(bp);
-    ND_PRINT(" %u nanoseconds", nsecs);
+    ND_PRINT(C_RESET, " %u nanoseconds", nsecs);
     *len -= 4;
     bp += 4;
 }
@@ -487,28 +487,28 @@ ptp_print_timestamp_identity(netdissect_options *ndo,
     uint16_t port_id;
     uint64_t port_identity;
 
-    ND_PRINT(", %s :", ttype);
+    ND_PRINT(C_RESET, ", %s :", ttype);
     /* sec time stamp 6 bytes */
     secs = GET_BE_U_6(bp);
-    ND_PRINT(" %"PRIu64" seconds,", secs);
+    ND_PRINT(C_RESET, " %"PRIu64" seconds,", secs);
     *len -= 6;
     bp += 6;
 
     /* NS time stamp 4 bytes */
     nsecs = GET_BE_U_4(bp);
-    ND_PRINT(" %u nanoseconds", nsecs);
+    ND_PRINT(C_RESET, " %u nanoseconds", nsecs);
     *len -= 4;
     bp += 4;
 
     /* port identity*/
     port_identity = GET_BE_U_8(bp);
-    ND_PRINT(", port identity : 0x%"PRIx64, port_identity);
+    ND_PRINT(C_RESET, ", port identity : 0x%"PRIx64, port_identity);
     *len -= 8;
     bp += 8;
 
     /* port id */
     port_id = GET_BE_U_2(bp);
-    ND_PRINT(", port id : %u", port_id);
+    ND_PRINT(C_RESET, ", port id : %u", port_id);
     *len -= 2;
     bp += 2;
 }
@@ -521,71 +521,71 @@ ptp_print_announce_msg(netdissect_options *ndo, const u_char *bp, u_int *len)
     uint64_t secs;
     uint32_t nsecs;
 
-    ND_PRINT(", %s :", p_origin_ts);
+    ND_PRINT(C_RESET, ", %s :", p_origin_ts);
     /* sec time stamp 6 bytes */
     secs = GET_BE_U_6(bp);
-    ND_PRINT(" %"PRIu64" seconds", secs);
+    ND_PRINT(C_RESET, " %"PRIu64" seconds", secs);
     *len -= 6;
     bp += 6;
 
     /* NS time stamp 4 bytes */
     nsecs = GET_BE_U_4(bp);
-    ND_PRINT(" %u nanoseconds", nsecs);
+    ND_PRINT(C_RESET, " %u nanoseconds", nsecs);
     *len -= 4;
     bp += 4;
 
     /* origin cur utc */
     origin_cur_utc = GET_BE_U_2(bp);
-    ND_PRINT(", origin cur utc :%u", origin_cur_utc);
+    ND_PRINT(C_RESET, ", origin cur utc :%u", origin_cur_utc);
     *len -= 2;
     bp += 2;
 
     /* rsvd */
     rsvd = GET_U_1(bp);
-    ND_PRINT(", rsvd : %u", rsvd);
+    ND_PRINT(C_RESET, ", rsvd : %u", rsvd);
     *len -= 1;
     bp += 1;
 
     /* gm prio */
     gm_prio_1 = GET_U_1(bp);
-    ND_PRINT(", gm priority_1 : %u", gm_prio_1);
+    ND_PRINT(C_RESET, ", gm priority_1 : %u", gm_prio_1);
     *len -= 1;
     bp += 1;
 
     /* GM clock class */
     gm_clk_cls = GET_U_1(bp);
-    ND_PRINT(", gm clock class : %u", gm_clk_cls);
+    ND_PRINT(C_RESET, ", gm clock class : %u", gm_clk_cls);
     *len -= 1;
     bp += 1;
     /* GM clock accuracy */
     gm_clk_acc = GET_U_1(bp);
-    ND_PRINT(", gm clock accuracy : %u", gm_clk_acc);
+    ND_PRINT(C_RESET, ", gm clock accuracy : %u", gm_clk_acc);
     *len -= 1;
     bp += 1;
     /* GM clock variance */
     gm_clk_var = GET_BE_U_2(bp);
-    ND_PRINT(", gm clock variance : %u", gm_clk_var);
+    ND_PRINT(C_RESET, ", gm clock variance : %u", gm_clk_var);
     *len -= 2;
     bp += 2;
     /* GM Prio 2 */
     gm_prio_2 = GET_U_1(bp);
-    ND_PRINT(", gm priority_2 : %u", gm_prio_2);
+    ND_PRINT(C_RESET, ", gm priority_2 : %u", gm_prio_2);
     *len -= 1;
     bp += 1;
 
     /* GM Clock Identity */
     gm_clock_id = GET_BE_U_8(bp);
-    ND_PRINT(", gm clock id : 0x%"PRIx64, gm_clock_id);
+    ND_PRINT(C_RESET, ", gm clock id : 0x%"PRIx64, gm_clock_id);
     *len -= 8;
     bp += 8;
     /* steps removed */
     steps_removed = GET_BE_U_2(bp);
-    ND_PRINT(", steps removed : %u", steps_removed);
+    ND_PRINT(C_RESET, ", steps removed : %u", steps_removed);
     *len -= 2;
     bp += 2;
     /* Time source */
     time_src = GET_U_1(bp);
-    ND_PRINT(", time source : 0x%x", time_src);
+    ND_PRINT(C_RESET, ", time source : 0x%x", time_src);
     *len -= 1;
     bp += 1;
 
@@ -598,13 +598,13 @@ ptp_print_port_id(netdissect_options *ndo, const u_char *bp, u_int *len)
 
     /* port identity*/
     port_identity = GET_BE_U_8(bp);
-    ND_PRINT(", port identity : 0x%"PRIx64, port_identity);
+    ND_PRINT(C_RESET, ", port identity : 0x%"PRIx64, port_identity);
     *len -= 8;
     bp += 8;
 
     /* port id */
     port_id = GET_BE_U_2(bp);
-    ND_PRINT(", port id : %u", port_id);
+    ND_PRINT(C_RESET, ", port id : %u", port_id);
     *len -= 2;
     bp += 2;
 

--- a/print-quic.c
+++ b/print-quic.c
@@ -54,7 +54,7 @@ hexprint(netdissect_options *ndo, const uint8_t *cp, size_t len)
 	size_t i;
 
 	for (i = 0; i < len; i++)
-		ND_PRINT("%02x", cp[i]);
+		ND_PRINT(C_RESET, "%02x", cp[i]);
 }
 
 #define QUIC_CID_LIST_MAX	512
@@ -169,24 +169,24 @@ quic_print_packet(netdissect_options *ndo, const u_char *bp, const u_char *end)
 		bp += 4;
 
 		if (version == 0)
-			ND_PRINT(", version negotiation");
+			ND_PRINT(C_RESET, ", version negotiation");
 		else if (packet_type == QUIC_LH_TYPE_INITIAL)
-			ND_PRINT(", initial");
+			ND_PRINT(C_RESET, ", initial");
 		else if (packet_type == QUIC_LH_TYPE_0RTT)
-			ND_PRINT(", 0-rtt");
+			ND_PRINT(C_RESET, ", 0-rtt");
 		else if (packet_type == QUIC_LH_TYPE_HANDSHAKE)
-			ND_PRINT(", handshake");
+			ND_PRINT(C_RESET, ", handshake");
 		else if (packet_type == QUIC_LH_TYPE_RETRY)
-			ND_PRINT(", retry");
+			ND_PRINT(C_RESET, ", retry");
 		if (version != 0 && version != 1)
-			ND_PRINT(", v%x", version);
+			ND_PRINT(C_RESET, ", v%x", version);
 		dcil = GET_U_1(bp);
 		bp += 1;
 		if (dcil > 0  && dcil <= QUIC_MAX_CID_LENGTH) {
 			memset(dcid, 0, sizeof(dcid));
 			GET_CPY_BYTES(&dcid, bp, dcil);
 			bp += dcil;
-			ND_PRINT(", dcid ");
+			ND_PRINT(C_RESET, ", dcid ");
 			hexprint(ndo, dcid, dcil);
 			register_quic_cid(dcid, dcil);
 		}
@@ -196,7 +196,7 @@ quic_print_packet(netdissect_options *ndo, const u_char *bp, const u_char *end)
 			memset(scid, 0, sizeof(dcid));
 			GET_CPY_BYTES(&scid, bp, scil);
 			bp += scil;
-			ND_PRINT(", scid ");
+			ND_PRINT(C_RESET, ", scid ");
 			hexprint(ndo, scid, scil);
 			register_quic_cid(scid, scil);
 		}
@@ -209,7 +209,7 @@ quic_print_packet(netdissect_options *ndo, const u_char *bp, const u_char *end)
 				} else {
 					uint32_t vn_version = GET_BE_U_4(bp);
 					bp += 4;
-					ND_PRINT(", version 0x%x", vn_version);
+					ND_PRINT(C_RESET, ", version 0x%x", vn_version);
 				}
 			}
 		} else {
@@ -220,12 +220,12 @@ quic_print_packet(netdissect_options *ndo, const u_char *bp, const u_char *end)
 					token = nd_malloc(ndo, (size_t)token_length);
 					GET_CPY_BYTES(token, bp, (size_t)token_length);
 					bp += token_length;
-					ND_PRINT(", token ");
+					ND_PRINT(C_RESET, ", token ");
 					hexprint(ndo, token, (size_t)token_length);
 				}
 			}
 			if (packet_type == QUIC_LH_TYPE_RETRY) {
-				ND_PRINT(", token ");
+				ND_PRINT(C_RESET, ", token ");
 				if (end > bp && end - bp > 16 &&
 				    ND_TTEST_LEN(bp, end - bp - 16)) {
 					token_length = end - bp - 16;
@@ -242,7 +242,7 @@ quic_print_packet(netdissect_options *ndo, const u_char *bp, const u_char *end)
 				uint64_t payload_length =
 					GET_BE_VLI(bp, &vli_length);
 				bp += vli_length;
-				ND_PRINT(", length %" PRIu64, payload_length);
+				ND_PRINT(C_RESET, ", length %" PRIu64, payload_length);
 				if (!ND_TTEST_LEN(bp, payload_length)) {
 					nd_print_trunc(ndo);
 					bp = end;
@@ -252,13 +252,13 @@ quic_print_packet(netdissect_options *ndo, const u_char *bp, const u_char *end)
 		}
 	} else {
 		/* Short Header */
-		ND_PRINT(", protected");
+		ND_PRINT(C_RESET, ", protected");
 		if (end > bp && end - bp > 16 &&
 		    ND_TTEST_LEN(bp, end - bp)) {
 			struct quic_cid_array *cid_array =
 				lookup_quic_cid(bp, end - bp);
 			if (cid_array != NULL) {
-				ND_PRINT(", dcid ");
+				ND_PRINT(C_RESET, ", dcid ");
 				hexprint(ndo, cid_array->cid,
 					 cid_array->length);
 			}

--- a/print-radius.c
+++ b/print-radius.c
@@ -104,7 +104,7 @@
 #define PRINT_HEX(bytes_len, ptr_data)                               \
            while(bytes_len)                                          \
            {                                                         \
-              ND_PRINT("%02X", GET_U_1(ptr_data));                   \
+              ND_PRINT(C_RESET, "%02X", GET_U_1(ptr_data));                   \
               ptr_data++;                                            \
               bytes_len--;                                           \
            }
@@ -779,12 +779,12 @@ print_attr_string(netdissect_options *ndo,
            if (length < 3)
               goto trunc;
            if (GET_U_1(data) && (GET_U_1(data) <= 0x1F))
-              ND_PRINT("Tag[%u] ", GET_U_1(data));
+              ND_PRINT(C_RESET, "Tag[%u] ", GET_U_1(data));
            else
-              ND_PRINT("Tag[Unused] ");
+              ND_PRINT(C_RESET, "Tag[Unused] ");
            data++;
            length--;
-           ND_PRINT("Salt %u ", GET_BE_U_2(data));
+           ND_PRINT(C_RESET, "Salt %u ", GET_BE_U_2(data));
            data+=2;
            length-=2;
         break;
@@ -799,9 +799,9 @@ print_attr_string(netdissect_options *ndo,
               if (length < 1)
                  goto trunc;
               if (GET_U_1(data))
-                ND_PRINT("Tag[%u] ", GET_U_1(data));
+                ND_PRINT(C_RESET, "Tag[%u] ", GET_U_1(data));
               else
-                ND_PRINT("Tag[Unused] ");
+                ND_PRINT(C_RESET, "Tag[Unused] ");
               data++;
               length--;
            }
@@ -809,7 +809,7 @@ print_attr_string(netdissect_options *ndo,
       case EGRESS_VLAN_NAME:
            if (length < 1)
               goto trunc;
-           ND_PRINT("%s (0x%02x) ",
+           ND_PRINT(C_RESET, "%s (0x%02x) ",
                   tok2str(rfc4675_tagged,"Unknown tag",GET_U_1(data)),
                   GET_U_1(data));
            data++;
@@ -823,7 +823,7 @@ print_attr_string(netdissect_options *ndo,
    }
 
    for (i=0; i < length && GET_U_1(data); i++, data++)
-       ND_PRINT("%c", ND_ASCII_ISPRINT(GET_U_1(data)) ? GET_U_1(data) : '.');
+       ND_PRINT(C_RESET, "%c", ND_ASCII_ISPRINT(GET_U_1(data)) ? GET_U_1(data) : '.');
 
    return;
 
@@ -849,7 +849,7 @@ print_vendor_attr(netdissect_options *ndo,
     data+=4;
     length-=4;
 
-    ND_PRINT("Vendor: %s (%u)",
+    ND_PRINT(C_RESET, "Vendor: %s (%u)",
            tok2str(smi_values,"Unknown",vendor_id),
            vendor_id);
 
@@ -859,14 +859,14 @@ print_vendor_attr(netdissect_options *ndo,
 
         if (vendor_length < 2)
         {
-            ND_PRINT("\n\t    Vendor Attribute: %u, Length: %u (bogus, must be >= 2)",
+            ND_PRINT(C_RESET, "\n\t    Vendor Attribute: %u, Length: %u (bogus, must be >= 2)",
                    vendor_type,
                    vendor_length);
             return;
         }
         if (vendor_length > length)
         {
-            ND_PRINT("\n\t    Vendor Attribute: %u, Length: %u (bogus, goes past end of vendor-specific attribute)",
+            ND_PRINT(C_RESET, "\n\t    Vendor Attribute: %u, Length: %u (bogus, goes past end of vendor-specific attribute)",
                    vendor_type,
                    vendor_length);
             return;
@@ -876,11 +876,11 @@ print_vendor_attr(netdissect_options *ndo,
         length-=2;
 	ND_TCHECK_LEN(data, vendor_length);
 
-        ND_PRINT("\n\t    Vendor Attribute: %u, Length: %u, Value: ",
+        ND_PRINT(C_RESET, "\n\t    Vendor Attribute: %u, Length: %u, Value: ",
                vendor_type,
                vendor_length);
         for (idx = 0; idx < vendor_length ; idx++, data++)
-            ND_PRINT("%c", ND_ASCII_ISPRINT(GET_U_1(data)) ? GET_U_1(data) : '.');
+            ND_PRINT(C_RESET, "%c", ND_ASCII_ISPRINT(GET_U_1(data)) ? GET_U_1(data) : '.');
         length-=vendor_length;
     }
     return;
@@ -904,7 +904,7 @@ print_attr_num(netdissect_options *ndo,
 
    if (length != 4)
    {
-       ND_PRINT("ERROR: length %u != 4", length);
+       ND_PRINT(C_RESET, "ERROR: length %u != 4", length);
        return;
    }
 
@@ -918,9 +918,9 @@ print_attr_num(netdissect_options *ndo,
       if ( (attr_code == TUNNEL_TYPE) || (attr_code == TUNNEL_MEDIUM) )
       {
          if (!GET_U_1(data))
-            ND_PRINT("Tag[Unused] ");
+            ND_PRINT(C_RESET, "Tag[Unused] ");
          else
-            ND_PRINT("Tag[%u] ", GET_U_1(data));
+            ND_PRINT(C_RESET, "Tag[%u] ", GET_U_1(data));
          data++;
          data_value = GET_BE_U_3(data);
       }
@@ -931,9 +931,9 @@ print_attr_num(netdissect_options *ndo,
       if ( data_value <= (uint32_t)(attr_type[attr_code].siz_subtypes - 1 +
             attr_type[attr_code].first_subtype) &&
 	   data_value >= attr_type[attr_code].first_subtype )
-         ND_PRINT("%s", table[data_value]);
+         ND_PRINT(C_RESET, "%s", table[data_value]);
       else
-         ND_PRINT("#%u", data_value);
+         ND_PRINT(C_RESET, "#%u", data_value);
    }
    else
    {
@@ -941,9 +941,9 @@ print_attr_num(netdissect_options *ndo,
       {
         case FRM_IPX:
              if (GET_BE_U_4(data) == 0xFFFFFFFE )
-                ND_PRINT("NAS Select");
+                ND_PRINT(C_RESET, "NAS Select");
              else
-                ND_PRINT("%u", GET_BE_U_4(data));
+                ND_PRINT(C_RESET, "%u", GET_BE_U_4(data));
           break;
 
         case SESSION_TIMEOUT:
@@ -953,14 +953,14 @@ print_attr_num(netdissect_options *ndo,
         case ACCT_INT_INTERVAL:
              timeout = GET_BE_U_4(data);
              if ( timeout < 60 )
-                ND_PRINT("%02d secs", timeout);
+                ND_PRINT(C_RESET, "%02d secs", timeout);
              else
              {
                 if ( timeout < 3600 )
-                   ND_PRINT("%02d:%02d min",
+                   ND_PRINT(C_RESET, "%02d:%02d min",
                           timeout / 60, timeout % 60);
                 else
-                   ND_PRINT("%02d:%02d:%02d hours",
+                   ND_PRINT(C_RESET, "%02d:%02d:%02d hours",
                           timeout / 3600, (timeout % 3600) / 60,
                           timeout % 60);
              }
@@ -968,37 +968,37 @@ print_attr_num(netdissect_options *ndo,
 
         case FRM_ATALK_LINK:
              if (GET_BE_U_4(data))
-                ND_PRINT("%u", GET_BE_U_4(data));
+                ND_PRINT(C_RESET, "%u", GET_BE_U_4(data));
              else
-                ND_PRINT("Unnumbered");
+                ND_PRINT(C_RESET, "Unnumbered");
           break;
 
         case FRM_ATALK_NETWORK:
              if (GET_BE_U_4(data))
-                ND_PRINT("%u", GET_BE_U_4(data));
+                ND_PRINT(C_RESET, "%u", GET_BE_U_4(data));
              else
-                ND_PRINT("NAS assigned");
+                ND_PRINT(C_RESET, "NAS assigned");
           break;
 
         case TUNNEL_PREFERENCE:
             if (GET_U_1(data))
-               ND_PRINT("Tag[%u] ", GET_U_1(data));
+               ND_PRINT(C_RESET, "Tag[%u] ", GET_U_1(data));
             else
-               ND_PRINT("Tag[Unused] ");
+               ND_PRINT(C_RESET, "Tag[Unused] ");
             data++;
-            ND_PRINT("%u", GET_BE_U_3(data));
+            ND_PRINT(C_RESET, "%u", GET_BE_U_3(data));
           break;
 
         case EGRESS_VLAN_ID:
-            ND_PRINT("%s (0x%02x) ",
+            ND_PRINT(C_RESET, "%s (0x%02x) ",
                    tok2str(rfc4675_tagged,"Unknown tag",GET_U_1(data)),
                    GET_U_1(data));
             data++;
-            ND_PRINT("%u", GET_BE_U_3(data));
+            ND_PRINT(C_RESET, "%u", GET_BE_U_3(data));
           break;
 
         default:
-             ND_PRINT("%u", GET_BE_U_4(data));
+             ND_PRINT(C_RESET, "%u", GET_BE_U_4(data));
           break;
 
       } /* switch */
@@ -1019,7 +1019,7 @@ print_attr_address(netdissect_options *ndo,
 {
    if (length != 4)
    {
-       ND_PRINT("ERROR: length %u != 4", length);
+       ND_PRINT(C_RESET, "ERROR: length %u != 4", length);
        return;
    }
 
@@ -1028,16 +1028,16 @@ print_attr_address(netdissect_options *ndo,
       case FRM_IPADDR:
       case LOG_IPHOST:
            if (GET_BE_U_4(data) == 0xFFFFFFFF )
-              ND_PRINT("User Selected");
+              ND_PRINT(C_RESET, "User Selected");
            else
               if (GET_BE_U_4(data) == 0xFFFFFFFE )
-                 ND_PRINT("NAS Select");
+                 ND_PRINT(C_RESET, "NAS Select");
               else
-                 ND_PRINT("%s",GET_IPADDR_STRING(data));
+                 ND_PRINT(C_RESET, "%s",GET_IPADDR_STRING(data));
       break;
 
       default:
-          ND_PRINT("%s", GET_IPADDR_STRING(data));
+          ND_PRINT(C_RESET, "%s", GET_IPADDR_STRING(data));
       break;
    }
 }
@@ -1055,11 +1055,11 @@ print_attr_address6(netdissect_options *ndo,
 {
    if (length != 16)
    {
-       ND_PRINT("ERROR: length %u != 16", length);
+       ND_PRINT(C_RESET, "ERROR: length %u != 16", length);
        return;
    }
 
-   ND_PRINT("%s", GET_IP6ADDR_STRING(data));
+   ND_PRINT(C_RESET, "%s", GET_IP6ADDR_STRING(data));
 }
 
 static void
@@ -1070,13 +1070,13 @@ print_attr_netmask6(netdissect_options *ndo,
 
    if (length < 2 || length > 18)
    {
-       ND_PRINT("ERROR: length %u not in range (2..18)", length);
+       ND_PRINT(C_RESET, "ERROR: length %u not in range (2..18)", length);
        return;
    }
    ND_TCHECK_LEN(data, length);
    if (GET_U_1(data + 1) > 128)
    {
-      ND_PRINT("ERROR: netmask %u not in range (0..128)", GET_U_1(data + 1));
+      ND_PRINT(C_RESET, "ERROR: netmask %u not in range (0..128)", GET_U_1(data + 1));
       return;
    }
 
@@ -1084,10 +1084,10 @@ print_attr_netmask6(netdissect_options *ndo,
    if (length > 2)
       memcpy(data2, data+2, length-2);
 
-   ND_PRINT("%s/%u", ip6addr_string(ndo, data2), GET_U_1(data + 1)); /* local buffer, not packet data; don't use GET_IP6ADDR_STRING() */
+   ND_PRINT(C_RESET, "%s/%u", ip6addr_string(ndo, data2), GET_U_1(data + 1)); /* local buffer, not packet data; don't use GET_IP6ADDR_STRING() */
 
    if (GET_U_1(data + 1) > 8 * (length - 2))
-      ND_PRINT(" (inconsistent prefix length)");
+      ND_PRINT(C_RESET, " (inconsistent prefix length)");
 
    return;
 
@@ -1101,17 +1101,17 @@ print_attr_mip6_home_link_prefix(netdissect_options *ndo,
 {
    if (length != 17)
    {
-      ND_PRINT("ERROR: length %u != 17", length);
+      ND_PRINT(C_RESET, "ERROR: length %u != 17", length);
       return;
    }
    ND_TCHECK_LEN(data, length);
    if (GET_U_1(data) > 128)
    {
-      ND_PRINT("ERROR: netmask %u not in range (0..128)", GET_U_1(data));
+      ND_PRINT(C_RESET, "ERROR: netmask %u not in range (0..128)", GET_U_1(data));
       return;
    }
 
-   ND_PRINT("%s/%u", GET_IP6ADDR_STRING(data + 1), GET_U_1(data));
+   ND_PRINT(C_RESET, "%s/%u", GET_IP6ADDR_STRING(data + 1), GET_U_1(data));
 
    return;
 
@@ -1128,12 +1128,12 @@ print_attr_operator_name(netdissect_options *ndo,
    ND_TCHECK_LEN(data, length);
    if (length < 2)
    {
-      ND_PRINT("ERROR: length %u < 2", length);
+      ND_PRINT(C_RESET, "ERROR: length %u < 2", length);
       return;
    }
    namespace_value = GET_U_1(data);
    data++;
-   ND_PRINT("[%s] ", tok2str(operator_name_vector, "unknown namespace %u", namespace_value));
+   ND_PRINT(C_RESET, "[%s] ", tok2str(operator_name_vector, "unknown namespace %u", namespace_value));
 
    nd_printjn(ndo, data, length - 1);
 
@@ -1153,7 +1153,7 @@ print_attr_location_information(netdissect_options *ndo,
    ND_TCHECK_LEN(data, length);
    if (length < 21)
    {
-     ND_PRINT("ERROR: length %u < 21", length);
+     ND_PRINT(C_RESET, "ERROR: length %u < 21", length);
       return;
    }
 
@@ -1166,25 +1166,25 @@ print_attr_location_information(netdissect_options *ndo,
    entity = GET_U_1(data);
    data++;
 
-   ND_PRINT("index %u, code %s, entity %s, ",
+   ND_PRINT(C_RESET, "index %u, code %s, entity %s, ",
        index,
        tok2str(location_information_code_vector, "Unknown (%u)", code),
        tok2str(location_information_entity_vector, "Unknown (%u)", entity)
    );
 
-   ND_PRINT("sighting time ");
+   ND_PRINT(C_RESET, "sighting time ");
    p_ntp_time(ndo, (const struct l_fixedpt *)data);
-   ND_PRINT(", ");
+   ND_PRINT(C_RESET, ", ");
    data += 8;
 
-   ND_PRINT("time to live ");
+   ND_PRINT(C_RESET, "time to live ");
    p_ntp_time(ndo, (const struct l_fixedpt *)data);
-   ND_PRINT(", ");
+   ND_PRINT(C_RESET, ", ");
    data += 8;
 
-   ND_PRINT("method \"");
+   ND_PRINT(C_RESET, "method \"");
    nd_printjn(ndo, data, length - 20);
-   ND_PRINT("\"");
+   ND_PRINT(C_RESET, "\"");
 
    return;
 
@@ -1201,13 +1201,13 @@ print_attr_location_data(netdissect_options *ndo,
    ND_TCHECK_LEN(data, length);
    if (length < 3)
    {
-     ND_PRINT("ERROR: length %u < 3", length);
+     ND_PRINT(C_RESET, "ERROR: length %u < 3", length);
       return;
    }
 
    index = GET_BE_U_2(data);
    data += 2;
-   ND_PRINT("index %u, location", index);
+   ND_PRINT(C_RESET, "index %u, location", index);
 
    /* The Location field of the String field of the Location-Data attribute
     * can have two completely different structures depending on the value of
@@ -1233,22 +1233,22 @@ print_basic_location_policy_rules(netdissect_options *ndo,
    ND_TCHECK_LEN(data, length);
    if (length < 10)
    {
-     ND_PRINT("ERROR: length %u < 10", length);
+     ND_PRINT(C_RESET, "ERROR: length %u < 10", length);
       return;
    }
 
    flags = GET_BE_U_2(data);
    data += 2;
-   ND_PRINT("flags [%s], ", bittok2str(blpr_bm, "none", flags));
+   ND_PRINT(C_RESET, "flags [%s], ", bittok2str(blpr_bm, "none", flags));
 
-   ND_PRINT("retention expires ");
+   ND_PRINT(C_RESET, "retention expires ");
    p_ntp_time(ndo, (const struct l_fixedpt *)data);
    data += 8;
 
    if (length > 10) {
-      ND_PRINT(", note well \"");
+      ND_PRINT(C_RESET, ", note well \"");
       nd_printjn(ndo, data, length - 10);
-      ND_PRINT("\"");
+      ND_PRINT(C_RESET, "\"");
    }
 
    return;
@@ -1275,7 +1275,7 @@ print_attr_time(netdissect_options *ndo,
 
    if (length != 4)
    {
-       ND_PRINT("ERROR: length %u != 4", length);
+       ND_PRINT(C_RESET, "ERROR: length %u != 4", length);
        return;
    }
 
@@ -1283,7 +1283,7 @@ print_attr_time(netdissect_options *ndo,
    strlcpy(string, ctime(&attr_time), sizeof(string));
    /* Get rid of the newline */
    string[24] = '\0';
-   ND_PRINT("%.24s", string);
+   ND_PRINT(C_RESET, "%.24s", string);
 }
 
 static void
@@ -1295,11 +1295,11 @@ print_attr_vector64(netdissect_options *ndo,
 
    if (length != 8)
    {
-       ND_PRINT("ERROR: length %u != 8", length);
+       ND_PRINT(C_RESET, "ERROR: length %u != 8", length);
        return;
    }
 
-   ND_PRINT("[");
+   ND_PRINT(C_RESET, "[");
 
    data_value = GET_BE_U_8(data);
    /* Print the 64-bit field in a format similar to bittok2str(), less
@@ -1308,12 +1308,12 @@ print_attr_vector64(netdissect_options *ndo,
     */
    for (i = 0; i < TAM_SIZE(mip6_feature_vector); i++) {
        if (data_value & mip6_feature_vector[i].v) {
-           ND_PRINT("%s%s", sep, mip6_feature_vector[i].s);
+           ND_PRINT(C_RESET, "%s%s", sep, mip6_feature_vector[i].s);
            sep = ", ";
        }
    }
 
-   ND_PRINT("]");
+   ND_PRINT(C_RESET, "]");
 }
 
 /***********************************/
@@ -1335,38 +1335,38 @@ print_attr_strange(netdissect_options *ndo,
       case ARAP_PASS:
            if (length != 16)
            {
-               ND_PRINT("ERROR: length %u != 16", length);
+               ND_PRINT(C_RESET, "ERROR: length %u != 16", length);
                return;
            }
-           ND_PRINT("User_challenge (");
+           ND_PRINT(C_RESET, "User_challenge (");
            len_data = 8;
            PRINT_HEX(len_data, data);
-           ND_PRINT(") User_resp(");
+           ND_PRINT(C_RESET, ") User_resp(");
            len_data = 8;
            PRINT_HEX(len_data, data);
-           ND_PRINT(")");
+           ND_PRINT(C_RESET, ")");
         break;
 
       case ARAP_FEATURES:
            if (length != 14)
            {
-               ND_PRINT("ERROR: length %u != 14", length);
+               ND_PRINT(C_RESET, "ERROR: length %u != 14", length);
                return;
            }
            if (GET_U_1(data))
-              ND_PRINT("User can change password");
+              ND_PRINT(C_RESET, "User can change password");
            else
-              ND_PRINT("User cannot change password");
+              ND_PRINT(C_RESET, "User cannot change password");
            data++;
-           ND_PRINT(", Min password length: %u", GET_U_1(data));
+           ND_PRINT(C_RESET, ", Min password length: %u", GET_U_1(data));
            data++;
-           ND_PRINT(", created at: ");
+           ND_PRINT(C_RESET, ", created at: ");
            len_data = 4;
            PRINT_HEX(len_data, data);
-           ND_PRINT(", expires in: ");
+           ND_PRINT(C_RESET, ", expires in: ");
            len_data = 4;
            PRINT_HEX(len_data, data);
-           ND_PRINT(", Current Time: ");
+           ND_PRINT(C_RESET, ", Current Time: ");
            len_data = 4;
            PRINT_HEX(len_data, data);
         break;
@@ -1374,7 +1374,7 @@ print_attr_strange(netdissect_options *ndo,
       case ARAP_CHALLENGE_RESP:
            if (length < 8)
            {
-               ND_PRINT("ERROR: length %u != 8", length);
+               ND_PRINT(C_RESET, "ERROR: length %u != 8", length);
                return;
            }
            len_data = 8;
@@ -1384,12 +1384,12 @@ print_attr_strange(netdissect_options *ndo,
       case ERROR_CAUSE:
            if (length != 4)
            {
-               ND_PRINT("Error: length %u != 4", length);
+               ND_PRINT(C_RESET, "Error: length %u != 4", length);
                return;
            }
 
            error_cause_value = GET_BE_U_4(data);
-           ND_PRINT("Error cause %u: %s", error_cause_value, tok2str(errorcausetype, "Error-Cause %u not known", error_cause_value));
+           ND_PRINT(C_RESET, "Error cause %u: %s", error_cause_value, tok2str(errorcausetype, "Error-Cause %u not known", error_cause_value));
         break;
    }
    return;
@@ -1416,21 +1416,21 @@ radius_attrs_print(netdissect_options *ndo,
      else
 	attr_string = "Unknown";
 
-     ND_PRINT("\n\t  %s Attribute (%u), length: %u",
+     ND_PRINT(C_RESET, "\n\t  %s Attribute (%u), length: %u",
                attr_string,
                type,
                len);
      if (len < 2)
      {
-       ND_PRINT(" (bogus, must be >= 2)");
+       ND_PRINT(C_RESET, " (bogus, must be >= 2)");
        return;
      }
      if (len > length)
      {
-        ND_PRINT(" (bogus, goes past end of packet)");
+        ND_PRINT(C_RESET, " (bogus, goes past end of packet)");
         return;
      }
-     ND_PRINT(", Value: ");
+     ND_PRINT(C_RESET, ", Value: ");
 
      if (type < TAM_SIZE(attr_type))
      {
@@ -1477,7 +1477,7 @@ radius_print(netdissect_options *ndo,
 	  len = length;
 
    if (ndo->ndo_vflag < 1) {
-       ND_PRINT("RADIUS, %s (%u), id: 0x%02x length: %u",
+       ND_PRINT(C_RESET, "RADIUS, %s (%u), id: 0x%02x length: %u",
               tok2str(radius_command_values,"Unknown Command",GET_U_1(rad->code)),
               GET_U_1(rad->code),
               GET_U_1(rad->id),
@@ -1485,14 +1485,14 @@ radius_print(netdissect_options *ndo,
        return;
    }
    else {
-       ND_PRINT("RADIUS, length: %u\n\t%s (%u), id: 0x%02x, Authenticator: ",
+       ND_PRINT(C_RESET, "RADIUS, length: %u\n\t%s (%u), id: 0x%02x, Authenticator: ",
               len,
               tok2str(radius_command_values,"Unknown Command",GET_U_1(rad->code)),
               GET_U_1(rad->code),
               GET_U_1(rad->id));
 
        for(auth_idx=0; auth_idx < 16; auth_idx++)
-            ND_PRINT("%02x", rad->auth[auth_idx]);
+            ND_PRINT(C_RESET, "%02x", rad->auth[auth_idx]);
    }
 
    if (len > MIN_RADIUS_LEN)

--- a/print-raw.c
+++ b/print-raw.c
@@ -39,7 +39,7 @@ raw_if_print(netdissect_options *ndo, const struct pcap_pkthdr *h, const u_char 
 	ndo->ndo_protocol = "raw";
 	ndo->ndo_ll_hdr_len += 0;
 	if (ndo->ndo_eflag)
-		ND_PRINT(C_RESET, C_RESET "ip: ");
+		ND_PRINT(C_RESET, "ip: ");
 
 	ipN_print(ndo, p, h->len);
 }

--- a/print-raw.c
+++ b/print-raw.c
@@ -39,7 +39,7 @@ raw_if_print(netdissect_options *ndo, const struct pcap_pkthdr *h, const u_char 
 	ndo->ndo_protocol = "raw";
 	ndo->ndo_ll_hdr_len += 0;
 	if (ndo->ndo_eflag)
-		ND_PRINT("ip: ");
+		ND_PRINT(C_RESET, C_RESET "ip: ");
 
 	ipN_print(ndo, p, h->len);
 }

--- a/print-realtek.c
+++ b/print-realtek.c
@@ -112,20 +112,20 @@ rrcp_print(netdissect_options *ndo,
 
 	ndo->ndo_protocol = "rrcp";
 	rrcp_opcode = GET_U_1((cp + RRCP_OPCODE_ISREPLY_OFFSET)) & RRCP_OPCODE_MASK;
-	ND_PRINT(C_RESET, C_RESET "RRCP %s: %s",
+	ND_PRINT(C_RESET, "RRCP %s: %s",
 		((GET_U_1(cp + RRCP_OPCODE_ISREPLY_OFFSET)) & RRCP_ISREPLY) ? "reply" : "query",
 		tok2str(opcode_values,"unknown opcode (0x%02x)",rrcp_opcode));
 	if (rrcp_opcode==RRCP_OPCODE_GET_CONFIGURATION ||
 	    rrcp_opcode==RRCP_OPCODE_SET_CONFIGURATION){
-    	    ND_PRINT(C_RESET, C_RESET " addr=0x%04x, data=0x%08x",
+    	    ND_PRINT(C_RESET, " addr=0x%04x, data=0x%08x",
 		     GET_LE_U_2(cp + RRCP_REG_ADDR_OFFSET),
 		     GET_LE_U_4(cp + RRCP_REG_DATA_OFFSET));
 	}
-	ND_PRINT(C_RESET, C_RESET ", auth=0x%04x",
+	ND_PRINT(C_RESET, ", auth=0x%04x",
 	         GET_BE_U_2(cp + RRCP_AUTHKEY_OFFSET));
 	if (rrcp_opcode==RRCP_OPCODE_HELLO &&
 	     ((GET_U_1(cp + RRCP_OPCODE_ISREPLY_OFFSET)) & RRCP_ISREPLY)){
-	    ND_PRINT(C_RESET, C_RESET " downlink_port=%u, uplink_port=%u, uplink_mac=%s, vendor_id=%08x ,chip_id=%04x ",
+	    ND_PRINT(C_RESET, " downlink_port=%u, uplink_port=%u, uplink_mac=%s, vendor_id=%08x ,chip_id=%04x ",
 		     GET_U_1(cp + RRCP_DOWNLINK_PORT_OFFSET),
 		     GET_U_1(cp + RRCP_UPLINK_PORT_OFFSET),
 		     GET_ETHERADDR_STRING(cp + RRCP_UPLINK_MAC_OFFSET),
@@ -133,7 +133,7 @@ rrcp_print(netdissect_options *ndo,
 		     GET_BE_U_2(cp + RRCP_CHIP_ID_OFFSET));
 	}else if (rrcp_opcode==RRCP_OPCODE_GET_CONFIGURATION ||
 	          rrcp_opcode==RRCP_OPCODE_SET_CONFIGURATION){
-	    ND_PRINT(C_RESET, C_RESET ", cookie=0x%08x%08x ",
+	    ND_PRINT(C_RESET, ", cookie=0x%08x%08x ",
 		    GET_BE_U_4(cp + RRCP_COOKIE2_OFFSET),
 		    GET_BE_U_4(cp + RRCP_COOKIE1_OFFSET));
 	}
@@ -216,7 +216,7 @@ rtl_print(netdissect_options *ndo,
 	ndo->ndo_protocol = "rtl";
 
 	if (src != NULL && dst != NULL) {
-		ND_PRINT(C_RESET, C_RESET "%s > %s, ",
+		ND_PRINT(C_RESET, "%s > %s, ",
 			(src->addr_string)(ndo, src->addr),
 			(dst->addr_string)(ndo, dst->addr));
 	}
@@ -229,20 +229,20 @@ rtl_print(netdissect_options *ndo,
 		/*
 		 * REP packets have no payload.
 		 */
-		ND_PRINT(C_RESET, C_RESET "REP");
+		ND_PRINT(C_RESET, "REP");
 	} else if (rtl_proto == RTL_PROTOCOL_RLDP ||
 	           rtl_proto == RTL_PROTOCOL_RLDP2) {
 		/*
 		 * RLDP packets have no payload.
 		 * (XXX - except when they do?  See above.)
 		 */
-		ND_PRINT(C_RESET, C_RESET "RLDP");
+		ND_PRINT(C_RESET, "RLDP");
 	} else if (rtl_proto == RTL_PROTOCOL_XXX_DSA)
-		ND_PRINT(C_RESET, C_RESET "Realtek 8-byte DSA tag");
+		ND_PRINT(C_RESET, "Realtek 8-byte DSA tag");
 	else if ((rtl_proto & 0xF0) == RTL_PROTOCOL_8306_DSA)
-		ND_PRINT(C_RESET, C_RESET "Realtek RTL8306 4-byte DSA tag");
+		ND_PRINT(C_RESET, "Realtek RTL8306 4-byte DSA tag");
 	else if ((rtl_proto & 0xF0) == RTL_PROTOCOL_8366RB_DSA)
-		ND_PRINT(C_RESET, C_RESET "Realtek RTL8366RB 4-byte DSA tag");
+		ND_PRINT(C_RESET, "Realtek RTL8366RB 4-byte DSA tag");
 	else
-		ND_PRINT(C_RESET, C_RESET "Realtek unknown type 0x%02x", rtl_proto);
+		ND_PRINT(C_RESET, "Realtek unknown type 0x%02x", rtl_proto);
 }

--- a/print-realtek.c
+++ b/print-realtek.c
@@ -112,20 +112,20 @@ rrcp_print(netdissect_options *ndo,
 
 	ndo->ndo_protocol = "rrcp";
 	rrcp_opcode = GET_U_1((cp + RRCP_OPCODE_ISREPLY_OFFSET)) & RRCP_OPCODE_MASK;
-	ND_PRINT("RRCP %s: %s",
+	ND_PRINT(C_RESET, C_RESET "RRCP %s: %s",
 		((GET_U_1(cp + RRCP_OPCODE_ISREPLY_OFFSET)) & RRCP_ISREPLY) ? "reply" : "query",
 		tok2str(opcode_values,"unknown opcode (0x%02x)",rrcp_opcode));
 	if (rrcp_opcode==RRCP_OPCODE_GET_CONFIGURATION ||
 	    rrcp_opcode==RRCP_OPCODE_SET_CONFIGURATION){
-    	    ND_PRINT(" addr=0x%04x, data=0x%08x",
+    	    ND_PRINT(C_RESET, C_RESET " addr=0x%04x, data=0x%08x",
 		     GET_LE_U_2(cp + RRCP_REG_ADDR_OFFSET),
 		     GET_LE_U_4(cp + RRCP_REG_DATA_OFFSET));
 	}
-	ND_PRINT(", auth=0x%04x",
+	ND_PRINT(C_RESET, C_RESET ", auth=0x%04x",
 	         GET_BE_U_2(cp + RRCP_AUTHKEY_OFFSET));
 	if (rrcp_opcode==RRCP_OPCODE_HELLO &&
 	     ((GET_U_1(cp + RRCP_OPCODE_ISREPLY_OFFSET)) & RRCP_ISREPLY)){
-	    ND_PRINT(" downlink_port=%u, uplink_port=%u, uplink_mac=%s, vendor_id=%08x ,chip_id=%04x ",
+	    ND_PRINT(C_RESET, C_RESET " downlink_port=%u, uplink_port=%u, uplink_mac=%s, vendor_id=%08x ,chip_id=%04x ",
 		     GET_U_1(cp + RRCP_DOWNLINK_PORT_OFFSET),
 		     GET_U_1(cp + RRCP_UPLINK_PORT_OFFSET),
 		     GET_ETHERADDR_STRING(cp + RRCP_UPLINK_MAC_OFFSET),
@@ -133,7 +133,7 @@ rrcp_print(netdissect_options *ndo,
 		     GET_BE_U_2(cp + RRCP_CHIP_ID_OFFSET));
 	}else if (rrcp_opcode==RRCP_OPCODE_GET_CONFIGURATION ||
 	          rrcp_opcode==RRCP_OPCODE_SET_CONFIGURATION){
-	    ND_PRINT(", cookie=0x%08x%08x ",
+	    ND_PRINT(C_RESET, C_RESET ", cookie=0x%08x%08x ",
 		    GET_BE_U_4(cp + RRCP_COOKIE2_OFFSET),
 		    GET_BE_U_4(cp + RRCP_COOKIE1_OFFSET));
 	}
@@ -216,7 +216,7 @@ rtl_print(netdissect_options *ndo,
 	ndo->ndo_protocol = "rtl";
 
 	if (src != NULL && dst != NULL) {
-		ND_PRINT("%s > %s, ",
+		ND_PRINT(C_RESET, C_RESET "%s > %s, ",
 			(src->addr_string)(ndo, src->addr),
 			(dst->addr_string)(ndo, dst->addr));
 	}
@@ -229,20 +229,20 @@ rtl_print(netdissect_options *ndo,
 		/*
 		 * REP packets have no payload.
 		 */
-		ND_PRINT("REP");
+		ND_PRINT(C_RESET, C_RESET "REP");
 	} else if (rtl_proto == RTL_PROTOCOL_RLDP ||
 	           rtl_proto == RTL_PROTOCOL_RLDP2) {
 		/*
 		 * RLDP packets have no payload.
 		 * (XXX - except when they do?  See above.)
 		 */
-		ND_PRINT("RLDP");
+		ND_PRINT(C_RESET, C_RESET "RLDP");
 	} else if (rtl_proto == RTL_PROTOCOL_XXX_DSA)
-		ND_PRINT("Realtek 8-byte DSA tag");
+		ND_PRINT(C_RESET, C_RESET "Realtek 8-byte DSA tag");
 	else if ((rtl_proto & 0xF0) == RTL_PROTOCOL_8306_DSA)
-		ND_PRINT("Realtek RTL8306 4-byte DSA tag");
+		ND_PRINT(C_RESET, C_RESET "Realtek RTL8306 4-byte DSA tag");
 	else if ((rtl_proto & 0xF0) == RTL_PROTOCOL_8366RB_DSA)
-		ND_PRINT("Realtek RTL8366RB 4-byte DSA tag");
+		ND_PRINT(C_RESET, C_RESET "Realtek RTL8366RB 4-byte DSA tag");
 	else
-		ND_PRINT("Realtek unknown type 0x%02x", rtl_proto);
+		ND_PRINT(C_RESET, C_RESET "Realtek unknown type 0x%02x", rtl_proto);
 }

--- a/print-resp.c
+++ b/print-resp.c
@@ -50,11 +50,11 @@
 #define RESP_BULK_STRING      '$'
 #define RESP_ARRAY            '*'
 
-#define resp_print_empty(ndo)            ND_PRINT(" empty")
-#define resp_print_null(ndo)             ND_PRINT(" null")
-#define resp_print_length_too_large(ndo) ND_PRINT(" length too large")
-#define resp_print_length_negative(ndo)  ND_PRINT(" length negative and not -1")
-#define resp_print_invalid(ndo)          ND_PRINT(" invalid")
+#define resp_print_empty(ndo)            ND_PRINT(C_RESET, " empty")
+#define resp_print_null(ndo)             ND_PRINT(C_RESET, " null")
+#define resp_print_length_too_large(ndo) ND_PRINT(C_RESET, " length too large")
+#define resp_print_length_negative(ndo)  ND_PRINT(C_RESET, " length negative and not -1")
+#define resp_print_invalid(ndo)          ND_PRINT(C_RESET, " invalid")
 
 static int resp_parse(netdissect_options *, const u_char *, int);
 static int resp_print_string_error_integer(netdissect_options *, const u_char *, int);
@@ -201,7 +201,7 @@ static int resp_get_length(netdissect_options *, const u_char *, int, const u_ch
  * Assumes the data has already been verified as present.
  */
 #define RESP_PRINT_SEGMENT(_ndo, _bp, _len)            \
-    ND_PRINT(" \"");                                   \
+    ND_PRINT(C_RESET, " \"");                                   \
     if (nd_printn(_ndo, _bp, _len, _ndo->ndo_snapend)) \
         goto trunc;                                    \
     fn_print_char(_ndo, '"');
@@ -213,7 +213,7 @@ resp_print(netdissect_options *ndo, const u_char *bp, u_int length)
 
     ndo->ndo_protocol = "resp";
 
-    ND_PRINT(": RESP");
+    ND_PRINT(C_RESET, ": RESP");
     while (length > 0) {
         /*
          * This block supports redis pipelining.

--- a/print-rip.c
+++ b/print-rip.c
@@ -199,7 +199,7 @@ rip_entry_print_v1(netdissect_options *ndo, const u_char *p,
 	ND_TCHECK_SIZE(ni);
 	family = GET_BE_U_2(ni->rip_family);
 	if (family != BSD_AFNUM_INET && family != 0) {
-		ND_PRINT("\n\t AFI %s, ", tok2str(bsd_af_values, "Unknown (%u)", family));
+		ND_PRINT(C_RESET, "\n\t AFI %s, ", tok2str(bsd_af_values, "Unknown (%u)", family));
 		print_unknown_data(ndo, p + sizeof(*eh), "\n\t  ", RIP_ROUTELEN - sizeof(*eh));
 		return (RIP_ROUTELEN);
 	}
@@ -211,12 +211,12 @@ rip_entry_print_v1(netdissect_options *ndo, const u_char *p,
 		return (RIP_ROUTELEN);
 	}
 	if (family == 0) {
-		ND_PRINT("\n\t  AFI 0, %s, metric: %u",
+		ND_PRINT(C_RESET, "\n\t  AFI 0, %s, metric: %u",
 			 GET_IPADDR_STRING(ni->rip_dest),
 			 GET_BE_U_4(ni->rip_metric));
 		return (RIP_ROUTELEN);
 	} /* BSD_AFNUM_INET */
-	ND_PRINT("\n\t  %s, metric: %u",
+	ND_PRINT(C_RESET, "\n\t  %s, metric: %u",
 		 GET_IPADDR_STRING(ni->rip_dest),
 		 GET_BE_U_4(ni->rip_metric));
 	return (RIP_ROUTELEN);
@@ -241,7 +241,7 @@ rip_entry_print_v2(netdissect_options *ndo, const u_char *p,
 		p += sizeof(*eh);
 		remaining -= sizeof(*eh);
 		if (auth_type == 2) {
-			ND_PRINT("\n\t  Simple Text Authentication data: ");
+			ND_PRINT(C_RESET, "\n\t  Simple Text Authentication data: ");
 			nd_printjnp(ndo, p, RIP_AUTHLEN);
 		} else if (auth_type == 3) {
 			const struct rip_auth_crypto_v2 *ch;
@@ -249,42 +249,42 @@ rip_entry_print_v2(netdissect_options *ndo, const u_char *p,
 			ch = (const struct rip_auth_crypto_v2 *)p;
 			ND_ICHECKMSG_ZU("remaining data length", remaining,
 					<, sizeof(*ch));
-			ND_PRINT("\n\t  Auth header:");
-			ND_PRINT(" Packet Len %u,",
+			ND_PRINT(C_RESET, "\n\t  Auth header:");
+			ND_PRINT(C_RESET, " Packet Len %u,",
 				 GET_BE_U_2(ch->rip_packet_len));
-			ND_PRINT(" Key-ID %u,", GET_U_1(ch->rip_key_id));
-			ND_PRINT(" Auth Data Len %u,",
+			ND_PRINT(C_RESET, " Key-ID %u,", GET_U_1(ch->rip_key_id));
+			ND_PRINT(C_RESET, " Auth Data Len %u,",
 				 GET_U_1(ch->rip_auth_data_len));
-			ND_PRINT(" SeqNo %u,", GET_BE_U_4(ch->rip_seq_num));
-			ND_PRINT(" MBZ %u,", GET_BE_U_4(ch->rip_mbz1));
-			ND_PRINT(" MBZ %u", GET_BE_U_4(ch->rip_mbz2));
+			ND_PRINT(C_RESET, " SeqNo %u,", GET_BE_U_4(ch->rip_seq_num));
+			ND_PRINT(C_RESET, " MBZ %u,", GET_BE_U_4(ch->rip_mbz1));
+			ND_PRINT(C_RESET, " MBZ %u", GET_BE_U_4(ch->rip_mbz2));
 		} else if (auth_type == 1) {
-			ND_PRINT("\n\t  Auth trailer:");
+			ND_PRINT(C_RESET, "\n\t  Auth trailer:");
 			print_unknown_data(ndo, p, "\n\t  ", remaining);
 			return (sizeof(*eh) + remaining); /* AT spans till the packet end */
 		} else {
-			ND_PRINT("\n\t  Unknown (%u) Authentication data:",
+			ND_PRINT(C_RESET, "\n\t  Unknown (%u) Authentication data:",
 				 auth_type);
 			print_unknown_data(ndo, p, "\n\t  ", remaining);
 			return (sizeof(*eh) + remaining); /* we don't know how long this is, so we go to the packet end */
 		}
 	} else if (family != BSD_AFNUM_INET && family != 0) {
-		ND_PRINT("\n\t  AFI %s", tok2str(bsd_af_values, "Unknown (%u)", family));
+		ND_PRINT(C_RESET, "\n\t  AFI %s", tok2str(bsd_af_values, "Unknown (%u)", family));
 		print_unknown_data(ndo, p + sizeof(*eh), "\n\t  ", RIP_ROUTELEN - sizeof(*eh));
 	} else { /* BSD_AFNUM_INET or AFI 0 */
 		ni = (const struct rip_netinfo_v2 *)p;
 		ND_ICHECKMSG_ZU("remaining data length", remaining, <,
 				sizeof(*ni));
-		ND_PRINT("\n\t  AFI %s, %15s/%-2d, tag 0x%04x, metric: %u, next-hop: ",
+		ND_PRINT(C_RESET, "\n\t  AFI %s, %15s/%-2d, tag 0x%04x, metric: %u, next-hop: ",
 			 tok2str(bsd_af_values, "%u", family),
 			 GET_IPADDR_STRING(ni->rip_dest),
 			 mask2plen(GET_BE_U_4(ni->rip_dest_mask)),
 			 GET_BE_U_2(ni->rip_tag),
 			 GET_BE_U_4(ni->rip_metric));
 		if (GET_BE_U_4(ni->rip_router))
-			ND_PRINT("%s", GET_IPADDR_STRING(ni->rip_router));
+			ND_PRINT(C_RESET, "%s", GET_IPADDR_STRING(ni->rip_router));
 		else
-			ND_PRINT("self");
+			ND_PRINT(C_RESET, "self");
 	}
 	return (RIP_ROUTELEN);
 invalid:
@@ -300,22 +300,22 @@ rip_print(netdissect_options *ndo,
 	unsigned entry_size;
 
 	ndo->ndo_protocol = "rip";
-	ND_PRINT("%s", (ndo->ndo_vflag >= 1) ? "\n\t" : "");
+	ND_PRINT(C_RESET, "%s", (ndo->ndo_vflag >= 1) ? "\n\t" : "");
 	nd_print_protocol_caps(ndo);
 	ND_ICHECKMSG_ZU("packet length", len, <, sizeof(*rp));
 
 	rp = (const struct rip *)p;
 
 	vers = GET_U_1(rp->rip_vers);
-	ND_PRINT("v%u", vers);
+	ND_PRINT(C_RESET, "v%u", vers);
 	if (vers != 1 && vers != 2) {
-		ND_PRINT(" [version != 1 && version != 2]");
+		ND_PRINT(C_RESET, " [version != 1 && version != 2]");
 		goto invalid;
 	}
 
 	/* dump version and lets see if we know the commands name*/
 	cmd = GET_U_1(rp->rip_cmd);
-	ND_PRINT(", %s, length: %u",
+	ND_PRINT(C_RESET, ", %s, length: %u",
 		tok2str(rip_cmd_values, "unknown command (%u)", cmd),
 		len);
 
@@ -332,7 +332,7 @@ rip_print(netdissect_options *ndo,
 		switch (vers) {
 
 		case 1:
-			ND_PRINT(", routes: %u", len / RIP_ROUTELEN);
+			ND_PRINT(C_RESET, ", routes: %u", len / RIP_ROUTELEN);
 			while (len != 0) {
 				entry_size = rip_entry_print_v1(ndo, p, len);
 				if (entry_size == 0) {
@@ -347,7 +347,7 @@ rip_print(netdissect_options *ndo,
 			break;
 
 		case 2:
-			ND_PRINT(", routes: %u or less", len / RIP_ROUTELEN);
+			ND_PRINT(C_RESET, ", routes: %u or less", len / RIP_ROUTELEN);
 			while (len != 0) {
 				entry_size = rip_entry_print_v2(ndo, p, len);
 				if (entry_size == 0) {
@@ -362,7 +362,7 @@ rip_print(netdissect_options *ndo,
 			break;
 
 		default:
-			ND_PRINT(", unknown version");
+			ND_PRINT(C_RESET, ", unknown version");
 			break;
 		}
 		break;

--- a/print-ripng.c
+++ b/print-ripng.c
@@ -95,14 +95,14 @@ rip6_entry_print(netdissect_options *ndo,
 	uint16_t tag;
 	uint8_t metric;
 
-	ND_PRINT("%s/%u", GET_IP6ADDR_STRING(ni->rip6_dest),
+	ND_PRINT(C_RESET, "%s/%u", GET_IP6ADDR_STRING(ni->rip6_dest),
 	         GET_U_1(ni->rip6_plen));
 	tag = GET_BE_U_2(ni->rip6_tag);
 	if (tag)
-		ND_PRINT(" [%u]", tag);
+		ND_PRINT(C_RESET, " [%u]", tag);
 	metric = GET_U_1(ni->rip6_metric);
 	if (metric && print_metric)
-		ND_PRINT(" (%u)", metric);
+		ND_PRINT(C_RESET, " (%u)", metric);
 }
 
 void
@@ -117,7 +117,7 @@ ripng_print(netdissect_options *ndo, const u_char *dat, unsigned int length)
 	ndo->ndo_protocol = "ripng";
 	vers = GET_U_1(rp->rip6_vers);
 	if (vers != RIP6_VERSION) {
-		ND_PRINT(" [vers %u]", vers);
+		ND_PRINT(C_RESET, " [vers %u]", vers);
 		goto invalid;
 	}
 	cmd = GET_U_1(rp->rip6_cmd);
@@ -132,20 +132,20 @@ ripng_print(netdissect_options *ndo, const u_char *dat, unsigned int length)
 		if (j == 1) {
 			if (GET_U_1(rp->rip6_nets->rip6_metric) == HOPCNT_INFINITY6
 			    && ND_IN6_IS_ADDR_UNSPECIFIED(&rp->rip6_nets->rip6_dest)) {
-				ND_PRINT(" ripng-req dump");
+				ND_PRINT(C_RESET, " ripng-req dump");
 				break;
 			}
 		}
 		if (j * sizeof(*ni) != length_left)
-			ND_PRINT(" ripng-req %u[%u]:", j, length);
+			ND_PRINT(C_RESET, " ripng-req %u[%u]:", j, length);
 		else
-			ND_PRINT(" ripng-req %u:", j);
+			ND_PRINT(C_RESET, " ripng-req %u:", j);
 		for (ni = rp->rip6_nets; length_left >= sizeof(*ni);
 		    length_left -= sizeof(*ni), ++ni) {
 			if (ndo->ndo_vflag > 1)
-				ND_PRINT("\n\t");
+				ND_PRINT(C_RESET, "\n\t");
 			else
-				ND_PRINT(" ");
+				ND_PRINT(C_RESET, " ");
 			rip6_entry_print(ndo, ni, FALSE);
 		}
 		if (length_left != 0)
@@ -158,22 +158,22 @@ ripng_print(netdissect_options *ndo, const u_char *dat, unsigned int length)
 		length_left -= (sizeof(struct rip6) - sizeof(struct netinfo6));
 		j = length_left / sizeof(*ni);
 		if (j * sizeof(*ni) != length_left)
-			ND_PRINT(" ripng-resp %u[%u]:", j, length);
+			ND_PRINT(C_RESET, " ripng-resp %u[%u]:", j, length);
 		else
-			ND_PRINT(" ripng-resp %u:", j);
+			ND_PRINT(C_RESET, " ripng-resp %u:", j);
 		for (ni = rp->rip6_nets; length_left >= sizeof(*ni);
 		    length_left -= sizeof(*ni), ++ni) {
 			if (ndo->ndo_vflag > 1)
-				ND_PRINT("\n\t");
+				ND_PRINT(C_RESET, "\n\t");
 			else
-				ND_PRINT(" ");
+				ND_PRINT(C_RESET, " ");
 			rip6_entry_print(ndo, ni, TRUE);
 		}
 		if (length_left != 0)
 			goto invalid;
 		break;
 	default:
-		ND_PRINT(" ripng-%u ?? %u", cmd, length);
+		ND_PRINT(C_RESET, " ripng-%u ?? %u", cmd, length);
 		goto invalid;
 	}
 	return;

--- a/print-rpki-rtr.c
+++ b/print-rpki-rtr.c
@@ -180,7 +180,7 @@ rpki_rtr_pdu_print(netdissect_options *ndo, const u_char *tptr, const u_int len,
     uint8_t pdu_ver;
 
     if (len < sizeof(rpki_rtr_pdu)) {
-	ND_PRINT("(%u bytes is too few to decode)", len);
+	ND_PRINT(C_RESET, "(%u bytes is too few to decode)", len);
 	goto invalid;
     }
     pdu_header = (const rpki_rtr_pdu *)tptr;
@@ -192,7 +192,7 @@ rpki_rtr_pdu_print(netdissect_options *ndo, const u_char *tptr, const u_int len,
 	 * version 0, there is no way to know exactly how to skip the
 	 * current PDU.
 	 */
-	ND_PRINT("%sRPKI-RTRv%u (unknown)", indent_string(8), pdu_ver);
+	ND_PRINT(C_RESET, "%sRPKI-RTRv%u (unknown)", indent_string(8), pdu_ver);
 	return len;
     }
     pdu_type = GET_U_1(pdu_header->pdu_type);
@@ -203,7 +203,7 @@ rpki_rtr_pdu_print(netdissect_options *ndo, const u_char *tptr, const u_int len,
      */
     hexdump = FALSE;
 
-    ND_PRINT("%sRPKI-RTRv%u, %s PDU (%u), length: %u",
+    ND_PRINT(C_RESET, "%sRPKI-RTRv%u, %s PDU (%u), length: %u",
 	   indent_string(8),
 	   pdu_ver,
 	   tok2str(rpki_rtr_pdu_values, "Unknown", pdu_type),
@@ -222,7 +222,7 @@ rpki_rtr_pdu_print(netdissect_options *ndo, const u_char *tptr, const u_int len,
 	if (pdu_len != sizeof(rpki_rtr_pdu) + 4)
 	    goto invalid;
         msg = (const u_char *)(pdu_header + 1);
-	ND_PRINT("%sSession ID: 0x%04x, Serial: %u",
+	ND_PRINT(C_RESET, "%sSession ID: 0x%04x, Serial: %u",
 	       indent_string(indent+2),
 	       GET_BE_U_2(pdu_header->u.session_id),
 	       GET_BE_U_4(msg));
@@ -246,7 +246,7 @@ rpki_rtr_pdu_print(netdissect_options *ndo, const u_char *tptr, const u_int len,
 	if (pdu_len != sizeof(rpki_rtr_pdu))
 	    goto invalid;
 	/* no additional boundary to check */
-	ND_PRINT("%sSession ID: 0x%04x",
+	ND_PRINT(C_RESET, "%sSession ID: 0x%04x",
 	       indent_string(indent+2),
 	       GET_BE_U_2(pdu_header->u.session_id));
 	break;
@@ -258,7 +258,7 @@ rpki_rtr_pdu_print(netdissect_options *ndo, const u_char *tptr, const u_int len,
 	    if (pdu_len != sizeof(rpki_rtr_pdu_ipv4_prefix))
 		goto invalid;
 	    pdu = (const rpki_rtr_pdu_ipv4_prefix *)tptr;
-	    ND_PRINT("%sIPv4 Prefix %s/%u-%u, origin-as %u, flags 0x%02x",
+	    ND_PRINT(C_RESET, "%sIPv4 Prefix %s/%u-%u, origin-as %u, flags 0x%02x",
 		   indent_string(indent+2),
 		   GET_IPADDR_STRING(pdu->prefix),
 		   GET_U_1(pdu->prefix_length), GET_U_1(pdu->max_length),
@@ -273,7 +273,7 @@ rpki_rtr_pdu_print(netdissect_options *ndo, const u_char *tptr, const u_int len,
 	    if (pdu_len != sizeof(rpki_rtr_pdu_ipv6_prefix))
 		goto invalid;
 	    pdu = (const rpki_rtr_pdu_ipv6_prefix *)tptr;
-	    ND_PRINT("%sIPv6 Prefix %s/%u-%u, origin-as %u, flags 0x%02x",
+	    ND_PRINT(C_RESET, "%sIPv6 Prefix %s/%u-%u, origin-as %u, flags 0x%02x",
 		   indent_string(indent+2),
 		   GET_IP6ADDR_STRING(pdu->prefix),
 		   GET_U_1(pdu->prefix_length), GET_U_1(pdu->max_length),
@@ -298,7 +298,7 @@ rpki_rtr_pdu_print(netdissect_options *ndo, const u_char *tptr, const u_int len,
 	     */
 
 	    error_code = GET_BE_U_2(pdu->pdu_header.u.error_code);
-	    ND_PRINT("%sError code: %s (%u), Encapsulated PDU length: %u",
+	    ND_PRINT(C_RESET, "%sError code: %s (%u), Encapsulated PDU length: %u",
 		   indent_string(indent+2),
 		   tok2str(rpki_rtr_error_codes, "Unknown", error_code),
 		   error_code, encapsulated_pdu_length);
@@ -322,7 +322,7 @@ rpki_rtr_pdu_print(netdissect_options *ndo, const u_char *tptr, const u_int len,
 		    ND_TCHECK_LEN(tptr, tlen + encapsulated_pdu_length);
 		}
 		else {
-		    ND_PRINT("%s-----encapsulated PDU-----", indent_string(indent+4));
+		    ND_PRINT(C_RESET, "%s-----encapsulated PDU-----", indent_string(indent+4));
 		    rpki_rtr_pdu_print(ndo, tptr + tlen,
 			encapsulated_pdu_length, 0, indent + 2);
 		}
@@ -343,7 +343,7 @@ rpki_rtr_pdu_print(netdissect_options *ndo, const u_char *tptr, const u_int len,
 	    if (text_length) {
 		if (pdu_len < tlen + text_length)
 		    goto invalid;
-		ND_PRINT("%sError text: ", indent_string(indent+2));
+		ND_PRINT(C_RESET, "%sError text: ", indent_string(indent+2));
 		nd_printjn(ndo, tptr + tlen, text_length);
 	    }
 	}
@@ -375,7 +375,7 @@ rpki_rtr_print(netdissect_options *ndo, const u_char *pptr, u_int len)
 {
     ndo->ndo_protocol = "rpki_rtr";
     if (!ndo->ndo_vflag) {
-	ND_PRINT(", RPKI-RTR");
+	ND_PRINT(C_RESET, ", RPKI-RTR");
 	return;
     }
     while (len) {

--- a/print-rsvp.c
+++ b/print-rsvp.c
@@ -523,7 +523,7 @@ rsvp_intserv_print(netdissect_options *ndo,
     parameter_id = GET_U_1(tptr);
     parameter_length = GET_BE_U_2(tptr + 2)<<2; /* convert wordcount to bytecount */
 
-    ND_PRINT("\n\t      Parameter ID: %s (%u), length: %u, Flags: [0x%02x]",
+    ND_PRINT(C_RESET, "\n\t      Parameter ID: %s (%u), length: %u, Flags: [0x%02x]",
            tok2str(rsvp_intserv_parameter_id_values,"unknown",parameter_id),
            parameter_id,
            parameter_length,
@@ -541,7 +541,7 @@ rsvp_intserv_print(netdissect_options *ndo,
         * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
         */
         if (parameter_length == 4) {
-            ND_PRINT("\n\t\tIS hop count: %u", GET_BE_U_4(tptr + 4));
+            ND_PRINT(C_RESET, "\n\t\tIS hop count: %u", GET_BE_U_4(tptr + 4));
         }
         break;
 
@@ -555,7 +555,7 @@ rsvp_intserv_print(netdissect_options *ndo,
         */
         if (parameter_length == 4) {
             bw.i = GET_BE_U_4(tptr + 4);
-            ND_PRINT("\n\t\tPath b/w estimate: %.10g Mbps", bw.f / 125000);
+            ND_PRINT(C_RESET, "\n\t\tPath b/w estimate: %.10g Mbps", bw.f / 125000);
         }
         break;
 
@@ -568,11 +568,11 @@ rsvp_intserv_print(netdissect_options *ndo,
         * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
         */
         if (parameter_length == 4) {
-            ND_PRINT("\n\t\tMinimum path latency: ");
+            ND_PRINT(C_RESET, "\n\t\tMinimum path latency: ");
             if (GET_BE_U_4(tptr + 4) == 0xffffffff)
-                ND_PRINT("don't care");
+                ND_PRINT(C_RESET, "don't care");
             else
-                ND_PRINT("%u", GET_BE_U_4(tptr + 4));
+                ND_PRINT(C_RESET, "%u", GET_BE_U_4(tptr + 4));
         }
         break;
 
@@ -586,7 +586,7 @@ rsvp_intserv_print(netdissect_options *ndo,
         * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
         */
         if (parameter_length == 4) {
-            ND_PRINT("\n\t\tComposed MTU: %u bytes", GET_BE_U_4(tptr + 4));
+            ND_PRINT(C_RESET, "\n\t\tComposed MTU: %u bytes", GET_BE_U_4(tptr + 4));
         }
         break;
     case 127:
@@ -608,14 +608,14 @@ rsvp_intserv_print(netdissect_options *ndo,
 
         if (parameter_length == 20) {
             bw.i = GET_BE_U_4(tptr + 4);
-            ND_PRINT("\n\t\tToken Bucket Rate: %.10g Mbps", bw.f / 125000);
+            ND_PRINT(C_RESET, "\n\t\tToken Bucket Rate: %.10g Mbps", bw.f / 125000);
             bw.i = GET_BE_U_4(tptr + 8);
-            ND_PRINT("\n\t\tToken Bucket Size: %.10g bytes", bw.f);
+            ND_PRINT(C_RESET, "\n\t\tToken Bucket Size: %.10g bytes", bw.f);
             bw.i = GET_BE_U_4(tptr + 12);
-            ND_PRINT("\n\t\tPeak Data Rate: %.10g Mbps", bw.f / 125000);
-            ND_PRINT("\n\t\tMinimum Policed Unit: %u bytes",
+            ND_PRINT(C_RESET, "\n\t\tPeak Data Rate: %.10g Mbps", bw.f / 125000);
+            ND_PRINT(C_RESET, "\n\t\tMinimum Policed Unit: %u bytes",
                      GET_BE_U_4(tptr + 16));
-            ND_PRINT("\n\t\tMaximum Packet Size: %u bytes",
+            ND_PRINT(C_RESET, "\n\t\tMaximum Packet Size: %u bytes",
                      GET_BE_U_4(tptr + 20));
         }
         break;
@@ -633,8 +633,8 @@ rsvp_intserv_print(netdissect_options *ndo,
 
         if (parameter_length == 8) {
             bw.i = GET_BE_U_4(tptr + 4);
-            ND_PRINT("\n\t\tRate: %.10g Mbps", bw.f / 125000);
-            ND_PRINT("\n\t\tSlack Term: %u", GET_BE_U_4(tptr + 8));
+            ND_PRINT(C_RESET, "\n\t\tRate: %.10g Mbps", bw.f / 125000);
+            ND_PRINT(C_RESET, "\n\t\tSlack Term: %u", GET_BE_U_4(tptr + 8));
         }
         break;
 
@@ -643,7 +643,7 @@ rsvp_intserv_print(netdissect_options *ndo,
     case 135:
     case 136:
         if (parameter_length == 4) {
-            ND_PRINT("\n\t\tValue: %u", GET_BE_U_4(tptr + 4));
+            ND_PRINT(C_RESET, "\n\t\tValue: %u", GET_BE_U_4(tptr + 4));
         }
         break;
 
@@ -701,17 +701,17 @@ rsvp_obj_print(netdissect_options *ndo,
         rsvp_obj_ctype=GET_U_1(rsvp_obj_header->ctype);
 
         if(rsvp_obj_len % 4) {
-            ND_PRINT("%sERROR: object header size %u not a multiple of 4", indent, rsvp_obj_len);
+            ND_PRINT(C_RESET, "%sERROR: object header size %u not a multiple of 4", indent, rsvp_obj_len);
             return -1;
         }
         if(rsvp_obj_len < sizeof(struct rsvp_object_header)) {
-            ND_PRINT("%sERROR: object header too short %u < %zu", indent, rsvp_obj_len,
+            ND_PRINT(C_RESET, "%sERROR: object header too short %u < %zu", indent, rsvp_obj_len,
                    sizeof(struct rsvp_object_header));
             return -1;
         }
 
         rsvp_obj_class_num = GET_U_1(rsvp_obj_header->class_num);
-        ND_PRINT("%s%s Object (%u) Flags: [%s",
+        ND_PRINT(C_RESET, "%s%s Object (%u) Flags: [%s",
                indent,
                tok2str(rsvp_obj_values,
                        "Unknown",
@@ -722,7 +722,7 @@ rsvp_obj_print(netdissect_options *ndo,
                                          "ignore silently") :
                    "reject");
 
-        ND_PRINT(" if unknown], Class-Type: %s (%u), length: %u",
+        ND_PRINT(C_RESET, " if unknown], Class-Type: %s (%u), length: %u",
                tok2str(rsvp_ctype_values,
                        "Unknown",
                        (rsvp_obj_class_num<<8)+rsvp_obj_ctype),
@@ -730,7 +730,7 @@ rsvp_obj_print(netdissect_options *ndo,
                rsvp_obj_len);
 
         if(tlen < rsvp_obj_len) {
-            ND_PRINT("%sERROR: object goes past end of objects TLV", indent);
+            ND_PRINT(C_RESET, "%sERROR: object goes past end of objects TLV", indent);
             return -1;
         }
 
@@ -747,11 +747,11 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_IPV4:
                 if (obj_tlen < 8)
                     goto obj_tooshort;
-                ND_PRINT("%s  IPv4 DestAddress: %s, Protocol ID: 0x%02x",
+                ND_PRINT(C_RESET, "%s  IPv4 DestAddress: %s, Protocol ID: 0x%02x",
                        indent,
                        GET_IPADDR_STRING(obj_tptr),
                        GET_U_1(obj_tptr + sizeof(nd_ipv4)));
-                ND_PRINT("%s  Flags: [0x%02x], DestPort %u",
+                ND_PRINT(C_RESET, "%s  Flags: [0x%02x], DestPort %u",
                        indent,
                        GET_U_1((obj_tptr + 5)),
                        GET_BE_U_2(obj_tptr + 6));
@@ -761,11 +761,11 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_IPV6:
                 if (obj_tlen < 20)
                     goto obj_tooshort;
-                ND_PRINT("%s  IPv6 DestAddress: %s, Protocol ID: 0x%02x",
+                ND_PRINT(C_RESET, "%s  IPv6 DestAddress: %s, Protocol ID: 0x%02x",
                        indent,
                        GET_IP6ADDR_STRING(obj_tptr),
                        GET_U_1(obj_tptr + sizeof(nd_ipv6)));
-                ND_PRINT("%s  Flags: [0x%02x], DestPort %u",
+                ND_PRINT(C_RESET, "%s  Flags: [0x%02x], DestPort %u",
                        indent,
                        GET_U_1((obj_tptr + sizeof(nd_ipv6) + 1)),
                        GET_BE_U_2(obj_tptr + sizeof(nd_ipv6) + 2));
@@ -776,7 +776,7 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_TUNNEL_IPV6:
                 if (obj_tlen < 36)
                     goto obj_tooshort;
-                ND_PRINT("%s  IPv6 Tunnel EndPoint: %s, Tunnel ID: 0x%04x, Extended Tunnel ID: %s",
+                ND_PRINT(C_RESET, "%s  IPv6 Tunnel EndPoint: %s, Tunnel ID: 0x%04x, Extended Tunnel ID: %s",
                        indent,
                        GET_IP6ADDR_STRING(obj_tptr),
                        GET_BE_U_2(obj_tptr + 18),
@@ -788,7 +788,7 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_14: /* IPv6 p2mp LSP Tunnel */
                 if (obj_tlen < 26)
                     goto obj_tooshort;
-                ND_PRINT("%s  IPv6 P2MP LSP ID: 0x%08x, Tunnel ID: 0x%04x, Extended Tunnel ID: %s",
+                ND_PRINT(C_RESET, "%s  IPv6 P2MP LSP ID: 0x%08x, Tunnel ID: 0x%04x, Extended Tunnel ID: %s",
                        indent,
                        GET_BE_U_4(obj_tptr),
                        GET_BE_U_2(obj_tptr + 6),
@@ -799,7 +799,7 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_13: /* IPv4 p2mp LSP Tunnel */
                 if (obj_tlen < 12)
                     goto obj_tooshort;
-                ND_PRINT("%s  IPv4 P2MP LSP ID: %s, Tunnel ID: 0x%04x, Extended Tunnel ID: %s",
+                ND_PRINT(C_RESET, "%s  IPv4 P2MP LSP ID: %s, Tunnel ID: 0x%04x, Extended Tunnel ID: %s",
                        indent,
                        GET_IPADDR_STRING(obj_tptr),
                        GET_BE_U_2(obj_tptr + 6),
@@ -811,7 +811,7 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_UNI_IPV4:
                 if (obj_tlen < 12)
                     goto obj_tooshort;
-                ND_PRINT("%s  IPv4 Tunnel EndPoint: %s, Tunnel ID: 0x%04x, Extended Tunnel ID: %s",
+                ND_PRINT(C_RESET, "%s  IPv4 Tunnel EndPoint: %s, Tunnel ID: 0x%04x, Extended Tunnel ID: %s",
                        indent,
                        GET_IPADDR_STRING(obj_tptr),
                        GET_BE_U_2(obj_tptr + 6),
@@ -829,7 +829,7 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_IPV4:
                 if (obj_tlen < sizeof(nd_ipv4))
                     goto obj_tooshort;
-                ND_PRINT("%s  IPv4 Receiver Address: %s",
+                ND_PRINT(C_RESET, "%s  IPv4 Receiver Address: %s",
                        indent,
                        GET_IPADDR_STRING(obj_tptr));
                 obj_tlen-=sizeof(nd_ipv4);
@@ -838,7 +838,7 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_IPV6:
                 if (obj_tlen < sizeof(nd_ipv6))
                     goto obj_tooshort;
-                ND_PRINT("%s  IPv6 Receiver Address: %s",
+                ND_PRINT(C_RESET, "%s  IPv6 Receiver Address: %s",
                        indent,
                        GET_IP6ADDR_STRING(obj_tptr));
                 obj_tlen-=sizeof(nd_ipv6);
@@ -854,7 +854,7 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_IPV4:
                 if (obj_tlen < sizeof(nd_ipv4))
                     goto obj_tooshort;
-                ND_PRINT("%s  IPv4 Notify Node Address: %s",
+                ND_PRINT(C_RESET, "%s  IPv4 Notify Node Address: %s",
                        indent,
                        GET_IPADDR_STRING(obj_tptr));
                 obj_tlen-=sizeof(nd_ipv4);
@@ -863,7 +863,7 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_IPV6:
                 if (obj_tlen < sizeof(nd_ipv6))
                     goto obj_tooshort;
-                ND_PRINT("%s  IPv6 Notify Node Address: %s",
+                ND_PRINT(C_RESET, "%s  IPv6 Notify Node Address: %s",
                        indent,
                        GET_IP6ADDR_STRING(obj_tptr));
                 obj_tlen-=sizeof(nd_ipv6);
@@ -881,7 +881,7 @@ rsvp_obj_print(netdissect_options *ndo,
             switch(rsvp_obj_ctype) {
             case RSVP_CTYPE_1:
                 while(obj_tlen >= 4 ) {
-                    ND_PRINT("%s  Label: %u", indent, GET_BE_U_4(obj_tptr));
+                    ND_PRINT(C_RESET, "%s  Label: %u", indent, GET_BE_U_4(obj_tptr));
                     obj_tlen-=4;
                     obj_tptr+=4;
                 }
@@ -889,7 +889,7 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_2:
                 if (obj_tlen < 4)
                     goto obj_tooshort;
-                ND_PRINT("%s  Generalized Label: %u",
+                ND_PRINT(C_RESET, "%s  Generalized Label: %u",
                        indent,
                        GET_BE_U_4(obj_tptr));
                 obj_tlen-=4;
@@ -898,7 +898,7 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_3:
                 if (obj_tlen < 12)
                     goto obj_tooshort;
-                ND_PRINT("%s  Waveband ID: %u%s  Start Label: %u, Stop Label: %u",
+                ND_PRINT(C_RESET, "%s  Waveband ID: %u%s  Start Label: %u, Stop Label: %u",
                        indent,
                        GET_BE_U_4(obj_tptr),
                        indent,
@@ -917,7 +917,7 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_1:
                 if (obj_tlen < 4)
                     goto obj_tooshort;
-                ND_PRINT("%s  Reservation Style: %s, Flags: [0x%02x]",
+                ND_PRINT(C_RESET, "%s  Reservation Style: %s, Flags: [0x%02x]",
                        indent,
                        tok2str(rsvp_resstyle_values,
                                "Unknown",
@@ -936,7 +936,7 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_IPV4:
                 if (obj_tlen < 8)
                     goto obj_tooshort;
-                ND_PRINT("%s  Source Address: %s, Source Port: %u",
+                ND_PRINT(C_RESET, "%s  Source Address: %s, Source Port: %u",
                        indent,
                        GET_IPADDR_STRING(obj_tptr),
                        GET_BE_U_2(obj_tptr + 6));
@@ -946,7 +946,7 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_IPV6:
                 if (obj_tlen < 20)
                     goto obj_tooshort;
-                ND_PRINT("%s  Source Address: %s, Source Port: %u",
+                ND_PRINT(C_RESET, "%s  Source Address: %s, Source Port: %u",
                        indent,
                        GET_IP6ADDR_STRING(obj_tptr),
                        GET_BE_U_2(obj_tptr + 18));
@@ -956,7 +956,7 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_13: /* IPv6 p2mp LSP tunnel */
                 if (obj_tlen < 40)
                     goto obj_tooshort;
-                ND_PRINT("%s  IPv6 Tunnel Sender Address: %s, LSP ID: 0x%04x"
+                ND_PRINT(C_RESET, "%s  IPv6 Tunnel Sender Address: %s, LSP ID: 0x%04x"
                        "%s  Sub-Group Originator ID: %s, Sub-Group ID: 0x%04x",
                        indent,
                        GET_IP6ADDR_STRING(obj_tptr),
@@ -970,7 +970,7 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_TUNNEL_IPV4:
                 if (obj_tlen < 8)
                     goto obj_tooshort;
-                ND_PRINT("%s  IPv4 Tunnel Sender Address: %s, LSP-ID: 0x%04x",
+                ND_PRINT(C_RESET, "%s  IPv4 Tunnel Sender Address: %s, LSP-ID: 0x%04x",
                        indent,
                        GET_IPADDR_STRING(obj_tptr),
                        GET_BE_U_2(obj_tptr + 6));
@@ -980,7 +980,7 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_12: /* IPv4 p2mp LSP tunnel */
                 if (obj_tlen < 16)
                     goto obj_tooshort;
-                ND_PRINT("%s  IPv4 Tunnel Sender Address: %s, LSP ID: 0x%04x"
+                ND_PRINT(C_RESET, "%s  IPv4 Tunnel Sender Address: %s, LSP ID: 0x%04x"
                        "%s  Sub-Group Originator ID: %s, Sub-Group ID: 0x%04x",
                        indent,
                        GET_IPADDR_STRING(obj_tptr),
@@ -1000,7 +1000,7 @@ rsvp_obj_print(netdissect_options *ndo,
             switch(rsvp_obj_ctype) {
             case RSVP_CTYPE_1:
                 while(obj_tlen >= 4 ) {
-                    ND_PRINT("%s  L3 Protocol ID: %s",
+                    ND_PRINT(C_RESET, "%s  L3 Protocol ID: %s",
                            indent,
                            tok2str(ethertype_values,
                                    "Unknown Protocol (0x%04x)",
@@ -1012,18 +1012,18 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_2:
                 if (obj_tlen < 12)
                     goto obj_tooshort;
-                ND_PRINT("%s  L3 Protocol ID: %s",
+                ND_PRINT(C_RESET, "%s  L3 Protocol ID: %s",
                        indent,
                        tok2str(ethertype_values,
                                "Unknown Protocol (0x%04x)",
                                GET_BE_U_2(obj_tptr + 2)));
-                ND_PRINT(",%s merge capability",
+                ND_PRINT(C_RESET, ",%s merge capability",
                          ((GET_U_1(obj_tptr + 4)) & 0x80) ? "no" : "" );
-                ND_PRINT("%s  Minimum VPI/VCI: %u/%u",
+                ND_PRINT(C_RESET, "%s  Minimum VPI/VCI: %u/%u",
                        indent,
                        (GET_BE_U_2(obj_tptr + 4))&0xfff,
                        (GET_BE_U_2(obj_tptr + 6)) & 0xfff);
-                ND_PRINT("%s  Maximum VPI/VCI: %u/%u",
+                ND_PRINT(C_RESET, "%s  Maximum VPI/VCI: %u/%u",
                        indent,
                        (GET_BE_U_2(obj_tptr + 8))&0xfff,
                        (GET_BE_U_2(obj_tptr + 10)) & 0xfff);
@@ -1033,12 +1033,12 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_3:
                 if (obj_tlen < 12)
                     goto obj_tooshort;
-                ND_PRINT("%s  L3 Protocol ID: %s",
+                ND_PRINT(C_RESET, "%s  L3 Protocol ID: %s",
                        indent,
                        tok2str(ethertype_values,
                                "Unknown Protocol (0x%04x)",
                                GET_BE_U_2(obj_tptr + 2)));
-                ND_PRINT("%s  Minimum/Maximum DLCI: %u/%u, %s%s bit DLCI",
+                ND_PRINT(C_RESET, "%s  Minimum/Maximum DLCI: %u/%u, %s%s bit DLCI",
                        indent,
                        (GET_BE_U_4(obj_tptr + 4))&0x7fffff,
                        (GET_BE_U_4(obj_tptr + 8))&0x7fffff,
@@ -1050,13 +1050,13 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_4:
                 if (obj_tlen < 4)
                     goto obj_tooshort;
-                ND_PRINT("%s  LSP Encoding Type: %s (%u)",
+                ND_PRINT(C_RESET, "%s  LSP Encoding Type: %s (%u)",
                        indent,
                        tok2str(gmpls_encoding_values,
                                "Unknown",
                                GET_U_1(obj_tptr)),
                        GET_U_1(obj_tptr));
-                ND_PRINT("%s  Switching Type: %s (%u), Payload ID: %s (0x%04x)",
+                ND_PRINT(C_RESET, "%s  Switching Type: %s (%u), Payload ID: %s (0x%04x)",
                        indent,
                        tok2str(gmpls_switch_cap_values,
                                "Unknown",
@@ -1083,19 +1083,19 @@ rsvp_obj_print(netdissect_options *ndo,
 
 		    ND_TCHECK_4(obj_tptr);
 		    length = GET_U_1(obj_tptr + 1);
-                    ND_PRINT("%s  Subobject Type: %s, length %u",
+                    ND_PRINT(C_RESET, "%s  Subobject Type: %s, length %u",
                            indent,
                            tok2str(rsvp_obj_xro_values,
                                    "Unknown %u",
                                    RSVP_OBJ_XRO_MASK_SUBOBJ(GET_U_1(obj_tptr))),
                            length);
                     if (obj_tlen < length) {
-                        ND_PRINT("%s  ERROR: ERO subobject length > object length", indent);
+                        ND_PRINT(C_RESET, "%s  ERROR: ERO subobject length > object length", indent);
                         break;
                     }
 
                     if (length == 0) { /* prevent infinite loops */
-                        ND_PRINT("%s  ERROR: zero length ERO subtype", indent);
+                        ND_PRINT(C_RESET, "%s  ERROR: zero length ERO subtype", indent);
                         break;
                     }
 
@@ -1104,17 +1104,17 @@ rsvp_obj_print(netdissect_options *ndo,
 
                     case RSVP_OBJ_XRO_IPV4:
 			if (length != 8) {
-				ND_PRINT(" ERROR: length != 8");
+				ND_PRINT(C_RESET, " ERROR: length != 8");
 				goto invalid;
 			}
 			ND_TCHECK_8(obj_tptr);
 			prefix_length = GET_U_1(obj_tptr + 6);
 			if (prefix_length != 32) {
-				ND_PRINT(" ERROR: Prefix length %u != 32",
+				ND_PRINT(C_RESET, " ERROR: Prefix length %u != 32",
 					  prefix_length);
 				goto invalid;
 			}
-                        ND_PRINT(", %s, %s/%u, Flags: [%s]",
+                        ND_PRINT(C_RESET, ", %s, %s/%u, Flags: [%s]",
                                RSVP_OBJ_XRO_MASK_LOOSE(GET_U_1(obj_tptr)) ? "Loose" : "Strict",
                                GET_IPADDR_STRING(obj_tptr+2),
                                GET_U_1((obj_tptr + 6)),
@@ -1124,10 +1124,10 @@ rsvp_obj_print(netdissect_options *ndo,
                     break;
                     case RSVP_OBJ_XRO_LABEL:
 			if (length != 8) {
-				ND_PRINT(" ERROR: length != 8");
+				ND_PRINT(C_RESET, " ERROR: length != 8");
 				goto invalid;
 			}
-                        ND_PRINT(", Flags: [%s] (%#x), Class-Type: %s (%u), %u",
+                        ND_PRINT(C_RESET, ", Flags: [%s] (%#x), Class-Type: %s (%u), %u",
                                bittok2str(rsvp_obj_rro_label_flag_values,
                                    "none",
                                    GET_U_1((obj_tptr + 2))),
@@ -1153,7 +1153,7 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_2:
                 if (obj_tlen < 8)
                     goto obj_tooshort;
-                ND_PRINT("%s  Source Instance: 0x%08x, Destination Instance: 0x%08x",
+                ND_PRINT(C_RESET, "%s  Source Instance: 0x%08x, Destination Instance: 0x%08x",
                        indent,
                        GET_BE_U_4(obj_tptr),
                        GET_BE_U_4(obj_tptr + 4));
@@ -1170,7 +1170,7 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_1:
                 if (obj_tlen < 8)
                     goto obj_tooshort;
-                ND_PRINT("%s  Restart  Time: %ums, Recovery Time: %ums",
+                ND_PRINT(C_RESET, "%s  Restart  Time: %ums, Recovery Time: %ums",
                        indent,
                        GET_BE_U_4(obj_tptr),
                        GET_BE_U_4(obj_tptr + 4));
@@ -1189,9 +1189,9 @@ rsvp_obj_print(netdissect_options *ndo,
                     goto obj_tooshort;
                 uint32_t unused_and_flags = GET_BE_U_4(obj_tptr);
                 if (unused_and_flags & ~RSVP_OBJ_CAPABILITY_FLAGS_MASK)
-                    ND_PRINT("%s  [reserved=0x%08x must be zero]", indent,
+                    ND_PRINT(C_RESET, "%s  [reserved=0x%08x must be zero]", indent,
                         unused_and_flags & ~RSVP_OBJ_CAPABILITY_FLAGS_MASK);
-                ND_PRINT("%s  Flags: [%s]",
+                ND_PRINT(C_RESET, "%s  Flags: [%s]",
                        indent,
                        bittok2str(rsvp_obj_capability_flag_values,
                                   "none",
@@ -1212,10 +1212,10 @@ rsvp_obj_print(netdissect_options *ndo,
                 namelen = GET_U_1(obj_tptr + 3);
                 if (obj_tlen < 4+namelen)
                     goto obj_tooshort;
-                ND_PRINT("%s  Session Name: ", indent);
+                ND_PRINT(C_RESET, "%s  Session Name: ", indent);
                 for (i = 0; i < namelen; i++)
                     fn_print_char(ndo, GET_U_1(obj_tptr + 4 + i));
-                ND_PRINT("%s  Setup Priority: %u, Holding Priority: %u, Flags: [%s] (%#x)",
+                ND_PRINT(C_RESET, "%s  Setup Priority: %u, Holding Priority: %u, Flags: [%s] (%#x)",
                        indent,
                        GET_U_1(obj_tptr),
                        GET_U_1(obj_tptr + 1),
@@ -1257,7 +1257,7 @@ rsvp_obj_print(netdissect_options *ndo,
                     subobj_type = (GET_BE_U_2(obj_tptr + 2))>>8;
                     af = (GET_BE_U_2(obj_tptr + 2))&0x00FF;
 
-                    ND_PRINT("%s  Subobject Type: %s (%u), AF: %s (%u), length: %u",
+                    ND_PRINT(C_RESET, "%s  Subobject Type: %s (%u), AF: %s (%u), length: %u",
                            indent,
                            tok2str(rsvp_obj_generalized_uni_values, "Unknown", subobj_type),
                            subobj_type,
@@ -1302,13 +1302,13 @@ rsvp_obj_print(netdissect_options *ndo,
                         case AFNUM_INET:
                             if (subobj_len < 8)
                                 goto subobj_tooshort;
-                            ND_PRINT("%s    UNI IPv4 TNA address: %s",
+                            ND_PRINT(C_RESET, "%s    UNI IPv4 TNA address: %s",
                                    indent, GET_IPADDR_STRING(obj_tptr + 4));
                             break;
                         case AFNUM_INET6:
                             if (subobj_len < 20)
                                 goto subobj_tooshort;
-                            ND_PRINT("%s    UNI IPv6 TNA address: %s",
+                            ND_PRINT(C_RESET, "%s    UNI IPv6 TNA address: %s",
                                    indent, GET_IP6ADDR_STRING(obj_tptr + 4));
                             break;
                         case AFNUM_NSAP:
@@ -1332,7 +1332,7 @@ rsvp_obj_print(netdissect_options *ndo,
                             goto subobj_tooshort;
                         }
 
-                        ND_PRINT("%s    U-bit: %x, Label type: %u, Logical port id: %u, Label: %u",
+                        ND_PRINT(C_RESET, "%s    U-bit: %x, Label type: %u, Logical port id: %u, Label: %u",
                                indent,
                                ((GET_BE_U_4(obj_tptr + 4))>>31),
                                ((GET_BE_U_4(obj_tptr + 4))&0xFF),
@@ -1345,7 +1345,7 @@ rsvp_obj_print(netdissect_options *ndo,
                             goto subobj_tooshort;
                         }
 
-                        ND_PRINT("%s    Service level: %u",
+                        ND_PRINT(C_RESET, "%s    Service level: %u",
                                indent, (GET_BE_U_4(obj_tptr + 4)) >> 24);
                         break;
 
@@ -1370,7 +1370,7 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_IPV4:
                 if (obj_tlen < 8)
                     goto obj_tooshort;
-                ND_PRINT("%s  Previous/Next Interface: %s, Logical Interface Handle: 0x%08x",
+                ND_PRINT(C_RESET, "%s  Previous/Next Interface: %s, Logical Interface Handle: 0x%08x",
                        indent,
                        GET_IPADDR_STRING(obj_tptr),
                        GET_BE_U_4(obj_tptr + 4));
@@ -1383,7 +1383,7 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_IPV6:
                 if (obj_tlen < 20)
                     goto obj_tooshort;
-                ND_PRINT("%s  Previous/Next Interface: %s, Logical Interface Handle: 0x%08x",
+                ND_PRINT(C_RESET, "%s  Previous/Next Interface: %s, Logical Interface Handle: 0x%08x",
                        indent,
                        GET_IP6ADDR_STRING(obj_tptr),
                        GET_BE_U_4(obj_tptr + 16));
@@ -1401,7 +1401,7 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_1:
                 if (obj_tlen < 4)
                     goto obj_tooshort;
-                ND_PRINT("%s  Refresh Period: %ums",
+                ND_PRINT(C_RESET, "%s  Refresh Period: %ums",
                        indent,
                        GET_BE_U_4(obj_tptr));
                 obj_tlen-=4;
@@ -1420,7 +1420,7 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_2:
                 if (obj_tlen < 4)
                     goto obj_tooshort;
-                ND_PRINT("%s  Msg-Version: %u, length: %u",
+                ND_PRINT(C_RESET, "%s  Msg-Version: %u, length: %u",
                        indent,
                        (GET_U_1(obj_tptr) & 0xf0) >> 4,
                        GET_BE_U_2(obj_tptr + 2) << 2);
@@ -1429,7 +1429,7 @@ rsvp_obj_print(netdissect_options *ndo,
 
                 while (obj_tlen >= 4) {
                     intserv_serv_tlen=GET_BE_U_2(obj_tptr + 2)<<2;
-                    ND_PRINT("%s  Service Type: %s (%u), break bit %sset, Service length: %u",
+                    ND_PRINT(C_RESET, "%s  Service Type: %s (%u), break bit %sset, Service length: %u",
                            indent,
                            tok2str(rsvp_intserv_service_type_values,"unknown",GET_U_1((obj_tptr))),
                            GET_U_1(obj_tptr),
@@ -1459,7 +1459,7 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_IPV4:
                 if (obj_tlen < 8)
                     goto obj_tooshort;
-                ND_PRINT("%s  Source Address: %s, Source Port: %u",
+                ND_PRINT(C_RESET, "%s  Source Address: %s, Source Port: %u",
                        indent,
                        GET_IPADDR_STRING(obj_tptr),
                        GET_BE_U_2(obj_tptr + 6));
@@ -1469,7 +1469,7 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_IPV6:
                 if (obj_tlen < 20)
                     goto obj_tooshort;
-                ND_PRINT("%s  Source Address: %s, Source Port: %u",
+                ND_PRINT(C_RESET, "%s  Source Address: %s, Source Port: %u",
                        indent,
                        GET_IP6ADDR_STRING(obj_tptr),
                        GET_BE_U_2(obj_tptr + 18));
@@ -1479,7 +1479,7 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_3:
                 if (obj_tlen < 20)
                     goto obj_tooshort;
-                ND_PRINT("%s  Source Address: %s, Flow Label: %u",
+                ND_PRINT(C_RESET, "%s  Source Address: %s, Flow Label: %u",
                        indent,
                        GET_IP6ADDR_STRING(obj_tptr),
                        GET_BE_U_3(obj_tptr + 17));
@@ -1489,7 +1489,7 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_TUNNEL_IPV6:
                 if (obj_tlen < 20)
                     goto obj_tooshort;
-                ND_PRINT("%s  Source Address: %s, LSP-ID: 0x%04x",
+                ND_PRINT(C_RESET, "%s  Source Address: %s, LSP-ID: 0x%04x",
                        indent,
                        GET_IPADDR_STRING(obj_tptr),
                        GET_BE_U_2(obj_tptr + 18));
@@ -1499,7 +1499,7 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_13: /* IPv6 p2mp LSP tunnel */
                 if (obj_tlen < 40)
                     goto obj_tooshort;
-                ND_PRINT("%s  IPv6 Tunnel Sender Address: %s, LSP ID: 0x%04x"
+                ND_PRINT(C_RESET, "%s  IPv6 Tunnel Sender Address: %s, LSP ID: 0x%04x"
                        "%s  Sub-Group Originator ID: %s, Sub-Group ID: 0x%04x",
                        indent,
                        GET_IP6ADDR_STRING(obj_tptr),
@@ -1513,7 +1513,7 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_TUNNEL_IPV4:
                 if (obj_tlen < 8)
                     goto obj_tooshort;
-                ND_PRINT("%s  Source Address: %s, LSP-ID: 0x%04x",
+                ND_PRINT(C_RESET, "%s  Source Address: %s, LSP-ID: 0x%04x",
                        indent,
                        GET_IPADDR_STRING(obj_tptr),
                        GET_BE_U_2(obj_tptr + 6));
@@ -1523,7 +1523,7 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_12: /* IPv4 p2mp LSP tunnel */
                 if (obj_tlen < 16)
                     goto obj_tooshort;
-                ND_PRINT("%s  IPv4 Tunnel Sender Address: %s, LSP ID: 0x%04x"
+                ND_PRINT(C_RESET, "%s  IPv4 Tunnel Sender Address: %s, LSP ID: 0x%04x"
                        "%s  Sub-Group Originator ID: %s, Sub-Group ID: 0x%04x",
                        indent,
                        GET_IPADDR_STRING(obj_tptr),
@@ -1548,13 +1548,13 @@ rsvp_obj_print(netdissect_options *ndo,
                 if (obj_tlen < sizeof(struct rsvp_obj_frr_t))
                     goto obj_tooshort;
                 bw.i = GET_BE_U_4(obj_ptr.rsvp_obj_frr->bandwidth);
-                ND_PRINT("%s  Setup Priority: %u, Holding Priority: %u, Hop-limit: %u, Bandwidth: %.10g Mbps",
+                ND_PRINT(C_RESET, "%s  Setup Priority: %u, Holding Priority: %u, Hop-limit: %u, Bandwidth: %.10g Mbps",
                        indent,
                        obj_ptr.rsvp_obj_frr->setup_prio,
                        obj_ptr.rsvp_obj_frr->hold_prio,
                        obj_ptr.rsvp_obj_frr->hop_limit,
                        bw.f * 8 / 1000000);
-                ND_PRINT("%s  Include-any: 0x%08x, Exclude-any: 0x%08x, Include-all: 0x%08x",
+                ND_PRINT(C_RESET, "%s  Include-any: 0x%08x, Exclude-any: 0x%08x, Include-all: 0x%08x",
                        indent,
                        GET_BE_U_4(obj_ptr.rsvp_obj_frr->include_any),
                        GET_BE_U_4(obj_ptr.rsvp_obj_frr->exclude_any),
@@ -1567,13 +1567,13 @@ rsvp_obj_print(netdissect_options *ndo,
                 if (obj_tlen < 16)
                     goto obj_tooshort;
                 bw.i = GET_BE_U_4(obj_ptr.rsvp_obj_frr->bandwidth);
-                ND_PRINT("%s  Setup Priority: %u, Holding Priority: %u, Hop-limit: %u, Bandwidth: %.10g Mbps",
+                ND_PRINT(C_RESET, "%s  Setup Priority: %u, Holding Priority: %u, Hop-limit: %u, Bandwidth: %.10g Mbps",
                        indent,
                        obj_ptr.rsvp_obj_frr->setup_prio,
                        obj_ptr.rsvp_obj_frr->hold_prio,
                        obj_ptr.rsvp_obj_frr->hop_limit,
                        bw.f * 8 / 1000000);
-                ND_PRINT("%s  Include Colors: 0x%08x, Exclude Colors: 0x%08x",
+                ND_PRINT(C_RESET, "%s  Include Colors: 0x%08x, Exclude Colors: 0x%08x",
                        indent,
                        GET_BE_U_4(obj_ptr.rsvp_obj_frr->include_any),
                        GET_BE_U_4(obj_ptr.rsvp_obj_frr->exclude_any));
@@ -1590,7 +1590,7 @@ rsvp_obj_print(netdissect_options *ndo,
             switch(rsvp_obj_ctype) {
             case RSVP_CTYPE_TUNNEL_IPV4:
                 while(obj_tlen >= 8) {
-                    ND_PRINT("%s  PLR-ID: %s, Avoid-Node-ID: %s",
+                    ND_PRINT(C_RESET, "%s  PLR-ID: %s, Avoid-Node-ID: %s",
                            indent,
                            GET_IPADDR_STRING(obj_tptr),
                            GET_IPADDR_STRING(obj_tptr + 4));
@@ -1609,7 +1609,7 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_1:
                 if (obj_tlen < 4)
                     goto obj_tooshort;
-                ND_PRINT("%s  CT: %u",
+                ND_PRINT(C_RESET, "%s  CT: %u",
                        indent,
                        GET_BE_U_4(obj_tptr) & 0x7);
                 obj_tlen-=4;
@@ -1628,7 +1628,7 @@ rsvp_obj_print(netdissect_options *ndo,
                     goto obj_tooshort;
                 error_code=GET_U_1(obj_tptr + 5);
                 error_value=GET_BE_U_2(obj_tptr + 6);
-                ND_PRINT("%s  Error Node Address: %s, Flags: [0x%02x]%s  Error Code: %s (%u)",
+                ND_PRINT(C_RESET, "%s  Error Node Address: %s, Flags: [0x%02x]%s  Error Code: %s (%u)",
                        indent,
                        GET_IPADDR_STRING(obj_tptr),
                        GET_U_1(obj_tptr + 4),
@@ -1637,18 +1637,18 @@ rsvp_obj_print(netdissect_options *ndo,
                        error_code);
                 switch (error_code) {
                 case RSVP_OBJ_ERROR_SPEC_CODE_ROUTING:
-                    ND_PRINT(", Error Value: %s (%u)",
+                    ND_PRINT(C_RESET, ", Error Value: %s (%u)",
                            tok2str(rsvp_obj_error_code_routing_values,"unknown",error_value),
                            error_value);
                     break;
                 case RSVP_OBJ_ERROR_SPEC_CODE_DIFFSERV_TE: /* fall through */
                 case RSVP_OBJ_ERROR_SPEC_CODE_DIFFSERV_TE_OLD:
-                    ND_PRINT(", Error Value: %s (%u)",
+                    ND_PRINT(C_RESET, ", Error Value: %s (%u)",
                            tok2str(rsvp_obj_error_code_diffserv_te_values,"unknown",error_value),
                            error_value);
                     break;
                 default:
-                    ND_PRINT(", Unknown Error Value (%u)", error_value);
+                    ND_PRINT(C_RESET, ", Unknown Error Value (%u)", error_value);
                     break;
                 }
                 obj_tlen-=8;
@@ -1660,7 +1660,7 @@ rsvp_obj_print(netdissect_options *ndo,
                     goto obj_tooshort;
                 error_code=GET_U_1(obj_tptr + 17);
                 error_value=GET_BE_U_2(obj_tptr + 18);
-                ND_PRINT("%s  Error Node Address: %s, Flags: [0x%02x]%s  Error Code: %s (%u)",
+                ND_PRINT(C_RESET, "%s  Error Node Address: %s, Flags: [0x%02x]%s  Error Code: %s (%u)",
                        indent,
                        GET_IP6ADDR_STRING(obj_tptr),
                        GET_U_1(obj_tptr + 16),
@@ -1670,7 +1670,7 @@ rsvp_obj_print(netdissect_options *ndo,
 
                 switch (error_code) {
                 case RSVP_OBJ_ERROR_SPEC_CODE_ROUTING:
-                    ND_PRINT(", Error Value: %s (%u)",
+                    ND_PRINT(C_RESET, ", Error Value: %s (%u)",
                            tok2str(rsvp_obj_error_code_routing_values,"unknown",error_value),
 			   error_value);
                     break;
@@ -1691,7 +1691,7 @@ rsvp_obj_print(netdissect_options *ndo,
                 if (obj_tlen < 4)
                     goto obj_tooshort;
                 padbytes = GET_BE_U_2(obj_tptr + 2);
-                ND_PRINT("%s  TLV count: %u, padding bytes: %u",
+                ND_PRINT(C_RESET, "%s  TLV count: %u, padding bytes: %u",
                        indent,
                        GET_BE_U_2(obj_tptr),
                        padbytes);
@@ -1699,7 +1699,7 @@ rsvp_obj_print(netdissect_options *ndo,
                 obj_tptr+=4;
                 /* loop through as long there is anything longer than the TLV header (2) */
                 while(obj_tlen >= 2 + padbytes) {
-                    ND_PRINT("%s    %s TLV (0x%02x), length: %u", /* length includes header */
+                    ND_PRINT(C_RESET, "%s    %s TLV (0x%02x), length: %u", /* length includes header */
                            indent,
                            tok2str(rsvp_obj_prop_tlv_values,"unknown",GET_U_1(obj_tptr)),
                            GET_U_1(obj_tptr),
@@ -1707,7 +1707,7 @@ rsvp_obj_print(netdissect_options *ndo,
                     if (obj_tlen < GET_U_1(obj_tptr + 1))
                         goto obj_tooshort;
                     if (GET_U_1(obj_tptr + 1) < 2) {
-                        ND_PRINT("%sERROR: property TLV is too short", indent);
+                        ND_PRINT(C_RESET, "%sERROR: property TLV is too short", indent);
                         return -1;
                     }
                     print_unknown_data(ndo, obj_tptr + 2, "\n\t\t",
@@ -1729,7 +1729,7 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_2:
                 if (obj_tlen < 4)
                     goto obj_tooshort;
-                ND_PRINT("%s  Flags [0x%02x], epoch: %u",
+                ND_PRINT(C_RESET, "%s  Flags [0x%02x], epoch: %u",
                        indent,
                        GET_U_1(obj_tptr),
                        GET_BE_U_3(obj_tptr + 1));
@@ -1737,7 +1737,7 @@ rsvp_obj_print(netdissect_options *ndo,
                 obj_tptr+=4;
                 /* loop through as long there are no messages left */
                 while(obj_tlen >= 4) {
-                    ND_PRINT("%s    Message-ID 0x%08x (%u)",
+                    ND_PRINT(C_RESET, "%s    Message-ID 0x%08x (%u)",
                            indent,
                            GET_BE_U_4(obj_tptr),
                            GET_BE_U_4(obj_tptr));
@@ -1756,7 +1756,7 @@ rsvp_obj_print(netdissect_options *ndo,
                 if (obj_tlen < sizeof(struct rsvp_obj_integrity_t))
                     goto obj_tooshort;
                 obj_ptr.rsvp_obj_integrity = (const struct rsvp_obj_integrity_t *)obj_tptr;
-                ND_PRINT("%s  Key-ID 0x%04x%08x, Sequence 0x%08x%08x, Flags [%s]",
+                ND_PRINT(C_RESET, "%s  Key-ID 0x%04x%08x, Sequence 0x%08x%08x, Flags [%s]",
                        indent,
                        GET_BE_U_2(obj_ptr.rsvp_obj_integrity->key_id),
                        GET_BE_U_4(obj_ptr.rsvp_obj_integrity->key_id + 2),
@@ -1765,7 +1765,7 @@ rsvp_obj_print(netdissect_options *ndo,
                        bittok2str(rsvp_obj_integrity_flag_values,
                                   "none",
                                   obj_ptr.rsvp_obj_integrity->flags));
-                ND_PRINT("%s  MD5-sum 0x%08x%08x%08x%08x ",
+                ND_PRINT(C_RESET, "%s  MD5-sum 0x%08x%08x%08x%08x ",
                        indent,
                        GET_BE_U_4(obj_ptr.rsvp_obj_integrity->digest),
                        GET_BE_U_4(obj_ptr.rsvp_obj_integrity->digest + 4),
@@ -1776,7 +1776,7 @@ rsvp_obj_print(netdissect_options *ndo,
                                             obj_ptr.rsvp_obj_integrity->digest,
                                             rsvp_clear_checksum,
                                             rsvp_com_header);
-                ND_PRINT(" (%s)", tok2str(signature_check_values, "Unknown", sigcheck));
+                ND_PRINT(C_RESET, " (%s)", tok2str(signature_check_values, "Unknown", sigcheck));
 
                 obj_tlen+=sizeof(struct rsvp_obj_integrity_t);
                 obj_tptr+=sizeof(struct rsvp_obj_integrity_t);
@@ -1791,7 +1791,7 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_1:
                 if (obj_tlen < 4)
                     goto obj_tooshort;
-                ND_PRINT("%s  Flags [%s]", indent,
+                ND_PRINT(C_RESET, "%s  Flags [%s]", indent,
                        bittok2str(rsvp_obj_admin_status_flag_values, "none",
                                   GET_BE_U_4(obj_tptr)));
                 obj_tlen-=4;
@@ -1809,7 +1809,7 @@ rsvp_obj_print(netdissect_options *ndo,
                     goto obj_tooshort;
                 action = (GET_BE_U_2(obj_tptr)>>8);
 
-                ND_PRINT("%s  Action: %s (%u), Label type: %u", indent,
+                ND_PRINT(C_RESET, "%s  Action: %s (%u), Label type: %u", indent,
                        tok2str(rsvp_obj_label_set_action_values, "Unknown", action),
                        action, (GET_BE_U_4(obj_tptr) & 0x7F));
 
@@ -1820,7 +1820,7 @@ rsvp_obj_print(netdissect_options *ndo,
 		    /* only a couple of subchannels are expected */
 		    if (obj_tlen < 12)
 			goto obj_tooshort;
-		    ND_PRINT("%s  Start range: %u, End range: %u", indent,
+		    ND_PRINT(C_RESET, "%s  Start range: %u, End range: %u", indent,
                            GET_BE_U_4(obj_tptr + 4),
                            GET_BE_U_4(obj_tptr + 8));
 		    obj_tlen-=12;
@@ -1832,7 +1832,7 @@ rsvp_obj_print(netdissect_options *ndo,
                     obj_tptr+=4;
                     subchannel = 1;
                     while(obj_tlen >= 4 ) {
-                        ND_PRINT("%s  Subchannel #%u: %u", indent, subchannel,
+                        ND_PRINT(C_RESET, "%s  Subchannel #%u: %u", indent, subchannel,
                                GET_BE_U_4(obj_tptr));
                         obj_tptr+=4;
                         obj_tlen-=4;
@@ -1851,7 +1851,7 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_IPV4:
                 if (obj_tlen < 4)
                     goto obj_tooshort;
-                ND_PRINT("%s  Sub-LSP destination address: %s",
+                ND_PRINT(C_RESET, "%s  Sub-LSP destination address: %s",
                        indent, GET_IPADDR_STRING(obj_tptr));
 
                 obj_tlen-=4;
@@ -1860,7 +1860,7 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_IPV6:
                 if (obj_tlen < 16)
                     goto obj_tooshort;
-                ND_PRINT("%s  Sub-LSP destination address: %s",
+                ND_PRINT(C_RESET, "%s  Sub-LSP destination address: %s",
                        indent, GET_IP6ADDR_STRING(obj_tptr));
 
                 obj_tlen-=16;
@@ -1895,10 +1895,10 @@ rsvp_obj_print(netdissect_options *ndo,
     }
     return 0;
 subobj_tooshort:
-    ND_PRINT("%sERROR: sub-object is too short", indent);
+    ND_PRINT(C_RESET, "%sERROR: sub-object is too short", indent);
     return -1;
 obj_tooshort:
-    ND_PRINT("%sERROR: object is too short", indent);
+    ND_PRINT(C_RESET, "%sERROR: object is too short", indent);
     return -1;
 invalid:
     nd_print_invalid(ndo);
@@ -1925,7 +1925,7 @@ rsvp_print(netdissect_options *ndo,
      * Sanity checking of the header.
      */
     if (RSVP_EXTRACT_VERSION(version_flags) != RSVP_VERSION) {
-	ND_PRINT("ERROR: RSVP version %u packet not supported",
+	ND_PRINT(C_RESET, "ERROR: RSVP version %u packet not supported",
                RSVP_EXTRACT_VERSION(version_flags));
 	return;
     }
@@ -1934,7 +1934,7 @@ rsvp_print(netdissect_options *ndo,
 
     /* in non-verbose mode just lets print the basic Message Type*/
     if (ndo->ndo_vflag < 1) {
-        ND_PRINT("RSVPv%u %s Message, length: %u",
+        ND_PRINT(C_RESET, "RSVPv%u %s Message, length: %u",
                RSVP_EXTRACT_VERSION(version_flags),
                tok2str(rsvp_msg_type_values, "unknown (%u)",msg_type),
                len);
@@ -1945,7 +1945,7 @@ rsvp_print(netdissect_options *ndo,
 
     plen = tlen = GET_BE_U_2(rsvp_com_header->length);
 
-    ND_PRINT("\n\tRSVPv%u %s Message (%u), Flags: [%s], length: %u, ttl: %u, checksum: 0x%04x",
+    ND_PRINT(C_RESET, "\n\tRSVPv%u %s Message (%u), Flags: [%s], length: %u, ttl: %u, checksum: 0x%04x",
            RSVP_EXTRACT_VERSION(version_flags),
            tok2str(rsvp_msg_type_values, "unknown, type: %u",msg_type),
            msg_type,
@@ -1955,7 +1955,7 @@ rsvp_print(netdissect_options *ndo,
            GET_BE_U_2(rsvp_com_header->checksum));
 
     if (tlen < sizeof(struct rsvp_common_header)) {
-        ND_PRINT("ERROR: common header too short %u < %zu", tlen,
+        ND_PRINT(C_RESET, "ERROR: common header too short %u < %zu", tlen,
                sizeof(struct rsvp_common_header));
         return;
     }
@@ -1985,7 +1985,7 @@ rsvp_print(netdissect_options *ndo,
              * Sanity checking of the header.
              */
             if (RSVP_EXTRACT_VERSION(version_flags) != RSVP_VERSION) {
-                ND_PRINT("ERROR: RSVP version %u packet not supported",
+                ND_PRINT(C_RESET, "ERROR: RSVP version %u packet not supported",
                        RSVP_EXTRACT_VERSION(version_flags));
                 return;
             }
@@ -1993,7 +1993,7 @@ rsvp_print(netdissect_options *ndo,
             subplen = subtlen = GET_BE_U_2(rsvp_com_header->length);
 
             msg_type = GET_U_1(rsvp_com_header->msg_type);
-            ND_PRINT("\n\t  RSVPv%u %s Message (%u), Flags: [%s], length: %u, ttl: %u, checksum: 0x%04x",
+            ND_PRINT(C_RESET, "\n\t  RSVPv%u %s Message (%u), Flags: [%s], length: %u, ttl: %u, checksum: 0x%04x",
                    RSVP_EXTRACT_VERSION(version_flags),
                    tok2str(rsvp_msg_type_values, "unknown, type: %u",msg_type),
                    msg_type,
@@ -2003,13 +2003,13 @@ rsvp_print(netdissect_options *ndo,
                    GET_BE_U_2(rsvp_com_header->checksum));
 
             if (subtlen < sizeof(struct rsvp_common_header)) {
-                ND_PRINT("ERROR: common header too short %u < %zu", subtlen,
+                ND_PRINT(C_RESET, "ERROR: common header too short %u < %zu", subtlen,
                        sizeof(struct rsvp_common_header));
                 return;
             }
 
             if (tlen < subtlen) {
-                ND_PRINT("ERROR: common header too large %u > %u", subtlen,
+                ND_PRINT(C_RESET, "ERROR: common header too large %u > %u", subtlen,
                        tlen);
                 return;
             }

--- a/print-rt6.c
+++ b/print-rt6.c
@@ -48,12 +48,12 @@ rt6_print(netdissect_options *ndo, const u_char *bp, const u_char *bp2 _U_)
 	dp = (const struct ip6_rthdr *)bp;
 
 	len = GET_U_1(dp->ip6r_len);
-	ND_PRINT(" (len=%u", len);	/*)*/
+	ND_PRINT(C_RESET, " (len=%u", len);	/*)*/
 	type = GET_U_1(dp->ip6r_type);
-	ND_PRINT(", type=%u", type);
+	ND_PRINT(C_RESET, ", type=%u", type);
 	if (type == IPV6_RTHDR_TYPE_0)
-		ND_PRINT(" [Deprecated]");
-	ND_PRINT(", segleft=%u", GET_U_1(dp->ip6r_segleft));
+		ND_PRINT(C_RESET, " [Deprecated]");
+	ND_PRINT(C_RESET, ", segleft=%u", GET_U_1(dp->ip6r_segleft));
 
 	switch (type) {
 	case IPV6_RTHDR_TYPE_0:
@@ -61,51 +61,51 @@ rt6_print(netdissect_options *ndo, const u_char *bp, const u_char *bp2 _U_)
 		dp0 = (const struct ip6_rthdr0 *)dp;
 
 		if (GET_BE_U_4(dp0->ip6r0_reserved) || ndo->ndo_vflag) {
-			ND_PRINT(", rsv=0x%0x",
+			ND_PRINT(C_RESET, ", rsv=0x%0x",
 			    GET_BE_U_4(dp0->ip6r0_reserved));
 		}
 
 		if (len % 2 == 1) {
-			ND_PRINT(" (invalid length %u)", len);
+			ND_PRINT(C_RESET, " (invalid length %u)", len);
 			goto invalid;
 		}
 		len >>= 1;
 		p = (const u_char *) dp0->ip6r0_addr;
 		for (i = 0; i < len; i++) {
-			ND_PRINT(", [%u]%s", i, GET_IP6ADDR_STRING(p));
+			ND_PRINT(C_RESET, ", [%u]%s", i, GET_IP6ADDR_STRING(p));
 			p += 16;
 		}
 		/*(*/
-		ND_PRINT(") ");
+		ND_PRINT(C_RESET, ") ");
 		return((GET_U_1(dp0->ip6r0_len) + 1) << 3);
 		break;
 	case IPV6_RTHDR_TYPE_4:
 		srh = (const struct ip6_srh *)dp;
-		ND_PRINT(", last-entry=%u", GET_U_1(srh->srh_last_ent));
+		ND_PRINT(C_RESET, ", last-entry=%u", GET_U_1(srh->srh_last_ent));
 
 		if (GET_U_1(srh->srh_flags) || ndo->ndo_vflag) {
-			ND_PRINT(", flags=0x%0x",
+			ND_PRINT(C_RESET, ", flags=0x%0x",
 				GET_U_1(srh->srh_flags));
 		}
 
-		ND_PRINT(", tag=%x", GET_BE_U_2(srh->srh_tag));
+		ND_PRINT(C_RESET, ", tag=%x", GET_BE_U_2(srh->srh_tag));
 
 		if (len % 2 == 1) {
-			ND_PRINT(" (invalid length %u)", len);
+			ND_PRINT(C_RESET, " (invalid length %u)", len);
 			goto invalid;
 		}
 		len >>= 1;
 		p  = (const u_char *) srh->srh_segments;
 		for (i = 0; i < len; i++) {
-			ND_PRINT(", [%u]%s", i, GET_IP6ADDR_STRING(p));
+			ND_PRINT(C_RESET, ", [%u]%s", i, GET_IP6ADDR_STRING(p));
 			p += 16;
 		}
 		/*(*/
-		ND_PRINT(") ");
+		ND_PRINT(C_RESET, ") ");
 		return((GET_U_1(srh->srh_len) + 1) << 3);
 		break;
 	default:
-		ND_PRINT(" (unknown type)");
+		ND_PRINT(C_RESET, " (unknown type)");
 		goto invalid;
 	}
 

--- a/print-rx.c
+++ b/print-rx.c
@@ -536,30 +536,30 @@ rx_print(netdissect_options *ndo,
 
 	ndo->ndo_protocol = "rx";
 	if (!ND_TTEST_LEN(bp, sizeof(struct rx_header))) {
-		ND_PRINT(" [|rx] (%u)", length);
+		ND_PRINT(C_RESET, " [|rx] (%u)", length);
 		return;
 	}
 
 	rxh = (const struct rx_header *) bp;
 
 	type = GET_U_1(rxh->type);
-	ND_PRINT(" rx %s", tok2str(rx_types, "type %u", type));
+	ND_PRINT(C_RESET, " rx %s", tok2str(rx_types, "type %u", type));
 
 	flags = GET_U_1(rxh->flags);
 	if (ndo->ndo_vflag) {
 		int firstflag = 0;
 
 		if (ndo->ndo_vflag > 1)
-			ND_PRINT(" cid %08x call# %u",
+			ND_PRINT(C_RESET, " cid %08x call# %u",
 			       GET_BE_U_4(rxh->cid),
 			       GET_BE_U_4(rxh->callNumber));
 
-		ND_PRINT(" seq %u ser %u",
+		ND_PRINT(C_RESET, " seq %u ser %u",
 		       GET_BE_U_4(rxh->seq),
 		       GET_BE_U_4(rxh->serial));
 
 		if (ndo->ndo_vflag > 2)
-			ND_PRINT(" secindex %u serviceid %hu",
+			ND_PRINT(C_RESET, " secindex %u serviceid %hu",
 				GET_U_1(rxh->securityIndex),
 				GET_BE_U_2(rxh->serviceId));
 
@@ -570,11 +570,11 @@ rx_print(netdissect_options *ndo,
 				     type == rx_flags[i].packetType)) {
 					if (!firstflag) {
 						firstflag = 1;
-						ND_PRINT(" ");
+						ND_PRINT(C_RESET, " ");
 					} else {
-						ND_PRINT(",");
+						ND_PRINT(C_RESET, ",");
 					}
-					ND_PRINT("<%s>", rx_flags[i].s);
+					ND_PRINT(C_RESET, "<%s>", rx_flags[i].s);
 				}
 			}
 	}
@@ -675,7 +675,7 @@ rx_print(netdissect_options *ndo,
 		rx_ack_print(ndo, bp, length);
 
 
-	ND_PRINT(" (%u)", length);
+	ND_PRINT(C_RESET, " (%u)", length);
 }
 
 /*
@@ -761,7 +761,7 @@ rx_cache_find(netdissect_options *ndo, const struct rx_header *rxh,
 			bp += sizeof(uint32_t); \
 			n3 = GET_BE_U_4(bp); \
 			bp += sizeof(uint32_t); \
-			ND_PRINT(" fid %u/%u/%u", n1, n2, n3); \
+			ND_PRINT(C_RESET, " fid %u/%u/%u", n1, n2, n3); \
 		}
 
 #define STROUT(MAX) { uint32_t _i; \
@@ -769,29 +769,29 @@ rx_cache_find(netdissect_options *ndo, const struct rx_header *rxh,
 			if (_i > (MAX)) \
 				goto trunc; \
 			bp += sizeof(uint32_t); \
-			ND_PRINT(" \""); \
+			ND_PRINT(C_RESET, " \""); \
 			if (nd_printn(ndo, bp, _i, ndo->ndo_snapend)) \
 				goto trunc; \
-			ND_PRINT("\""); \
+			ND_PRINT(C_RESET, "\""); \
 			bp += ((_i + sizeof(uint32_t) - 1) / sizeof(uint32_t)) * sizeof(uint32_t); \
 		}
 
 #define INTOUT() { int32_t _i; \
 			_i = GET_BE_S_4(bp); \
 			bp += sizeof(int32_t); \
-			ND_PRINT(" %d", _i); \
+			ND_PRINT(C_RESET, " %d", _i); \
 		}
 
 #define UINTOUT() { uint32_t _i; \
 			_i = GET_BE_U_4(bp); \
 			bp += sizeof(uint32_t); \
-			ND_PRINT(" %u", _i); \
+			ND_PRINT(C_RESET, " %u", _i); \
 		}
 
 #define UINT64OUT() { uint64_t _i; \
 			_i = GET_BE_U_8(bp); \
 			bp += sizeof(uint64_t); \
-			ND_PRINT(" %" PRIu64, _i); \
+			ND_PRINT(C_RESET, " %" PRIu64, _i); \
 		}
 
 #define DATEOUT() { time_t _t; struct tm *tm; char str[256]; \
@@ -799,25 +799,25 @@ rx_cache_find(netdissect_options *ndo, const struct rx_header *rxh,
 			bp += sizeof(int32_t); \
 			tm = localtime(&_t); \
 			strftime(str, 256, "%Y/%m/%d %H:%M:%S", tm); \
-			ND_PRINT(" %s", str); \
+			ND_PRINT(C_RESET, " %s", str); \
 		}
 
 #define STOREATTROUT() { uint32_t mask, _i; \
 			ND_TCHECK_LEN(bp, (sizeof(uint32_t) * 6)); \
 			mask = GET_BE_U_4(bp); bp += sizeof(uint32_t); \
-			if (mask) ND_PRINT(" StoreStatus"); \
-		        if (mask & 1) { ND_PRINT(" date"); DATEOUT(); } \
+			if (mask) ND_PRINT(C_RESET, " StoreStatus"); \
+		        if (mask & 1) { ND_PRINT(C_RESET, " date"); DATEOUT(); } \
 			else bp += sizeof(uint32_t); \
 			_i = GET_BE_U_4(bp); bp += sizeof(uint32_t); \
-		        if (mask & 2) ND_PRINT(" owner %u", _i);  \
+		        if (mask & 2) ND_PRINT(C_RESET, " owner %u", _i);  \
 			_i = GET_BE_U_4(bp); bp += sizeof(uint32_t); \
-		        if (mask & 4) ND_PRINT(" group %u", _i); \
+		        if (mask & 4) ND_PRINT(C_RESET, " group %u", _i); \
 			_i = GET_BE_U_4(bp); bp += sizeof(uint32_t); \
-		        if (mask & 8) ND_PRINT(" mode %o", _i & 07777); \
+		        if (mask & 8) ND_PRINT(C_RESET, " mode %o", _i & 07777); \
 			_i = GET_BE_U_4(bp); bp += sizeof(uint32_t); \
-		        if (mask & 16) ND_PRINT(" segsize %u", _i); \
+		        if (mask & 16) ND_PRINT(C_RESET, " segsize %u", _i); \
 			/* undocumented in 3.3 docu */ \
-		        if (mask & 1024) ND_PRINT(" fsync");  \
+		        if (mask & 1024) ND_PRINT(C_RESET, " fsync");  \
 		}
 
 #define UBIK_VERSIONOUT() {uint32_t epoch; uint32_t counter; \
@@ -826,24 +826,24 @@ rx_cache_find(netdissect_options *ndo, const struct rx_header *rxh,
 			bp += sizeof(uint32_t); \
 			counter = GET_BE_U_4(bp); \
 			bp += sizeof(uint32_t); \
-			ND_PRINT(" %u.%u", epoch, counter); \
+			ND_PRINT(C_RESET, " %u.%u", epoch, counter); \
 		}
 
 #define AFSUUIDOUT() {uint32_t temp; int _i; \
 			ND_TCHECK_LEN(bp, 11 * sizeof(uint32_t)); \
 			temp = GET_BE_U_4(bp); \
 			bp += sizeof(uint32_t); \
-			ND_PRINT(" %08x", temp); \
+			ND_PRINT(C_RESET, " %08x", temp); \
 			temp = GET_BE_U_4(bp); \
 			bp += sizeof(uint32_t); \
-			ND_PRINT("%04x", temp); \
+			ND_PRINT(C_RESET, "%04x", temp); \
 			temp = GET_BE_U_4(bp); \
 			bp += sizeof(uint32_t); \
-			ND_PRINT("%04x", temp); \
+			ND_PRINT(C_RESET, "%04x", temp); \
 			for (_i = 0; _i < 8; _i++) { \
 				temp = GET_BE_U_4(bp); \
 				bp += sizeof(uint32_t); \
-				ND_PRINT("%02x", (unsigned char) temp); \
+				ND_PRINT(C_RESET, "%02x", (unsigned char) temp); \
 			} \
 		}
 
@@ -862,9 +862,9 @@ rx_cache_find(netdissect_options *ndo, const struct rx_header *rxh,
 				bp += sizeof(uint32_t); \
 			} \
 			s[(MAX)] = '\0'; \
-			ND_PRINT(" \""); \
+			ND_PRINT(C_RESET, " \""); \
 			fn_print_str(ndo, s); \
-			ND_PRINT("\""); \
+			ND_PRINT(C_RESET, "\""); \
 		}
 
 #define DESTSERVEROUT() { uint32_t n1, n2, n3; \
@@ -875,7 +875,7 @@ rx_cache_find(netdissect_options *ndo, const struct rx_header *rxh,
 			bp += sizeof(uint32_t); \
 			n3 = GET_BE_U_4(bp); \
 			bp += sizeof(uint32_t); \
-			ND_PRINT(" server %u:%u:%u", n1, n2, n3); \
+			ND_PRINT(C_RESET, " server %u:%u:%u", n1, n2, n3); \
 		}
 
 /*
@@ -899,7 +899,7 @@ fs_print(netdissect_options *ndo,
 
 	fs_op = GET_BE_U_4(bp + sizeof(struct rx_header));
 
-	ND_PRINT(" fs call %s", tok2str(fs_req, "op#%u", fs_op));
+	ND_PRINT(C_RESET, " fs call %s", tok2str(fs_req, "op#%u", fs_op));
 
 	/*
 	 * Print out arguments to some of the AFS calls.  This stuff is
@@ -915,9 +915,9 @@ fs_print(netdissect_options *ndo,
 	switch (fs_op) {
 		case 130:	/* Fetch data */
 			FIDOUT();
-			ND_PRINT(" offset");
+			ND_PRINT(C_RESET, " offset");
 			UINTOUT();
-			ND_PRINT(" length");
+			ND_PRINT(C_RESET, " length");
 			UINTOUT();
 			break;
 		case 131:	/* Fetch ACL */
@@ -937,11 +937,11 @@ fs_print(netdissect_options *ndo,
 		case 133:	/* Store data */
 			FIDOUT();
 			STOREATTROUT();
-			ND_PRINT(" offset");
+			ND_PRINT(C_RESET, " offset");
 			UINTOUT();
-			ND_PRINT(" length");
+			ND_PRINT(C_RESET, " length");
 			UINTOUT();
-			ND_PRINT(" flen");
+			ND_PRINT(C_RESET, " flen");
 			UINTOUT();
 			break;
 		case 134:	/* Store ACL */
@@ -969,23 +969,23 @@ fs_print(netdissect_options *ndo,
 			STROUT(AFSNAMEMAX);
 			break;
 		case 138:	/* Rename file */
-			ND_PRINT(" old");
+			ND_PRINT(C_RESET, " old");
 			FIDOUT();
 			STROUT(AFSNAMEMAX);
-			ND_PRINT(" new");
+			ND_PRINT(C_RESET, " new");
 			FIDOUT();
 			STROUT(AFSNAMEMAX);
 			break;
 		case 139:	/* Symlink */
 			FIDOUT();
 			STROUT(AFSNAMEMAX);
-			ND_PRINT(" link to");
+			ND_PRINT(C_RESET, " link to");
 			STROUT(AFSNAMEMAX);
 			break;
 		case 140:	/* Link */
 			FIDOUT();
 			STROUT(AFSNAMEMAX);
-			ND_PRINT(" link to");
+			ND_PRINT(C_RESET, " link to");
 			FIDOUT();
 			break;
 		case 148:	/* Get volume info */
@@ -993,11 +993,11 @@ fs_print(netdissect_options *ndo,
 			break;
 		case 149:	/* Get volume stats */
 		case 150:	/* Set volume stats */
-			ND_PRINT(" volid");
+			ND_PRINT(C_RESET, " volid");
 			UINTOUT();
 			break;
 		case 154:	/* New get volume info */
-			ND_PRINT(" volname");
+			ND_PRINT(C_RESET, " volname");
 			STROUT(AFSNAMEMAX);
 			break;
 		case 155:	/* Bulk stat */
@@ -1010,31 +1010,31 @@ fs_print(netdissect_options *ndo,
 			for (i = 0; i < j; i++) {
 				FIDOUT();
 				if (i != j - 1)
-					ND_PRINT(",");
+					ND_PRINT(C_RESET, ",");
 			}
 			if (j == 0)
-				ND_PRINT(" <none!>");
+				ND_PRINT(C_RESET, " <none!>");
 			break;
 		}
 		case 65537:	/* Fetch data 64 */
 			FIDOUT();
-			ND_PRINT(" offset");
+			ND_PRINT(C_RESET, " offset");
 			UINT64OUT();
-			ND_PRINT(" length");
+			ND_PRINT(C_RESET, " length");
 			UINT64OUT();
 			break;
 		case 65538:	/* Store data 64 */
 			FIDOUT();
 			STOREATTROUT();
-			ND_PRINT(" offset");
+			ND_PRINT(C_RESET, " offset");
 			UINT64OUT();
-			ND_PRINT(" length");
+			ND_PRINT(C_RESET, " length");
 			UINT64OUT();
-			ND_PRINT(" flen");
+			ND_PRINT(C_RESET, " flen");
 			UINT64OUT();
 			break;
 		case 65541:    /* CallBack rx conn address */
-			ND_PRINT(" addr");
+			ND_PRINT(C_RESET, " addr");
 			UINTOUT();
 		default:
 			;
@@ -1043,7 +1043,7 @@ fs_print(netdissect_options *ndo,
 	return;
 
 trunc:
-	ND_PRINT(" [|fs]");
+	ND_PRINT(C_RESET, " [|fs]");
 }
 
 /*
@@ -1068,7 +1068,7 @@ fs_reply_print(netdissect_options *ndo,
 	 * gleaned from fsint/afsint.xg
 	 */
 
-	ND_PRINT(" fs reply %s", tok2str(fs_req, "op#%u", opcode));
+	ND_PRINT(C_RESET, " fs reply %s", tok2str(fs_req, "op#%u", opcode));
 
 	type = GET_U_1(rxh->type);
 	bp += sizeof(struct rx_header);
@@ -1093,11 +1093,11 @@ fs_reply_print(netdissect_options *ndo,
 		}
 		case 137:	/* Create file */
 		case 141:	/* MakeDir */
-			ND_PRINT(" new");
+			ND_PRINT(C_RESET, " new");
 			FIDOUT();
 			break;
 		case 151:	/* Get root volume */
-			ND_PRINT(" root volume");
+			ND_PRINT(C_RESET, " root volume");
 			STROUT(AFSNAMEMAX);
 			break;
 		case 153:	/* Get time */
@@ -1115,15 +1115,15 @@ fs_reply_print(netdissect_options *ndo,
 		errcode = GET_BE_S_4(bp);
 		bp += sizeof(int32_t);
 
-		ND_PRINT(" error %s", tok2str(afs_fs_errors, "#%d", errcode));
+		ND_PRINT(C_RESET, " error %s", tok2str(afs_fs_errors, "#%d", errcode));
 	} else {
-		ND_PRINT(" strange fs reply of type %u", type);
+		ND_PRINT(C_RESET, " strange fs reply of type %u", type);
 	}
 
 	return;
 
 trunc:
-	ND_PRINT(" [|fs]");
+	ND_PRINT(C_RESET, " [|fs]");
 }
 
 /*
@@ -1164,7 +1164,7 @@ acl_print(netdissect_options *ndo,
 	 */
 
 #define ACLOUT(acl) \
-	ND_PRINT("%s%s%s%s%s%s%s", \
+	ND_PRINT(C_RESET, "%s%s%s%s%s%s%s", \
 	          acl & PRSFS_READ       ? "r" : "", \
 	          acl & PRSFS_LOOKUP     ? "l" : "", \
 	          acl & PRSFS_INSERT     ? "i" : "", \
@@ -1177,11 +1177,11 @@ acl_print(netdissect_options *ndo,
 		if (sscanf((char *) s, "%" NUMSTRINGIFY(USERNAMEMAX) "s %d\n%n", user, &acl, &n) != 2)
 			return;
 		s += n;
-		ND_PRINT(" +{");
+		ND_PRINT(C_RESET, " +{");
 		fn_print_str(ndo, (u_char *)user);
-		ND_PRINT(" ");
+		ND_PRINT(C_RESET, " ");
 		ACLOUT(acl);
-		ND_PRINT("}");
+		ND_PRINT(C_RESET, "}");
 		if (s > end)
 			return;
 	}
@@ -1190,11 +1190,11 @@ acl_print(netdissect_options *ndo,
 		if (sscanf((char *) s, "%" NUMSTRINGIFY(USERNAMEMAX) "s %d\n%n", user, &acl, &n) != 2)
 			return;
 		s += n;
-		ND_PRINT(" -{");
+		ND_PRINT(C_RESET, " -{");
 		fn_print_str(ndo, (u_char *)user);
-		ND_PRINT(" ");
+		ND_PRINT(C_RESET, " ");
 		ACLOUT(acl);
-		ND_PRINT("}");
+		ND_PRINT(C_RESET, "}");
 		if (s > end)
 			return;
 	}
@@ -1223,7 +1223,7 @@ cb_print(netdissect_options *ndo,
 
 	cb_op = GET_BE_U_4(bp + sizeof(struct rx_header));
 
-	ND_PRINT(" cb call %s", tok2str(cb_req, "op#%u", cb_op));
+	ND_PRINT(C_RESET, " cb call %s", tok2str(cb_req, "op#%u", cb_op));
 
 	bp += sizeof(struct rx_header) + 4;
 
@@ -1242,22 +1242,22 @@ cb_print(netdissect_options *ndo,
 			for (i = 0; i < j; i++) {
 				FIDOUT();
 				if (i != j - 1)
-					ND_PRINT(",");
+					ND_PRINT(C_RESET, ",");
 			}
 
 			if (j == 0)
-				ND_PRINT(" <none!>");
+				ND_PRINT(C_RESET, " <none!>");
 
 			j = GET_BE_U_4(bp);
 			bp += sizeof(uint32_t);
 
 			if (j != 0)
-				ND_PRINT(";");
+				ND_PRINT(C_RESET, ";");
 
 			for (i = 0; i < j; i++) {
-				ND_PRINT(" ver");
+				ND_PRINT(C_RESET, " ver");
 				INTOUT();
-				ND_PRINT(" expires");
+				ND_PRINT(C_RESET, " expires");
 				DATEOUT();
 				t = GET_BE_U_4(bp);
 				bp += sizeof(uint32_t);
@@ -1266,7 +1266,7 @@ cb_print(netdissect_options *ndo,
 			break;
 		}
 		case 214: {
-			ND_PRINT(" afsuuid");
+			ND_PRINT(C_RESET, " afsuuid");
 			AFSUUIDOUT();
 			break;
 		}
@@ -1277,7 +1277,7 @@ cb_print(netdissect_options *ndo,
 	return;
 
 trunc:
-	ND_PRINT(" [|cb]");
+	ND_PRINT(C_RESET, " [|cb]");
 }
 
 /*
@@ -1301,7 +1301,7 @@ cb_reply_print(netdissect_options *ndo,
 	 * gleaned from fsint/afscbint.xg
 	 */
 
-	ND_PRINT(" cb reply %s", tok2str(cb_req, "op#%u", opcode));
+	ND_PRINT(C_RESET, " cb reply %s", tok2str(cb_req, "op#%u", opcode));
 
 	type = GET_U_1(rxh->type);
 	bp += sizeof(struct rx_header);
@@ -1322,14 +1322,14 @@ cb_reply_print(netdissect_options *ndo,
 		/*
 		 * Otherwise, just print out the return code
 		 */
-		ND_PRINT(" errcode");
+		ND_PRINT(C_RESET, " errcode");
 		INTOUT();
 	}
 
 	return;
 
 trunc:
-	ND_PRINT(" [|cb]");
+	ND_PRINT(C_RESET, " [|cb]");
 }
 
 /*
@@ -1353,14 +1353,14 @@ prot_print(netdissect_options *ndo,
 
 	pt_op = GET_BE_U_4(bp + sizeof(struct rx_header));
 
-	ND_PRINT(" pt");
+	ND_PRINT(C_RESET, " pt");
 
 	if (is_ubik(pt_op)) {
 		ubik_print(ndo, bp);
 		return;
 	}
 
-	ND_PRINT(" call %s", tok2str(pt_req, "op#%u", pt_op));
+	ND_PRINT(C_RESET, " call %s", tok2str(pt_req, "op#%u", pt_op));
 
 	/*
 	 * Decode some of the arguments to the PT calls
@@ -1371,9 +1371,9 @@ prot_print(netdissect_options *ndo,
 	switch (pt_op) {
 		case 500:	/* I New User */
 			STROUT(PRNAMEMAX);
-			ND_PRINT(" id");
+			ND_PRINT(C_RESET, " id");
 			INTOUT();
-			ND_PRINT(" oldid");
+			ND_PRINT(C_RESET, " oldid");
 			INTOUT();
 			break;
 		case 501:	/* Where is it */
@@ -1385,19 +1385,19 @@ prot_print(netdissect_options *ndo,
 		case 518:	/* Get CPS2 */
 		case 519:	/* Get host CPS */
 		case 530:	/* List super groups */
-			ND_PRINT(" id");
+			ND_PRINT(C_RESET, " id");
 			INTOUT();
 			break;
 		case 502:	/* Dump entry */
-			ND_PRINT(" pos");
+			ND_PRINT(C_RESET, " pos");
 			INTOUT();
 			break;
 		case 503:	/* Add to group */
 		case 507:	/* Remove from group */
 		case 515:	/* Is a member of? */
-			ND_PRINT(" uid");
+			ND_PRINT(C_RESET, " uid");
 			INTOUT();
-			ND_PRINT(" gid");
+			ND_PRINT(C_RESET, " gid");
 			INTOUT();
 			break;
 		case 504:	/* Name to ID */
@@ -1417,45 +1417,45 @@ prot_print(netdissect_options *ndo,
 				VECOUT(PRNAMEMAX);
 			}
 			if (j == 0)
-				ND_PRINT(" <none!>");
+				ND_PRINT(C_RESET, " <none!>");
 		}
 			break;
 		case 505:	/* Id to name */
 		{
 			uint32_t j;
-			ND_PRINT(" ids:");
+			ND_PRINT(C_RESET, " ids:");
 			i = GET_BE_U_4(bp);
 			bp += sizeof(uint32_t);
 			for (j = 0; j < i; j++)
 				INTOUT();
 			if (j == 0)
-				ND_PRINT(" <none!>");
+				ND_PRINT(C_RESET, " <none!>");
 		}
 			break;
 		case 509:	/* New entry */
 			STROUT(PRNAMEMAX);
-			ND_PRINT(" flag");
+			ND_PRINT(C_RESET, " flag");
 			INTOUT();
-			ND_PRINT(" oid");
+			ND_PRINT(C_RESET, " oid");
 			INTOUT();
 			break;
 		case 511:	/* Set max */
-			ND_PRINT(" id");
+			ND_PRINT(C_RESET, " id");
 			INTOUT();
-			ND_PRINT(" gflag");
+			ND_PRINT(C_RESET, " gflag");
 			INTOUT();
 			break;
 		case 513:	/* Change entry */
-			ND_PRINT(" id");
+			ND_PRINT(C_RESET, " id");
 			INTOUT();
 			STROUT(PRNAMEMAX);
-			ND_PRINT(" oldid");
+			ND_PRINT(C_RESET, " oldid");
 			INTOUT();
-			ND_PRINT(" newid");
+			ND_PRINT(C_RESET, " newid");
 			INTOUT();
 			break;
 		case 520:	/* Update entry */
-			ND_PRINT(" id");
+			ND_PRINT(C_RESET, " id");
 			INTOUT();
 			STROUT(PRNAMEMAX);
 			break;
@@ -1467,7 +1467,7 @@ prot_print(netdissect_options *ndo,
 	return;
 
 trunc:
-	ND_PRINT(" [|pt]");
+	ND_PRINT(C_RESET, " [|pt]");
 }
 
 /*
@@ -1493,14 +1493,14 @@ prot_reply_print(netdissect_options *ndo,
 	 * Ubik call, however.
 	 */
 
-	ND_PRINT(" pt");
+	ND_PRINT(C_RESET, " pt");
 
 	if (is_ubik(opcode)) {
 		ubik_reply_print(ndo, bp, length, opcode);
 		return;
 	}
 
-	ND_PRINT(" reply %s", tok2str(pt_req, "op#%u", opcode));
+	ND_PRINT(C_RESET, " reply %s", tok2str(pt_req, "op#%u", opcode));
 
 	type = GET_U_1(rxh->type);
 	bp += sizeof(struct rx_header);
@@ -1514,13 +1514,13 @@ prot_reply_print(netdissect_options *ndo,
 		case 504:		/* Name to ID */
 		{
 			uint32_t j;
-			ND_PRINT(" ids:");
+			ND_PRINT(C_RESET, " ids:");
 			i = GET_BE_U_4(bp);
 			bp += sizeof(uint32_t);
 			for (j = 0; j < i; j++)
 				INTOUT();
 			if (j == 0)
-				ND_PRINT(" <none!>");
+				ND_PRINT(C_RESET, " <none!>");
 		}
 			break;
 		case 505:		/* ID to name */
@@ -1540,7 +1540,7 @@ prot_reply_print(netdissect_options *ndo,
 				VECOUT(PRNAMEMAX);
 			}
 			if (j == 0)
-				ND_PRINT(" <none!>");
+				ND_PRINT(C_RESET, " <none!>");
 		}
 			break;
 		case 508:		/* Get CPS */
@@ -1556,13 +1556,13 @@ prot_reply_print(netdissect_options *ndo,
 				INTOUT();
 			}
 			if (j == 0)
-				ND_PRINT(" <none!>");
+				ND_PRINT(C_RESET, " <none!>");
 		}
 			break;
 		case 510:		/* List max */
-			ND_PRINT(" maxuid");
+			ND_PRINT(C_RESET, " maxuid");
 			INTOUT();
-			ND_PRINT(" maxgid");
+			ND_PRINT(C_RESET, " maxgid");
 			INTOUT();
 			break;
 		default:
@@ -1572,14 +1572,14 @@ prot_reply_print(netdissect_options *ndo,
 		/*
 		 * Otherwise, just print out the return code
 		 */
-		ND_PRINT(" errcode");
+		ND_PRINT(C_RESET, " errcode");
 		INTOUT();
 	}
 
 	return;
 
 trunc:
-	ND_PRINT(" [|pt]");
+	ND_PRINT(C_RESET, " [|pt]");
 }
 
 /*
@@ -1603,13 +1603,13 @@ vldb_print(netdissect_options *ndo,
 
 	vldb_op = GET_BE_U_4(bp + sizeof(struct rx_header));
 
-	ND_PRINT(" vldb");
+	ND_PRINT(C_RESET, " vldb");
 
 	if (is_ubik(vldb_op)) {
 		ubik_print(ndo, bp);
 		return;
 	}
-	ND_PRINT(" call %s", tok2str(vldb_req, "op#%u", vldb_op));
+	ND_PRINT(C_RESET, " call %s", tok2str(vldb_req, "op#%u", vldb_op));
 
 	/*
 	 * Decode some of the arguments to the VLDB calls
@@ -1628,12 +1628,12 @@ vldb_print(netdissect_options *ndo,
 		case 508:	/* Set lock */
 		case 509:	/* Release lock */
 		case 518:	/* Get entry by ID N */
-			ND_PRINT(" volid");
+			ND_PRINT(C_RESET, " volid");
 			INTOUT();
 			i = GET_BE_U_4(bp);
 			bp += sizeof(uint32_t);
 			if (i <= 2)
-				ND_PRINT(" type %s", voltype[i]);
+				ND_PRINT(C_RESET, " type %s", voltype[i]);
 			break;
 		case 504:	/* Get entry by name */
 		case 519:	/* Get entry by name N */
@@ -1642,22 +1642,22 @@ vldb_print(netdissect_options *ndo,
 			STROUT(VLNAMEMAX);
 			break;
 		case 505:	/* Get new vol id */
-			ND_PRINT(" bump");
+			ND_PRINT(C_RESET, " bump");
 			INTOUT();
 			break;
 		case 506:	/* Replace entry */
 		case 520:	/* Replace entry N */
-			ND_PRINT(" volid");
+			ND_PRINT(C_RESET, " volid");
 			INTOUT();
 			i = GET_BE_U_4(bp);
 			bp += sizeof(uint32_t);
 			if (i <= 2)
-				ND_PRINT(" type %s", voltype[i]);
+				ND_PRINT(C_RESET, " type %s", voltype[i]);
 			VECOUT(VLNAMEMAX);
 			break;
 		case 510:	/* List entry */
 		case 521:	/* List entry N */
-			ND_PRINT(" index");
+			ND_PRINT(C_RESET, " index");
 			INTOUT();
 			break;
 		default:
@@ -1667,7 +1667,7 @@ vldb_print(netdissect_options *ndo,
 	return;
 
 trunc:
-	ND_PRINT(" [|vldb]");
+	ND_PRINT(C_RESET, " [|vldb]");
 }
 
 /*
@@ -1693,14 +1693,14 @@ vldb_reply_print(netdissect_options *ndo,
 	 * Ubik call, however.
 	 */
 
-	ND_PRINT(" vldb");
+	ND_PRINT(C_RESET, " vldb");
 
 	if (is_ubik(opcode)) {
 		ubik_reply_print(ndo, bp, length, opcode);
 		return;
 	}
 
-	ND_PRINT(" reply %s", tok2str(vldb_req, "op#%u", opcode));
+	ND_PRINT(C_RESET, " reply %s", tok2str(vldb_req, "op#%u", opcode));
 
 	type = GET_U_1(rxh->type);
 	bp += sizeof(struct rx_header);
@@ -1712,9 +1712,9 @@ vldb_reply_print(netdissect_options *ndo,
 	if (type == RX_PACKET_TYPE_DATA)
 		switch (opcode) {
 		case 510:	/* List entry */
-			ND_PRINT(" count");
+			ND_PRINT(C_RESET, " count");
 			INTOUT();
-			ND_PRINT(" nextindex");
+			ND_PRINT(C_RESET, " nextindex");
 			INTOUT();
 			ND_FALL_THROUGH;
 		case 503:	/* Get entry by id */
@@ -1723,80 +1723,80 @@ vldb_reply_print(netdissect_options *ndo,
 			VECOUT(VLNAMEMAX);
 			ND_TCHECK_4(bp);
 			bp += sizeof(uint32_t);
-			ND_PRINT(" numservers");
+			ND_PRINT(C_RESET, " numservers");
 			nservers = GET_BE_U_4(bp);
 			bp += sizeof(uint32_t);
-			ND_PRINT(" %u", nservers);
-			ND_PRINT(" servers");
+			ND_PRINT(C_RESET, " %u", nservers);
+			ND_PRINT(C_RESET, " servers");
 			for (i = 0; i < 8; i++) {
 				ND_TCHECK_4(bp);
 				if (i < nservers)
-					ND_PRINT(" %s",
+					ND_PRINT(C_RESET, " %s",
 					   intoa(GET_IPV4_TO_NETWORK_ORDER(bp)));
 				bp += sizeof(nd_ipv4);
 			}
-			ND_PRINT(" partitions");
+			ND_PRINT(C_RESET, " partitions");
 			for (i = 0; i < 8; i++) {
 				j = GET_BE_U_4(bp);
 				if (i < nservers && j <= 26)
-					ND_PRINT(" %c", 'a' + j);
+					ND_PRINT(C_RESET, " %c", 'a' + j);
 				else if (i < nservers)
-					ND_PRINT(" %u", j);
+					ND_PRINT(C_RESET, " %u", j);
 				bp += sizeof(uint32_t);
 			}
 			ND_TCHECK_LEN(bp, 8 * sizeof(uint32_t));
 			bp += 8 * sizeof(uint32_t);
-			ND_PRINT(" rwvol");
+			ND_PRINT(C_RESET, " rwvol");
 			UINTOUT();
-			ND_PRINT(" rovol");
+			ND_PRINT(C_RESET, " rovol");
 			UINTOUT();
-			ND_PRINT(" backup");
+			ND_PRINT(C_RESET, " backup");
 			UINTOUT();
 		}
 			break;
 		case 505:	/* Get new volume ID */
-			ND_PRINT(" newvol");
+			ND_PRINT(C_RESET, " newvol");
 			UINTOUT();
 			break;
 		case 521:	/* List entry */
 		case 529:	/* List entry U */
-			ND_PRINT(" count");
+			ND_PRINT(C_RESET, " count");
 			INTOUT();
-			ND_PRINT(" nextindex");
+			ND_PRINT(C_RESET, " nextindex");
 			INTOUT();
 			ND_FALL_THROUGH;
 		case 518:	/* Get entry by ID N */
 		case 519:	/* Get entry by name N */
 		{	uint32_t nservers, j;
 			VECOUT(VLNAMEMAX);
-			ND_PRINT(" numservers");
+			ND_PRINT(C_RESET, " numservers");
 			nservers = GET_BE_U_4(bp);
 			bp += sizeof(uint32_t);
-			ND_PRINT(" %u", nservers);
-			ND_PRINT(" servers");
+			ND_PRINT(C_RESET, " %u", nservers);
+			ND_PRINT(C_RESET, " servers");
 			for (i = 0; i < 13; i++) {
 				ND_TCHECK_4(bp);
 				if (i < nservers)
-					ND_PRINT(" %s",
+					ND_PRINT(C_RESET, " %s",
 					   intoa(GET_IPV4_TO_NETWORK_ORDER(bp)));
 				bp += sizeof(nd_ipv4);
 			}
-			ND_PRINT(" partitions");
+			ND_PRINT(C_RESET, " partitions");
 			for (i = 0; i < 13; i++) {
 				j = GET_BE_U_4(bp);
 				if (i < nservers && j <= 26)
-					ND_PRINT(" %c", 'a' + j);
+					ND_PRINT(C_RESET, " %c", 'a' + j);
 				else if (i < nservers)
-					ND_PRINT(" %u", j);
+					ND_PRINT(C_RESET, " %u", j);
 				bp += sizeof(uint32_t);
 			}
 			ND_TCHECK_LEN(bp, 13 * sizeof(uint32_t));
 			bp += 13 * sizeof(uint32_t);
-			ND_PRINT(" rwvol");
+			ND_PRINT(C_RESET, " rwvol");
 			UINTOUT();
-			ND_PRINT(" rovol");
+			ND_PRINT(C_RESET, " rovol");
 			UINTOUT();
-			ND_PRINT(" backup");
+			ND_PRINT(C_RESET, " backup");
 			UINTOUT();
 		}
 			break;
@@ -1804,14 +1804,14 @@ vldb_reply_print(netdissect_options *ndo,
 		case 527:	/* Get entry by name U */
 		{	uint32_t nservers, j;
 			VECOUT(VLNAMEMAX);
-			ND_PRINT(" numservers");
+			ND_PRINT(C_RESET, " numservers");
 			nservers = GET_BE_U_4(bp);
 			bp += sizeof(uint32_t);
-			ND_PRINT(" %u", nservers);
-			ND_PRINT(" servers");
+			ND_PRINT(C_RESET, " %u", nservers);
+			ND_PRINT(C_RESET, " servers");
 			for (i = 0; i < 13; i++) {
 				if (i < nservers) {
-					ND_PRINT(" afsuuid");
+					ND_PRINT(C_RESET, " afsuuid");
 					AFSUUIDOUT();
 				} else {
 					ND_TCHECK_LEN(bp, 44);
@@ -1820,22 +1820,22 @@ vldb_reply_print(netdissect_options *ndo,
 			}
 			ND_TCHECK_LEN(bp, 4 * 13);
 			bp += 4 * 13;
-			ND_PRINT(" partitions");
+			ND_PRINT(C_RESET, " partitions");
 			for (i = 0; i < 13; i++) {
 				j = GET_BE_U_4(bp);
 				if (i < nservers && j <= 26)
-					ND_PRINT(" %c", 'a' + j);
+					ND_PRINT(C_RESET, " %c", 'a' + j);
 				else if (i < nservers)
-					ND_PRINT(" %u", j);
+					ND_PRINT(C_RESET, " %u", j);
 				bp += sizeof(uint32_t);
 			}
 			ND_TCHECK_LEN(bp, 13 * sizeof(uint32_t));
 			bp += 13 * sizeof(uint32_t);
-			ND_PRINT(" rwvol");
+			ND_PRINT(C_RESET, " rwvol");
 			UINTOUT();
-			ND_PRINT(" rovol");
+			ND_PRINT(C_RESET, " rovol");
 			UINTOUT();
-			ND_PRINT(" backup");
+			ND_PRINT(C_RESET, " backup");
 			UINTOUT();
 		}
 		default:
@@ -1846,14 +1846,14 @@ vldb_reply_print(netdissect_options *ndo,
 		/*
 		 * Otherwise, just print out the return code
 		 */
-		ND_PRINT(" errcode");
+		ND_PRINT(C_RESET, " errcode");
 		INTOUT();
 	}
 
 	return;
 
 trunc:
-	ND_PRINT(" [|vldb]");
+	ND_PRINT(C_RESET, " [|vldb]");
 }
 
 /*
@@ -1876,7 +1876,7 @@ kauth_print(netdissect_options *ndo,
 
 	kauth_op = GET_BE_U_4(bp + sizeof(struct rx_header));
 
-	ND_PRINT(" kauth");
+	ND_PRINT(C_RESET, " kauth");
 
 	if (is_ubik(kauth_op)) {
 		ubik_print(ndo, bp);
@@ -1884,7 +1884,7 @@ kauth_print(netdissect_options *ndo,
 	}
 
 
-	ND_PRINT(" call %s", tok2str(kauth_req, "op#%u", kauth_op));
+	ND_PRINT(C_RESET, " call %s", tok2str(kauth_req, "op#%u", kauth_op));
 
 	/*
 	 * Decode some of the arguments to the KA calls
@@ -1903,7 +1903,7 @@ kauth_print(netdissect_options *ndo,
 		case 8:		/* Get entry */
 		case 14:	/* Unlock */
 		case 15:	/* Lock status */
-			ND_PRINT(" principal");
+			ND_PRINT(C_RESET, " principal");
 			STROUT(KANAMEMAX);
 			STROUT(KANAMEMAX);
 			break;
@@ -1911,28 +1911,28 @@ kauth_print(netdissect_options *ndo,
 		case 23:	/* GetTicket */
 		{
 			uint32_t i;
-			ND_PRINT(" kvno");
+			ND_PRINT(C_RESET, " kvno");
 			INTOUT();
-			ND_PRINT(" domain");
+			ND_PRINT(C_RESET, " domain");
 			STROUT(KANAMEMAX);
 			i = GET_BE_U_4(bp);
 			bp += sizeof(uint32_t);
 			ND_TCHECK_LEN(bp, i);
 			bp += i;
-			ND_PRINT(" principal");
+			ND_PRINT(C_RESET, " principal");
 			STROUT(KANAMEMAX);
 			STROUT(KANAMEMAX);
 			break;
 		}
 		case 4:		/* Set Password */
-			ND_PRINT(" principal");
+			ND_PRINT(C_RESET, " principal");
 			STROUT(KANAMEMAX);
 			STROUT(KANAMEMAX);
-			ND_PRINT(" kvno");
+			ND_PRINT(C_RESET, " kvno");
 			INTOUT();
 			break;
 		case 12:	/* Get password */
-			ND_PRINT(" name");
+			ND_PRINT(C_RESET, " name");
 			STROUT(KANAMEMAX);
 			break;
 		default:
@@ -1942,7 +1942,7 @@ kauth_print(netdissect_options *ndo,
 	return;
 
 trunc:
-	ND_PRINT(" [|kauth]");
+	ND_PRINT(C_RESET, " [|kauth]");
 }
 
 /*
@@ -1966,14 +1966,14 @@ kauth_reply_print(netdissect_options *ndo,
 	 * gleaned from kauth/kauth.rg
 	 */
 
-	ND_PRINT(" kauth");
+	ND_PRINT(C_RESET, " kauth");
 
 	if (is_ubik(opcode)) {
 		ubik_reply_print(ndo, bp, length, opcode);
 		return;
 	}
 
-	ND_PRINT(" reply %s", tok2str(kauth_req, "op#%u", opcode));
+	ND_PRINT(C_RESET, " reply %s", tok2str(kauth_req, "op#%u", opcode));
 
 	type = GET_U_1(rxh->type);
 	bp += sizeof(struct rx_header);
@@ -1989,7 +1989,7 @@ kauth_reply_print(netdissect_options *ndo,
 		/*
 		 * Otherwise, just print out the return code
 		 */
-		ND_PRINT(" errcode");
+		ND_PRINT(C_RESET, " errcode");
 		INTOUT();
 	}
 }
@@ -2014,126 +2014,126 @@ vol_print(netdissect_options *ndo,
 
 	vol_op = GET_BE_U_4(bp + sizeof(struct rx_header));
 
-	ND_PRINT(" vol call %s", tok2str(vol_req, "op#%u", vol_op));
+	ND_PRINT(C_RESET, " vol call %s", tok2str(vol_req, "op#%u", vol_op));
 
 	bp += sizeof(struct rx_header) + 4;
 
 	switch (vol_op) {
 		case 100:	/* Create volume */
-			ND_PRINT(" partition");
+			ND_PRINT(C_RESET, " partition");
 			UINTOUT();
-			ND_PRINT(" name");
+			ND_PRINT(C_RESET, " name");
 			STROUT(AFSNAMEMAX);
-			ND_PRINT(" type");
+			ND_PRINT(C_RESET, " type");
 			UINTOUT();
-			ND_PRINT(" parent");
+			ND_PRINT(C_RESET, " parent");
 			UINTOUT();
 			break;
 		case 101:	/* Delete volume */
 		case 107:	/* Get flags */
-			ND_PRINT(" trans");
+			ND_PRINT(C_RESET, " trans");
 			UINTOUT();
 			break;
 		case 102:	/* Restore */
-			ND_PRINT(" totrans");
+			ND_PRINT(C_RESET, " totrans");
 			UINTOUT();
-			ND_PRINT(" flags");
+			ND_PRINT(C_RESET, " flags");
 			UINTOUT();
 			break;
 		case 103:	/* Forward */
-			ND_PRINT(" fromtrans");
+			ND_PRINT(C_RESET, " fromtrans");
 			UINTOUT();
-			ND_PRINT(" fromdate");
+			ND_PRINT(C_RESET, " fromdate");
 			DATEOUT();
 			DESTSERVEROUT();
-			ND_PRINT(" desttrans");
+			ND_PRINT(C_RESET, " desttrans");
 			INTOUT();
 			break;
 		case 104:	/* End trans */
-			ND_PRINT(" trans");
+			ND_PRINT(C_RESET, " trans");
 			UINTOUT();
 			break;
 		case 105:	/* Clone */
-			ND_PRINT(" trans");
+			ND_PRINT(C_RESET, " trans");
 			UINTOUT();
-			ND_PRINT(" purgevol");
+			ND_PRINT(C_RESET, " purgevol");
 			UINTOUT();
-			ND_PRINT(" newtype");
+			ND_PRINT(C_RESET, " newtype");
 			UINTOUT();
-			ND_PRINT(" newname");
+			ND_PRINT(C_RESET, " newname");
 			STROUT(AFSNAMEMAX);
 			break;
 		case 106:	/* Set flags */
-			ND_PRINT(" trans");
+			ND_PRINT(C_RESET, " trans");
 			UINTOUT();
-			ND_PRINT(" flags");
+			ND_PRINT(C_RESET, " flags");
 			UINTOUT();
 			break;
 		case 108:	/* Trans create */
-			ND_PRINT(" vol");
+			ND_PRINT(C_RESET, " vol");
 			UINTOUT();
-			ND_PRINT(" partition");
+			ND_PRINT(C_RESET, " partition");
 			UINTOUT();
-			ND_PRINT(" flags");
+			ND_PRINT(C_RESET, " flags");
 			UINTOUT();
 			break;
 		case 109:	/* Dump */
 		case 655537:	/* Get size */
-			ND_PRINT(" fromtrans");
+			ND_PRINT(C_RESET, " fromtrans");
 			UINTOUT();
-			ND_PRINT(" fromdate");
+			ND_PRINT(C_RESET, " fromdate");
 			DATEOUT();
 			break;
 		case 110:	/* Get n-th volume */
-			ND_PRINT(" index");
+			ND_PRINT(C_RESET, " index");
 			UINTOUT();
 			break;
 		case 111:	/* Set forwarding */
-			ND_PRINT(" tid");
+			ND_PRINT(C_RESET, " tid");
 			UINTOUT();
-			ND_PRINT(" newsite");
+			ND_PRINT(C_RESET, " newsite");
 			UINTOUT();
 			break;
 		case 112:	/* Get name */
 		case 113:	/* Get status */
-			ND_PRINT(" tid");
+			ND_PRINT(C_RESET, " tid");
 			break;
 		case 114:	/* Signal restore */
-			ND_PRINT(" name");
+			ND_PRINT(C_RESET, " name");
 			STROUT(AFSNAMEMAX);
-			ND_PRINT(" type");
+			ND_PRINT(C_RESET, " type");
 			UINTOUT();
-			ND_PRINT(" pid");
+			ND_PRINT(C_RESET, " pid");
 			UINTOUT();
-			ND_PRINT(" cloneid");
+			ND_PRINT(C_RESET, " cloneid");
 			UINTOUT();
 			break;
 		case 116:	/* List volumes */
-			ND_PRINT(" partition");
+			ND_PRINT(C_RESET, " partition");
 			UINTOUT();
-			ND_PRINT(" flags");
+			ND_PRINT(C_RESET, " flags");
 			UINTOUT();
 			break;
 		case 117:	/* Set id types */
-			ND_PRINT(" tid");
+			ND_PRINT(C_RESET, " tid");
 			UINTOUT();
-			ND_PRINT(" name");
+			ND_PRINT(C_RESET, " name");
 			STROUT(AFSNAMEMAX);
-			ND_PRINT(" type");
+			ND_PRINT(C_RESET, " type");
 			UINTOUT();
-			ND_PRINT(" pid");
+			ND_PRINT(C_RESET, " pid");
 			UINTOUT();
-			ND_PRINT(" clone");
+			ND_PRINT(C_RESET, " clone");
 			UINTOUT();
-			ND_PRINT(" backup");
+			ND_PRINT(C_RESET, " backup");
 			UINTOUT();
 			break;
 		case 119:	/* Partition info */
-			ND_PRINT(" name");
+			ND_PRINT(C_RESET, " name");
 			STROUT(AFSNAMEMAX);
 			break;
 		case 120:	/* Reclone */
-			ND_PRINT(" tid");
+			ND_PRINT(C_RESET, " tid");
 			UINTOUT();
 			break;
 		case 121:	/* List one volume */
@@ -2141,25 +2141,25 @@ vol_print(netdissect_options *ndo,
 		case 124:	/* Extended List volumes */
 		case 125:	/* Extended List one volume */
 		case 65536:	/* Convert RO to RW volume */
-			ND_PRINT(" partid");
+			ND_PRINT(C_RESET, " partid");
 			UINTOUT();
-			ND_PRINT(" volid");
+			ND_PRINT(C_RESET, " volid");
 			UINTOUT();
 			break;
 		case 123:	/* Set date */
-			ND_PRINT(" tid");
+			ND_PRINT(C_RESET, " tid");
 			UINTOUT();
-			ND_PRINT(" date");
+			ND_PRINT(C_RESET, " date");
 			DATEOUT();
 			break;
 		case 126:	/* Set info */
-			ND_PRINT(" tid");
+			ND_PRINT(C_RESET, " tid");
 			UINTOUT();
 			break;
 		case 128:	/* Forward multiple */
-			ND_PRINT(" fromtrans");
+			ND_PRINT(C_RESET, " fromtrans");
 			UINTOUT();
-			ND_PRINT(" fromdate");
+			ND_PRINT(C_RESET, " fromdate");
 			DATEOUT();
 			{
 				uint32_t i, j;
@@ -2168,18 +2168,18 @@ vol_print(netdissect_options *ndo,
 				for (i = 0; i < j; i++) {
 					DESTSERVEROUT();
 					if (i != j - 1)
-						ND_PRINT(",");
+						ND_PRINT(C_RESET, ",");
 				}
 				if (j == 0)
-					ND_PRINT(" <none!>");
+					ND_PRINT(C_RESET, " <none!>");
 			}
 			break;
 		case 65538:	/* Dump version 2 */
-			ND_PRINT(" fromtrans");
+			ND_PRINT(C_RESET, " fromtrans");
 			UINTOUT();
-			ND_PRINT(" fromdate");
+			ND_PRINT(C_RESET, " fromdate");
 			DATEOUT();
-			ND_PRINT(" flags");
+			ND_PRINT(C_RESET, " flags");
 			UINTOUT();
 			break;
 		default:
@@ -2188,7 +2188,7 @@ vol_print(netdissect_options *ndo,
 	return;
 
 trunc:
-	ND_PRINT(" [|vol]");
+	ND_PRINT(C_RESET, " [|vol]");
 }
 
 /*
@@ -2212,7 +2212,7 @@ vol_reply_print(netdissect_options *ndo,
 	 * gleaned from volser/volint.xg
 	 */
 
-	ND_PRINT(" vol reply %s", tok2str(vol_req, "op#%u", opcode));
+	ND_PRINT(C_RESET, " vol reply %s", tok2str(vol_req, "op#%u", opcode));
 
 	type = GET_U_1(rxh->type);
 	bp += sizeof(struct rx_header);
@@ -2224,66 +2224,66 @@ vol_reply_print(netdissect_options *ndo,
 	if (type == RX_PACKET_TYPE_DATA) {
 		switch (opcode) {
 			case 100:	/* Create volume */
-				ND_PRINT(" volid");
+				ND_PRINT(C_RESET, " volid");
 				UINTOUT();
-				ND_PRINT(" trans");
+				ND_PRINT(C_RESET, " trans");
 				UINTOUT();
 				break;
 			case 104:	/* End transaction */
 				UINTOUT();
 				break;
 			case 105:	/* Clone */
-				ND_PRINT(" newvol");
+				ND_PRINT(C_RESET, " newvol");
 				UINTOUT();
 				break;
 			case 107:	/* Get flags */
 				UINTOUT();
 				break;
 			case 108:	/* Transaction create */
-				ND_PRINT(" trans");
+				ND_PRINT(C_RESET, " trans");
 				UINTOUT();
 				break;
 			case 110:	/* Get n-th volume */
-				ND_PRINT(" volume");
+				ND_PRINT(C_RESET, " volume");
 				UINTOUT();
-				ND_PRINT(" partition");
+				ND_PRINT(C_RESET, " partition");
 				UINTOUT();
 				break;
 			case 112:	/* Get name */
 				STROUT(AFSNAMEMAX);
 				break;
 			case 113:	/* Get status */
-				ND_PRINT(" volid");
+				ND_PRINT(C_RESET, " volid");
 				UINTOUT();
-				ND_PRINT(" nextuniq");
+				ND_PRINT(C_RESET, " nextuniq");
 				UINTOUT();
-				ND_PRINT(" type");
+				ND_PRINT(C_RESET, " type");
 				UINTOUT();
-				ND_PRINT(" parentid");
+				ND_PRINT(C_RESET, " parentid");
 				UINTOUT();
-				ND_PRINT(" clone");
+				ND_PRINT(C_RESET, " clone");
 				UINTOUT();
-				ND_PRINT(" backup");
+				ND_PRINT(C_RESET, " backup");
 				UINTOUT();
-				ND_PRINT(" restore");
+				ND_PRINT(C_RESET, " restore");
 				UINTOUT();
-				ND_PRINT(" maxquota");
+				ND_PRINT(C_RESET, " maxquota");
 				UINTOUT();
-				ND_PRINT(" minquota");
+				ND_PRINT(C_RESET, " minquota");
 				UINTOUT();
-				ND_PRINT(" owner");
+				ND_PRINT(C_RESET, " owner");
 				UINTOUT();
-				ND_PRINT(" create");
+				ND_PRINT(C_RESET, " create");
 				DATEOUT();
-				ND_PRINT(" access");
+				ND_PRINT(C_RESET, " access");
 				DATEOUT();
-				ND_PRINT(" update");
+				ND_PRINT(C_RESET, " update");
 				DATEOUT();
-				ND_PRINT(" expire");
+				ND_PRINT(C_RESET, " expire");
 				DATEOUT();
-				ND_PRINT(" backup");
+				ND_PRINT(C_RESET, " backup");
 				DATEOUT();
-				ND_PRINT(" copy");
+				ND_PRINT(C_RESET, " copy");
 				DATEOUT();
 				break;
 			case 115:	/* Old list partitions */
@@ -2295,17 +2295,17 @@ vol_reply_print(netdissect_options *ndo,
 					j = GET_BE_U_4(bp);
 					bp += sizeof(uint32_t);
 					for (i = 0; i < j; i++) {
-						ND_PRINT(" name");
+						ND_PRINT(C_RESET, " name");
 						VECOUT(32);
-						ND_PRINT(" volid");
+						ND_PRINT(C_RESET, " volid");
 						UINTOUT();
-						ND_PRINT(" type");
+						ND_PRINT(C_RESET, " type");
 						bp += sizeof(uint32_t) * 21;
 						if (i != j - 1)
-							ND_PRINT(",");
+							ND_PRINT(C_RESET, ",");
 					}
 					if (j == 0)
-						ND_PRINT(" <none!>");
+						ND_PRINT(C_RESET, " <none!>");
 				}
 				break;
 
@@ -2317,14 +2317,14 @@ vol_reply_print(netdissect_options *ndo,
 		/*
 		 * Otherwise, just print out the return code
 		 */
-		ND_PRINT(" errcode");
+		ND_PRINT(C_RESET, " errcode");
 		INTOUT();
 	}
 
 	return;
 
 trunc:
-	ND_PRINT(" [|vol]");
+	ND_PRINT(C_RESET, " [|vol]");
 }
 
 /*
@@ -2347,7 +2347,7 @@ bos_print(netdissect_options *ndo,
 
 	bos_op = GET_BE_U_4(bp + sizeof(struct rx_header));
 
-	ND_PRINT(" bos call %s", tok2str(bos_req, "op#%u", bos_op));
+	ND_PRINT(C_RESET, " bos call %s", tok2str(bos_req, "op#%u", bos_op));
 
 	/*
 	 * Decode some of the arguments to the BOS calls
@@ -2357,9 +2357,9 @@ bos_print(netdissect_options *ndo,
 
 	switch (bos_op) {
 		case 80:	/* Create B node */
-			ND_PRINT(" type");
+			ND_PRINT(C_RESET, " type");
 			STROUT(BOSNAMEMAX);
-			ND_PRINT(" instance");
+			ND_PRINT(C_RESET, " instance");
 			STROUT(BOSNAMEMAX);
 			break;
 		case 81:	/* Delete B node */
@@ -2380,12 +2380,12 @@ bos_print(netdissect_options *ndo,
 		case 82:	/* Set status */
 		case 98:	/* Set T status */
 			STROUT(BOSNAMEMAX);
-			ND_PRINT(" status");
+			ND_PRINT(C_RESET, " status");
 			INTOUT();
 			break;
 		case 86:	/* Get instance parm */
 			STROUT(BOSNAMEMAX);
-			ND_PRINT(" num");
+			ND_PRINT(C_RESET, " num");
 			INTOUT();
 			break;
 		case 84:	/* Enumerate instance */
@@ -2398,11 +2398,11 @@ bos_print(netdissect_options *ndo,
 			break;
 		case 105:	/* Install */
 			STROUT(BOSNAMEMAX);
-			ND_PRINT(" size");
+			ND_PRINT(C_RESET, " size");
 			INTOUT();
-			ND_PRINT(" flags");
+			ND_PRINT(C_RESET, " flags");
 			INTOUT();
-			ND_PRINT(" date");
+			ND_PRINT(C_RESET, " date");
 			INTOUT();
 			break;
 		default:
@@ -2412,7 +2412,7 @@ bos_print(netdissect_options *ndo,
 	return;
 
 trunc:
-	ND_PRINT(" [|bos]");
+	ND_PRINT(C_RESET, " [|bos]");
 }
 
 /*
@@ -2436,7 +2436,7 @@ bos_reply_print(netdissect_options *ndo,
 	 * gleaned from volser/volint.xg
 	 */
 
-	ND_PRINT(" bos reply %s", tok2str(bos_req, "op#%u", opcode));
+	ND_PRINT(C_RESET, " bos reply %s", tok2str(bos_req, "op#%u", opcode));
 
 	type = GET_U_1(rxh->type);
 	bp += sizeof(struct rx_header);
@@ -2452,7 +2452,7 @@ bos_reply_print(netdissect_options *ndo,
 		/*
 		 * Otherwise, just print out the return code
 		 */
-		ND_PRINT(" errcode");
+		ND_PRINT(C_RESET, " errcode");
 		INTOUT();
 	}
 }
@@ -2493,7 +2493,7 @@ ubik_print(netdissect_options *ndo,
 	 */
 	ubik_op = GET_BE_U_4(bp + sizeof(struct rx_header));
 
-	ND_PRINT(" ubik call %s", tok2str(ubik_req, "op#%u", ubik_op));
+	ND_PRINT(C_RESET, " ubik call %s", tok2str(ubik_req, "op#%u", ubik_op));
 
 	/*
 	 * Decode some of the arguments to the Ubik calls
@@ -2505,16 +2505,16 @@ ubik_print(netdissect_options *ndo,
 		case 10000:		/* Beacon */
 			temp = GET_BE_U_4(bp);
 			bp += sizeof(uint32_t);
-			ND_PRINT(" syncsite %s", temp ? "yes" : "no");
-			ND_PRINT(" votestart");
+			ND_PRINT(C_RESET, " syncsite %s", temp ? "yes" : "no");
+			ND_PRINT(C_RESET, " votestart");
 			DATEOUT();
-			ND_PRINT(" dbversion");
+			ND_PRINT(C_RESET, " dbversion");
 			UBIK_VERSIONOUT();
-			ND_PRINT(" tid");
+			ND_PRINT(C_RESET, " tid");
 			UBIK_VERSIONOUT();
 			break;
 		case 10003:		/* Get sync site */
-			ND_PRINT(" site");
+			ND_PRINT(C_RESET, " site");
 			UINTOUT();
 			break;
 		case 20000:		/* Begin */
@@ -2522,56 +2522,56 @@ ubik_print(netdissect_options *ndo,
 		case 20007:		/* Abort */
 		case 20008:		/* Release locks */
 		case 20010:		/* Writev */
-			ND_PRINT(" tid");
+			ND_PRINT(C_RESET, " tid");
 			UBIK_VERSIONOUT();
 			break;
 		case 20002:		/* Lock */
-			ND_PRINT(" tid");
+			ND_PRINT(C_RESET, " tid");
 			UBIK_VERSIONOUT();
-			ND_PRINT(" file");
+			ND_PRINT(C_RESET, " file");
 			INTOUT();
-			ND_PRINT(" pos");
+			ND_PRINT(C_RESET, " pos");
 			INTOUT();
-			ND_PRINT(" length");
+			ND_PRINT(C_RESET, " length");
 			INTOUT();
 			temp = GET_BE_U_4(bp);
 			bp += sizeof(uint32_t);
 			tok2str(ubik_lock_types, "type %u", temp);
 			break;
 		case 20003:		/* Write */
-			ND_PRINT(" tid");
+			ND_PRINT(C_RESET, " tid");
 			UBIK_VERSIONOUT();
-			ND_PRINT(" file");
+			ND_PRINT(C_RESET, " file");
 			INTOUT();
-			ND_PRINT(" pos");
+			ND_PRINT(C_RESET, " pos");
 			INTOUT();
 			break;
 		case 20005:		/* Get file */
-			ND_PRINT(" file");
+			ND_PRINT(C_RESET, " file");
 			INTOUT();
 			break;
 		case 20006:		/* Send file */
-			ND_PRINT(" file");
+			ND_PRINT(C_RESET, " file");
 			INTOUT();
-			ND_PRINT(" length");
+			ND_PRINT(C_RESET, " length");
 			INTOUT();
-			ND_PRINT(" dbversion");
+			ND_PRINT(C_RESET, " dbversion");
 			UBIK_VERSIONOUT();
 			break;
 		case 20009:		/* Truncate */
-			ND_PRINT(" tid");
+			ND_PRINT(C_RESET, " tid");
 			UBIK_VERSIONOUT();
-			ND_PRINT(" file");
+			ND_PRINT(C_RESET, " file");
 			INTOUT();
-			ND_PRINT(" length");
+			ND_PRINT(C_RESET, " length");
 			INTOUT();
 			break;
 		case 20012:		/* Set version */
-			ND_PRINT(" tid");
+			ND_PRINT(C_RESET, " tid");
 			UBIK_VERSIONOUT();
-			ND_PRINT(" oldversion");
+			ND_PRINT(C_RESET, " oldversion");
 			UBIK_VERSIONOUT();
-			ND_PRINT(" newversion");
+			ND_PRINT(C_RESET, " newversion");
 			UBIK_VERSIONOUT();
 			break;
 		default:
@@ -2581,7 +2581,7 @@ ubik_print(netdissect_options *ndo,
 	return;
 
 trunc:
-	ND_PRINT(" [|ubik]");
+	ND_PRINT(C_RESET, " [|ubik]");
 }
 
 /*
@@ -2605,7 +2605,7 @@ ubik_reply_print(netdissect_options *ndo,
 	 * from ubik/ubik_int.xg
 	 */
 
-	ND_PRINT(" ubik reply %s", tok2str(ubik_req, "op#%u", opcode));
+	ND_PRINT(C_RESET, " ubik reply %s", tok2str(ubik_req, "op#%u", opcode));
 
 	type = GET_U_1(rxh->type);
 	bp += sizeof(struct rx_header);
@@ -2617,10 +2617,10 @@ ubik_reply_print(netdissect_options *ndo,
 	if (type == RX_PACKET_TYPE_DATA)
 		switch (opcode) {
 		case 10000:		/* Beacon */
-			ND_PRINT(" vote no");
+			ND_PRINT(C_RESET, " vote no");
 			break;
 		case 20004:		/* Get version */
-			ND_PRINT(" dbversion");
+			ND_PRINT(C_RESET, " dbversion");
 			UBIK_VERSIONOUT();
 			break;
 		default:
@@ -2636,18 +2636,18 @@ ubik_reply_print(netdissect_options *ndo,
 	else
 		switch (opcode) {
 		case 10000:		/* Beacon */
-			ND_PRINT(" vote yes until");
+			ND_PRINT(C_RESET, " vote yes until");
 			DATEOUT();
 			break;
 		default:
-			ND_PRINT(" errcode");
+			ND_PRINT(C_RESET, " errcode");
 			INTOUT();
 		}
 
 	return;
 
 trunc:
-	ND_PRINT(" [|ubik]");
+	ND_PRINT(C_RESET, " [|ubik]");
 }
 
 /*
@@ -2678,12 +2678,12 @@ rx_ack_print(netdissect_options *ndo,
 	 */
 
 	if (ndo->ndo_vflag > 2)
-		ND_PRINT(" bufspace %u maxskew %u",
+		ND_PRINT(C_RESET, " bufspace %u maxskew %u",
 		       GET_BE_U_2(rxa->bufferSpace),
 		       GET_BE_U_2(rxa->maxSkew));
 
 	firstPacket = GET_BE_U_4(rxa->firstPacket);
-	ND_PRINT(" first %u serial %u reason %s",
+	ND_PRINT(C_RESET, " first %u serial %u reason %s",
 	       firstPacket, GET_BE_U_4(rxa->serial),
 	       tok2str(rx_ack_reasons, "#%u", GET_U_1(rxa->reason)));
 
@@ -2727,7 +2727,7 @@ rx_ack_print(netdissect_options *ndo,
 				 */
 
 				if (last == -2) {
-					ND_PRINT(" acked %u", firstPacket + i);
+					ND_PRINT(C_RESET, " acked %u", firstPacket + i);
 					start = i;
 				}
 
@@ -2741,7 +2741,7 @@ rx_ack_print(netdissect_options *ndo,
 				 */
 
 				else if (last != i - 1) {
-					ND_PRINT(",%u", firstPacket + i);
+					ND_PRINT(C_RESET, ",%u", firstPacket + i);
 					start = i;
 				}
 
@@ -2767,7 +2767,7 @@ rx_ack_print(netdissect_options *ndo,
 				 * range.
 				 */
 			} else if (last == i - 1 && start != last)
-				ND_PRINT("-%u", firstPacket + i - 1);
+				ND_PRINT(C_RESET, "-%u", firstPacket + i - 1);
 
 		/*
 		 * So, what's going on here?  We ran off the end of the
@@ -2781,7 +2781,7 @@ rx_ack_print(netdissect_options *ndo,
 		 */
 
 		if (last == i - 1 && start != last)
-			ND_PRINT("-%u", firstPacket + i - 1);
+			ND_PRINT(C_RESET, "-%u", firstPacket + i - 1);
 
 		/*
 		 * Same as above, just without comments
@@ -2790,18 +2790,18 @@ rx_ack_print(netdissect_options *ndo,
 		for (i = 0, start = last = -2; i < nAcks; i++)
 			if (GET_U_1(bp + i) == RX_ACK_TYPE_NACK) {
 				if (last == -2) {
-					ND_PRINT(" nacked %u", firstPacket + i);
+					ND_PRINT(C_RESET, " nacked %u", firstPacket + i);
 					start = i;
 				} else if (last != i - 1) {
-					ND_PRINT(",%u", firstPacket + i);
+					ND_PRINT(C_RESET, ",%u", firstPacket + i);
 					start = i;
 				}
 				last = i;
 			} else if (last == i - 1 && start != last)
-				ND_PRINT("-%u", firstPacket + i - 1);
+				ND_PRINT(C_RESET, "-%u", firstPacket + i - 1);
 
 		if (last == i - 1 && start != last)
-			ND_PRINT("-%u", firstPacket + i - 1);
+			ND_PRINT(C_RESET, "-%u", firstPacket + i - 1);
 
 		bp += nAcks;
 	}
@@ -2818,25 +2818,25 @@ rx_ack_print(netdissect_options *ndo,
 
 	if (ndo->ndo_vflag > 1) {
 		TRUNCRET(4);
-		ND_PRINT(" ifmtu");
+		ND_PRINT(C_RESET, " ifmtu");
 		UINTOUT();
 
 		TRUNCRET(4);
-		ND_PRINT(" maxmtu");
+		ND_PRINT(C_RESET, " maxmtu");
 		UINTOUT();
 
 		TRUNCRET(4);
-		ND_PRINT(" rwind");
+		ND_PRINT(C_RESET, " rwind");
 		UINTOUT();
 
 		TRUNCRET(4);
-		ND_PRINT(" maxpackets");
+		ND_PRINT(C_RESET, " maxpackets");
 		UINTOUT();
 	}
 
 	return;
 
 trunc:
-	ND_PRINT(" [|ack]");
+	ND_PRINT(C_RESET, " [|ack]");
 }
 #undef TRUNCRET

--- a/print-sctp.c
+++ b/print-sctp.c
@@ -481,13 +481,13 @@ sctp_print(netdissect_options *ndo,
     ip6 = NULL;
 
   if (ip6) {
-    ND_PRINT("%s.%u > %s.%u: sctp",
+    ND_PRINT(C_RESET, "%s.%u > %s.%u: sctp",
       GET_IP6ADDR_STRING(ip6->ip6_src),
       sourcePort,
       GET_IP6ADDR_STRING(ip6->ip6_dst),
       destPort);
   } else {
-    ND_PRINT("%s.%u > %s.%u: sctp",
+    ND_PRINT(C_RESET, "%s.%u > %s.%u: sctp",
       GET_IPADDR_STRING(ip->ip_src),
       sourcePort,
       GET_IPADDR_STRING(ip->ip_dst),
@@ -495,11 +495,11 @@ sctp_print(netdissect_options *ndo,
   }
 
   if (isForCES_port(sourcePort)) {
-	 ND_PRINT("[%s]", tok2str(ForCES_channels, NULL, sourcePort));
+	 ND_PRINT(C_RESET, "[%s]", tok2str(ForCES_channels, NULL, sourcePort));
 	 isforces = 1;
   }
   if (isForCES_port(destPort)) {
-	 ND_PRINT("[%s]", tok2str(ForCES_channels, NULL, destPort));
+	 ND_PRINT(C_RESET, "[%s]", tok2str(ForCES_channels, NULL, destPort));
 	 isforces = 1;
   }
 
@@ -520,13 +520,13 @@ sctp_print(netdissect_options *ndo,
 
       chunkDescPtr = (const struct sctpChunkDesc *)bp;
       if (sctpPacketLengthRemaining < sizeof(*chunkDescPtr)) {
-	ND_PRINT("%s%u) [chunk descriptor cut off at end of packet]", sep, chunkCount+1);
+	ND_PRINT(C_RESET, "%s%u) [chunk descriptor cut off at end of packet]", sep, chunkCount+1);
 	break;
       }
       ND_TCHECK_SIZE(chunkDescPtr);
       chunkLength = GET_BE_U_2(chunkDescPtr->chunkLength);
       if (chunkLength < sizeof(*chunkDescPtr)) {
-	ND_PRINT("%s%u) [Bad chunk length %u, < size of chunk descriptor]", sep, chunkCount+1, chunkLength);
+	ND_PRINT(C_RESET, "%s%u) [Bad chunk length %u, < size of chunk descriptor]", sep, chunkCount+1, chunkLength);
 	break;
       }
       chunkLengthRemaining = chunkLength;
@@ -536,7 +536,7 @@ sctp_print(netdissect_options *ndo,
 	align = 4 - align;
 
       if (sctpPacketLengthRemaining < align) {
-	ND_PRINT("%s%u) [Bad chunk length %u, > remaining data in packet]", sep, chunkCount+1, chunkLength);
+	ND_PRINT(C_RESET, "%s%u) [Bad chunk length %u, > remaining data in packet]", sep, chunkCount+1, chunkLength);
 	break;
       }
 
@@ -546,9 +546,9 @@ sctp_print(netdissect_options *ndo,
       sctpPacketLengthRemaining -= sizeof(*chunkDescPtr);
       chunkLengthRemaining -= sizeof(*chunkDescPtr);
 
-      ND_PRINT("%s%u) ", sep, chunkCount+1);
+      ND_PRINT(C_RESET, "%s%u) ", sep, chunkCount+1);
       chunkID = GET_U_1(chunkDescPtr->chunkID);
-      ND_PRINT("[%s] ", tok2str(sctp_chunkid_str, "Unknown chunk type: 0x%x",
+      ND_PRINT(C_RESET, "[%s] ", tok2str(sctp_chunkid_str, "Unknown chunk type: 0x%x",
 	       chunkID));
       switch (chunkID)
 	{
@@ -561,28 +561,28 @@ sctp_print(netdissect_options *ndo,
 
 	    chunkFlg = GET_U_1(chunkDescPtr->chunkFlg);
 	    if ((chunkFlg & SCTP_DATA_UNORDERED) == SCTP_DATA_UNORDERED)
-	      ND_PRINT("(U)");
+	      ND_PRINT(C_RESET, "(U)");
 
 	    if ((chunkFlg & SCTP_DATA_FIRST_FRAG) == SCTP_DATA_FIRST_FRAG)
-	      ND_PRINT("(B)");
+	      ND_PRINT(C_RESET, "(B)");
 
 	    if ((chunkFlg & SCTP_DATA_LAST_FRAG) == SCTP_DATA_LAST_FRAG)
-	      ND_PRINT("(E)");
+	      ND_PRINT(C_RESET, "(E)");
 
 	    if( ((chunkFlg & SCTP_DATA_UNORDERED) == SCTP_DATA_UNORDERED) ||
 		((chunkFlg & SCTP_DATA_FIRST_FRAG) == SCTP_DATA_FIRST_FRAG) ||
 		((chunkFlg & SCTP_DATA_LAST_FRAG) == SCTP_DATA_LAST_FRAG) )
-	      ND_PRINT(" ");
+	      ND_PRINT(C_RESET, " ");
 
 	    ND_ICHECKMSG_ZU("chunk length", chunkLengthRemaining, <,
 			    sizeof(*dataHdrPtr));
 	    dataHdrPtr=(const struct sctpDataPart*)bp;
 
 	    ppid = GET_BE_U_4(dataHdrPtr->payloadtype);
-	    ND_PRINT("[TSN: %u] ", GET_BE_U_4(dataHdrPtr->TSN));
-	    ND_PRINT("[SID: %u] ", GET_BE_U_2(dataHdrPtr->streamId));
-	    ND_PRINT("[SSEQ %u] ", GET_BE_U_2(dataHdrPtr->sequence));
-	    ND_PRINT("[PPID %s] ",
+	    ND_PRINT(C_RESET, "[TSN: %u] ", GET_BE_U_4(dataHdrPtr->TSN));
+	    ND_PRINT(C_RESET, "[SID: %u] ", GET_BE_U_2(dataHdrPtr->streamId));
+	    ND_PRINT(C_RESET, "[SSEQ %u] ", GET_BE_U_2(dataHdrPtr->sequence));
+	    ND_PRINT(C_RESET, "[PPID %s] ",
 		    tok2str(PayloadProto_idents, "0x%x", ppid));
 
 	    if (!isforces) {
@@ -610,12 +610,12 @@ sctp_print(netdissect_options *ndo,
 			ndo->ndo_protocol = "sctp";
 			break;
 		default:
-			ND_PRINT("[Payload");
+			ND_PRINT(C_RESET, "[Payload");
 			if (!ndo->ndo_suppress_default_print) {
-				ND_PRINT(":");
+				ND_PRINT(C_RESET, ":");
 				ND_DEFAULTPRINT(bp, payload_size);
 			}
-			ND_PRINT("]");
+			ND_PRINT(C_RESET, "]");
 			break;
 		}
 	    }
@@ -631,18 +631,18 @@ sctp_print(netdissect_options *ndo,
 	    ND_ICHECKMSG_ZU("chunk length", chunkLengthRemaining, <,
 			    sizeof(*init));
 	    init=(const struct sctpInitiation*)bp;
-	    ND_PRINT("[init tag: %u] ", GET_BE_U_4(init->initTag));
-	    ND_PRINT("[rwnd: %u] ", GET_BE_U_4(init->rcvWindowCredit));
-	    ND_PRINT("[OS: %u] ", GET_BE_U_2(init->NumPreopenStreams));
-	    ND_PRINT("[MIS: %u] ", GET_BE_U_2(init->MaxInboundStreams));
-	    ND_PRINT("[init TSN: %u] ", GET_BE_U_4(init->initialTSN));
+	    ND_PRINT(C_RESET, "[init tag: %u] ", GET_BE_U_4(init->initTag));
+	    ND_PRINT(C_RESET, "[rwnd: %u] ", GET_BE_U_4(init->rcvWindowCredit));
+	    ND_PRINT(C_RESET, "[OS: %u] ", GET_BE_U_2(init->NumPreopenStreams));
+	    ND_PRINT(C_RESET, "[MIS: %u] ", GET_BE_U_2(init->MaxInboundStreams));
+	    ND_PRINT(C_RESET, "[init TSN: %u] ", GET_BE_U_4(init->initialTSN));
 	    bp += sizeof(*init);
 	    sctpPacketLengthRemaining -= sizeof(*init);
 	    chunkLengthRemaining -= sizeof(*init);
 
 #if 0 /* ALC you can add code for optional params here */
 	    if( chunkLengthRemaining != 0 )
-	      ND_PRINT(" @@@@@ UNFINISHED @@@@@@%s\n",
+	      ND_PRINT(C_RESET, " @@@@@ UNFINISHED @@@@@@%s\n",
 		     "Optional params present, but not printed.");
 #endif
 	    bp += chunkLengthRemaining;
@@ -657,18 +657,18 @@ sctp_print(netdissect_options *ndo,
 	    ND_ICHECKMSG_ZU("chunk length", chunkLengthRemaining, <,
 			    sizeof(*init));
 	    init=(const struct sctpInitiation*)bp;
-	    ND_PRINT("[init tag: %u] ", GET_BE_U_4(init->initTag));
-	    ND_PRINT("[rwnd: %u] ", GET_BE_U_4(init->rcvWindowCredit));
-	    ND_PRINT("[OS: %u] ", GET_BE_U_2(init->NumPreopenStreams));
-	    ND_PRINT("[MIS: %u] ", GET_BE_U_2(init->MaxInboundStreams));
-	    ND_PRINT("[init TSN: %u] ", GET_BE_U_4(init->initialTSN));
+	    ND_PRINT(C_RESET, "[init tag: %u] ", GET_BE_U_4(init->initTag));
+	    ND_PRINT(C_RESET, "[rwnd: %u] ", GET_BE_U_4(init->rcvWindowCredit));
+	    ND_PRINT(C_RESET, "[OS: %u] ", GET_BE_U_2(init->NumPreopenStreams));
+	    ND_PRINT(C_RESET, "[MIS: %u] ", GET_BE_U_2(init->MaxInboundStreams));
+	    ND_PRINT(C_RESET, "[init TSN: %u] ", GET_BE_U_4(init->initialTSN));
 	    bp += sizeof(*init);
 	    sctpPacketLengthRemaining -= sizeof(*init);
 	    chunkLengthRemaining -= sizeof(*init);
 
 #if 0 /* ALC you can add code for optional params here */
 	    if( chunkLengthRemaining != 0 )
-	      ND_PRINT(" @@@@@ UNFINISHED @@@@@@%s\n",
+	      ND_PRINT(C_RESET, " @@@@@ UNFINISHED @@@@@@%s\n",
 		     "Optional params present, but not printed.");
 #endif
 	    bp += chunkLengthRemaining;
@@ -686,10 +686,10 @@ sctp_print(netdissect_options *ndo,
 	    ND_ICHECKMSG_ZU("chunk length", chunkLengthRemaining, <,
 			    sizeof(*sack));
 	    sack=(const struct sctpSelectiveAck*)bp;
-	    ND_PRINT("[cum ack %u] ", GET_BE_U_4(sack->highestConseqTSN));
-	    ND_PRINT("[a_rwnd %u] ", GET_BE_U_4(sack->updatedRwnd));
-	    ND_PRINT("[#gap acks %u] ", GET_BE_U_2(sack->numberOfdesc));
-	    ND_PRINT("[#dup tsns %u] ", GET_BE_U_2(sack->numDupTsns));
+	    ND_PRINT(C_RESET, "[cum ack %u] ", GET_BE_U_4(sack->highestConseqTSN));
+	    ND_PRINT(C_RESET, "[a_rwnd %u] ", GET_BE_U_4(sack->updatedRwnd));
+	    ND_PRINT(C_RESET, "[#gap acks %u] ", GET_BE_U_2(sack->numberOfdesc));
+	    ND_PRINT(C_RESET, "[#dup tsns %u] ", GET_BE_U_2(sack->numDupTsns));
 	    bp += sizeof(*sack);
 	    sctpPacketLengthRemaining -= sizeof(*sack);
 	    chunkLengthRemaining -= sizeof(*sack);
@@ -702,7 +702,7 @@ sctp_print(netdissect_options *ndo,
 	      ND_ICHECKMSG_ZU("chunk length", chunkLengthRemaining, <,
 			    sizeof(*frag));
 	      frag = (const struct sctpSelectiveFrag *)bp;
-	      ND_PRINT("\n\t\t[gap ack block #%u: start = %u, end = %u] ",
+	      ND_PRINT(C_RESET, "\n\t\t[gap ack block #%u: start = %u, end = %u] ",
 		     fragNo+1,
 		     GET_BE_U_4(sack->highestConseqTSN) + GET_BE_U_2(frag->fragmentStart),
 		     GET_BE_U_4(sack->highestConseqTSN) + GET_BE_U_2(frag->fragmentEnd));
@@ -714,7 +714,7 @@ sctp_print(netdissect_options *ndo,
 		 bp += 4, sctpPacketLengthRemaining -= 4, chunkLengthRemaining -= 4, tsnNo++) {
 	      ND_ICHECKMSG_U("chunk length", chunkLengthRemaining, <, 4);
 	      dupTSN = (const u_char *)bp;
-	      ND_PRINT("\n\t\t[dup TSN #%u: %u] ", tsnNo+1,
+	      ND_PRINT(C_RESET, "\n\t\t[dup TSN #%u: %u] ", tsnNo+1,
 		       GET_BE_U_4(dupTSN));
 	    }
 	    break;

--- a/print-sflow.c
+++ b/print-sflow.c
@@ -319,35 +319,35 @@ print_sflow_counter_generic(netdissect_options *ndo,
 	return 1;
 
     sflow_gen_counter = (const struct sflow_generic_counter_t *)pointer;
-    ND_PRINT("\n\t      ifindex %u, iftype %u, ifspeed %" PRIu64 ", ifdirection %u (%s)",
+    ND_PRINT(C_RESET, "\n\t      ifindex %u, iftype %u, ifspeed %" PRIu64 ", ifdirection %u (%s)",
 	   GET_BE_U_4(sflow_gen_counter->ifindex),
 	   GET_BE_U_4(sflow_gen_counter->iftype),
 	   GET_BE_U_8(sflow_gen_counter->ifspeed),
 	   GET_BE_U_4(sflow_gen_counter->ifdirection),
 	   tok2str(sflow_iface_direction_values, "Unknown",
 	   GET_BE_U_4(sflow_gen_counter->ifdirection)));
-    ND_PRINT("\n\t      ifstatus %u, adminstatus: %s, operstatus: %s",
+    ND_PRINT(C_RESET, "\n\t      ifstatus %u, adminstatus: %s, operstatus: %s",
 	   GET_BE_U_4(sflow_gen_counter->ifstatus),
 	   GET_BE_U_4(sflow_gen_counter->ifstatus)&1 ? "up" : "down",
 	   (GET_BE_U_4(sflow_gen_counter->ifstatus)>>1)&1 ? "up" : "down");
-    ND_PRINT("\n\t      In octets %" PRIu64
+    ND_PRINT(C_RESET, "\n\t      In octets %" PRIu64
 	   ", unicast pkts %u, multicast pkts %u, broadcast pkts %u, discards %u",
 	   GET_BE_U_8(sflow_gen_counter->ifinoctets),
 	   GET_BE_U_4(sflow_gen_counter->ifinunicastpkts),
 	   GET_BE_U_4(sflow_gen_counter->ifinmulticastpkts),
 	   GET_BE_U_4(sflow_gen_counter->ifinbroadcastpkts),
 	   GET_BE_U_4(sflow_gen_counter->ifindiscards));
-    ND_PRINT("\n\t      In errors %u, unknown protos %u",
+    ND_PRINT(C_RESET, "\n\t      In errors %u, unknown protos %u",
 	   GET_BE_U_4(sflow_gen_counter->ifinerrors),
 	   GET_BE_U_4(sflow_gen_counter->ifinunkownprotos));
-    ND_PRINT("\n\t      Out octets %" PRIu64
+    ND_PRINT(C_RESET, "\n\t      Out octets %" PRIu64
 	   ", unicast pkts %u, multicast pkts %u, broadcast pkts %u, discards %u",
 	   GET_BE_U_8(sflow_gen_counter->ifoutoctets),
 	   GET_BE_U_4(sflow_gen_counter->ifoutunicastpkts),
 	   GET_BE_U_4(sflow_gen_counter->ifoutmulticastpkts),
 	   GET_BE_U_4(sflow_gen_counter->ifoutbroadcastpkts),
 	   GET_BE_U_4(sflow_gen_counter->ifoutdiscards));
-    ND_PRINT("\n\t      Out errors %u, promisc mode %u",
+    ND_PRINT(C_RESET, "\n\t      Out errors %u, promisc mode %u",
 	   GET_BE_U_4(sflow_gen_counter->ifouterrors),
 	   GET_BE_U_4(sflow_gen_counter->ifpromiscmode));
 
@@ -364,18 +364,18 @@ print_sflow_counter_ethernet(netdissect_options *ndo,
 	return 1;
 
     sflow_eth_counter = (const struct sflow_ethernet_counter_t *)pointer;
-    ND_PRINT("\n\t      align errors %u, fcs errors %u, single collision %u, multiple collision %u, test error %u",
+    ND_PRINT(C_RESET, "\n\t      align errors %u, fcs errors %u, single collision %u, multiple collision %u, test error %u",
 	   GET_BE_U_4(sflow_eth_counter->alignerrors),
 	   GET_BE_U_4(sflow_eth_counter->fcserrors),
 	   GET_BE_U_4(sflow_eth_counter->single_collision_frames),
 	   GET_BE_U_4(sflow_eth_counter->multiple_collision_frames),
 	   GET_BE_U_4(sflow_eth_counter->test_errors));
-    ND_PRINT("\n\t      deferred %u, late collision %u, excessive collision %u, mac trans error %u",
+    ND_PRINT(C_RESET, "\n\t      deferred %u, late collision %u, excessive collision %u, mac trans error %u",
 	   GET_BE_U_4(sflow_eth_counter->deferred_transmissions),
 	   GET_BE_U_4(sflow_eth_counter->late_collisions),
 	   GET_BE_U_4(sflow_eth_counter->excessive_collisions),
 	   GET_BE_U_4(sflow_eth_counter->mac_transmit_errors));
-    ND_PRINT("\n\t      carrier error %u, frames too long %u, mac receive errors %u, symbol errors %u",
+    ND_PRINT(C_RESET, "\n\t      carrier error %u, frames too long %u, mac receive errors %u, symbol errors %u",
 	   GET_BE_U_4(sflow_eth_counter->carrier_sense_errors),
 	   GET_BE_U_4(sflow_eth_counter->frame_too_longs),
 	   GET_BE_U_4(sflow_eth_counter->mac_receive_errors),
@@ -401,23 +401,23 @@ print_sflow_counter_basevg(netdissect_options *ndo,
 	return 1;
 
     sflow_100basevg_counter = (const struct sflow_100basevg_counter_t *)pointer;
-    ND_PRINT("\n\t      in high prio frames %u, in high prio octets %" PRIu64,
+    ND_PRINT(C_RESET, "\n\t      in high prio frames %u, in high prio octets %" PRIu64,
 	   GET_BE_U_4(sflow_100basevg_counter->in_highpriority_frames),
 	   GET_BE_U_8(sflow_100basevg_counter->in_highpriority_octets));
-    ND_PRINT("\n\t      in norm prio frames %u, in norm prio octets %" PRIu64,
+    ND_PRINT(C_RESET, "\n\t      in norm prio frames %u, in norm prio octets %" PRIu64,
 	   GET_BE_U_4(sflow_100basevg_counter->in_normpriority_frames),
 	   GET_BE_U_8(sflow_100basevg_counter->in_normpriority_octets));
-    ND_PRINT("\n\t      in ipm errors %u, oversized %u, in data errors %u, null addressed frames %u",
+    ND_PRINT(C_RESET, "\n\t      in ipm errors %u, oversized %u, in data errors %u, null addressed frames %u",
 	   GET_BE_U_4(sflow_100basevg_counter->in_ipmerrors),
 	   GET_BE_U_4(sflow_100basevg_counter->in_oversized),
 	   GET_BE_U_4(sflow_100basevg_counter->in_data_errors),
 	   GET_BE_U_4(sflow_100basevg_counter->in_null_addressed_frames));
-    ND_PRINT("\n\t      out high prio frames %u, out high prio octets %" PRIu64
+    ND_PRINT(C_RESET, "\n\t      out high prio frames %u, out high prio octets %" PRIu64
 	   ", trans into frames %u",
 	   GET_BE_U_4(sflow_100basevg_counter->out_highpriority_frames),
 	   GET_BE_U_8(sflow_100basevg_counter->out_highpriority_octets),
 	   GET_BE_U_4(sflow_100basevg_counter->transitioninto_frames));
-    ND_PRINT("\n\t      in hc high prio octets %" PRIu64
+    ND_PRINT(C_RESET, "\n\t      in hc high prio octets %" PRIu64
 	   ", in hc norm prio octets %" PRIu64
 	   ", out hc high prio octets %" PRIu64,
 	   GET_BE_U_8(sflow_100basevg_counter->hc_in_highpriority_octets),
@@ -437,7 +437,7 @@ print_sflow_counter_vlan(netdissect_options *ndo,
 	return 1;
 
     sflow_vlan_counter = (const struct sflow_vlan_counter_t *)pointer;
-    ND_PRINT("\n\t      vlan_id %u, octets %" PRIu64
+    ND_PRINT(C_RESET, "\n\t      vlan_id %u, octets %" PRIu64
 	   ", unicast_pkt %u, multicast_pkt %u, broadcast_pkt %u, discards %u",
 	   GET_BE_U_4(sflow_vlan_counter->vlan_id),
 	   GET_BE_U_8(sflow_vlan_counter->octets),
@@ -467,7 +467,7 @@ print_sflow_counter_processor(netdissect_options *ndo,
 	return 1;
 
     sflow_processor_counter = (const struct sflow_processor_counter_t *)pointer;
-    ND_PRINT("\n\t      5sec %u, 1min %u, 5min %u, total_mem %" PRIu64
+    ND_PRINT(C_RESET, "\n\t      5sec %u, 1min %u, 5min %u, total_mem %" PRIu64
 	   ", total_mem %" PRIu64,
 	   GET_BE_U_4(sflow_processor_counter->five_sec_util),
 	   GET_BE_U_4(sflow_processor_counter->one_min_util),
@@ -504,7 +504,7 @@ sflow_print_counter_records(netdissect_options *ndo,
 	counter_type = enterprise & 0x0FFF;
 	enterprise = enterprise >> 20;
 	counter_len  = GET_BE_U_4(sflow_counter_record->length);
-	ND_PRINT("\n\t    enterprise %u, %s (%u) length %u",
+	ND_PRINT(C_RESET, "\n\t    enterprise %u, %s (%u) length %u",
 	       enterprise,
 	       (enterprise == 0) ? tok2str(sflow_counter_type_values,"Unknown",counter_type) : "Unknown",
 	       counter_type,
@@ -570,7 +570,7 @@ sflow_print_counter_sample(netdissect_options *ndo,
 
     nrecords   = GET_BE_U_4(sflow_counter_sample->records);
 
-    ND_PRINT(" seqnum %u, type %u, idx %u, records %u",
+    ND_PRINT(C_RESET, " seqnum %u, type %u, idx %u, records %u",
 	   GET_BE_U_4(sflow_counter_sample->seqnum),
 	   GET_U_1(sflow_counter_sample->type),
 	   GET_BE_U_3(sflow_counter_sample->index),
@@ -596,7 +596,7 @@ sflow_print_expanded_counter_sample(netdissect_options *ndo,
 
     nrecords = GET_BE_U_4(sflow_expanded_counter_sample->records);
 
-    ND_PRINT(" seqnum %u, type %u, idx %u, records %u",
+    ND_PRINT(C_RESET, " seqnum %u, type %u, idx %u, records %u",
 	   GET_BE_U_4(sflow_expanded_counter_sample->seqnum),
 	   GET_BE_U_4(sflow_expanded_counter_sample->type),
 	   GET_BE_U_4(sflow_expanded_counter_sample->index),
@@ -617,7 +617,7 @@ print_sflow_raw_packet(netdissect_options *ndo,
 	return 1;
 
     sflow_flow_raw = (const struct sflow_expanded_flow_raw_t *)pointer;
-    ND_PRINT("\n\t      protocol %s (%u), length %u, stripped bytes %u, header_size %u",
+    ND_PRINT(C_RESET, "\n\t      protocol %s (%u), length %u, stripped bytes %u, header_size %u",
 	   tok2str(sflow_flow_raw_protocol_values,"Unknown",GET_BE_U_4(sflow_flow_raw->protocol)),
 	   GET_BE_U_4(sflow_flow_raw->protocol),
 	   GET_BE_U_4(sflow_flow_raw->length),
@@ -641,7 +641,7 @@ print_sflow_ethernet_frame(netdissect_options *ndo,
 
     sflow_ethernet_frame = (const struct sflow_ethernet_frame_t *)pointer;
 
-    ND_PRINT("\n\t      frame len %u, type %u",
+    ND_PRINT(C_RESET, "\n\t      frame len %u, type %u",
 	   GET_BE_U_4(sflow_ethernet_frame->length),
 	   GET_BE_U_4(sflow_ethernet_frame->type));
 
@@ -658,7 +658,7 @@ print_sflow_extended_switch_data(netdissect_options *ndo,
 	return 1;
 
     sflow_extended_sw_data = (const struct sflow_extended_switch_data_t *)pointer;
-    ND_PRINT("\n\t      src vlan %u, src pri %u, dst vlan %u, dst pri %u",
+    ND_PRINT(C_RESET, "\n\t      src vlan %u, src pri %u, dst vlan %u, dst pri %u",
 	   GET_BE_U_4(sflow_extended_sw_data->src_vlan),
 	   GET_BE_U_4(sflow_extended_sw_data->src_pri),
 	   GET_BE_U_4(sflow_extended_sw_data->dst_vlan),
@@ -697,7 +697,7 @@ sflow_print_flow_records(netdissect_options *ndo,
 	flow_type = enterprise & 0x0FFF;
 	enterprise = enterprise >> 12;
 	flow_len  = GET_BE_U_4(sflow_flow_record->length);
-	ND_PRINT("\n\t    enterprise %u %s (%u) length %u",
+	ND_PRINT(C_RESET, "\n\t    enterprise %u %s (%u) length %u",
 	       enterprise,
 	       (enterprise == 0) ? tok2str(sflow_flow_type_values,"Unknown",flow_type) : "Unknown",
 	       flow_type,
@@ -767,7 +767,7 @@ sflow_print_flow_sample(netdissect_options *ndo,
 
     nrecords = GET_BE_U_4(sflow_flow_sample->records);
 
-    ND_PRINT(" seqnum %u, type %u, idx %u, rate %u, pool %u, drops %u, input %u output %u records %u",
+    ND_PRINT(C_RESET, " seqnum %u, type %u, idx %u, rate %u, pool %u, drops %u, input %u output %u records %u",
 	   GET_BE_U_4(sflow_flow_sample->seqnum),
 	   GET_U_1(sflow_flow_sample->type),
 	   GET_BE_U_3(sflow_flow_sample->index),
@@ -797,7 +797,7 @@ sflow_print_expanded_flow_sample(netdissect_options *ndo,
 
     nrecords = GET_BE_U_4(sflow_expanded_flow_sample->records);
 
-    ND_PRINT(" seqnum %u, type %u, idx %u, rate %u, pool %u, drops %u, records %u",
+    ND_PRINT(C_RESET, " seqnum %u, type %u, idx %u, rate %u, pool %u, drops %u, records %u",
 	   GET_BE_U_4(sflow_expanded_flow_sample->seqnum),
 	   GET_BE_U_4(sflow_expanded_flow_sample->type),
 	   GET_BE_U_4(sflow_expanded_flow_sample->index),
@@ -834,8 +834,8 @@ sflow_print(netdissect_options *ndo,
 
     if ((len < sizeof(struct sflow_datagram_t) && (ip_version == 1)) ||
         (len < sizeof(struct sflow_v6_datagram_t) && (ip_version == 2))) {
-        ND_PRINT("sFlowv%u", GET_BE_U_4(sflow_datagram->version));
-        ND_PRINT(" [length %u < %zu]", len, sizeof(struct sflow_datagram_t));
+        ND_PRINT(C_RESET, "sFlowv%u", GET_BE_U_4(sflow_datagram->version));
+        ND_PRINT(C_RESET, " [length %u < %zu]", len, sizeof(struct sflow_datagram_t));
         nd_print_invalid(ndo);
         return;
     }
@@ -845,13 +845,13 @@ sflow_print(netdissect_options *ndo,
      * Sanity checking of the header.
      */
     if (GET_BE_U_4(sflow_datagram->version) != 5) {
-        ND_PRINT("sFlow version %u packet not supported",
+        ND_PRINT(C_RESET, "sFlow version %u packet not supported",
                GET_BE_U_4(sflow_datagram->version));
         return;
     }
 
     if (ndo->ndo_vflag < 1) {
-        ND_PRINT("sFlowv%u, %s agent %s, agent-id %u, length %u",
+        ND_PRINT(C_RESET, "sFlowv%u, %s agent %s, agent-id %u, length %u",
                GET_BE_U_4(sflow_datagram->version),
                ip_version == 1 ? "IPv4" : "IPv6",
                ip_version == 1 ? GET_IPADDR_STRING(sflow_datagram->agent) :
@@ -865,7 +865,7 @@ sflow_print(netdissect_options *ndo,
     /* ok they seem to want to know everything - lets fully decode it */
     if (ip_version == 1) {
         nsamples = GET_BE_U_4(sflow_datagram->samples);
-        ND_PRINT("sFlowv%u, %s agent %s, agent-id %u, seqnum %u, uptime %u, samples %u, length %u",
+        ND_PRINT(C_RESET, "sFlowv%u, %s agent %s, agent-id %u, seqnum %u, uptime %u, samples %u, length %u",
                GET_BE_U_4(sflow_datagram->version),
                "IPv4",
                GET_IPADDR_STRING(sflow_datagram->agent),
@@ -881,7 +881,7 @@ sflow_print(netdissect_options *ndo,
         tlen -= sizeof(struct sflow_datagram_t);
     } else {
         nsamples = GET_BE_U_4(sflow_v6_datagram->samples);
-        ND_PRINT("sFlowv%u, %s agent %s, agent-id %u, seqnum %u, uptime %u, samples %u, length %u",
+        ND_PRINT(C_RESET, "sFlowv%u, %s agent %s, agent-id %u, seqnum %u, uptime %u, samples %u, length %u",
                GET_BE_U_4(sflow_v6_datagram->version),
                "IPv6",
                GET_IP6ADDR_STRING(sflow_v6_datagram->agent),
@@ -908,7 +908,7 @@ sflow_print(netdissect_options *ndo,
         tptr += sizeof(struct sflow_sample_header);
         tlen -= sizeof(struct sflow_sample_header);
 
-        ND_PRINT("\n\t%s (%u), length %u,",
+        ND_PRINT(C_RESET, "\n\t%s (%u), length %u,",
                tok2str(sflow_format_values, "Unknown", sflow_sample_type),
                sflow_sample_type,
                sflow_sample_len);

--- a/print-sl.c
+++ b/print-sl.c
@@ -80,7 +80,7 @@ sl_if_print(netdissect_options *ndo,
 		ip6_print(ndo, (const u_char *)ip, length);
 		break;
 	default:
-		ND_PRINT("ip v%u", IP_V(ip));
+		ND_PRINT(C_RESET, "ip v%u", IP_V(ip));
 	}
 }
 
@@ -119,22 +119,22 @@ sliplink_print(netdissect_options *ndo,
 	switch (dir) {
 
 	case SLIPDIR_IN:
-		ND_PRINT("I ");
+		ND_PRINT(C_RESET, "I ");
 		break;
 
 	case SLIPDIR_OUT:
-		ND_PRINT("O ");
+		ND_PRINT(C_RESET, "O ");
 		break;
 
 	default:
-		ND_PRINT("Invalid direction %d ", dir);
+		ND_PRINT(C_RESET, "Invalid direction %d ", dir);
 		dir = -1;
 		break;
 	}
 	switch (GET_U_1(p + SLX_CHDR) & 0xf0) {
 
 	case TYPE_IP:
-		ND_PRINT("ip %u: ", length + SLIP_HDRLEN);
+		ND_PRINT(C_RESET, "ip %u: ", length + SLIP_HDRLEN);
 		break;
 
 	case TYPE_UNCOMPRESSED_TCP:
@@ -144,7 +144,7 @@ sliplink_print(netdissect_options *ndo,
 		 * has restored the IP header copy to IPPROTO_TCP.
 		 */
 		lastconn = GET_U_1(((const struct ip *)(p + SLX_CHDR))->ip_p);
-		ND_PRINT("utcp %u: ", lastconn);
+		ND_PRINT(C_RESET, "utcp %u: ", lastconn);
 		if (dir == -1) {
 			/* Direction is bogus, don't use it */
 			return;
@@ -161,9 +161,9 @@ sliplink_print(netdissect_options *ndo,
 		}
 		if (GET_U_1(p + SLX_CHDR) & TYPE_COMPRESSED_TCP) {
 			compressed_sl_print(ndo, p + SLX_CHDR, ip, length, dir);
-			ND_PRINT(": ");
+			ND_PRINT(C_RESET, ": ");
 		} else
-			ND_PRINT("slip-%u!: ", GET_U_1(p + SLX_CHDR));
+			ND_PRINT(C_RESET, "slip-%u!: ", GET_U_1(p + SLX_CHDR));
 	}
 }
 
@@ -178,7 +178,7 @@ print_sl_change(netdissect_options *ndo,
 		i = GET_BE_U_2(cp);
 		cp += 2;
 	}
-	ND_PRINT(" %s%u", str, i);
+	ND_PRINT(C_RESET, " %s%u", str, i);
 	return (cp);
 }
 
@@ -194,9 +194,9 @@ print_sl_winchange(netdissect_options *ndo,
 		cp += 2;
 	}
 	if (i >= 0)
-		ND_PRINT(" W+%d", i);
+		ND_PRINT(C_RESET, " W+%d", i);
 	else
-		ND_PRINT(" W%d", i);
+		ND_PRINT(C_RESET, " W%d", i);
 	return (cp);
 }
 
@@ -213,20 +213,20 @@ compressed_sl_print(netdissect_options *ndo,
 	if (flags & NEW_C) {
 		lastconn = GET_U_1(cp);
 		cp++;
-		ND_PRINT("ctcp %u", lastconn);
+		ND_PRINT(C_RESET, "ctcp %u", lastconn);
 	} else
-		ND_PRINT("ctcp *");
+		ND_PRINT(C_RESET, "ctcp *");
 
 	/* skip tcp checksum */
 	cp += 2;
 
 	switch (flags & SPECIALS_MASK) {
 	case SPECIAL_I:
-		ND_PRINT(" *SA+%u", lastlen[dir][lastconn]);
+		ND_PRINT(C_RESET, " *SA+%u", lastlen[dir][lastconn]);
 		break;
 
 	case SPECIAL_D:
-		ND_PRINT(" *S+%u", lastlen[dir][lastconn]);
+		ND_PRINT(C_RESET, " *S+%u", lastlen[dir][lastconn]);
 		break;
 
 	default:
@@ -251,5 +251,5 @@ compressed_sl_print(netdissect_options *ndo,
 	hlen = IP_HL(ip);
 	hlen += TH_OFF((const struct tcphdr *)&((const int32_t *)ip)[hlen]);
 	lastlen[dir][lastconn] = length - (hlen << 2);
-	ND_PRINT(" %u (%ld)", lastlen[dir][lastconn], (long)(cp - chdr));
+	ND_PRINT(C_RESET, " %u (%ld)", lastlen[dir][lastconn], (long)(cp - chdr));
 }

--- a/print-sll.c
+++ b/print-sll.c
@@ -160,7 +160,7 @@ sll_print(netdissect_options *ndo, const struct sll_header *sllp, u_int length)
 	u_short ether_type;
 
 	ndo->ndo_protocol = "sll";
-        ND_PRINT("%3s ",
+        ND_PRINT(C_RESET, "%3s ",
 		 tok2str(sll_pkttype_values,"?",GET_BE_U_2(sllp->sll_pkttype)));
 
 	/*
@@ -169,7 +169,7 @@ sll_print(netdissect_options *ndo, const struct sll_header *sllp, u_int length)
 	 * XXX - print others as strings of hex?
 	 */
 	if (GET_BE_U_2(sllp->sll_halen) == MAC_ADDR_LEN)
-		ND_PRINT("%s ", GET_ETHERADDR_STRING(sllp->sll_addr));
+		ND_PRINT(C_RESET, "%s ", GET_ETHERADDR_STRING(sllp->sll_addr));
 
 	if (!ndo->ndo_qflag) {
 		ether_type = GET_BE_U_2(sllp->sll_protocol);
@@ -184,30 +184,30 @@ sll_print(netdissect_options *ndo, const struct sll_header *sllp, u_int length)
 				/*
 				 * Ethernet_802.3 IPX frame.
 				 */
-				ND_PRINT("802.3");
+				ND_PRINT(C_RESET, "802.3");
 				break;
 
 			case LINUX_SLL_P_802_2:
 				/*
 				 * 802.2.
 				 */
-				ND_PRINT("802.2");
+				ND_PRINT(C_RESET, "802.2");
 				break;
 
 			default:
 				/*
 				 * What is it?
 				 */
-				ND_PRINT("ethertype Unknown (0x%04x)",
+				ND_PRINT(C_RESET, "ethertype Unknown (0x%04x)",
 				    ether_type);
 				break;
 			}
 		} else {
-			ND_PRINT("ethertype %s (0x%04x)",
+			ND_PRINT(C_RESET, "ethertype %s (0x%04x)",
 			    tok2str(ethertype_values, "Unknown", ether_type),
 			    ether_type);
 		}
-		ND_PRINT(", length %u: ", length);
+		ND_PRINT(C_RESET, ", length %u: ", length);
 	}
 }
 
@@ -310,14 +310,14 @@ recurse:
 	        if (ndo->ndo_eflag) {
 			uint16_t tag = GET_BE_U_2(p);
 
-			ND_PRINT("%s, ", ieee8021q_tci_string(tag));
+			ND_PRINT(C_RESET, "%s, ", ieee8021q_tci_string(tag));
 		}
 
 		ether_type = GET_BE_U_2(p + 2);
 		if (ether_type <= MAX_ETHERNET_LENGTH_VAL)
 			ether_type = LINUX_SLL_P_802_2;
 		if (!ndo->ndo_qflag) {
-			ND_PRINT("ethertype %s, ",
+			ND_PRINT(C_RESET, "ethertype %s, ",
 			    tok2str(ethertype_values, "Unknown", ether_type));
 		}
 		p += 4;
@@ -344,7 +344,7 @@ sll2_print(netdissect_options *ndo, const struct sll2_header *sllp, u_int length
 	u_short ether_type;
 
 	ndo->ndo_protocol = "sll2";
-	ND_PRINT("ifindex %u ", GET_BE_U_4(sllp->sll2_if_index));
+	ND_PRINT(C_RESET, "ifindex %u ", GET_BE_U_4(sllp->sll2_if_index));
 
 	/*
 	 * XXX - check the link-layer address type value?
@@ -352,7 +352,7 @@ sll2_print(netdissect_options *ndo, const struct sll2_header *sllp, u_int length
 	 * XXX - print others as strings of hex?
 	 */
 	if (GET_U_1(sllp->sll2_halen) == MAC_ADDR_LEN)
-		ND_PRINT("%s ", GET_ETHERADDR_STRING(sllp->sll2_addr));
+		ND_PRINT(C_RESET, "%s ", GET_ETHERADDR_STRING(sllp->sll2_addr));
 
 	if (!ndo->ndo_qflag) {
 		ether_type = GET_BE_U_2(sllp->sll2_protocol);
@@ -367,30 +367,30 @@ sll2_print(netdissect_options *ndo, const struct sll2_header *sllp, u_int length
 				/*
 				 * Ethernet_802.3 IPX frame.
 				 */
-				ND_PRINT("802.3");
+				ND_PRINT(C_RESET, "802.3");
 				break;
 
 			case LINUX_SLL_P_802_2:
 				/*
 				 * 802.2.
 				 */
-				ND_PRINT("802.2");
+				ND_PRINT(C_RESET, "802.2");
 				break;
 
 			default:
 				/*
 				 * What is it?
 				 */
-				ND_PRINT("ethertype Unknown (0x%04x)",
+				ND_PRINT(C_RESET, "ethertype Unknown (0x%04x)",
 				    ether_type);
 				break;
 			}
 		} else {
-			ND_PRINT("ethertype %s (0x%04x)",
+			ND_PRINT(C_RESET, "ethertype %s (0x%04x)",
 			    tok2str(ethertype_values, "Unknown", ether_type),
 			    ether_type);
 		}
-		ND_PRINT(", length %u: ", length);
+		ND_PRINT(C_RESET, ", length %u: ", length);
 	}
 }
 
@@ -423,10 +423,10 @@ sll2_if_print(netdissect_options *ndo, const struct pcap_pkthdr *h, const u_char
 	if_index = GET_BE_U_4(sllp->sll2_if_index);
 	if (!if_indextoname(if_index, ifname))
 		strncpy(ifname, "?", 2);
-	ND_PRINT("%-5s ", ifname);
+	ND_PRINT(C_RESET, "%-5s ", ifname);
 #endif
 
-	ND_PRINT("%-3s ",
+	ND_PRINT(C_RESET, "%-3s ",
 		 tok2str(sll_pkttype_values, "?", GET_U_1(sllp->sll2_pkttype)));
 
 	if (ndo->ndo_eflag)
@@ -506,14 +506,14 @@ recurse:
 	        if (ndo->ndo_eflag) {
 			uint16_t tag = GET_BE_U_2(p);
 
-			ND_PRINT("%s, ", ieee8021q_tci_string(tag));
+			ND_PRINT(C_RESET, "%s, ", ieee8021q_tci_string(tag));
 		}
 
 		ether_type = GET_BE_U_2(p + 2);
 		if (ether_type <= MAX_ETHERNET_LENGTH_VAL)
 			ether_type = LINUX_SLL_P_802_2;
 		if (!ndo->ndo_qflag) {
-			ND_PRINT("ethertype %s, ",
+			ND_PRINT(C_RESET, "ethertype %s, ",
 			    tok2str(ethertype_values, "Unknown", ether_type));
 		}
 		p += 4;

--- a/print-slow.c
+++ b/print-slow.c
@@ -262,7 +262,7 @@ slow_print(netdissect_options *ndo,
         if (len < 2)
             goto tooshort;
         if (GET_U_1(pptr + 1) != LACP_VERSION) {
-            ND_PRINT("LACP version %u packet not supported",
+            ND_PRINT(C_RESET, "LACP version %u packet not supported",
                      GET_U_1(pptr + 1));
             return;
         }
@@ -273,7 +273,7 @@ slow_print(netdissect_options *ndo,
         if (len < 2)
             goto tooshort;
         if (GET_U_1(pptr + 1) != MARKER_VERSION) {
-            ND_PRINT("MARKER version %u packet not supported",
+            ND_PRINT(C_RESET, "MARKER version %u packet not supported",
                      GET_U_1(pptr + 1));
             return;
         }
@@ -291,13 +291,13 @@ slow_print(netdissect_options *ndo,
     }
 
     if (print_version == 1) {
-        ND_PRINT("%sv%u, length %u",
+        ND_PRINT(C_RESET, "%sv%u, length %u",
                tok2str(slow_proto_values, "unknown (%u)", subtype),
                GET_U_1((pptr + 1)),
                len);
     } else {
         /* some slow protos don't have a version number in the header */
-        ND_PRINT("%s, length %u",
+        ND_PRINT(C_RESET, "%s, length %u",
                tok2str(slow_proto_values, "unknown (%u)", subtype),
                len);
     }
@@ -334,9 +334,9 @@ slow_print(netdissect_options *ndo,
 
 tooshort:
     if (!ndo->ndo_vflag)
-        ND_PRINT(" (packet is too short)");
+        ND_PRINT(C_RESET, " (packet is too short)");
     else
-        ND_PRINT("\n\t\t packet is too short");
+        ND_PRINT(C_RESET, "\n\t\t packet is too short");
 }
 
 static void
@@ -364,7 +364,7 @@ slow_marker_lacp_print(netdissect_options *ndo,
         tlv_type = GET_U_1(tlv_header->type);
         tlv_len = GET_U_1(tlv_header->length);
 
-        ND_PRINT("\n\t%s TLV (0x%02x), length %u",
+        ND_PRINT(C_RESET, "\n\t%s TLV (0x%02x), length %u",
                tok2str(slow_tlv_values,
                        "Unknown",
                        (proto_subtype << 8) + tlv_type),
@@ -381,7 +381,7 @@ slow_marker_lacp_print(netdissect_options *ndo,
 
         /* length includes the type and length fields */
         if (tlv_len < sizeof(struct tlv_header_t)) {
-            ND_PRINT("\n\t    ERROR: illegal length - should be >= %zu",
+            ND_PRINT(C_RESET, "\n\t    ERROR: illegal length - should be >= %zu",
                      sizeof(struct tlv_header_t));
             return;
         }
@@ -402,14 +402,14 @@ slow_marker_lacp_print(netdissect_options *ndo,
         case ((SLOW_PROTO_LACP << 8) + LACP_TLV_PARTNER_INFO):
             if (tlv_tlen !=
                 sizeof(struct lacp_tlv_actor_partner_info_t)) {
-                ND_PRINT("\n\t    ERROR: illegal length - should be %zu",
+                ND_PRINT(C_RESET, "\n\t    ERROR: illegal length - should be %zu",
                          sizeof(struct tlv_header_t) + sizeof(struct lacp_tlv_actor_partner_info_t));
                 goto badlength;
             }
 
             tlv_ptr.lacp_tlv_actor_partner_info = (const struct lacp_tlv_actor_partner_info_t *)tlv_tptr;
 
-            ND_PRINT("\n\t  System %s, System Priority %u, Key %u"
+            ND_PRINT(C_RESET, "\n\t  System %s, System Priority %u, Key %u"
                    ", Port %u, Port Priority %u\n\t  State Flags [%s]",
                    GET_ETHERADDR_STRING(tlv_ptr.lacp_tlv_actor_partner_info->sys),
                    GET_BE_U_2(tlv_ptr.lacp_tlv_actor_partner_info->sys_pri),
@@ -425,14 +425,14 @@ slow_marker_lacp_print(netdissect_options *ndo,
         case ((SLOW_PROTO_LACP << 8) + LACP_TLV_COLLECTOR_INFO):
             if (tlv_tlen !=
                 sizeof(struct lacp_tlv_collector_info_t)) {
-                ND_PRINT("\n\t    ERROR: illegal length - should be %zu",
+                ND_PRINT(C_RESET, "\n\t    ERROR: illegal length - should be %zu",
                          sizeof(struct tlv_header_t) + sizeof(struct lacp_tlv_collector_info_t));
                 goto badlength;
             }
 
             tlv_ptr.lacp_tlv_collector_info = (const struct lacp_tlv_collector_info_t *)tlv_tptr;
 
-            ND_PRINT("\n\t  Max Delay %u",
+            ND_PRINT(C_RESET, "\n\t  Max Delay %u",
                    GET_BE_U_2(tlv_ptr.lacp_tlv_collector_info->max_delay));
 
             break;
@@ -440,14 +440,14 @@ slow_marker_lacp_print(netdissect_options *ndo,
         case ((SLOW_PROTO_MARKER << 8) + MARKER_TLV_MARKER_INFO):
             if (tlv_tlen !=
                 sizeof(struct marker_tlv_marker_info_t)) {
-                ND_PRINT("\n\t    ERROR: illegal length - should be %zu",
+                ND_PRINT(C_RESET, "\n\t    ERROR: illegal length - should be %zu",
                          sizeof(struct tlv_header_t) + sizeof(struct marker_tlv_marker_info_t));
                 goto badlength;
             }
 
             tlv_ptr.marker_tlv_marker_info = (const struct marker_tlv_marker_info_t *)tlv_tptr;
 
-            ND_PRINT("\n\t  Request System %s, Request Port %u, Request Transaction ID 0x%08x",
+            ND_PRINT(C_RESET, "\n\t  Request System %s, Request Port %u, Request Transaction ID 0x%08x",
                    GET_ETHERADDR_STRING(tlv_ptr.marker_tlv_marker_info->req_sys),
                    GET_BE_U_2(tlv_ptr.marker_tlv_marker_info->req_port),
                    GET_BE_U_4(tlv_ptr.marker_tlv_marker_info->req_trans_id));
@@ -473,7 +473,7 @@ slow_marker_lacp_print(netdissect_options *ndo,
     return;
 
 tooshort:
-    ND_PRINT("\n\t\t packet is too short");
+    ND_PRINT(C_RESET, "\n\t\t packet is too short");
 }
 
 static void
@@ -517,7 +517,7 @@ slow_oam_print(netdissect_options *ndo,
     tlen -= sizeof(struct slow_oam_common_header_t);
 
     code = GET_U_1(ptr.slow_oam_common_header->code);
-    ND_PRINT("\n\tCode %s OAM PDU, Flags [%s]",
+    ND_PRINT(C_RESET, "\n\tCode %s OAM PDU, Flags [%s]",
            tok2str(slow_oam_code_values, "Unknown (%u)", code),
            bittok2str(slow_oam_flag_values,
                       "none",
@@ -532,7 +532,7 @@ slow_oam_print(netdissect_options *ndo,
             ND_TCHECK_SIZE(ptr.slow_oam_tlv_header);
             type = GET_U_1(ptr.slow_oam_tlv_header->type);
             length = GET_U_1(ptr.slow_oam_tlv_header->length);
-            ND_PRINT("\n\t  %s Information Type (%u), length %u",
+            ND_PRINT(C_RESET, "\n\t  %s Information Type (%u), length %u",
                    tok2str(slow_oam_info_type_values, "Reserved", type),
                    type,
                    length);
@@ -547,7 +547,7 @@ slow_oam_print(netdissect_options *ndo,
 
             /* length includes the type and length fields */
             if (length < sizeof(struct slow_oam_tlv_header_t)) {
-                ND_PRINT("\n\t    ERROR: illegal length - should be >= %zu",
+                ND_PRINT(C_RESET, "\n\t    ERROR: illegal length - should be >= %zu",
                          sizeof(struct slow_oam_tlv_header_t));
                 return;
             }
@@ -564,28 +564,28 @@ slow_oam_print(netdissect_options *ndo,
 
                 if (GET_U_1(tlv.slow_oam_info->info_length) !=
                     sizeof(struct slow_oam_info_t)) {
-                    ND_PRINT("\n\t    ERROR: illegal length - should be %zu",
+                    ND_PRINT(C_RESET, "\n\t    ERROR: illegal length - should be %zu",
                            sizeof(struct slow_oam_info_t));
                     hexdump = TRUE;
                     goto badlength_code_info;
                 }
 
-                ND_PRINT("\n\t    OAM-Version %u, Revision %u",
+                ND_PRINT(C_RESET, "\n\t    OAM-Version %u, Revision %u",
                        GET_U_1(tlv.slow_oam_info->oam_version),
                        GET_BE_U_2(tlv.slow_oam_info->revision));
 
                 state = GET_U_1(tlv.slow_oam_info->state);
-                ND_PRINT("\n\t    State-Parser-Action %s, State-MUX-Action %s",
+                ND_PRINT(C_RESET, "\n\t    State-Parser-Action %s, State-MUX-Action %s",
                        tok2str(slow_oam_info_type_state_parser_values, "Reserved",
                                state & OAM_INFO_TYPE_PARSER_MASK),
                        tok2str(slow_oam_info_type_state_mux_values, "Reserved",
                                state & OAM_INFO_TYPE_MUX_MASK));
-                ND_PRINT("\n\t    OAM-Config Flags [%s], OAM-PDU-Config max-PDU size %u",
+                ND_PRINT(C_RESET, "\n\t    OAM-Config Flags [%s], OAM-PDU-Config max-PDU size %u",
                        bittok2str(slow_oam_info_type_oam_config_values, "none",
                                   GET_U_1(tlv.slow_oam_info->oam_config)),
                        GET_BE_U_2(tlv.slow_oam_info->oam_pdu_config) &
                        OAM_INFO_TYPE_PDU_SIZE_MASK);
-                ND_PRINT("\n\t    OUI %s (0x%06x), Vendor-Private 0x%08x",
+                ND_PRINT(C_RESET, "\n\t    OUI %s (0x%06x), Vendor-Private 0x%08x",
                        tok2str(oui_values, "Unknown",
                                GET_BE_U_3(tlv.slow_oam_info->oui)),
                        GET_BE_U_3(tlv.slow_oam_info->oui),
@@ -617,7 +617,7 @@ slow_oam_print(netdissect_options *ndo,
         /* Sequence number */
         if (tlen < 2)
             goto tooshort;
-        ND_PRINT("\n\t  Sequence Number %u", GET_BE_U_2(tptr));
+        ND_PRINT(C_RESET, "\n\t  Sequence Number %u", GET_BE_U_2(tptr));
         tlen -= 2;
         tptr += 2;
 
@@ -628,7 +628,7 @@ slow_oam_print(netdissect_options *ndo,
                 goto tooshort;
             type = GET_U_1(ptr.slow_oam_tlv_header->type);
             length = GET_U_1(ptr.slow_oam_tlv_header->length);
-            ND_PRINT("\n\t  %s Link Event Type (%u), length %u",
+            ND_PRINT(C_RESET, "\n\t  %s Link Event Type (%u), length %u",
                    tok2str(slow_oam_link_event_values, "Reserved",
                            type),
                    type,
@@ -644,7 +644,7 @@ slow_oam_print(netdissect_options *ndo,
 
             /* length includes the type and length fields */
             if (length < sizeof(struct slow_oam_tlv_header_t)) {
-                ND_PRINT("\n\t    ERROR: illegal length - should be >= %zu",
+                ND_PRINT(C_RESET, "\n\t    ERROR: illegal length - should be >= %zu",
                          sizeof(struct slow_oam_tlv_header_t));
                 return;
             }
@@ -663,13 +663,13 @@ slow_oam_print(netdissect_options *ndo,
 
                 if (GET_U_1(tlv.slow_oam_link_event->event_length) !=
                     sizeof(struct slow_oam_link_event_t)) {
-                    ND_PRINT("\n\t    ERROR: illegal length - should be %zu",
+                    ND_PRINT(C_RESET, "\n\t    ERROR: illegal length - should be %zu",
                              sizeof(struct slow_oam_link_event_t));
                     hexdump = TRUE;
                     goto badlength_event_notif;
                 }
 
-                ND_PRINT("\n\t    Timestamp %u ms, Errored Window %" PRIu64
+                ND_PRINT(C_RESET, "\n\t    Timestamp %u ms, Errored Window %" PRIu64
                        "\n\t    Errored Threshold %" PRIu64
                        "\n\t    Errors %" PRIu64
                        "\n\t    Error Running Total %" PRIu64
@@ -708,7 +708,7 @@ slow_oam_print(netdissect_options *ndo,
         if (tlen < sizeof(*tlv.slow_oam_loopbackctrl))
             goto tooshort;
         command = GET_U_1(tlv.slow_oam_loopbackctrl->command);
-        ND_PRINT("\n\t  Command %s (%u)",
+        ND_PRINT(C_RESET, "\n\t  Command %s (%u)",
                tok2str(slow_oam_loopbackctrl_cmd_values,
                        "Unknown",
                        command),
@@ -733,5 +733,5 @@ slow_oam_print(netdissect_options *ndo,
     return;
 
 tooshort:
-    ND_PRINT("\n\t\t packet is too short");
+    ND_PRINT(C_RESET, "\n\t\t packet is too short");
 }

--- a/print-smb.c
+++ b/print-smb.c
@@ -101,7 +101,7 @@ trans2_findfirst(netdissect_options *ndo,
 
     smb_fdata(ndo, param, fmt, param + pcnt, unicodestr);
     if (dcnt) {
-	ND_PRINT("data:\n");
+	ND_PRINT(C_RESET, "data:\n");
 	smb_data_print(ndo, data, dcnt);
     }
 }
@@ -135,7 +135,7 @@ trans2_qfsinfo(netdissect_options *ndo,
 	smb_fdata(ndo, data, fmt, data + dcnt, unicodestr);
     }
     if (dcnt) {
-	ND_PRINT("data:\n");
+	ND_PRINT(C_RESET, "data:\n");
 	smb_data_print(ndo, data, dcnt);
     }
 }
@@ -186,8 +186,8 @@ print_trans2(netdissect_options *ndo,
 	fn = smbfindint(GET_LE_U_2(w + 14 * 2), trans2_fns);
     } else {
 	if (GET_U_1(words) == 0) {
-	    ND_PRINT("%s\n", fn->name);
-	    ND_PRINT("Trans2Interim\n");
+	    ND_PRINT(C_RESET, "%s\n", fn->name);
+	    ND_PRINT(C_RESET, "Trans2Interim\n");
 	    return;
 	}
 	ND_TCHECK_2(w + (7 * 2));
@@ -197,7 +197,7 @@ print_trans2(netdissect_options *ndo,
 	data = buf + GET_LE_U_2(w + 7 * 2);
     }
 
-    ND_PRINT("%s param_length=%u data_length=%u\n", fn->name, pcnt, dcnt);
+    ND_PRINT(C_RESET, "%s param_length=%u data_length=%u\n", fn->name, pcnt, dcnt);
 
     if (request) {
 	if (GET_U_1(words) == 8) {
@@ -221,7 +221,7 @@ print_trans2(netdissect_options *ndo,
     }
 
     bcc = GET_LE_U_2(dat);
-    ND_PRINT("smb_bcc=%u\n", bcc);
+    ND_PRINT(C_RESET, "smb_bcc=%u\n", bcc);
     if (fn->descript.fn)
 	(*fn->descript.fn)(ndo, param, data, pcnt, dcnt);
     else {
@@ -360,7 +360,7 @@ print_trans(netdissect_options *ndo,
               unicodestr);
 
     bcc = GET_LE_U_2(data1);
-    ND_PRINT("smb_bcc=%u\n", bcc);
+    ND_PRINT(C_RESET, "smb_bcc=%u\n", bcc);
     if (bcc > 0) {
 	smb_fdata(ndo, data1 + 2, f2, maxbuf - (paramlen + datalen), unicodestr);
 
@@ -417,7 +417,7 @@ print_negprot(netdissect_options *ndo,
 	smb_data_print(ndo, words + 1, ND_MIN(wct * 2, ND_BYTES_BETWEEN(maxbuf, words + 1)));
 
     bcc = GET_LE_U_2(data);
-    ND_PRINT("smb_bcc=%u\n", bcc);
+    ND_PRINT(C_RESET, "smb_bcc=%u\n", bcc);
     if (bcc > 0) {
 	if (f2)
 	    smb_fdata(ndo, data + 2, f2, ND_MIN(data + 2 + GET_LE_U_2(data),
@@ -457,7 +457,7 @@ print_sesssetup(netdissect_options *ndo,
 	smb_data_print(ndo, words + 1, ND_MIN(wct * 2, ND_BYTES_BETWEEN(maxbuf, words + 1)));
 
     bcc = GET_LE_U_2(data);
-    ND_PRINT("smb_bcc=%u\n", bcc);
+    ND_PRINT(C_RESET, "smb_bcc=%u\n", bcc);
     if (bcc > 0) {
 	if (f2)
 	    smb_fdata(ndo, data + 2, f2, ND_MIN(data + 2 + GET_LE_U_2(data),
@@ -492,7 +492,7 @@ print_lockingandx(netdissect_options *ndo,
 	smb_fdata(ndo, words + 1, f1, maxwords, unicodestr);
 
     bcc = GET_LE_U_2(data);
-    ND_PRINT("smb_bcc=%u\n", bcc);
+    ND_PRINT(C_RESET, "smb_bcc=%u\n", bcc);
     if (bcc > 0) {
 	if (f2)
 	    smb_fdata(ndo, data + 2, f2, ND_MIN(data + 2 + GET_LE_U_2(data),
@@ -799,14 +799,14 @@ print_smb(netdissect_options *ndo,
     fn = smbfind(command, smb_fns);
 
     if (ndo->ndo_vflag > 1)
-	ND_PRINT("\n");
+	ND_PRINT(C_RESET, "\n");
 
-    ND_PRINT("SMB PACKET: %s (%s)", fn->name, request ? "REQUEST" : "REPLY");
+    ND_PRINT(C_RESET, "SMB PACKET: %s (%s)", fn->name, request ? "REQUEST" : "REPLY");
 
     if (ndo->ndo_vflag < 2)
 	return;
 
-    ND_PRINT("\n");
+    ND_PRINT(C_RESET, "\n");
     flags2 = GET_LE_U_2(buf + 10);
     unicodestr = flags2 & 0x8000;
     nterrcodes = flags2 & 0x4000;
@@ -817,10 +817,10 @@ print_smb(netdissect_options *ndo,
     if (nterrcodes) {
 	nterror = GET_LE_U_4(buf + 5);
 	if (nterror)
-	    ND_PRINT("NTError = %s\n", nt_errstr(nterror));
+	    ND_PRINT(C_RESET, "NTError = %s\n", nt_errstr(nterror));
     } else {
 	if (GET_U_1(buf + 5))
-	    ND_PRINT("SMBError = %s\n", smb_errstr(GET_U_1(buf + 5),
+	    ND_PRINT(C_RESET, "SMBError = %s\n", smb_errstr(GET_U_1(buf + 5),
                                                    GET_LE_U_2(buf + 7)));
     }
 
@@ -858,19 +858,19 @@ print_smb(netdissect_options *ndo,
 
 		    for (i = 0; words + 1 + 2 * i < maxwords; i++) {
 			v = GET_LE_U_2(words + 1 + 2 * i);
-			ND_PRINT("smb_vwv[%u]=%u (0x%X)\n", i, v, v);
+			ND_PRINT(C_RESET, "smb_vwv[%u]=%u (0x%X)\n", i, v, v);
 		    }
 		}
 	    }
 
 	    bcc = GET_LE_U_2(data);
-	    ND_PRINT("smb_bcc=%u\n", bcc);
+	    ND_PRINT(C_RESET, "smb_bcc=%u\n", bcc);
 	    if (f2) {
 		if (bcc > 0)
 		    smb_fdata(ndo, data + 2, f2, data + 2 + bcc, unicodestr);
 	    } else {
 		if (bcc > 0) {
-		    ND_PRINT("smb_buf[]=\n");
+		    ND_PRINT(C_RESET, "smb_buf[]=\n");
 		    smb_data_print(ndo, data + 2, ND_MIN(bcc, ND_BYTES_BETWEEN(maxbuf, data + 2)));
 		}
 	    }
@@ -887,10 +887,10 @@ print_smb(netdissect_options *ndo,
 
 	fn = smbfind(command, smb_fns);
 
-	ND_PRINT("\nSMB PACKET: %s (%s) (CHAINED)\n",
+	ND_PRINT(C_RESET, "\nSMB PACKET: %s (%s) (CHAINED)\n",
 	    fn->name, request ? "REQUEST" : "REPLY");
 	if (newsmboffset <= smboffset) {
-	    ND_PRINT("Bad andX offset: %u <= %u\n", newsmboffset, smboffset);
+	    ND_PRINT(C_RESET, "Bad andX offset: %u <= %u\n", newsmboffset, smboffset);
 	    break;
 	}
 	smboffset = newsmboffset;
@@ -927,18 +927,18 @@ nbt_tcp_print(netdissect_options *ndo,
     startbuf = data;
 
     if (ndo->ndo_vflag < 2) {
-	ND_PRINT(" NBT Session Packet: ");
+	ND_PRINT(C_RESET, " NBT Session Packet: ");
 	switch (type) {
 	case 0x00:
-	    ND_PRINT("Session Message");
+	    ND_PRINT(C_RESET, "Session Message");
 	    break;
 
 	case 0x81:
-	    ND_PRINT("Session Request");
+	    ND_PRINT(C_RESET, "Session Request");
 	    break;
 
 	case 0x82:
-	    ND_PRINT("Session Granted");
+	    ND_PRINT(C_RESET, "Session Granted");
 	    break;
 
 	case 0x83:
@@ -953,29 +953,29 @@ nbt_tcp_print(netdissect_options *ndo,
 		goto trunc;
 	    ecode = GET_U_1(data + 4);
 
-	    ND_PRINT("Session Reject, ");
+	    ND_PRINT(C_RESET, "Session Reject, ");
 	    switch (ecode) {
 	    case 0x80:
-		ND_PRINT("Not listening on called name");
+		ND_PRINT(C_RESET, "Not listening on called name");
 		break;
 	    case 0x81:
-		ND_PRINT("Not listening for calling name");
+		ND_PRINT(C_RESET, "Not listening for calling name");
 		break;
 	    case 0x82:
-		ND_PRINT("Called name not present");
+		ND_PRINT(C_RESET, "Called name not present");
 		break;
 	    case 0x83:
-		ND_PRINT("Called name present, but insufficient resources");
+		ND_PRINT(C_RESET, "Called name present, but insufficient resources");
 		break;
 	    default:
-		ND_PRINT("Unspecified error 0x%X", ecode);
+		ND_PRINT(C_RESET, "Unspecified error 0x%X", ecode);
 		break;
 	    }
 	  }
 	    break;
 
 	case 0x85:
-	    ND_PRINT("Session Keepalive");
+	    ND_PRINT(C_RESET, "Session Keepalive");
 	    break;
 
 	default:
@@ -983,7 +983,7 @@ nbt_tcp_print(netdissect_options *ndo,
 	    break;
 	}
     } else {
-	ND_PRINT("\n>>> NBT Session Packet\n");
+	ND_PRINT(C_RESET, "\n>>> NBT Session Packet\n");
 	switch (type) {
 	case 0x00:
 	    data = smb_fdata(ndo, data, "[P1]NBT Session Message\nFlags=[B]\nLength=[ru]\n",
@@ -993,14 +993,14 @@ nbt_tcp_print(netdissect_options *ndo,
 	    if (nbt_len >= 4 && caplen >= 4 && memcmp(data,"\377SMB",4) == 0) {
 		if (nbt_len > caplen) {
 		    if (nbt_len > length)
-			ND_PRINT("WARNING: Packet is continued in later TCP segments\n");
+			ND_PRINT(C_RESET, "WARNING: Packet is continued in later TCP segments\n");
 		    else
-			ND_PRINT("WARNING: Short packet. Try increasing the snap length by %u\n",
+			ND_PRINT(C_RESET, "WARNING: Short packet. Try increasing the snap length by %u\n",
 			    nbt_len - caplen);
 		}
 		print_smb(ndo, data, maxbuf > data + nbt_len ? data + nbt_len : maxbuf);
 	    } else
-		ND_PRINT("Session packet:(raw data or continuation?)\n");
+		ND_PRINT(C_RESET, "Session packet:(raw data or continuation?)\n");
 	    break;
 
 	case 0x81:
@@ -1027,19 +1027,19 @@ nbt_tcp_print(netdissect_options *ndo,
 		ecode = GET_U_1(origdata + 4);
 		switch (ecode) {
 		case 0x80:
-		    ND_PRINT("Not listening on called name\n");
+		    ND_PRINT(C_RESET, "Not listening on called name\n");
 		    break;
 		case 0x81:
-		    ND_PRINT("Not listening for calling name\n");
+		    ND_PRINT(C_RESET, "Not listening for calling name\n");
 		    break;
 		case 0x82:
-		    ND_PRINT("Called name not present\n");
+		    ND_PRINT(C_RESET, "Called name not present\n");
 		    break;
 		case 0x83:
-		    ND_PRINT("Called name present, but insufficient resources\n");
+		    ND_PRINT(C_RESET, "Called name present, but insufficient resources\n");
 		    break;
 		default:
-		    ND_PRINT("Unspecified error 0x%X\n", ecode);
+		    ND_PRINT(C_RESET, "Unspecified error 0x%X\n", ecode);
 		    break;
 		}
 	    }
@@ -1100,19 +1100,19 @@ nbt_udp137_print(netdissect_options *ndo,
 	return;
 
     if (ndo->ndo_vflag > 1)
-	ND_PRINT("\n>>> ");
+	ND_PRINT(C_RESET, "\n>>> ");
 
-    ND_PRINT("NBT UDP PACKET(137): %s", tok2str(opcode_str, "OPUNKNOWN", opcode));
+    ND_PRINT(C_RESET, "NBT UDP PACKET(137): %s", tok2str(opcode_str, "OPUNKNOWN", opcode));
     if (response) {
-        ND_PRINT("; %s", rcode ? "NEGATIVE" : "POSITIVE");
+        ND_PRINT(C_RESET, "; %s", rcode ? "NEGATIVE" : "POSITIVE");
     }
-    ND_PRINT("; %s; %s", response ? "RESPONSE" : "REQUEST",
+    ND_PRINT(C_RESET, "; %s; %s", response ? "RESPONSE" : "REQUEST",
               (nm_flags & 1) ? "BROADCAST" : "UNICAST");
 
     if (ndo->ndo_vflag < 2)
 	return;
 
-    ND_PRINT("\nTrnID=0x%X\nOpCode=%u\nNmFlags=0x%X\nRcode=%u\nQueryCount=%u\nAnswerCount=%u\nAuthorityCount=%u\nAddressRecCount=%u\n",
+    ND_PRINT(C_RESET, "\nTrnID=0x%X\nOpCode=%u\nNmFlags=0x%X\nRcode=%u\nQueryCount=%u\nAnswerCount=%u\nAuthorityCount=%u\nAddressRecCount=%u\n",
 	name_trn_id, opcode, nm_flags, rcode, qdcount, ancount, nscount,
 	arcount);
 
@@ -1121,12 +1121,12 @@ nbt_udp137_print(netdissect_options *ndo,
     total = ancount + nscount + arcount;
 
     if (qdcount > 100 || total > 100) {
-	ND_PRINT("Corrupt packet??\n");
+	ND_PRINT(C_RESET, "Corrupt packet??\n");
 	return;
     }
 
     if (qdcount) {
-	ND_PRINT("QuestionRecords:\n");
+	ND_PRINT(C_RESET, "QuestionRecords:\n");
 	for (i = 0; i < qdcount; i++) {
 	    p = smb_fdata(ndo, p,
 		"|Name=[n1]\nQuestionType=[rw]\nQuestionClass=[rw]\n#",
@@ -1137,7 +1137,7 @@ nbt_udp137_print(netdissect_options *ndo,
     }
 
     if (total) {
-	ND_PRINT("\nResourceRecords:\n");
+	ND_PRINT(C_RESET, "\nResourceRecords:\n");
 	for (i = 0; i < total; i++) {
 	    u_int rdlen;
 	    u_int restype;
@@ -1150,7 +1150,7 @@ nbt_udp137_print(netdissect_options *ndo,
 	    if (p == NULL)
 		goto out;
 	    rdlen = GET_BE_U_2(p);
-	    ND_PRINT("ResourceLength=%u\nResourceData=\n", rdlen);
+	    ND_PRINT(C_RESET, "ResourceLength=%u\nResourceData=\n", rdlen);
 	    p += 2;
 	    if (rdlen == 6) {
 		p = smb_fdata(ndo, p, "AddrType=[rw]\nAddress=[b.b.b.b]\n", p + rdlen, 0);
@@ -1172,22 +1172,22 @@ nbt_udp137_print(netdissect_options *ndo,
 			if (p >= maxbuf)
 			    goto out;
 			if (GET_U_1(p) & 0x80)
-			    ND_PRINT("<GROUP> ");
+			    ND_PRINT(C_RESET, "<GROUP> ");
 			switch (GET_U_1(p) & 0x60) {
-			case 0x00: ND_PRINT("B "); break;
-			case 0x20: ND_PRINT("P "); break;
-			case 0x40: ND_PRINT("M "); break;
-			case 0x60: ND_PRINT("_ "); break;
+			case 0x00: ND_PRINT(C_RESET, "B "); break;
+			case 0x20: ND_PRINT(C_RESET, "P "); break;
+			case 0x40: ND_PRINT(C_RESET, "M "); break;
+			case 0x60: ND_PRINT(C_RESET, "_ "); break;
 			}
 			if (GET_U_1(p) & 0x10)
-			    ND_PRINT("<DEREGISTERING> ");
+			    ND_PRINT(C_RESET, "<DEREGISTERING> ");
 			if (GET_U_1(p) & 0x08)
-			    ND_PRINT("<CONFLICT> ");
+			    ND_PRINT(C_RESET, "<CONFLICT> ");
 			if (GET_U_1(p) & 0x04)
-			    ND_PRINT("<ACTIVE> ");
+			    ND_PRINT(C_RESET, "<ACTIVE> ");
 			if (GET_U_1(p) & 0x02)
-			    ND_PRINT("<PERMANENT> ");
-			ND_PRINT("\n");
+			    ND_PRINT(C_RESET, "<PERMANENT> ");
+			ND_PRINT(C_RESET, "\n");
 			p += 2;
 			numnames--;
 		    }
@@ -1240,15 +1240,15 @@ smb_tcp_print(netdissect_options *ndo,
     if (smb_len >= 4 && caplen >= 4 && memcmp(data,"\377SMB",4) == 0) {
 	if (smb_len > caplen) {
 	    if (smb_len > length)
-		ND_PRINT(" WARNING: Packet is continued in later TCP segments\n");
+		ND_PRINT(C_RESET, " WARNING: Packet is continued in later TCP segments\n");
 	    else
-		ND_PRINT(" WARNING: Short packet. Try increasing the snap length by %u\n",
+		ND_PRINT(C_RESET, " WARNING: Short packet. Try increasing the snap length by %u\n",
 		    smb_len - caplen);
 	} else
-	    ND_PRINT(" ");
+	    ND_PRINT(C_RESET, " ");
 	print_smb(ndo, data, maxbuf > data + smb_len ? data + smb_len : maxbuf);
     } else
-	ND_PRINT(" SMB-over-TCP packet:(raw data or continuation?)\n");
+	ND_PRINT(C_RESET, " SMB-over-TCP packet:(raw data or continuation?)\n");
     return;
 trunc:
     nd_print_trunc(ndo);
@@ -1271,7 +1271,7 @@ nbt_udp138_print(netdissect_options *ndo,
     startbuf = data;
 
     if (ndo->ndo_vflag < 2) {
-	ND_PRINT("NBT UDP PACKET(138)");
+	ND_PRINT(C_RESET, "NBT UDP PACKET(138)");
 	return;
     }
 
@@ -1374,10 +1374,10 @@ netbeui_print(netdissect_options *ndo,
     startbuf = data;
 
     if (ndo->ndo_vflag < 2) {
-	ND_PRINT("NBF Packet: ");
+	ND_PRINT(C_RESET, "NBF Packet: ");
 	data = smb_fdata(ndo, data, "[P5]#", maxbuf, 0);
     } else {
-	ND_PRINT("\n>>> NBF Packet\nType=0x%X ", control);
+	ND_PRINT(C_RESET, "\n>>> NBF Packet\nType=0x%X ", control);
 	data = smb_fdata(ndo, data, "Length=[u] Signature=[w] Command=[B]\n#", maxbuf, 0);
     }
     if (data == NULL)
@@ -1390,15 +1390,15 @@ netbeui_print(netdissect_options *ndo,
 	    data = smb_fdata(ndo, data, "Unknown NBF Command\n", data2, 0);
     } else {
 	if (ndo->ndo_vflag < 2) {
-	    ND_PRINT("%s", nbf_strings[command].name);
+	    ND_PRINT(C_RESET, "%s", nbf_strings[command].name);
 	    if (nbf_strings[command].nonverbose != NULL)
 		data = smb_fdata(ndo, data, nbf_strings[command].nonverbose, data2, 0);
 	} else {
-	    ND_PRINT("%s:\n", nbf_strings[command].name);
+	    ND_PRINT(C_RESET, "%s:\n", nbf_strings[command].name);
 	    if (nbf_strings[command].verbose != NULL)
 		data = smb_fdata(ndo, data, nbf_strings[command].verbose, data2, 0);
 	    else
-		ND_PRINT("\n");
+		ND_PRINT(C_RESET, "\n");
 	}
     }
 
@@ -1430,7 +1430,7 @@ netbeui_print(netdissect_options *ndo,
 	    if ((data2 + i + 3) >= maxbuf)
 		break;
 	    if (memcmp(data2 + i, "\377SMB", 4) == 0) {
-		ND_PRINT("found SMB packet at %u\n", i);
+		ND_PRINT(C_RESET, "found SMB packet at %u\n", i);
 		print_smb(ndo, data2 + i, maxbuf);
 		break;
 	    }

--- a/print-someip.c
+++ b/print-someip.c
@@ -104,35 +104,35 @@ someip_print(netdissect_options *ndo, const u_char *bp, const u_int len)
     event_flag = (message_id & 0x00008000) >> 15;
     method_or_event_id = message_id & 0x00007FFF;
     bp += 4;
-    ND_PRINT(", service %u, %s %u",
+    ND_PRINT(C_RESET, ", service %u, %s %u",
              service_id, event_flag ? "event" : "method", method_or_event_id);
 
     message_len = GET_BE_U_4(bp);
     bp += 4;
-    ND_PRINT(", len %u", message_len);
+    ND_PRINT(C_RESET, ", len %u", message_len);
 
     request_id = GET_BE_U_4(bp);
     client_id = request_id >> 16;
     session_id = request_id & 0x0000FFFF;
     bp += 4;
-    ND_PRINT(", client %u, session %u", client_id, session_id);
+    ND_PRINT(C_RESET, ", client %u, session %u", client_id, session_id);
 
     protocol_version = GET_U_1(bp);
     bp += 1;
-    ND_PRINT(", pver %u", protocol_version);
+    ND_PRINT(C_RESET, ", pver %u", protocol_version);
 
     interface_version = GET_U_1(bp);
     bp += 1;
-    ND_PRINT(", iver %u", interface_version);
+    ND_PRINT(C_RESET, ", iver %u", interface_version);
 
     message_type = GET_U_1(bp);
     bp += 1;
-    ND_PRINT(", msgtype %s",
+    ND_PRINT(C_RESET, ", msgtype %s",
              tok2str(message_type_values, "Unknown", message_type));
 
     return_code = GET_U_1(bp);
     bp += 1;
-    ND_PRINT(", retcode %s\n",
+    ND_PRINT(C_RESET, ", retcode %s\n",
 	     tok2str(return_code_values, "Unknown", return_code));
 
     return;

--- a/print-ssh.c
+++ b/print-ssh.c
@@ -84,9 +84,9 @@ ssh_print_version(netdissect_options *ndo, const u_char *pptr, u_int len)
 trunc:
 	return -1;
 print:
-	ND_PRINT(": ");
+	ND_PRINT(C_RESET, ": ");
 	nd_print_protocol_caps(ndo);
-	ND_PRINT(": %.*s", (int)idx, pptr);
+	ND_PRINT(C_RESET, ": %.*s", (int)idx, pptr);
 	return idx;
 }
 

--- a/print-stp.c
+++ b/print-stp.c
@@ -105,10 +105,10 @@ stp_print_config_bpdu(netdissect_options *ndo, const struct stp_bpdu_ *stp_bpdu,
     uint8_t bpdu_flags;
 
     bpdu_flags = GET_U_1(stp_bpdu->flags);
-    ND_PRINT(", Flags [%s]",
+    ND_PRINT(C_RESET, C_RESET ", Flags [%s]",
            bittok2str(stp_bpdu_flag_values, "none", bpdu_flags));
 
-    ND_PRINT(", bridge-id %s.%04x, length %u",
+    ND_PRINT(C_RESET, C_RESET ", bridge-id %s.%04x, length %u",
            stp_print_bridge_id(ndo, stp_bpdu->bridge_id),
            GET_BE_U_2(stp_bpdu->port_id), length);
 
@@ -117,20 +117,20 @@ stp_print_config_bpdu(netdissect_options *ndo, const struct stp_bpdu_ *stp_bpdu,
         return;
     }
 
-    ND_PRINT("\n\tmessage-age %.2fs, max-age %.2fs"
+    ND_PRINT(C_RESET, C_RESET "\n\tmessage-age %.2fs, max-age %.2fs"
            ", hello-time %.2fs, forwarding-delay %.2fs",
            (float) GET_BE_U_2(stp_bpdu->message_age) / STP_TIME_BASE,
            (float) GET_BE_U_2(stp_bpdu->max_age) / STP_TIME_BASE,
            (float) GET_BE_U_2(stp_bpdu->hello_time) / STP_TIME_BASE,
            (float) GET_BE_U_2(stp_bpdu->forward_delay) / STP_TIME_BASE);
 
-    ND_PRINT("\n\troot-id %s, root-pathcost %u",
+    ND_PRINT(C_RESET, C_RESET "\n\troot-id %s, root-pathcost %u",
            stp_print_bridge_id(ndo, stp_bpdu->root_id),
            GET_BE_U_4(stp_bpdu->root_path_cost));
 
     /* Port role is only valid for 802.1w */
     if (GET_U_1(stp_bpdu->protocol_version) == STP_PROTO_RAPID) {
-        ND_PRINT(", port-role %s",
+        ND_PRINT(C_RESET, C_RESET ", port-role %s",
                tok2str(rstp_obj_port_role_values, "Unknown",
                        RSTP_EXTRACT_PORT_ROLE(bpdu_flags)));
     }
@@ -244,7 +244,7 @@ stp_print_mstp_bpdu(netdissect_options *ndo, const struct stp_bpdu_ *stp_bpdu,
 
     ptr = (const u_char *)stp_bpdu;
     bpdu_flags = GET_U_1(stp_bpdu->flags);
-    ND_PRINT(", CIST Flags [%s], length %u",
+    ND_PRINT(C_RESET, C_RESET ", CIST Flags [%s], length %u",
            bittok2str(stp_bpdu_flag_values, "none", bpdu_flags), length);
 
     /*
@@ -254,30 +254,30 @@ stp_print_mstp_bpdu(netdissect_options *ndo, const struct stp_bpdu_ *stp_bpdu,
         return;
     }
 
-    ND_PRINT("\n\tport-role %s, ",
+    ND_PRINT(C_RESET, C_RESET "\n\tport-role %s, ",
            tok2str(rstp_obj_port_role_values, "Unknown",
                    RSTP_EXTRACT_PORT_ROLE(bpdu_flags)));
 
-    ND_PRINT("CIST root-id %s, CIST ext-pathcost %u",
+    ND_PRINT(C_RESET, C_RESET "CIST root-id %s, CIST ext-pathcost %u",
            stp_print_bridge_id(ndo, stp_bpdu->root_id),
            GET_BE_U_4(stp_bpdu->root_path_cost));
 
-    ND_PRINT("\n\tCIST regional-root-id %s, ",
+    ND_PRINT(C_RESET, C_RESET "\n\tCIST regional-root-id %s, ",
            stp_print_bridge_id(ndo, stp_bpdu->bridge_id));
 
-    ND_PRINT("CIST port-id %04x,", GET_BE_U_2(stp_bpdu->port_id));
+    ND_PRINT(C_RESET, C_RESET "CIST port-id %04x,", GET_BE_U_2(stp_bpdu->port_id));
 
-    ND_PRINT("\n\tmessage-age %.2fs, max-age %.2fs"
+    ND_PRINT(C_RESET, C_RESET "\n\tmessage-age %.2fs, max-age %.2fs"
            ", hello-time %.2fs, forwarding-delay %.2fs",
            (float) GET_BE_U_2(stp_bpdu->message_age) / STP_TIME_BASE,
            (float) GET_BE_U_2(stp_bpdu->max_age) / STP_TIME_BASE,
            (float) GET_BE_U_2(stp_bpdu->hello_time) / STP_TIME_BASE,
            (float) GET_BE_U_2(stp_bpdu->forward_delay) / STP_TIME_BASE);
 
-    ND_PRINT("\n\tv3len %u, ", GET_BE_U_2(ptr + MST_BPDU_VER3_LEN_OFFSET));
-    ND_PRINT("MCID Name ");
+    ND_PRINT(C_RESET, C_RESET "\n\tv3len %u, ", GET_BE_U_2(ptr + MST_BPDU_VER3_LEN_OFFSET));
+    ND_PRINT(C_RESET, C_RESET "MCID Name ");
     nd_printjnp(ndo, ptr + MST_BPDU_CONFIG_NAME_OFFSET, 32);
-    ND_PRINT(", rev %u,"
+    ND_PRINT(C_RESET, C_RESET ", rev %u,"
             "\n\t\tdigest %08x%08x%08x%08x, ",
 	          GET_BE_U_2(ptr + MST_BPDU_CONFIG_NAME_OFFSET + 32),
 	          GET_BE_U_4(ptr + MST_BPDU_CONFIG_DIGEST_OFFSET),
@@ -285,13 +285,13 @@ stp_print_mstp_bpdu(netdissect_options *ndo, const struct stp_bpdu_ *stp_bpdu,
 	          GET_BE_U_4(ptr + MST_BPDU_CONFIG_DIGEST_OFFSET + 8),
 	          GET_BE_U_4(ptr + MST_BPDU_CONFIG_DIGEST_OFFSET + 12));
 
-    ND_PRINT("CIST int-root-pathcost %u,",
+    ND_PRINT(C_RESET, C_RESET "CIST int-root-pathcost %u,",
             GET_BE_U_4(ptr + MST_BPDU_CIST_INT_PATH_COST_OFFSET));
 
-    ND_PRINT("\n\tCIST bridge-id %s, ",
+    ND_PRINT(C_RESET, C_RESET "\n\tCIST bridge-id %s, ",
            stp_print_bridge_id(ndo, ptr + MST_BPDU_CIST_BRIDGE_ID_OFFSET));
 
-    ND_PRINT("CIST remaining-hops %u",
+    ND_PRINT(C_RESET, C_RESET "CIST remaining-hops %u",
              GET_U_1(ptr + MST_BPDU_CIST_REMAIN_HOPS_OFFSET));
 
     /* Dump all MSTI's */
@@ -303,16 +303,16 @@ stp_print_mstp_bpdu(netdissect_options *ndo, const struct stp_bpdu_ *stp_bpdu,
             msti = GET_BE_U_2(ptr + offset + MST_BPDU_MSTI_ROOT_PRIO_OFFSET);
             msti = msti & 0x0FFF;
 
-            ND_PRINT("\n\tMSTI %u, Flags [%s], port-role %s",
+            ND_PRINT(C_RESET, C_RESET "\n\tMSTI %u, Flags [%s], port-role %s",
                    msti,
                    bittok2str(stp_bpdu_flag_values, "none", GET_U_1(ptr + offset)),
                    tok2str(rstp_obj_port_role_values, "Unknown",
                            RSTP_EXTRACT_PORT_ROLE(GET_U_1(ptr + offset))));
-            ND_PRINT("\n\t\tMSTI regional-root-id %s, pathcost %u",
+            ND_PRINT(C_RESET, C_RESET "\n\t\tMSTI regional-root-id %s, pathcost %u",
                    stp_print_bridge_id(ndo, ptr + offset +
                                        MST_BPDU_MSTI_ROOT_PRIO_OFFSET),
                    GET_BE_U_4(ptr + offset + MST_BPDU_MSTI_ROOT_PATH_COST_OFFSET));
-            ND_PRINT("\n\t\tMSTI bridge-prio %u, port-prio %u, hops %u",
+            ND_PRINT(C_RESET, C_RESET "\n\t\tMSTI bridge-prio %u, port-prio %u, hops %u",
                    GET_U_1(ptr + offset + MST_BPDU_MSTI_BRIDGE_PRIO_OFFSET) >> 4,
                    GET_U_1(ptr + offset + MST_BPDU_MSTI_PORT_PRIO_OFFSET) >> 4,
                    GET_U_1(ptr + offset + MST_BPDU_MSTI_REMAIN_HOPS_OFFSET));
@@ -338,17 +338,17 @@ stp_print_spb_bpdu(netdissect_options *ndo, const struct stp_bpdu_ *stp_bpdu,
 
     ptr = (const u_char *)stp_bpdu;
 
-    ND_PRINT("\n\tv4len %u, ", GET_BE_U_2(ptr + offset));
-    ND_PRINT("AUXMCID Name ");
+    ND_PRINT(C_RESET, C_RESET "\n\tv4len %u, ", GET_BE_U_2(ptr + offset));
+    ND_PRINT(C_RESET, C_RESET "AUXMCID Name ");
     nd_printjnp(ndo, ptr + offset + SPB_BPDU_CONFIG_NAME_OFFSET, 32);
-    ND_PRINT(", Rev %u,\n\t\tdigest %08x%08x%08x%08x",
+    ND_PRINT(C_RESET, C_RESET ", Rev %u,\n\t\tdigest %08x%08x%08x%08x",
             GET_BE_U_2(ptr + offset + SPB_BPDU_CONFIG_REV_OFFSET),
             GET_BE_U_4(ptr + offset + SPB_BPDU_CONFIG_DIGEST_OFFSET),
             GET_BE_U_4(ptr + offset + SPB_BPDU_CONFIG_DIGEST_OFFSET + 4),
             GET_BE_U_4(ptr + offset + SPB_BPDU_CONFIG_DIGEST_OFFSET + 8),
             GET_BE_U_4(ptr + offset + SPB_BPDU_CONFIG_DIGEST_OFFSET + 12));
 
-    ND_PRINT("\n\tAgreement num %u, Discarded Agreement num %u, Agreement valid-"
+    ND_PRINT(C_RESET, C_RESET "\n\tAgreement num %u, Discarded Agreement num %u, Agreement valid-"
             "flag %u,\n\tRestricted role-flag: %u, Format id %u cap %u, "
             "Convention id %u cap %u,\n\tEdge count %u, "
             "Agreement digest %08x%08x%08x%08x%08x",
@@ -388,12 +388,12 @@ stp_print(netdissect_options *ndo, const u_char *p, u_int length)
         goto invalid;
 
     if (GET_BE_U_2(stp_bpdu->protocol_id)) {
-        ND_PRINT("unknown STP version, length %u", length);
+        ND_PRINT(C_RESET, C_RESET "unknown STP version, length %u", length);
         return;
     }
 
     protocol_version = GET_U_1(stp_bpdu->protocol_version);
-    ND_PRINT("STP %s", tok2str(stp_proto_values, "Unknown STP protocol (0x%02x)",
+    ND_PRINT(C_RESET, C_RESET "STP %s", tok2str(stp_proto_values, "Unknown STP protocol (0x%02x)",
                          protocol_version));
 
     switch (protocol_version) {
@@ -407,7 +407,7 @@ stp_print(netdissect_options *ndo, const u_char *p, u_int length)
     }
 
     bpdu_type = GET_U_1(stp_bpdu->bpdu_type);
-    ND_PRINT(", %s", tok2str(stp_bpdu_type_values, "Unknown BPDU Type (0x%02x)",
+    ND_PRINT(C_RESET, C_RESET ", %s", tok2str(stp_bpdu_type_values, "Unknown BPDU Type (0x%02x)",
                            bpdu_type));
 
     switch (bpdu_type) {

--- a/print-stp.c
+++ b/print-stp.c
@@ -105,10 +105,10 @@ stp_print_config_bpdu(netdissect_options *ndo, const struct stp_bpdu_ *stp_bpdu,
     uint8_t bpdu_flags;
 
     bpdu_flags = GET_U_1(stp_bpdu->flags);
-    ND_PRINT(C_RESET, C_RESET ", Flags [%s]",
+    ND_PRINT(C_RESET, ", Flags [%s]",
            bittok2str(stp_bpdu_flag_values, "none", bpdu_flags));
 
-    ND_PRINT(C_RESET, C_RESET ", bridge-id %s.%04x, length %u",
+    ND_PRINT(C_RESET, ", bridge-id %s.%04x, length %u",
            stp_print_bridge_id(ndo, stp_bpdu->bridge_id),
            GET_BE_U_2(stp_bpdu->port_id), length);
 
@@ -117,20 +117,20 @@ stp_print_config_bpdu(netdissect_options *ndo, const struct stp_bpdu_ *stp_bpdu,
         return;
     }
 
-    ND_PRINT(C_RESET, C_RESET "\n\tmessage-age %.2fs, max-age %.2fs"
+    ND_PRINT(C_RESET, "\n\tmessage-age %.2fs, max-age %.2fs"
            ", hello-time %.2fs, forwarding-delay %.2fs",
            (float) GET_BE_U_2(stp_bpdu->message_age) / STP_TIME_BASE,
            (float) GET_BE_U_2(stp_bpdu->max_age) / STP_TIME_BASE,
            (float) GET_BE_U_2(stp_bpdu->hello_time) / STP_TIME_BASE,
            (float) GET_BE_U_2(stp_bpdu->forward_delay) / STP_TIME_BASE);
 
-    ND_PRINT(C_RESET, C_RESET "\n\troot-id %s, root-pathcost %u",
+    ND_PRINT(C_RESET, "\n\troot-id %s, root-pathcost %u",
            stp_print_bridge_id(ndo, stp_bpdu->root_id),
            GET_BE_U_4(stp_bpdu->root_path_cost));
 
     /* Port role is only valid for 802.1w */
     if (GET_U_1(stp_bpdu->protocol_version) == STP_PROTO_RAPID) {
-        ND_PRINT(C_RESET, C_RESET ", port-role %s",
+        ND_PRINT(C_RESET, ", port-role %s",
                tok2str(rstp_obj_port_role_values, "Unknown",
                        RSTP_EXTRACT_PORT_ROLE(bpdu_flags)));
     }
@@ -244,7 +244,7 @@ stp_print_mstp_bpdu(netdissect_options *ndo, const struct stp_bpdu_ *stp_bpdu,
 
     ptr = (const u_char *)stp_bpdu;
     bpdu_flags = GET_U_1(stp_bpdu->flags);
-    ND_PRINT(C_RESET, C_RESET ", CIST Flags [%s], length %u",
+    ND_PRINT(C_RESET, ", CIST Flags [%s], length %u",
            bittok2str(stp_bpdu_flag_values, "none", bpdu_flags), length);
 
     /*
@@ -254,30 +254,30 @@ stp_print_mstp_bpdu(netdissect_options *ndo, const struct stp_bpdu_ *stp_bpdu,
         return;
     }
 
-    ND_PRINT(C_RESET, C_RESET "\n\tport-role %s, ",
+    ND_PRINT(C_RESET, "\n\tport-role %s, ",
            tok2str(rstp_obj_port_role_values, "Unknown",
                    RSTP_EXTRACT_PORT_ROLE(bpdu_flags)));
 
-    ND_PRINT(C_RESET, C_RESET "CIST root-id %s, CIST ext-pathcost %u",
+    ND_PRINT(C_RESET, "CIST root-id %s, CIST ext-pathcost %u",
            stp_print_bridge_id(ndo, stp_bpdu->root_id),
            GET_BE_U_4(stp_bpdu->root_path_cost));
 
-    ND_PRINT(C_RESET, C_RESET "\n\tCIST regional-root-id %s, ",
+    ND_PRINT(C_RESET, "\n\tCIST regional-root-id %s, ",
            stp_print_bridge_id(ndo, stp_bpdu->bridge_id));
 
-    ND_PRINT(C_RESET, C_RESET "CIST port-id %04x,", GET_BE_U_2(stp_bpdu->port_id));
+    ND_PRINT(C_RESET, "CIST port-id %04x,", GET_BE_U_2(stp_bpdu->port_id));
 
-    ND_PRINT(C_RESET, C_RESET "\n\tmessage-age %.2fs, max-age %.2fs"
+    ND_PRINT(C_RESET, "\n\tmessage-age %.2fs, max-age %.2fs"
            ", hello-time %.2fs, forwarding-delay %.2fs",
            (float) GET_BE_U_2(stp_bpdu->message_age) / STP_TIME_BASE,
            (float) GET_BE_U_2(stp_bpdu->max_age) / STP_TIME_BASE,
            (float) GET_BE_U_2(stp_bpdu->hello_time) / STP_TIME_BASE,
            (float) GET_BE_U_2(stp_bpdu->forward_delay) / STP_TIME_BASE);
 
-    ND_PRINT(C_RESET, C_RESET "\n\tv3len %u, ", GET_BE_U_2(ptr + MST_BPDU_VER3_LEN_OFFSET));
-    ND_PRINT(C_RESET, C_RESET "MCID Name ");
+    ND_PRINT(C_RESET, "\n\tv3len %u, ", GET_BE_U_2(ptr + MST_BPDU_VER3_LEN_OFFSET));
+    ND_PRINT(C_RESET, "MCID Name ");
     nd_printjnp(ndo, ptr + MST_BPDU_CONFIG_NAME_OFFSET, 32);
-    ND_PRINT(C_RESET, C_RESET ", rev %u,"
+    ND_PRINT(C_RESET, ", rev %u,"
             "\n\t\tdigest %08x%08x%08x%08x, ",
 	          GET_BE_U_2(ptr + MST_BPDU_CONFIG_NAME_OFFSET + 32),
 	          GET_BE_U_4(ptr + MST_BPDU_CONFIG_DIGEST_OFFSET),
@@ -285,13 +285,13 @@ stp_print_mstp_bpdu(netdissect_options *ndo, const struct stp_bpdu_ *stp_bpdu,
 	          GET_BE_U_4(ptr + MST_BPDU_CONFIG_DIGEST_OFFSET + 8),
 	          GET_BE_U_4(ptr + MST_BPDU_CONFIG_DIGEST_OFFSET + 12));
 
-    ND_PRINT(C_RESET, C_RESET "CIST int-root-pathcost %u,",
+    ND_PRINT(C_RESET, "CIST int-root-pathcost %u,",
             GET_BE_U_4(ptr + MST_BPDU_CIST_INT_PATH_COST_OFFSET));
 
-    ND_PRINT(C_RESET, C_RESET "\n\tCIST bridge-id %s, ",
+    ND_PRINT(C_RESET, "\n\tCIST bridge-id %s, ",
            stp_print_bridge_id(ndo, ptr + MST_BPDU_CIST_BRIDGE_ID_OFFSET));
 
-    ND_PRINT(C_RESET, C_RESET "CIST remaining-hops %u",
+    ND_PRINT(C_RESET, "CIST remaining-hops %u",
              GET_U_1(ptr + MST_BPDU_CIST_REMAIN_HOPS_OFFSET));
 
     /* Dump all MSTI's */
@@ -303,16 +303,16 @@ stp_print_mstp_bpdu(netdissect_options *ndo, const struct stp_bpdu_ *stp_bpdu,
             msti = GET_BE_U_2(ptr + offset + MST_BPDU_MSTI_ROOT_PRIO_OFFSET);
             msti = msti & 0x0FFF;
 
-            ND_PRINT(C_RESET, C_RESET "\n\tMSTI %u, Flags [%s], port-role %s",
+            ND_PRINT(C_RESET, "\n\tMSTI %u, Flags [%s], port-role %s",
                    msti,
                    bittok2str(stp_bpdu_flag_values, "none", GET_U_1(ptr + offset)),
                    tok2str(rstp_obj_port_role_values, "Unknown",
                            RSTP_EXTRACT_PORT_ROLE(GET_U_1(ptr + offset))));
-            ND_PRINT(C_RESET, C_RESET "\n\t\tMSTI regional-root-id %s, pathcost %u",
+            ND_PRINT(C_RESET, "\n\t\tMSTI regional-root-id %s, pathcost %u",
                    stp_print_bridge_id(ndo, ptr + offset +
                                        MST_BPDU_MSTI_ROOT_PRIO_OFFSET),
                    GET_BE_U_4(ptr + offset + MST_BPDU_MSTI_ROOT_PATH_COST_OFFSET));
-            ND_PRINT(C_RESET, C_RESET "\n\t\tMSTI bridge-prio %u, port-prio %u, hops %u",
+            ND_PRINT(C_RESET, "\n\t\tMSTI bridge-prio %u, port-prio %u, hops %u",
                    GET_U_1(ptr + offset + MST_BPDU_MSTI_BRIDGE_PRIO_OFFSET) >> 4,
                    GET_U_1(ptr + offset + MST_BPDU_MSTI_PORT_PRIO_OFFSET) >> 4,
                    GET_U_1(ptr + offset + MST_BPDU_MSTI_REMAIN_HOPS_OFFSET));
@@ -338,17 +338,17 @@ stp_print_spb_bpdu(netdissect_options *ndo, const struct stp_bpdu_ *stp_bpdu,
 
     ptr = (const u_char *)stp_bpdu;
 
-    ND_PRINT(C_RESET, C_RESET "\n\tv4len %u, ", GET_BE_U_2(ptr + offset));
-    ND_PRINT(C_RESET, C_RESET "AUXMCID Name ");
+    ND_PRINT(C_RESET, "\n\tv4len %u, ", GET_BE_U_2(ptr + offset));
+    ND_PRINT(C_RESET, "AUXMCID Name ");
     nd_printjnp(ndo, ptr + offset + SPB_BPDU_CONFIG_NAME_OFFSET, 32);
-    ND_PRINT(C_RESET, C_RESET ", Rev %u,\n\t\tdigest %08x%08x%08x%08x",
+    ND_PRINT(C_RESET, ", Rev %u,\n\t\tdigest %08x%08x%08x%08x",
             GET_BE_U_2(ptr + offset + SPB_BPDU_CONFIG_REV_OFFSET),
             GET_BE_U_4(ptr + offset + SPB_BPDU_CONFIG_DIGEST_OFFSET),
             GET_BE_U_4(ptr + offset + SPB_BPDU_CONFIG_DIGEST_OFFSET + 4),
             GET_BE_U_4(ptr + offset + SPB_BPDU_CONFIG_DIGEST_OFFSET + 8),
             GET_BE_U_4(ptr + offset + SPB_BPDU_CONFIG_DIGEST_OFFSET + 12));
 
-    ND_PRINT(C_RESET, C_RESET "\n\tAgreement num %u, Discarded Agreement num %u, Agreement valid-"
+    ND_PRINT(C_RESET, "\n\tAgreement num %u, Discarded Agreement num %u, Agreement valid-"
             "flag %u,\n\tRestricted role-flag: %u, Format id %u cap %u, "
             "Convention id %u cap %u,\n\tEdge count %u, "
             "Agreement digest %08x%08x%08x%08x%08x",
@@ -388,12 +388,12 @@ stp_print(netdissect_options *ndo, const u_char *p, u_int length)
         goto invalid;
 
     if (GET_BE_U_2(stp_bpdu->protocol_id)) {
-        ND_PRINT(C_RESET, C_RESET "unknown STP version, length %u", length);
+        ND_PRINT(C_RESET, "unknown STP version, length %u", length);
         return;
     }
 
     protocol_version = GET_U_1(stp_bpdu->protocol_version);
-    ND_PRINT(C_RESET, C_RESET "STP %s", tok2str(stp_proto_values, "Unknown STP protocol (0x%02x)",
+    ND_PRINT(C_RESET, "STP %s", tok2str(stp_proto_values, "Unknown STP protocol (0x%02x)",
                          protocol_version));
 
     switch (protocol_version) {
@@ -407,7 +407,7 @@ stp_print(netdissect_options *ndo, const u_char *p, u_int length)
     }
 
     bpdu_type = GET_U_1(stp_bpdu->bpdu_type);
-    ND_PRINT(C_RESET, C_RESET ", %s", tok2str(stp_bpdu_type_values, "Unknown BPDU Type (0x%02x)",
+    ND_PRINT(C_RESET, ", %s", tok2str(stp_bpdu_type_values, "Unknown BPDU Type (0x%02x)",
                            bpdu_type));
 
     switch (bpdu_type) {

--- a/print-sunatm.c
+++ b/print-sunatm.c
@@ -73,7 +73,10 @@ sunatm_if_print(netdissect_options *ndo,
 	ndo->ndo_protocol = "sunatm";
 
 	if (ndo->ndo_eflag) {
-		ND_PRINT(GET_U_1(p + DIR_POS) & 0x80 ? "Tx: " : "Rx: ");
+		if(GET_U_1(p + DIR_POS) & 0x80)
+			ND_PRINT(C_RESET, "Tx: ");
+		else
+			ND_PRINT(C_RESET, "Rx: ");
 	}
 
 	switch (GET_U_1(p + DIR_POS) & 0x0f) {

--- a/print-sunrpc.c
+++ b/print-sunrpc.c
@@ -181,26 +181,26 @@ sunrpc_print(netdissect_options *ndo, const u_char *bp,
 	switch (IP_V((const struct ip *)bp2)) {
 	case 4:
 		ip = (const struct ip *)bp2;
-		ND_PRINT("%s.%s > %s.%s: %u",
+		ND_PRINT(C_RESET, "%s.%s > %s.%s: %u",
 		    GET_IPADDR_STRING(ip->ip_src), srcid,
 		    GET_IPADDR_STRING(ip->ip_dst), dstid, length);
 		break;
 	case 6:
 		ip6 = (const struct ip6_hdr *)bp2;
-		ND_PRINT("%s.%s > %s.%s: %u",
+		ND_PRINT(C_RESET, "%s.%s > %s.%s: %u",
 		    GET_IP6ADDR_STRING(ip6->ip6_src), srcid,
 		    GET_IP6ADDR_STRING(ip6->ip6_dst), dstid, length);
 		break;
 	default:
-		ND_PRINT("%s.%s > %s.%s: %u", "?", srcid, "?", dstid, length);
+		ND_PRINT(C_RESET, "%s.%s > %s.%s: %u", "?", srcid, "?", dstid, length);
 		break;
 	}
 
-	ND_PRINT(" %s", tok2str(proc2str, " proc #%u",
+	ND_PRINT(C_RESET, " %s", tok2str(proc2str, " proc #%u",
 	    GET_BE_U_4(rp->rm_call.cb_proc)));
 	x = GET_BE_U_4(rp->rm_call.cb_rpcvers);
 	if (x != SUNRPC_MSG_VERSION)
-		ND_PRINT(" [rpcver %u]", x);
+		ND_PRINT(C_RESET, " [rpcver %u]", x);
 
 	switch (GET_BE_U_4(rp->rm_call.cb_proc)) {
 
@@ -210,10 +210,10 @@ sunrpc_print(netdissect_options *ndo, const u_char *bp,
 	case SUNRPC_PMAPPROC_CALLIT:
 		x = GET_BE_U_4(rp->rm_call.cb_prog);
 		if (!ndo->ndo_nflag)
-			ND_PRINT(" %s", progstr(x));
+			ND_PRINT(C_RESET, " %s", progstr(x));
 		else
-			ND_PRINT(" %u", x);
-		ND_PRINT(".%u", GET_BE_U_4(rp->rm_call.cb_vers));
+			ND_PRINT(C_RESET, " %u", x);
+		ND_PRINT(C_RESET, ".%u", GET_BE_U_4(rp->rm_call.cb_vers));
 		break;
 	}
 }

--- a/print-symantec.c
+++ b/print-symantec.c
@@ -49,19 +49,19 @@ symantec_hdr_print(netdissect_options *ndo, const u_char *bp, u_int length)
 	etype = GET_BE_U_2(sp->ether_type);
 	if (!ndo->ndo_qflag) {
 	        if (etype <= MAX_ETHERNET_LENGTH_VAL)
-		          ND_PRINT("invalid ethertype %u", etype);
+		          ND_PRINT(C_RESET, "invalid ethertype %u", etype);
                 else
-		          ND_PRINT("ethertype %s (0x%04x)",
+		          ND_PRINT(C_RESET, "ethertype %s (0x%04x)",
 				       tok2str(ethertype_values,"Unknown", etype),
                                        etype);
         } else {
                 if (etype <= MAX_ETHERNET_LENGTH_VAL)
-                          ND_PRINT("invalid ethertype %u", etype);
+                          ND_PRINT(C_RESET, "invalid ethertype %u", etype);
                 else
-                          ND_PRINT("%s", tok2str(ethertype_values,"Unknown Ethertype (0x%04x)", etype));
+                          ND_PRINT(C_RESET, "%s", tok2str(ethertype_values,"Unknown Ethertype (0x%04x)", etype));
         }
 
-	ND_PRINT(", length %u: ", length);
+	ND_PRINT(C_RESET, ", length %u: ", length);
 }
 
 /*

--- a/print-syslog.c
+++ b/print-syslog.c
@@ -111,14 +111,14 @@ syslog_print(netdissect_options *ndo,
 
     if (ndo->ndo_vflag < 1 )
     {
-        ND_PRINT("SYSLOG %s.%s, length: %u",
+        ND_PRINT(C_RESET, "SYSLOG %s.%s, length: %u",
                tok2str(syslog_facility_values, "unknown (%u)", facility),
                tok2str(syslog_severity_values, "unknown (%u)", severity),
                len);
         return;
     }
 
-    ND_PRINT("SYSLOG, length: %u\n\tFacility %s (%u), Severity %s (%u)\n\tMsg: ",
+    ND_PRINT(C_RESET, "SYSLOG, length: %u\n\tFacility %s (%u), Severity %s (%u)\n\tMsg: ",
            len,
            tok2str(syslog_facility_values, "unknown (%u)", facility),
            facility,

--- a/print-tcp.c
+++ b/print-tcp.c
@@ -187,11 +187,11 @@ tcp_print(netdissect_options *ndo,
         ch = '\0';
         if (!ND_TTEST_2(tp->th_dport)) {
                 if (ip6) {
-                        ND_PRINT("%s > %s:",
+                        ND_PRINT(C_RESET, "%s > %s:",
                                  GET_IP6ADDR_STRING(ip6->ip6_src),
                                  GET_IP6ADDR_STRING(ip6->ip6_dst));
                 } else {
-                        ND_PRINT("%s > %s:",
+                        ND_PRINT(C_RESET, "%s > %s:",
                                  GET_IPADDR_STRING(ip->ip_src),
                                  GET_IPADDR_STRING(ip->ip_dst));
                 }
@@ -203,24 +203,24 @@ tcp_print(netdissect_options *ndo,
 
         if (ip6) {
                 if (GET_U_1(ip6->ip6_nxt) == IPPROTO_TCP) {
-                        ND_PRINT("%s.%s > %s.%s: ",
+                        ND_PRINT(C_RESET, "%s.%s > %s.%s: ",
                                  GET_IP6ADDR_STRING(ip6->ip6_src),
                                  tcpport_string(ndo, sport),
                                  GET_IP6ADDR_STRING(ip6->ip6_dst),
                                  tcpport_string(ndo, dport));
                 } else {
-                        ND_PRINT("%s > %s: ",
+                        ND_PRINT(C_RESET, "%s > %s: ",
                                  tcpport_string(ndo, sport), tcpport_string(ndo, dport));
                 }
         } else {
                 if (GET_U_1(ip->ip_p) == IPPROTO_TCP) {
-                        ND_PRINT("%s.%s > %s.%s: ",
+                        ND_PRINT(C_RESET, "%s.%s > %s.%s: ",
                                  GET_IPADDR_STRING(ip->ip_src),
                                  tcpport_string(ndo, sport),
                                  GET_IPADDR_STRING(ip->ip_dst),
                                  tcpport_string(ndo, dport));
                 } else {
-                        ND_PRINT("%s > %s: ",
+                        ND_PRINT(C_RESET, "%s > %s: ",
                                  tcpport_string(ndo, sport), tcpport_string(ndo, dport));
                 }
         }
@@ -228,7 +228,7 @@ tcp_print(netdissect_options *ndo,
         hlen = TH_OFF(tp) * 4;
 
         if (hlen < sizeof(*tp)) {
-                ND_PRINT(" tcp %u [bad hdr length %u - too short, < %zu]",
+                ND_PRINT(C_RESET, " tcp %u [bad hdr length %u - too short, < %zu]",
                          length - hlen, hlen, sizeof(*tp));
                 goto invalid;
         }
@@ -239,9 +239,9 @@ tcp_print(netdissect_options *ndo,
         urp = GET_BE_U_2(tp->th_urp);
 
         if (ndo->ndo_qflag) {
-                ND_PRINT("tcp %u", length - hlen);
+                ND_PRINT(C_RESET, "tcp %u", length - hlen);
                 if (hlen > length) {
-                        ND_PRINT(" [bad hdr length %u - too long, > %u]",
+                        ND_PRINT(C_RESET, " [bad hdr length %u - too long, > %u]",
                                  hlen, length);
                         goto invalid;
                 }
@@ -249,7 +249,7 @@ tcp_print(netdissect_options *ndo,
         }
 
         flags = GET_U_1(tp->th_flags);
-        ND_PRINT("Flags [%s]", bittok2str_nosep(tcp_flag_values, "none", flags));
+        ND_PRINT(C_RESET, "Flags [%s]", bittok2str_nosep(tcp_flag_values, "none", flags));
 
         if (!ndo->ndo_Sflag && (flags & TH_ACK)) {
                 /*
@@ -380,7 +380,7 @@ tcp_print(netdissect_options *ndo,
                 thseq = thack = rev = 0;
         }
         if (hlen > length) {
-                ND_PRINT(" [bad hdr length %u - too long, > %u]",
+                ND_PRINT(C_RESET, " [bad hdr length %u - too long, > %u]",
                          hlen, length);
                 goto invalid;
         }
@@ -394,24 +394,24 @@ tcp_print(netdissect_options *ndo,
                                 sum = tcp_cksum(ndo, ip, tp, length);
                                 tcp_sum = GET_BE_U_2(tp->th_sum);
 
-                                ND_PRINT(", cksum 0x%04x", tcp_sum);
+                                ND_PRINT(C_RESET, ", cksum 0x%04x", tcp_sum);
                                 if (sum != 0)
-                                        ND_PRINT(" (incorrect -> 0x%04x)",
+                                        ND_PRINT(C_RESET, " (incorrect -> 0x%04x)",
                                             in_cksum_shouldbe(tcp_sum, sum));
                                 else
-                                        ND_PRINT(" (correct)");
+                                        ND_PRINT(C_RESET, " (correct)");
                         }
                 } else if (IP_V(ip) == 6) {
                         if (ND_TTEST_LEN(tp->th_sport, length)) {
                                 sum = tcp6_cksum(ndo, ip6, tp, length);
                                 tcp_sum = GET_BE_U_2(tp->th_sum);
 
-                                ND_PRINT(", cksum 0x%04x", tcp_sum);
+                                ND_PRINT(C_RESET, ", cksum 0x%04x", tcp_sum);
                                 if (sum != 0)
-                                        ND_PRINT(" (incorrect -> 0x%04x)",
+                                        ND_PRINT(C_RESET, " (incorrect -> 0x%04x)",
                                             in_cksum_shouldbe(tcp_sum, sum));
                                 else
-                                        ND_PRINT(" (correct)");
+                                        ND_PRINT(C_RESET, " (correct)");
 
                         }
                 }
@@ -419,21 +419,21 @@ tcp_print(netdissect_options *ndo,
 
         length -= hlen;
         if (ndo->ndo_vflag > 1 || length > 0 || flags & (TH_SYN | TH_FIN | TH_RST)) {
-                ND_PRINT(", seq %u", seq);
+                ND_PRINT(C_RESET, ", seq %u", seq);
 
                 if (length > 0) {
-                        ND_PRINT(":%u", seq + length);
+                        ND_PRINT(C_RESET, ":%u", seq + length);
                 }
         }
 
         if (flags & TH_ACK) {
-                ND_PRINT(", ack %u", ack);
+                ND_PRINT(C_RESET, ", ack %u", ack);
         }
 
-        ND_PRINT(", win %u", win);
+        ND_PRINT(C_RESET, ", win %u", win);
 
         if (flags & TH_URG)
-                ND_PRINT(", urg %u", urp);
+                ND_PRINT(C_RESET, ", urg %u", urp);
         /*
          * Handle any options.
          */
@@ -444,10 +444,10 @@ tcp_print(netdissect_options *ndo,
 
                 hlen -= sizeof(*tp);
                 cp = (const u_char *)tp + sizeof(*tp);
-                ND_PRINT(", options [");
+                ND_PRINT(C_RESET, ", options [");
                 while (hlen > 0) {
                         if (ch != '\0')
-                                ND_PRINT("%c", ch);
+                                ND_PRINT(C_RESET, "%c", ch);
                         opt = GET_U_1(cp);
                         cp++;
                         if (ZEROLENOPT(opt))
@@ -466,30 +466,30 @@ tcp_print(netdissect_options *ndo,
 #define LENCHECK(l) { if ((l) > hlen) goto bad; }
 
 
-                        ND_PRINT("%s", tok2str(tcp_option_values, "unknown-%u", opt));
+                        ND_PRINT(C_RESET, "%s", tok2str(tcp_option_values, "unknown-%u", opt));
 
                         switch (opt) {
 
                         case TCPOPT_MAXSEG:
                                 datalen = 2;
                                 LENCHECK(datalen);
-                                ND_PRINT(" %u", GET_BE_U_2(cp));
+                                ND_PRINT(C_RESET, " %u", GET_BE_U_2(cp));
                                 break;
 
                         case TCPOPT_WSCALE:
                                 datalen = 1;
                                 LENCHECK(datalen);
-                                ND_PRINT(" %u", GET_U_1(cp));
+                                ND_PRINT(C_RESET, " %u", GET_U_1(cp));
                                 break;
 
                         case TCPOPT_SACK:
                                 datalen = len - 2;
                                 if (datalen % 8 != 0) {
-                                        ND_PRINT(" invalid sack");
+                                        ND_PRINT(C_RESET, " invalid sack");
                                 } else {
                                         uint32_t s, e;
 
-                                        ND_PRINT(" %u ", datalen / 8);
+                                        ND_PRINT(C_RESET, " %u ", datalen / 8);
                                         for (i = 0; i < datalen; i += 8) {
                                                 LENCHECK(i + 4);
                                                 s = GET_BE_U_4(cp + i);
@@ -502,7 +502,7 @@ tcp_print(netdissect_options *ndo,
                                                         s -= thack;
                                                         e -= thack;
                                                 }
-                                                ND_PRINT("{%u:%u}", s, e);
+                                                ND_PRINT(C_RESET, "{%u:%u}", s, e);
                                         }
                                 }
                                 break;
@@ -519,13 +519,13 @@ tcp_print(netdissect_options *ndo,
                                  */
                                 datalen = 4;
                                 LENCHECK(datalen);
-                                ND_PRINT(" %u", GET_BE_U_4(cp));
+                                ND_PRINT(C_RESET, " %u", GET_BE_U_4(cp));
                                 break;
 
                         case TCPOPT_TIMESTAMP:
                                 datalen = 8;
                                 LENCHECK(datalen);
-                                ND_PRINT(" val %u ecr %u",
+                                ND_PRINT(C_RESET, " val %u ecr %u",
                                              GET_BE_U_4(cp),
                                              GET_BE_U_4(cp + 4));
                                 break;
@@ -534,13 +534,13 @@ tcp_print(netdissect_options *ndo,
                                 datalen = TCP_SIGLEN;
                                 LENCHECK(datalen);
                                 ND_TCHECK_LEN(cp, datalen);
-                                ND_PRINT(" ");
+                                ND_PRINT(C_RESET, " ");
 #ifdef HAVE_LIBCRYPTO
                                 switch (tcp_verify_signature(ndo, ip, tp,
                                                              bp + TH_OFF(tp) * 4, length, cp)) {
 
                                 case SIGNATURE_VALID:
-                                        ND_PRINT("valid");
+                                        ND_PRINT(C_RESET, "valid");
                                         break;
 
                                 case SIGNATURE_INVALID:
@@ -548,22 +548,22 @@ tcp_print(netdissect_options *ndo,
                                         break;
 
                                 case CANT_CHECK_SIGNATURE:
-                                        ND_PRINT("can't check - ");
+                                        ND_PRINT(C_RESET, "can't check - ");
                                         for (i = 0; i < TCP_SIGLEN; ++i)
-                                                ND_PRINT("%02x",
+                                                ND_PRINT(C_RESET, "%02x",
                                                          GET_U_1(cp + i));
                                         break;
                                 }
 #else
                                 for (i = 0; i < TCP_SIGLEN; ++i)
-                                        ND_PRINT("%02x", GET_U_1(cp + i));
+                                        ND_PRINT(C_RESET, "%02x", GET_U_1(cp + i));
 #endif
                                 break;
 
                         case TCPOPT_SCPS:
                                 datalen = 2;
                                 LENCHECK(datalen);
-                                ND_PRINT(" cap %02x id %u", GET_U_1(cp),
+                                ND_PRINT(C_RESET, " cap %02x id %u", GET_U_1(cp),
                                          GET_U_1(cp + 1));
                                 break;
 
@@ -578,15 +578,15 @@ tcp_print(netdissect_options *ndo,
                                         nd_print_invalid(ndo);
                                 } else {
                                         LENCHECK(1);
-                                        ND_PRINT(" keyid %u", GET_U_1(cp));
+                                        ND_PRINT(C_RESET, " keyid %u", GET_U_1(cp));
                                         LENCHECK(2);
-                                        ND_PRINT(" rnextkeyid %u",
+                                        ND_PRINT(C_RESET, " rnextkeyid %u",
                                                  GET_U_1(cp + 1));
                                         if (datalen > 2) {
-                                                ND_PRINT(" mac 0x");
+                                                ND_PRINT(C_RESET, " mac 0x");
                                                 for (i = 2; i < datalen; i++) {
                                                         LENCHECK(i + 1);
-                                                        ND_PRINT("%02x",
+                                                        ND_PRINT(C_RESET, "%02x",
                                                                  GET_U_1(cp + i));
                                                 }
                                         }
@@ -606,12 +606,12 @@ tcp_print(netdissect_options *ndo,
                                 datalen = 2;
                                 LENCHECK(datalen);
                                 utoval = GET_BE_U_2(cp);
-                                ND_PRINT(" 0x%x", utoval);
+                                ND_PRINT(C_RESET, " 0x%x", utoval);
                                 if (utoval & 0x0001)
                                         utoval = (utoval >> 1) * 60;
                                 else
                                         utoval >>= 1;
-                                ND_PRINT(" %u", utoval);
+                                ND_PRINT(C_RESET, " %u", utoval);
                                 break;
 
                         case TCPOPT_MPTCP:
@@ -647,7 +647,7 @@ tcp_print(netdissect_options *ndo,
                                 datalen = len - 2;
                                 LENCHECK(datalen);
                                 ND_TCHECK_LEN(cp, datalen);
-                                ND_PRINT(" ");
+                                ND_PRINT(C_RESET, " ");
                                 print_tcp_fastopen_option(ndo, cp, datalen);
                                 break;
 
@@ -659,18 +659,18 @@ tcp_print(netdissect_options *ndo,
                                         goto bad;
                                 /* RFC6994 */
                                 magic = GET_BE_U_2(cp);
-                                ND_PRINT("-");
+                                ND_PRINT(C_RESET, "-");
 
                                 switch(magic) {
 
                                 case 0xf989: /* TCP Fast Open RFC 7413 */
-                                        ND_PRINT("tfo");
+                                        ND_PRINT(C_RESET, "tfo");
                                         print_tcp_fastopen_option(ndo, cp + 2, datalen - 2);
                                         break;
 
                                 default:
                                         /* Unknown magic number */
-                                        ND_PRINT("%04x", magic);
+                                        ND_PRINT(C_RESET, "%04x", magic);
                                         break;
                                 }
                                 break;
@@ -678,10 +678,10 @@ tcp_print(netdissect_options *ndo,
                         default:
                                 datalen = len - 2;
                                 if (datalen)
-                                        ND_PRINT(" 0x");
+                                        ND_PRINT(C_RESET, " 0x");
                                 for (i = 0; i < datalen; ++i) {
                                         LENCHECK(i + 1);
-                                        ND_PRINT("%02x", GET_U_1(cp + i));
+                                        ND_PRINT(C_RESET, "%02x", GET_U_1(cp + i));
                                 }
                                 break;
                         }
@@ -695,18 +695,18 @@ tcp_print(netdissect_options *ndo,
                         if (!ZEROLENOPT(opt))
                                 ++datalen;	/* size octet */
                         if (datalen != len)
-                                ND_PRINT("[len %u]", len);
+                                ND_PRINT(C_RESET, "[len %u]", len);
                         ch = ',';
                         if (opt == TCPOPT_EOL)
                                 break;
                 }
-                ND_PRINT("]");
+                ND_PRINT(C_RESET, "]");
         }
 
         /*
          * Print length field before crawling down the stack.
          */
-        ND_PRINT(", length %u", length);
+        ND_PRINT(C_RESET, ", length %u", length);
 
         if (length == 0)
                 return;
@@ -720,7 +720,7 @@ tcp_print(netdissect_options *ndo,
          * At least the header data is required.
          */
         if (!ND_TTEST_LEN(bp, header_len)) {
-                ND_PRINT(" [remaining caplen(%u) < header length(%u)]",
+                ND_PRINT(C_RESET, " [remaining caplen(%u) < header length(%u)]",
                          ND_BYTES_AVAILABLE_AFTER(bp), header_len);
                 nd_trunc_longjmp(ndo);
         }
@@ -749,10 +749,10 @@ tcp_print(netdissect_options *ndo,
         if (IS_SRC_OR_DST_PORT(TELNET_PORT)) {
                 telnet_print(ndo, bp, length);
         } else if (IS_SRC_OR_DST_PORT(SMTP_PORT)) {
-                ND_PRINT(": ");
+                ND_PRINT(C_RESET, ": ");
                 smtp_print(ndo, bp, length);
         } else if (IS_SRC_OR_DST_PORT(WHOIS_PORT)) {
-                ND_PRINT(": ");
+                ND_PRINT(C_RESET, ": ");
                 whois_print(ndo, bp, length);
         } else if (IS_SRC_OR_DST_PORT(BGP_PORT))
                 bgp_print(ndo, bp, length);
@@ -773,13 +773,13 @@ tcp_print(netdissect_options *ndo,
         else if (IS_SRC_OR_DST_PORT(OPENFLOW_PORT_OLD) || IS_SRC_OR_DST_PORT(OPENFLOW_PORT_IANA))
                 openflow_print(ndo, bp, length);
         else if (IS_SRC_OR_DST_PORT(FTP_PORT)) {
-                ND_PRINT(": ");
+                ND_PRINT(C_RESET, ": ");
                 ftp_print(ndo, bp, length);
         } else if (IS_SRC_OR_DST_PORT(HTTP_PORT) || IS_SRC_OR_DST_PORT(HTTP_PORT_ALT)) {
-                ND_PRINT(": ");
+                ND_PRINT(C_RESET, ": ");
                 http_print(ndo, bp, length);
         } else if (IS_SRC_OR_DST_PORT(RTSP_PORT) || IS_SRC_OR_DST_PORT(RTSP_PORT_ALT)) {
-                ND_PRINT(": ");
+                ND_PRINT(C_RESET, ": ");
                 rtsp_print(ndo, bp, length);
         } else if (IS_SRC_OR_DST_PORT(NAMESERVER_PORT)) {
                 /* over_tcp: TRUE, is_mdns: FALSE */
@@ -809,13 +809,13 @@ tcp_print(netdissect_options *ndo,
                 if (ND_TTEST_4(rp->rm_direction)) {
                         direction = (enum sunrpc_msg_type) GET_BE_U_4(rp->rm_direction);
                         if (dport == NFS_PORT && direction == SUNRPC_CALL) {
-                                ND_PRINT(": NFS request xid %u ",
+                                ND_PRINT(C_RESET, ": NFS request xid %u ",
                                          GET_BE_U_4(rp->rm_xid));
                                 nfsreq_noaddr_print(ndo, (const u_char *)rp, fraglen, (const u_char *)ip);
                                 return;
                         }
                         if (sport == NFS_PORT && direction == SUNRPC_REPLY) {
-                                ND_PRINT(": NFS reply xid %u ",
+                                ND_PRINT(C_RESET, ": NFS reply xid %u ",
                                          GET_BE_U_4(rp->rm_xid));
                                 nfsreply_noaddr_print(ndo, (const u_char *)rp, fraglen, (const u_char *)ip);
                                 return;
@@ -825,9 +825,9 @@ tcp_print(netdissect_options *ndo,
 
         return;
 bad:
-        ND_PRINT("[bad opt]");
+        ND_PRINT(C_RESET, "[bad opt]");
         if (ch != '\0')
-                ND_PRINT("]");
+                ND_PRINT(C_RESET, "]");
         return;
 invalid:
         nd_print_invalid(ndo);
@@ -852,14 +852,18 @@ static void
 print_tcp_rst_data(netdissect_options *ndo,
                    const u_char *sp, u_int length)
 {
-        ND_PRINT(ND_TTEST_LEN(sp, length) ? " [RST" : " [!RST");
+        if(ND_TTEST_LEN(sp, length))
+                ND_PRINT(C_RESET, " [RST");
+        else
+                ND_PRINT(C_RESET, " [!RST");
+
         if (length > MAX_RST_DATA_LEN) {
                 length = MAX_RST_DATA_LEN;	/* can use -X for longer */
-                ND_PRINT("+");			/* indicate we truncate */
+                ND_PRINT(C_RESET, "+");			/* indicate we truncate */
         }
-        ND_PRINT(" ");
+        ND_PRINT(C_RESET, " ");
         (void)nd_printn(ndo, sp, length, ndo->ndo_snapend);
-        ND_PRINT("]");
+        ND_PRINT(C_RESET, "]");
 }
 
 static void
@@ -870,15 +874,15 @@ print_tcp_fastopen_option(netdissect_options *ndo, const u_char *cp,
 
         if (datalen == 0) {
                 /* Fast Open Cookie Request */
-                ND_PRINT(" cookiereq");
+                ND_PRINT(C_RESET, " cookiereq");
         } else {
                 /* Fast Open Cookie */
                 if (datalen % 2 != 0 || datalen < 4 || datalen > 16) {
                         nd_print_invalid(ndo);
                 } else {
-                        ND_PRINT(" cookie ");
+                        ND_PRINT(C_RESET, " cookie ");
                         for (i = 0; i < datalen; ++i)
-                                ND_PRINT("%02x", GET_U_1(cp + i));
+                                ND_PRINT(C_RESET, "%02x", GET_U_1(cp + i));
                 }
         }
 }
@@ -900,14 +904,14 @@ tcp_verify_signature(netdissect_options *ndo,
         uint8_t nxt;
 
         if (!ND_TTEST_LEN(data, length)) {
-                ND_PRINT("snaplen too short, ");
+                ND_PRINT(C_RESET, "snaplen too short, ");
                 return (CANT_CHECK_SIGNATURE);
         }
 
         tp1 = *tp;
 
         if (ndo->ndo_sigsecret == NULL) {
-                ND_PRINT("shared secret not supplied with -M, ");
+                ND_PRINT(C_RESET, "shared secret not supplied with -M, ");
                 return (CANT_CHECK_SIGNATURE);
         }
 
@@ -936,7 +940,7 @@ tcp_verify_signature(netdissect_options *ndo,
                 nxt = IPPROTO_TCP;
                 MD5_Update(&ctx, (const char *)&nxt, sizeof(nxt));
         } else {
-                ND_PRINT("IP version not 4 or 6, ");
+                ND_PRINT(C_RESET, "IP version not 4 or 6, ");
                 return (CANT_CHECK_SIGNATURE);
         }
 

--- a/print-telnet.c
+++ b/print-telnet.c
@@ -400,7 +400,7 @@ telnet_parse(netdissect_options *ndo, const u_char *sp, u_int length, int print)
 	FETCH(c, sp, length);
 	if (c == IAC) {		/* <IAC><IAC>! */
 		if (print)
-			ND_PRINT("IAC IAC");
+			ND_PRINT(C_RESET, "IAC IAC");
 		goto done;
 	}
 
@@ -418,10 +418,10 @@ telnet_parse(netdissect_options *ndo, const u_char *sp, u_int length, int print)
 		FETCH(x, sp, length);
 		if (x >= 0 && x < NTELOPTS) {
 			if (print)
-				ND_PRINT("%s %s", telcmds[i], telopts[x]);
+				ND_PRINT(C_RESET, "%s %s", telcmds[i], telopts[x]);
 		} else {
 			if (print)
-				ND_PRINT("%s %#x", telcmds[i], x);
+				ND_PRINT(C_RESET, "%s %#x", telcmds[i], x);
 		}
 		if (c != SB)
 			break;
@@ -441,46 +441,46 @@ telnet_parse(netdissect_options *ndo, const u_char *sp, u_int length, int print)
 				break;
 			FETCH(c, sp, length);
 			if (print)
-				ND_PRINT(" %s", STR_OR_ID(c, authcmd));
+				ND_PRINT(C_RESET, " %s", STR_OR_ID(c, authcmd));
 			if (p <= sp)
 				break;
 			FETCH(c, sp, length);
 			if (print)
-				ND_PRINT(" %s", STR_OR_ID(c, authtype));
+				ND_PRINT(C_RESET, " %s", STR_OR_ID(c, authtype));
 			break;
 		case TELOPT_ENCRYPT:
 			if (p <= sp)
 				break;
 			FETCH(c, sp, length);
 			if (print)
-				ND_PRINT(" %s", STR_OR_ID(c, enccmd));
+				ND_PRINT(C_RESET, " %s", STR_OR_ID(c, enccmd));
 			if (p <= sp)
 				break;
 			FETCH(c, sp, length);
 			if (print)
-				ND_PRINT(" %s", STR_OR_ID(c, enctype));
+				ND_PRINT(C_RESET, " %s", STR_OR_ID(c, enctype));
 			break;
 		default:
 			if (p <= sp)
 				break;
 			FETCH(c, sp, length);
 			if (print)
-				ND_PRINT(" %s", STR_OR_ID(c, cmds));
+				ND_PRINT(C_RESET, " %s", STR_OR_ID(c, cmds));
 			break;
 		}
 		while (p > sp) {
 			FETCH(x, sp, length);
 			if (print)
-				ND_PRINT(" %#x", x);
+				ND_PRINT(C_RESET, " %#x", x);
 		}
 		/* terminating IAC SE */
 		if (print)
-			ND_PRINT(" SE");
+			ND_PRINT(C_RESET, " SE");
 		sp += 2;
 		break;
 	default:
 		if (print)
-			ND_PRINT("%s", telcmds[i]);
+			ND_PRINT(C_RESET, "%s", telcmds[i]);
 		goto done;
 	}
 
@@ -516,14 +516,14 @@ telnet_print(netdissect_options *ndo, const u_char *sp, u_int length)
 		 */
 		if (ndo->ndo_Xflag && 2 < ndo->ndo_vflag) {
 			if (first)
-				ND_PRINT("\nTelnet:");
+				ND_PRINT(C_RESET, "\nTelnet:");
 			hex_print_with_offset(ndo, "\n", sp, l, (u_int)(sp - osp));
 			if (l > 8)
-				ND_PRINT("\n\t\t\t\t");
+				ND_PRINT(C_RESET, "\n\t\t\t\t");
 			else
-				ND_PRINT("%*s\t", (8 - l) * 3, "");
+				ND_PRINT(C_RESET, "%*s\t", (8 - l) * 3, "");
 		} else
-			ND_PRINT("%s", (first) ? " [telnet " : ", ");
+			ND_PRINT(C_RESET, "%s", (first) ? " [telnet " : ", ");
 
 		(void)telnet_parse(ndo, sp, length, 1);
 		first = 0;
@@ -533,8 +533,8 @@ telnet_print(netdissect_options *ndo, const u_char *sp, u_int length)
 	}
 	if (!first) {
 		if (ndo->ndo_Xflag && 2 < ndo->ndo_vflag)
-			ND_PRINT("\n");
+			ND_PRINT(C_RESET, "\n");
 		else
-			ND_PRINT("]");
+			ND_PRINT(C_RESET, "]");
 	}
 }

--- a/print-tftp.c
+++ b/print-tftp.c
@@ -97,14 +97,14 @@ tftp_print(netdissect_options *ndo,
 	/* Print protocol */
 	nd_print_protocol_caps(ndo);
 	/* Print length */
-	ND_PRINT(", length %u", length);
+	ND_PRINT(C_RESET, ", length %u", length);
 
 	/* Print tftp request type */
 	if (length < 2)
 		goto trunc;
 	opcode = GET_BE_U_2(bp);
 	cp = tok2str(op2str, "tftp-#%u", opcode);
-	ND_PRINT(", %s", cp);
+	ND_PRINT(C_RESET, ", %s", cp);
 	/* Bail if bogus opcode */
 	if (*cp == 't')
 		return;
@@ -117,11 +117,11 @@ tftp_print(netdissect_options *ndo,
 	case WRQ:
 		if (length == 0)
 			goto trunc;
-		ND_PRINT(" ");
+		ND_PRINT(C_RESET, " ");
 		/* Print filename */
-		ND_PRINT("\"");
+		ND_PRINT(C_RESET, "\"");
 		ui = nd_printztn(ndo, bp, length, ndo->ndo_snapend);
-		ND_PRINT("\"");
+		ND_PRINT(C_RESET, "\"");
 		if (ui == 0)
 			goto trunc;
 		bp += ui;
@@ -130,7 +130,7 @@ tftp_print(netdissect_options *ndo,
 		/* Print the mode - RRQ and WRQ only */
 		if (length == 0)
 			goto trunc;	/* no mode */
-		ND_PRINT(" ");
+		ND_PRINT(C_RESET, " ");
 		ui = nd_printztn(ndo, bp, length, ndo->ndo_snapend);
 		if (ui == 0)
 			goto trunc;
@@ -140,7 +140,7 @@ tftp_print(netdissect_options *ndo,
 		/* Print options, if any */
 		while (length != 0) {
 			if (GET_U_1(bp) != '\0')
-				ND_PRINT(" ");
+				ND_PRINT(C_RESET, " ");
 			ui = nd_printztn(ndo, bp, length, ndo->ndo_snapend);
 			if (ui == 0)
 				goto trunc;
@@ -153,7 +153,7 @@ tftp_print(netdissect_options *ndo,
 		/* Print options */
 		while (length != 0) {
 			if (GET_U_1(bp) != '\0')
-				ND_PRINT(" ");
+				ND_PRINT(C_RESET, " ");
 			ui = nd_printztn(ndo, bp, length, ndo->ndo_snapend);
 			if (ui == 0)
 				goto trunc;
@@ -166,30 +166,30 @@ tftp_print(netdissect_options *ndo,
 	case DATA:
 		if (length < 2)
 			goto trunc;	/* no block number */
-		ND_PRINT(" block %u", GET_BE_U_2(bp));
+		ND_PRINT(C_RESET, " block %u", GET_BE_U_2(bp));
 		break;
 
 	case TFTP_ERROR:
 		/* Print error code string */
 		if (length < 2)
 			goto trunc;	/* no error code */
-		ND_PRINT(" %s", tok2str(err2str, "tftp-err-#%u \"",
+		ND_PRINT(C_RESET, " %s", tok2str(err2str, "tftp-err-#%u \"",
 				       GET_BE_U_2(bp)));
 		bp += 2;
 		length -= 2;
 		/* Print error message string */
 		if (length == 0)
 			goto trunc;	/* no error message */
-		ND_PRINT(" \"");
+		ND_PRINT(C_RESET, " \"");
 		ui = nd_printztn(ndo, bp, length, ndo->ndo_snapend);
-		ND_PRINT("\"");
+		ND_PRINT(C_RESET, "\"");
 		if (ui == 0)
 			goto trunc;
 		break;
 
 	default:
 		/* We shouldn't get here */
-		ND_PRINT("(unknown #%u)", opcode);
+		ND_PRINT(C_RESET, "(unknown #%u)", opcode);
 		break;
 	}
 	return;

--- a/print-timed.c
+++ b/print-timed.c
@@ -118,15 +118,15 @@ timed_print(netdissect_options *ndo,
 
 	ndo->ndo_protocol = "timed";
 	tsp_type = GET_U_1(tsp->tsp_type);
-	ND_PRINT(C_RESET, C_RESET "%s", tok2str(tsptype_str, "(tsp_type %#x)", tsp_type));
+	ND_PRINT(C_RESET, "%s", tok2str(tsptype_str, "(tsp_type %#x)", tsp_type));
 
-	ND_PRINT(C_RESET, C_RESET " vers %u", GET_U_1(tsp->tsp_vers));
+	ND_PRINT(C_RESET, " vers %u", GET_U_1(tsp->tsp_vers));
 
-	ND_PRINT(C_RESET, C_RESET " seq %u", GET_BE_U_2(tsp->tsp_seq));
+	ND_PRINT(C_RESET, " seq %u", GET_BE_U_2(tsp->tsp_seq));
 
 	switch (tsp_type) {
 	case TSP_LOOP:
-		ND_PRINT(C_RESET, C_RESET " hopcnt %u", GET_U_1(tsp->tsp_hopcnt));
+		ND_PRINT(C_RESET, " hopcnt %u", GET_U_1(tsp->tsp_hopcnt));
 		break;
 	case TSP_SETTIME:
 	case TSP_ADJTIME:
@@ -138,16 +138,16 @@ timed_print(netdissect_options *ndo,
 		if (usec < 0)
 			/* invalid, skip the rest of the packet */
 			return;
-		ND_PRINT(C_RESET, C_RESET " time ");
+		ND_PRINT(C_RESET, " time ");
 		if (sec < 0 && usec != 0) {
 			sec++;
 			if (sec == 0)
-				ND_PRINT(C_RESET, C_RESET "-");
+				ND_PRINT(C_RESET, "-");
 			usec = 1000000 - usec;
 		}
-		ND_PRINT(C_RESET, C_RESET "%d.%06d", sec, usec);
+		ND_PRINT(C_RESET, "%d.%06d", sec, usec);
 		break;
 	}
-	ND_PRINT(C_RESET, C_RESET " name ");
+	ND_PRINT(C_RESET, " name ");
 	nd_printjnp(ndo, tsp->tsp_name, sizeof(tsp->tsp_name));
 }

--- a/print-timed.c
+++ b/print-timed.c
@@ -118,15 +118,15 @@ timed_print(netdissect_options *ndo,
 
 	ndo->ndo_protocol = "timed";
 	tsp_type = GET_U_1(tsp->tsp_type);
-	ND_PRINT("%s", tok2str(tsptype_str, "(tsp_type %#x)", tsp_type));
+	ND_PRINT(C_RESET, C_RESET "%s", tok2str(tsptype_str, "(tsp_type %#x)", tsp_type));
 
-	ND_PRINT(" vers %u", GET_U_1(tsp->tsp_vers));
+	ND_PRINT(C_RESET, C_RESET " vers %u", GET_U_1(tsp->tsp_vers));
 
-	ND_PRINT(" seq %u", GET_BE_U_2(tsp->tsp_seq));
+	ND_PRINT(C_RESET, C_RESET " seq %u", GET_BE_U_2(tsp->tsp_seq));
 
 	switch (tsp_type) {
 	case TSP_LOOP:
-		ND_PRINT(" hopcnt %u", GET_U_1(tsp->tsp_hopcnt));
+		ND_PRINT(C_RESET, C_RESET " hopcnt %u", GET_U_1(tsp->tsp_hopcnt));
 		break;
 	case TSP_SETTIME:
 	case TSP_ADJTIME:
@@ -138,16 +138,16 @@ timed_print(netdissect_options *ndo,
 		if (usec < 0)
 			/* invalid, skip the rest of the packet */
 			return;
-		ND_PRINT(" time ");
+		ND_PRINT(C_RESET, C_RESET " time ");
 		if (sec < 0 && usec != 0) {
 			sec++;
 			if (sec == 0)
-				ND_PRINT("-");
+				ND_PRINT(C_RESET, C_RESET "-");
 			usec = 1000000 - usec;
 		}
-		ND_PRINT("%d.%06d", sec, usec);
+		ND_PRINT(C_RESET, C_RESET "%d.%06d", sec, usec);
 		break;
 	}
-	ND_PRINT(" name ");
+	ND_PRINT(C_RESET, C_RESET " name ");
 	nd_printjnp(ndo, tsp->tsp_name, sizeof(tsp->tsp_name));
 }

--- a/print-tipc.c
+++ b/print-tipc.c
@@ -180,7 +180,7 @@ print_payload(netdissect_options *ndo, const struct payload_tipc_pkthdr *ap)
 	orig_port = GET_BE_U_4(ap->orig_port);
 	dest_port = GET_BE_U_4(ap->dest_port);
 	if (hsize <= 6) {
-		ND_PRINT(C_RESET, C_RESET "TIPC v%u.0 %u.%u.%u:%u > %u, headerlength %u bytes, MessageSize %u bytes, %s, messageType %s",
+		ND_PRINT(C_RESET, "TIPC v%u.0 %u.%u.%u:%u > %u, headerlength %u bytes, MessageSize %u bytes, %s, messageType %s",
 		    TIPC_VER(w0),
 		    TIPC_ZONE(prev_node), TIPC_CLUSTER(prev_node), TIPC_NODE(prev_node),
 		    orig_port, dest_port,
@@ -190,7 +190,7 @@ print_payload(netdissect_options *ndo, const struct payload_tipc_pkthdr *ap)
 	} else {
 		orig_node = GET_BE_U_4(ap->orig_node);
 		dest_node = GET_BE_U_4(ap->dest_node);
-		ND_PRINT(C_RESET, C_RESET "TIPC v%u.0 %u.%u.%u:%u > %u.%u.%u:%u, headerlength %u bytes, MessageSize %u bytes, %s, messageType %s",
+		ND_PRINT(C_RESET, "TIPC v%u.0 %u.%u.%u:%u > %u.%u.%u:%u, headerlength %u bytes, MessageSize %u bytes, %s, messageType %s",
 		    TIPC_VER(w0),
 		    TIPC_ZONE(orig_node), TIPC_CLUSTER(orig_node), TIPC_NODE(orig_node),
 		    orig_port,
@@ -205,7 +205,7 @@ print_payload(netdissect_options *ndo, const struct payload_tipc_pkthdr *ap)
 			w2 = GET_BE_U_4(ap->w2);
 			link_ack = TIPC_LINK_ACK(w2);
 			link_seq = TIPC_LINK_SEQ(w2);
-			ND_PRINT(C_RESET, C_RESET "\n\tPrevious Node %u.%u.%u, Broadcast Ack %u, Link Ack %u, Link Sequence %u",
+			ND_PRINT(C_RESET, "\n\tPrevious Node %u.%u.%u, Broadcast Ack %u, Link Ack %u, Link Sequence %u",
 			    TIPC_ZONE(prev_node), TIPC_CLUSTER(prev_node), TIPC_NODE(prev_node),
 			    broadcast_ack, link_ack, link_seq);
 		}
@@ -242,7 +242,7 @@ print_internal(netdissect_options *ndo, const struct internal_tipc_pkthdr *ap)
 	mtype = TIPC_MTYPE(w1);
 	orig_node = GET_BE_U_4(ap->orig_node);
 	dest_node = GET_BE_U_4(ap->dest_node);
-	ND_PRINT(C_RESET, C_RESET "TIPC v%u.0 %u.%u.%u > %u.%u.%u, headerlength %u bytes, MessageSize %u bytes, %s, messageType %s (0x%08x)",
+	ND_PRINT(C_RESET, "TIPC v%u.0 %u.%u.%u > %u.%u.%u, headerlength %u bytes, MessageSize %u bytes, %s, messageType %s (0x%08x)",
 	    TIPC_VER(w0),
 	    TIPC_ZONE(orig_node), TIPC_CLUSTER(orig_node), TIPC_NODE(orig_node),
 	    TIPC_ZONE(dest_node), TIPC_CLUSTER(dest_node), TIPC_NODE(dest_node),
@@ -266,7 +266,7 @@ print_internal(netdissect_options *ndo, const struct internal_tipc_pkthdr *ap)
 		w9 = GET_BE_U_4(ap->w9);
 		msg_cnt = TIPC_MSG_CNT(w9);
 		link_tol = TIPC_LINK_TOL(w9);
-		ND_PRINT(C_RESET, C_RESET "\n\tPrevious Node %u.%u.%u, Session No. %u, Broadcast Ack %u, Sequence Gap %u,  Broadcast Gap After %u, Broadcast Gap To %u, Last Sent Packet No. %u, Next sent Packet No. %u, Transport Sequence %u, msg_count %u, Link Tolerance %u",
+		ND_PRINT(C_RESET, "\n\tPrevious Node %u.%u.%u, Session No. %u, Broadcast Ack %u, Sequence Gap %u,  Broadcast Gap After %u, Broadcast Gap To %u, Last Sent Packet No. %u, Next sent Packet No. %u, Transport Sequence %u, msg_count %u, Link Tolerance %u",
 		    TIPC_ZONE(prev_node), TIPC_CLUSTER(prev_node), TIPC_NODE(prev_node),
 		    sess_no, broadcast_ack, seq_gap, bc_gap_after, bc_gap_to,
 		    last_sent_frag, next_sent_frag, trans_seq, msg_cnt,
@@ -297,7 +297,7 @@ print_link_conf(netdissect_options *ndo, const struct link_conf_tipc_pkthdr *ap)
 	dest_domain = GET_BE_U_4(ap->dest_domain);
 	prev_node = GET_BE_U_4(ap->prev_node);
 
-	ND_PRINT(C_RESET, C_RESET "TIPC v%u.0 %u.%u.%u > %u.%u.%u, headerlength %u bytes, MessageSize %u bytes, %s, messageType %s",
+	ND_PRINT(C_RESET, "TIPC v%u.0 %u.%u.%u > %u.%u.%u, headerlength %u bytes, MessageSize %u bytes, %s, messageType %s",
 	    TIPC_VER(w0),
 	    TIPC_ZONE(prev_node), TIPC_CLUSTER(prev_node), TIPC_NODE(prev_node),
 	    TIPC_ZONE(dest_domain), TIPC_CLUSTER(dest_domain), TIPC_NODE(dest_domain),
@@ -309,7 +309,7 @@ print_link_conf(netdissect_options *ndo, const struct link_conf_tipc_pkthdr *ap)
 		ntwrk_id = GET_BE_U_4(ap->ntwrk_id);
 		w5 = GET_BE_U_4(ap->w5);
 		media_id = TIPC_MEDIA_ID(w5);
-		ND_PRINT(C_RESET, C_RESET "\n\tNodeSignature %u, network_id %u, media_id %u",
+		ND_PRINT(C_RESET, "\n\tNodeSignature %u, network_id %u, media_id %u",
 		    node_sig, ntwrk_id, media_id);
 	}
 }

--- a/print-tipc.c
+++ b/print-tipc.c
@@ -180,7 +180,7 @@ print_payload(netdissect_options *ndo, const struct payload_tipc_pkthdr *ap)
 	orig_port = GET_BE_U_4(ap->orig_port);
 	dest_port = GET_BE_U_4(ap->dest_port);
 	if (hsize <= 6) {
-		ND_PRINT("TIPC v%u.0 %u.%u.%u:%u > %u, headerlength %u bytes, MessageSize %u bytes, %s, messageType %s",
+		ND_PRINT(C_RESET, C_RESET "TIPC v%u.0 %u.%u.%u:%u > %u, headerlength %u bytes, MessageSize %u bytes, %s, messageType %s",
 		    TIPC_VER(w0),
 		    TIPC_ZONE(prev_node), TIPC_CLUSTER(prev_node), TIPC_NODE(prev_node),
 		    orig_port, dest_port,
@@ -190,7 +190,7 @@ print_payload(netdissect_options *ndo, const struct payload_tipc_pkthdr *ap)
 	} else {
 		orig_node = GET_BE_U_4(ap->orig_node);
 		dest_node = GET_BE_U_4(ap->dest_node);
-		ND_PRINT("TIPC v%u.0 %u.%u.%u:%u > %u.%u.%u:%u, headerlength %u bytes, MessageSize %u bytes, %s, messageType %s",
+		ND_PRINT(C_RESET, C_RESET "TIPC v%u.0 %u.%u.%u:%u > %u.%u.%u:%u, headerlength %u bytes, MessageSize %u bytes, %s, messageType %s",
 		    TIPC_VER(w0),
 		    TIPC_ZONE(orig_node), TIPC_CLUSTER(orig_node), TIPC_NODE(orig_node),
 		    orig_port,
@@ -205,7 +205,7 @@ print_payload(netdissect_options *ndo, const struct payload_tipc_pkthdr *ap)
 			w2 = GET_BE_U_4(ap->w2);
 			link_ack = TIPC_LINK_ACK(w2);
 			link_seq = TIPC_LINK_SEQ(w2);
-			ND_PRINT("\n\tPrevious Node %u.%u.%u, Broadcast Ack %u, Link Ack %u, Link Sequence %u",
+			ND_PRINT(C_RESET, C_RESET "\n\tPrevious Node %u.%u.%u, Broadcast Ack %u, Link Ack %u, Link Sequence %u",
 			    TIPC_ZONE(prev_node), TIPC_CLUSTER(prev_node), TIPC_NODE(prev_node),
 			    broadcast_ack, link_ack, link_seq);
 		}
@@ -242,7 +242,7 @@ print_internal(netdissect_options *ndo, const struct internal_tipc_pkthdr *ap)
 	mtype = TIPC_MTYPE(w1);
 	orig_node = GET_BE_U_4(ap->orig_node);
 	dest_node = GET_BE_U_4(ap->dest_node);
-	ND_PRINT("TIPC v%u.0 %u.%u.%u > %u.%u.%u, headerlength %u bytes, MessageSize %u bytes, %s, messageType %s (0x%08x)",
+	ND_PRINT(C_RESET, C_RESET "TIPC v%u.0 %u.%u.%u > %u.%u.%u, headerlength %u bytes, MessageSize %u bytes, %s, messageType %s (0x%08x)",
 	    TIPC_VER(w0),
 	    TIPC_ZONE(orig_node), TIPC_CLUSTER(orig_node), TIPC_NODE(orig_node),
 	    TIPC_ZONE(dest_node), TIPC_CLUSTER(dest_node), TIPC_NODE(dest_node),
@@ -266,7 +266,7 @@ print_internal(netdissect_options *ndo, const struct internal_tipc_pkthdr *ap)
 		w9 = GET_BE_U_4(ap->w9);
 		msg_cnt = TIPC_MSG_CNT(w9);
 		link_tol = TIPC_LINK_TOL(w9);
-		ND_PRINT("\n\tPrevious Node %u.%u.%u, Session No. %u, Broadcast Ack %u, Sequence Gap %u,  Broadcast Gap After %u, Broadcast Gap To %u, Last Sent Packet No. %u, Next sent Packet No. %u, Transport Sequence %u, msg_count %u, Link Tolerance %u",
+		ND_PRINT(C_RESET, C_RESET "\n\tPrevious Node %u.%u.%u, Session No. %u, Broadcast Ack %u, Sequence Gap %u,  Broadcast Gap After %u, Broadcast Gap To %u, Last Sent Packet No. %u, Next sent Packet No. %u, Transport Sequence %u, msg_count %u, Link Tolerance %u",
 		    TIPC_ZONE(prev_node), TIPC_CLUSTER(prev_node), TIPC_NODE(prev_node),
 		    sess_no, broadcast_ack, seq_gap, bc_gap_after, bc_gap_to,
 		    last_sent_frag, next_sent_frag, trans_seq, msg_cnt,
@@ -297,7 +297,7 @@ print_link_conf(netdissect_options *ndo, const struct link_conf_tipc_pkthdr *ap)
 	dest_domain = GET_BE_U_4(ap->dest_domain);
 	prev_node = GET_BE_U_4(ap->prev_node);
 
-	ND_PRINT("TIPC v%u.0 %u.%u.%u > %u.%u.%u, headerlength %u bytes, MessageSize %u bytes, %s, messageType %s",
+	ND_PRINT(C_RESET, C_RESET "TIPC v%u.0 %u.%u.%u > %u.%u.%u, headerlength %u bytes, MessageSize %u bytes, %s, messageType %s",
 	    TIPC_VER(w0),
 	    TIPC_ZONE(prev_node), TIPC_CLUSTER(prev_node), TIPC_NODE(prev_node),
 	    TIPC_ZONE(dest_domain), TIPC_CLUSTER(dest_domain), TIPC_NODE(dest_domain),
@@ -309,7 +309,7 @@ print_link_conf(netdissect_options *ndo, const struct link_conf_tipc_pkthdr *ap)
 		ntwrk_id = GET_BE_U_4(ap->ntwrk_id);
 		w5 = GET_BE_U_4(ap->w5);
 		media_id = TIPC_MEDIA_ID(w5);
-		ND_PRINT("\n\tNodeSignature %u, network_id %u, media_id %u",
+		ND_PRINT(C_RESET, C_RESET "\n\tNodeSignature %u, network_id %u, media_id %u",
 		    node_sig, ntwrk_id, media_id);
 	}
 }

--- a/print-token.c
+++ b/print-token.c
@@ -112,10 +112,10 @@ token_hdr_print(netdissect_options *ndo,
 	dstname = etheraddr_string(ndo, fdst);
 
 	if (!ndo->ndo_qflag)
-		ND_PRINT("%02x %02x ",
+		ND_PRINT(C_RESET, C_RESET "%02x %02x ",
 		       GET_U_1(trp->token_ac),
 		       GET_U_1(trp->token_fc));
-	ND_PRINT("%s > %s, length %u: ",
+	ND_PRINT(C_RESET, C_RESET "%s > %s, length %u: ",
 	       srcname, dstname,
 	       length);
 }
@@ -184,20 +184,20 @@ token_print(netdissect_options *ndo, const u_char *p, u_int length, u_int caplen
 			return hdr_len;
 		}
 		if (ndo->ndo_vflag) {
-			ND_PRINT("%s ", broadcast_indicator[BROADCAST(trp)]);
-			ND_PRINT("%s", direction[DIRECTION(trp)]);
+			ND_PRINT(C_RESET, C_RESET "%s ", broadcast_indicator[BROADCAST(trp)]);
+			ND_PRINT(C_RESET, C_RESET "%s", direction[DIRECTION(trp)]);
 
 			for (seg = 0; seg < SEGMENT_COUNT(trp); seg++)
-				ND_PRINT(" [%u:%u]", RING_NUMBER(trp, seg),
+				ND_PRINT(C_RESET, C_RESET " [%u:%u]", RING_NUMBER(trp, seg),
 				    BRIDGE_NUMBER(trp, seg));
 		} else {
-			ND_PRINT("rt = %x", GET_BE_U_2(trp->token_rcf));
+			ND_PRINT(C_RESET, C_RESET "rt = %x", GET_BE_U_2(trp->token_rcf));
 
 			for (seg = 0; seg < SEGMENT_COUNT(trp); seg++)
-				ND_PRINT(":%x",
+				ND_PRINT(C_RESET, C_RESET ":%x",
 					 GET_BE_U_2(trp->token_rseg[seg]));
 		}
-		ND_PRINT(" (%s) ", largest_frame[LARGEST_FRAME(trp)]);
+		ND_PRINT(C_RESET, C_RESET " (%s) ", largest_frame[LARGEST_FRAME(trp)]);
 	} else {
 		if (ndo->ndo_eflag)
 			token_hdr_print(ndo, trp, length, srcmac, dstmac);

--- a/print-token.c
+++ b/print-token.c
@@ -112,10 +112,10 @@ token_hdr_print(netdissect_options *ndo,
 	dstname = etheraddr_string(ndo, fdst);
 
 	if (!ndo->ndo_qflag)
-		ND_PRINT(C_RESET, C_RESET "%02x %02x ",
+		ND_PRINT(C_RESET, "%02x %02x ",
 		       GET_U_1(trp->token_ac),
 		       GET_U_1(trp->token_fc));
-	ND_PRINT(C_RESET, C_RESET "%s > %s, length %u: ",
+	ND_PRINT(C_RESET, "%s > %s, length %u: ",
 	       srcname, dstname,
 	       length);
 }
@@ -184,20 +184,20 @@ token_print(netdissect_options *ndo, const u_char *p, u_int length, u_int caplen
 			return hdr_len;
 		}
 		if (ndo->ndo_vflag) {
-			ND_PRINT(C_RESET, C_RESET "%s ", broadcast_indicator[BROADCAST(trp)]);
-			ND_PRINT(C_RESET, C_RESET "%s", direction[DIRECTION(trp)]);
+			ND_PRINT(C_RESET, "%s ", broadcast_indicator[BROADCAST(trp)]);
+			ND_PRINT(C_RESET, "%s", direction[DIRECTION(trp)]);
 
 			for (seg = 0; seg < SEGMENT_COUNT(trp); seg++)
-				ND_PRINT(C_RESET, C_RESET " [%u:%u]", RING_NUMBER(trp, seg),
+				ND_PRINT(C_RESET, " [%u:%u]", RING_NUMBER(trp, seg),
 				    BRIDGE_NUMBER(trp, seg));
 		} else {
-			ND_PRINT(C_RESET, C_RESET "rt = %x", GET_BE_U_2(trp->token_rcf));
+			ND_PRINT(C_RESET, "rt = %x", GET_BE_U_2(trp->token_rcf));
 
 			for (seg = 0; seg < SEGMENT_COUNT(trp); seg++)
-				ND_PRINT(C_RESET, C_RESET ":%x",
+				ND_PRINT(C_RESET, ":%x",
 					 GET_BE_U_2(trp->token_rseg[seg]));
 		}
-		ND_PRINT(C_RESET, C_RESET " (%s) ", largest_frame[LARGEST_FRAME(trp)]);
+		ND_PRINT(C_RESET, " (%s) ", largest_frame[LARGEST_FRAME(trp)]);
 	} else {
 		if (ndo->ndo_eflag)
 			token_hdr_print(ndo, trp, length, srcmac, dstmac);

--- a/print-udld.c
+++ b/print-udld.c
@@ -119,7 +119,7 @@ udld_print(netdissect_options *ndo,
     tptr += 1;
     length -= 1;
 
-    ND_PRINT("UDLDv%u, Code %s (%x), Flags [%s] (0x%02x), length %u",
+    ND_PRINT(C_RESET, "UDLDv%u, Code %s (%x), Flags [%s] (0x%02x), length %u",
            ver,
            tok2str(udld_code_values, "Reserved", code),
            code,
@@ -134,7 +134,7 @@ udld_print(netdissect_options *ndo,
         goto tcheck_remainder;
     }
 
-    ND_PRINT("\n\tChecksum 0x%04x (unverified)", GET_BE_U_2(tptr));
+    ND_PRINT(C_RESET, "\n\tChecksum 0x%04x (unverified)", GET_BE_U_2(tptr));
     tptr += 2;
     length -= 2;
 
@@ -152,7 +152,7 @@ udld_print(netdissect_options *ndo,
         tptr += 2;
         length -= 2;
 
-        ND_PRINT("\n\t%s (0x%04x) TLV, length %u",
+        ND_PRINT(C_RESET, "\n\t%s (0x%04x) TLV, length %u",
                tok2str(udld_tlv_values, "Unknown", type),
                type, len);
 
@@ -168,12 +168,12 @@ udld_print(netdissect_options *ndo,
         case UDLD_DEVICE_ID_TLV:
         case UDLD_PORT_ID_TLV:
         case UDLD_DEVICE_NAME_TLV:
-            ND_PRINT(", ");
+            ND_PRINT(C_RESET, ", ");
             nd_printjnp(ndo, tptr, len);
             break;
 
         case UDLD_ECHO_TLV:
-            ND_PRINT(", ");
+            ND_PRINT(C_RESET, ", ");
             nd_printjn(ndo, tptr, len);
             break;
 
@@ -181,13 +181,13 @@ udld_print(netdissect_options *ndo,
         case UDLD_TIMEOUT_INTERVAL_TLV:
             if (len != 1)
                 goto invalid;
-            ND_PRINT(", %us", (GET_U_1(tptr)));
+            ND_PRINT(C_RESET, ", %us", (GET_U_1(tptr)));
             break;
 
         case UDLD_SEQ_NUMBER_TLV:
             if (len != 4)
                 goto invalid;
-            ND_PRINT(", %u", GET_BE_U_4(tptr));
+            ND_PRINT(C_RESET, ", %u", GET_BE_U_4(tptr));
             break;
 
         default:

--- a/print-udp.c
+++ b/print-udp.c
@@ -100,13 +100,13 @@ vat_print(netdissect_options *ndo, const u_char *hdr, u_int length)
 
 	ndo->ndo_protocol = "vat";
 	if (length < 2) {
-		ND_PRINT("udp/va/vat, length %u < 2", length);
+		ND_PRINT(C_RESET, "udp/va/vat, length %u < 2", length);
 		return;
 	}
 	ts = GET_BE_U_2(hdr);
 	if ((ts & 0xf060) != 0) {
 		/* probably vt */
-		ND_PRINT("udp/vt %u %u / %u",
+		ND_PRINT(C_RESET, "udp/vt %u %u / %u",
 			     length,
 			     ts & 0x3ff, ts >> 10);
 	} else {
@@ -114,20 +114,20 @@ vat_print(netdissect_options *ndo, const u_char *hdr, u_int length)
 		uint32_t i0, i1;
 
 		if (length < 8) {
-			ND_PRINT("udp/vat, length %u < 8", length);
+			ND_PRINT(C_RESET, "udp/vat, length %u < 8", length);
 			return;
 		}
 		i0 = GET_BE_U_4(&((const u_int *)hdr)[0]);
 		i1 = GET_BE_U_4(&((const u_int *)hdr)[1]);
-		ND_PRINT("udp/vat %u c%u %u%s",
+		ND_PRINT(C_RESET, "udp/vat %u c%u %u%s",
 			length - 8,
 			i0 & 0xffff,
 			i1, i0 & 0x800000? "*" : "");
 		/* audio format */
 		if (i0 & 0x1f0000)
-			ND_PRINT(" f%u", (i0 >> 16) & 0x1f);
+			ND_PRINT(C_RESET, " f%u", (i0 >> 16) & 0x1f);
 		if (i0 & 0x3f000000)
-			ND_PRINT(" s%u", (i0 >> 24) & 0x3f);
+			ND_PRINT(C_RESET, " s%u", (i0 >> 24) & 0x3f);
 	}
 }
 
@@ -142,7 +142,7 @@ rtp_print(netdissect_options *ndo, const u_char *hdr, u_int len)
 
 	ndo->ndo_protocol = "rtp";
 	if (len < 8) {
-		ND_PRINT("udp/rtp, length %u < 8", len);
+		ND_PRINT(C_RESET, "udp/rtp, length %u < 8", len);
 		return;
 	}
 	i0 = GET_BE_U_4(&((const u_int *)hdr)[0]);
@@ -162,7 +162,7 @@ rtp_print(netdissect_options *ndo, const u_char *hdr, u_int len)
 	} else {
 		/* rtp v2 - RFC 3550 */
 		if (dlen < 4) {
-			ND_PRINT("udp/rtp, length %u < 12", dlen + 8);
+			ND_PRINT(C_RESET, "udp/rtp, length %u < 12", dlen + 8);
 			return;
 		}
 		hasext = i0 & 0x10000000;
@@ -173,7 +173,7 @@ rtp_print(netdissect_options *ndo, const u_char *hdr, u_int len)
 		ip += 1;
 		len -= 1;
 	}
-	ND_PRINT("udp/%s %u c%u %s%s %u %u",
+	ND_PRINT(C_RESET, "udp/%s %u c%u %s%s %u %u",
 		ptype,
 		dlen,
 		contype,
@@ -182,14 +182,14 @@ rtp_print(netdissect_options *ndo, const u_char *hdr, u_int len)
 		i0 & 0xffff,
 		i1);
 	if (ndo->ndo_vflag) {
-		ND_PRINT(" %u", GET_BE_U_4(&((const u_int *)hdr)[2]));
+		ND_PRINT(C_RESET, " %u", GET_BE_U_4(&((const u_int *)hdr)[2]));
 		if (hasopt) {
 			u_int i2, optlen;
 			do {
 				i2 = GET_BE_U_4(ip);
 				optlen = (i2 >> 16) & 0xff;
 				if (optlen == 0 || optlen > len) {
-					ND_PRINT(" !opt");
+					ND_PRINT(C_RESET, " !opt");
 					return;
 				}
 				ip += optlen;
@@ -201,13 +201,13 @@ rtp_print(netdissect_options *ndo, const u_char *hdr, u_int len)
 			i2 = GET_BE_U_4(ip);
 			extlen = (i2 & 0xffff) + 1;
 			if (extlen > len) {
-				ND_PRINT(" !ext");
+				ND_PRINT(C_RESET, " !ext");
 				return;
 			}
 			ip += extlen;
 		}
 		if (contype == 0x1f) /*XXX H.261 */
-			ND_PRINT(" 0x%04x", GET_BE_U_4(ip) >> 16);
+			ND_PRINT(C_RESET, " 0x%04x", GET_BE_U_4(ip) >> 16);
 	}
 }
 
@@ -232,51 +232,51 @@ rtcp_print(netdissect_options *ndo, const u_char *hdr)
 	switch (flags & 0xff) {
 	case RTCP_PT_SR:
 		sr = (const struct rtcp_sr *)(rh + 1);
-		ND_PRINT(" sr");
+		ND_PRINT(C_RESET, " sr");
 		if (len != cnt * sizeof(*rr) + sizeof(*sr) + sizeof(*rh))
-			ND_PRINT(" [%u]", len);
+			ND_PRINT(C_RESET, " [%u]", len);
 		if (ndo->ndo_vflag)
-			ND_PRINT(" %u", ssrc);
+			ND_PRINT(C_RESET, " %u", ssrc);
 		ts = (double)(GET_BE_U_4(sr->sr_ntp.upper)) +
 		    ((double)(GET_BE_U_4(sr->sr_ntp.lower)) /
 		     FMAXINT);
-		ND_PRINT(" @%.2f %u %up %ub", ts, GET_BE_U_4(sr->sr_ts),
+		ND_PRINT(C_RESET, " @%.2f %u %up %ub", ts, GET_BE_U_4(sr->sr_ts),
 			  GET_BE_U_4(sr->sr_np), GET_BE_U_4(sr->sr_nb));
 		rr = (const struct rtcp_rr *)(sr + 1);
 		break;
 	case RTCP_PT_RR:
-		ND_PRINT(" rr");
+		ND_PRINT(C_RESET, " rr");
 		if (len != cnt * sizeof(*rr) + sizeof(*rh))
-			ND_PRINT(" [%u]", len);
+			ND_PRINT(C_RESET, " [%u]", len);
 		rr = (const struct rtcp_rr *)(rh + 1);
 		if (ndo->ndo_vflag)
-			ND_PRINT(" %u", ssrc);
+			ND_PRINT(C_RESET, " %u", ssrc);
 		break;
 	case RTCP_PT_SDES:
-		ND_PRINT(" sdes %u", len);
+		ND_PRINT(C_RESET, " sdes %u", len);
 		if (ndo->ndo_vflag)
-			ND_PRINT(" %u", ssrc);
+			ND_PRINT(C_RESET, " %u", ssrc);
 		cnt = 0;
 		break;
 	case RTCP_PT_BYE:
-		ND_PRINT(" bye %u", len);
+		ND_PRINT(C_RESET, " bye %u", len);
 		if (ndo->ndo_vflag)
-			ND_PRINT(" %u", ssrc);
+			ND_PRINT(C_RESET, " %u", ssrc);
 		cnt = 0;
 		break;
 	default:
-		ND_PRINT(" type-0x%x %u", flags & 0xff, len);
+		ND_PRINT(C_RESET, " type-0x%x %u", flags & 0xff, len);
 		cnt = 0;
 		break;
 	}
 	if (cnt > 1)
-		ND_PRINT(" c%u", cnt);
+		ND_PRINT(C_RESET, " c%u", cnt);
 	while (cnt != 0) {
 		if (ndo->ndo_vflag)
-			ND_PRINT(" %u", GET_BE_U_4(rr->rr_srcid));
+			ND_PRINT(C_RESET, " %u", GET_BE_U_4(rr->rr_srcid));
 		ts = (double)(GET_BE_U_4(rr->rr_lsr)) / 65536.;
 		dts = (double)(GET_BE_U_4(rr->rr_dlsr)) / 65536.;
-		ND_PRINT(" %ul %us %uj @%.2f+%.2f",
+		ND_PRINT(C_RESET, " %ul %us %uj @%.2f+%.2f",
 		    GET_BE_U_4(rr->rr_nl) & 0x00ffffff,
 		    GET_BE_U_4(rr->rr_ls),
 		    GET_BE_U_4(rr->rr_dv), ts, dts);
@@ -307,19 +307,19 @@ udpipaddr_print(netdissect_options *ndo,
 	const struct ip6_hdr *ip6 = (const struct ip6_hdr *)ip;
 
 	if (IP_V(ip) == 4 && GET_U_1(ip->ip_p) == IPPROTO_UDP) {
-		ND_PRINT("%s.%s > %s.%s: ",
+		ND_PRINT(C_RESET, "%s.%s > %s.%s: ",
 			GET_IPADDR_STRING(ip->ip_src),
 			udpport_string(ndo, sport),
 			GET_IPADDR_STRING(ip->ip_dst),
 			udpport_string(ndo, dport));
 	} else if (IP_V(ip) == 6 && GET_U_1(ip6->ip6_nxt) == IPPROTO_UDP) {
-		ND_PRINT("%s.%s > %s.%s: ",
+		ND_PRINT(C_RESET, "%s.%s > %s.%s: ",
 			GET_IP6ADDR_STRING(ip6->ip6_src),
 			udpport_string(ndo, sport),
 			GET_IP6ADDR_STRING(ip6->ip6_dst),
 			udpport_string(ndo, dport));
 	} else
-		ND_PRINT("%s > %s: ",
+		ND_PRINT(C_RESET, "%s > %s: ",
 			udpport_string(ndo, sport), udpport_string(ndo, dport));
 }
 
@@ -329,11 +329,11 @@ udpipaddr_noport_print(netdissect_options *ndo, const struct ip *ip)
 	const struct ip6_hdr *ip6 = (const struct ip6_hdr *)ip;
 
 	if (IP_V(ip) == 4 && GET_U_1(ip->ip_p) == IPPROTO_UDP) {
-		ND_PRINT("%s > %s: ",
+		ND_PRINT(C_RESET, "%s > %s: ",
 			GET_IPADDR_STRING(ip->ip_src),
 			GET_IPADDR_STRING(ip->ip_dst));
 	} else if (IP_V(ip) == 6 && GET_U_1(ip6->ip6_nxt) == IPPROTO_UDP) {
-		ND_PRINT("%s > %s: ",
+		ND_PRINT(C_RESET, "%s > %s: ",
 			GET_IP6ADDR_STRING(ip6->ip6_src),
 			GET_IP6ADDR_STRING(ip6->ip6_dst));
 	}
@@ -479,14 +479,14 @@ udp_print(netdissect_options *ndo, const u_char *bp, u_int length,
 		if (ND_TTEST_4(rp->rm_direction)) {
 			direction = (enum sunrpc_msg_type) GET_BE_U_4(rp->rm_direction);
 			if (dport == NFS_PORT && direction == SUNRPC_CALL) {
-				ND_PRINT("NFS request xid %u ",
+				ND_PRINT(C_RESET, "NFS request xid %u ",
 					 GET_BE_U_4(rp->rm_xid));
 				nfsreq_noaddr_print(ndo, (const u_char *)rp, length,
 				    (const u_char *)ip);
 				return;
 			}
 			if (sport == NFS_PORT && direction == SUNRPC_REPLY) {
-				ND_PRINT("NFS reply xid %u ",
+				ND_PRINT(C_RESET, "NFS reply xid %u ",
 					 GET_BE_U_4(rp->rm_xid));
 				nfsreply_noaddr_print(ndo, (const u_char *)rp, length,
 				    (const u_char *)ip);
@@ -511,16 +511,16 @@ udp_print(netdissect_options *ndo, const u_char *bp, u_int length,
 		 */
 		if (IP_V(ip) == 4 && (ndo->ndo_vflag > 1)) {
 			if (udp_sum == 0) {
-				ND_PRINT("[no cksum] ");
+				ND_PRINT(C_RESET, "[no cksum] ");
 			} else if (ND_TTEST_LEN(cp, length)) {
 				sum = udp_cksum(ndo, ip, up, length + sizeof(struct udphdr));
 
 				if (sum != 0) {
-					ND_PRINT("[bad udp cksum 0x%04x -> 0x%04x!] ",
+					ND_PRINT(C_RESET, "[bad udp cksum 0x%04x -> 0x%04x!] ",
 					    udp_sum,
 					    in_cksum_shouldbe(udp_sum, sum));
 				} else
-					ND_PRINT("[udp sum ok] ");
+					ND_PRINT(C_RESET, "[udp sum ok] ");
 			}
 		}
 		else if (IP_V(ip) == 6) {
@@ -529,11 +529,11 @@ udp_print(netdissect_options *ndo, const u_char *bp, u_int length,
 				sum = udp6_cksum(ndo, ip6, up, length + sizeof(struct udphdr));
 
 				if (sum != 0) {
-					ND_PRINT("[bad udp cksum 0x%04x -> 0x%04x!] ",
+					ND_PRINT(C_RESET, "[bad udp cksum 0x%04x -> 0x%04x!] ",
 					    udp_sum,
 					    in_cksum_shouldbe(udp_sum, sum));
 				} else
-					ND_PRINT("[udp sum ok] ");
+					ND_PRINT(C_RESET, "[udp sum ok] ");
 			}
 		}
 	}
@@ -666,7 +666,7 @@ udp_print(netdissect_options *ndo, const u_char *bp, u_int length,
 		else if ((atalk_port(sport) || atalk_port(dport)) &&
 			 GET_U_1(((const struct LAP *)cp)->type) == lapDDP) {
 			if (ndo->ndo_vflag)
-				ND_PRINT("kip ");
+				ND_PRINT(C_RESET, "kip ");
 			llap_print(ndo, cp, length);
 		} else if (IS_SRC_OR_DST_PORT(PTP_EVENT_PORT) ||
 			IS_SRC_OR_DST_PORT(PTP_GENERAL_PORT)) {
@@ -678,17 +678,17 @@ udp_print(netdissect_options *ndo, const u_char *bp, u_int length,
 			quic_print(ndo, cp, length);
 		else {
 			if (ulen > length && !fragmented)
-				ND_PRINT("UDP, bad length %u > %u",
+				ND_PRINT(C_RESET, "UDP, bad length %u > %u",
 				    ulen, length);
 			else
-				ND_PRINT("UDP, length %u", ulen);
+				ND_PRINT(C_RESET, "UDP, length %u", ulen);
 		}
 	} else {
 		if (ulen > length && !fragmented)
-			ND_PRINT("UDP, bad length %u > %u",
+			ND_PRINT(C_RESET, "UDP, bad length %u > %u",
 			    ulen, length);
 		else
-			ND_PRINT("UDP, length %u", ulen);
+			ND_PRINT(C_RESET, "UDP, length %u", ulen);
 	}
 	return;
 

--- a/print-usb.c
+++ b/print-usb.c
@@ -194,48 +194,48 @@ usb_header_print(netdissect_options *ndo, const pcap_usb_header *uh)
 	if (ndo->ndo_qflag)
 		return;
 
-	ND_PRINT(" ");
+	ND_PRINT(C_RESET, " ");
 	transfer_type = GET_U_1(uh->transfer_type);
 	switch(transfer_type)
 	{
 		case URB_ISOCHRONOUS:
-			ND_PRINT("ISOCHRONOUS");
+			ND_PRINT(C_RESET, "ISOCHRONOUS");
 			break;
 		case URB_INTERRUPT:
-			ND_PRINT("INTERRUPT");
+			ND_PRINT(C_RESET, "INTERRUPT");
 			break;
 		case URB_CONTROL:
-			ND_PRINT("CONTROL");
+			ND_PRINT(C_RESET, "CONTROL");
 			break;
 		case URB_BULK:
-			ND_PRINT("BULK");
+			ND_PRINT(C_RESET, "BULK");
 			break;
 		default:
-			ND_PRINT(" ?");
+			ND_PRINT(C_RESET, " ?");
 	}
 
 	event_type = GET_U_1(uh->event_type);
 	switch(event_type)
 	{
 		case URB_SUBMIT:
-			ND_PRINT(" SUBMIT");
+			ND_PRINT(C_RESET, " SUBMIT");
 			break;
 		case URB_COMPLETE:
-			ND_PRINT(" COMPLETE");
+			ND_PRINT(C_RESET, " COMPLETE");
 			break;
 		case URB_ERROR:
-			ND_PRINT(" ERROR");
+			ND_PRINT(C_RESET, " ERROR");
 			break;
 		default:
-			ND_PRINT(" ?");
+			ND_PRINT(C_RESET, " ?");
 	}
 
 	direction = get_direction(transfer_type, event_type);
 	if(direction == 1)
-		ND_PRINT(" from");
+		ND_PRINT(C_RESET, " from");
 	else if(direction == 2)
-		ND_PRINT(" to");
-	ND_PRINT(" %u:%u:%u", GET_HE_U_2(uh->bus_id),
+		ND_PRINT(C_RESET, " to");
+	ND_PRINT(C_RESET, " %u:%u:%u", GET_HE_U_2(uh->bus_id),
 		 GET_U_1(uh->device_address),
 		 GET_U_1(uh->endpoint_number) & 0x7f);
 }

--- a/print-vjc.c
+++ b/print-vjc.c
@@ -92,31 +92,31 @@ vjc_print(netdissect_options *ndo, const u_char *bp, u_short proto _U_)
 	switch (GET_U_1(bp) & 0xf0) {
 	case TYPE_IP:
 		if (ndo->ndo_eflag)
-			ND_PRINT("(vjc type=IP) ");
+			ND_PRINT(C_RESET, "(vjc type=IP) ");
 		return PPP_IP;
 	case TYPE_UNCOMPRESSED_TCP:
 		if (ndo->ndo_eflag)
-			ND_PRINT("(vjc type=raw TCP) ");
+			ND_PRINT(C_RESET, "(vjc type=raw TCP) ");
 		return PPP_IP;
 	case TYPE_COMPRESSED_TCP:
 		if (ndo->ndo_eflag)
-			ND_PRINT("(vjc type=compressed TCP) ");
+			ND_PRINT(C_RESET, "(vjc type=compressed TCP) ");
 		for (i = 0; i < 8; i++) {
 			if (GET_U_1(bp + 1) & (0x80 >> i))
-				ND_PRINT("%c", "?CI?SAWU"[i]);
+				ND_PRINT(C_RESET, "%c", "?CI?SAWU"[i]);
 		}
 		if (GET_U_1(bp + 1))
-			ND_PRINT(" ");
-		ND_PRINT("C=0x%02x ", GET_U_1(bp + 2));
-		ND_PRINT("sum=0x%04x ", GET_HE_U_2(bp + 3));
+			ND_PRINT(C_RESET, " ");
+		ND_PRINT(C_RESET, "C=0x%02x ", GET_U_1(bp + 2));
+		ND_PRINT(C_RESET, "sum=0x%04x ", GET_HE_U_2(bp + 3));
 		return -1;
 	case TYPE_ERROR:
 		if (ndo->ndo_eflag)
-			ND_PRINT("(vjc type=error) ");
+			ND_PRINT(C_RESET, "(vjc type=error) ");
 		return -1;
 	default:
 		if (ndo->ndo_eflag)
-			ND_PRINT("(vjc type=0x%02x) ", GET_U_1(bp) & 0xf0);
+			ND_PRINT(C_RESET, "(vjc type=0x%02x) ", GET_U_1(bp) & 0xf0);
 		return -1;
 	}
 }

--- a/print-vqp.c
+++ b/print-vqp.c
@@ -122,14 +122,14 @@ vqp_print(netdissect_options *ndo, const u_char *pptr, u_int len)
      * Sanity checking of the header.
      */
     if (version != VQP_VERSION) {
-	ND_PRINT("VQP version %u packet not supported",
+	ND_PRINT(C_RESET, "VQP version %u packet not supported",
                version);
 	return;
     }
 
     /* in non-verbose mode just lets print the basic Message Type */
     if (ndo->ndo_vflag < 1) {
-        ND_PRINT("VQPv%u %s Message, error-code %s (%u), length %u",
+        ND_PRINT(C_RESET, "VQPv%u %s Message, error-code %s (%u), length %u",
                version,
                tok2str(vqp_msg_type_values, "unknown (%u)",GET_U_1(vqp_common_header->msg_type)),
                tok2str(vqp_error_code_values, "unknown", GET_U_1(vqp_common_header->error_code)),
@@ -140,7 +140,7 @@ vqp_print(netdissect_options *ndo, const u_char *pptr, u_int len)
 
     /* ok they seem to want to know everything - lets fully decode it */
     nitems = GET_U_1(vqp_common_header->nitems);
-    ND_PRINT("\n\tVQPv%u, %s Message, error-code %s (%u), seq 0x%08x, items %u, length %u",
+    ND_PRINT(C_RESET, "\n\tVQPv%u, %s Message, error-code %s (%u), seq 0x%08x, items %u, length %u",
            version,
 	   tok2str(vqp_msg_type_values, "unknown (%u)",GET_U_1(vqp_common_header->msg_type)),
 	   tok2str(vqp_error_code_values, "unknown", GET_U_1(vqp_common_header->error_code)),
@@ -164,7 +164,7 @@ vqp_print(netdissect_options *ndo, const u_char *pptr, u_int len)
         tptr+=sizeof(struct vqp_obj_tlv_t);
         tlen-=sizeof(struct vqp_obj_tlv_t);
 
-        ND_PRINT("\n\t  %s Object (0x%08x), length %u, value: ",
+        ND_PRINT(C_RESET, "\n\t  %s Object (0x%08x), length %u, value: ",
                tok2str(vqp_obj_values, "Unknown", vqp_obj_type),
                vqp_obj_type, vqp_obj_len);
 
@@ -182,7 +182,7 @@ vqp_print(netdissect_options *ndo, const u_char *pptr, u_int len)
 	case VQP_OBJ_IP_ADDRESS:
             if (vqp_obj_len != 4)
                 goto invalid;
-            ND_PRINT("%s (0x%08x)", GET_IPADDR_STRING(tptr),
+            ND_PRINT(C_RESET, "%s (0x%08x)", GET_IPADDR_STRING(tptr),
                      GET_BE_U_4(tptr));
             break;
             /* those objects have similar semantics - fall through */
@@ -197,7 +197,7 @@ vqp_print(netdissect_options *ndo, const u_char *pptr, u_int len)
 	case VQP_OBJ_MAC_NULL:
             if (vqp_obj_len != MAC_ADDR_LEN)
                 goto invalid;
-	      ND_PRINT("%s", GET_ETHERADDR_STRING(tptr));
+	      ND_PRINT(C_RESET, "%s", GET_ETHERADDR_STRING(tptr));
               break;
         default:
             if (ndo->ndo_vflag <= 1)

--- a/print-vrrp.c
+++ b/print-vrrp.c
@@ -116,20 +116,20 @@ vrrp_print(netdissect_options *ndo,
 	version = (GET_U_1(bp) & 0xf0) >> 4;
 	type = GET_U_1(bp) & 0x0f;
 	type_s = tok2str(type2str, "unknown type (%u)", type);
-	ND_PRINT("v%u, %s", version, type_s);
+	ND_PRINT(C_RESET, "v%u, %s", version, type_s);
 	if (ttl != 255)
-		ND_PRINT(", (ttl %u)", ttl);
+		ND_PRINT(C_RESET, ", (ttl %u)", ttl);
 	if (version < 2 || version > 3 || type != VRRP_TYPE_ADVERTISEMENT)
 		return;
-	ND_PRINT(", vrid %u, prio %u", GET_U_1(bp + 1), GET_U_1(bp + 2));
+	ND_PRINT(C_RESET, ", vrid %u, prio %u", GET_U_1(bp + 1), GET_U_1(bp + 2));
 
 	if (version == 2) {
 		auth_type = GET_U_1(bp + 4);
-		ND_PRINT(", authtype %s", tok2str(auth2str, NULL, auth_type));
-		ND_PRINT(", intvl %us, length %u", GET_U_1(bp + 5), len);
+		ND_PRINT(C_RESET, ", authtype %s", tok2str(auth2str, NULL, auth_type));
+		ND_PRINT(C_RESET, ", intvl %us, length %u", GET_U_1(bp + 5), len);
 	} else { /* version == 3 */
 		uint16_t intvl = (GET_U_1(bp + 4) & 0x0f) << 8 | GET_U_1(bp + 5);
-		ND_PRINT(", intvl %ucs, length %u", intvl, len);
+		ND_PRINT(C_RESET, ", intvl %ucs, length %u", intvl, len);
 	}
 
 	if (ndo->ndo_vflag) {
@@ -143,7 +143,7 @@ vrrp_print(netdissect_options *ndo,
 			vec[0].ptr = bp;
 			vec[0].len = len;
 			if (in_cksum(vec, 1))
-				ND_PRINT(", (bad vrrp cksum %x)",
+				ND_PRINT(C_RESET, ", (bad vrrp cksum %x)",
 					GET_BE_U_2(bp + 6));
 		}
 
@@ -157,34 +157,34 @@ vrrp_print(netdissect_options *ndo,
 				cksum = nextproto6_cksum(ndo, (const struct ip6_hdr *)bp2, bp,
 					len, len, IPPROTO_VRRP);
 			if (cksum)
-				ND_PRINT(", (bad vrrp cksum %x)",
+				ND_PRINT(C_RESET, ", (bad vrrp cksum %x)",
 					GET_BE_U_2(bp + 6));
 		}
 
-		ND_PRINT(", addrs");
+		ND_PRINT(C_RESET, ", addrs");
 		if (naddrs > 1)
-			ND_PRINT("(%u)", naddrs);
-		ND_PRINT(":");
+			ND_PRINT(C_RESET, "(%u)", naddrs);
+		ND_PRINT(C_RESET, ":");
 		c = ' ';
 		bp += 8;
 		for (i = 0; i < naddrs; i++) {
 			if (ver == 4) {
-				ND_PRINT("%c%s", c, GET_IPADDR_STRING(bp));
+				ND_PRINT(C_RESET, "%c%s", c, GET_IPADDR_STRING(bp));
 				bp += 4;
 			} else {
-				ND_PRINT("%c%s", c, GET_IP6ADDR_STRING(bp));
+				ND_PRINT(C_RESET, "%c%s", c, GET_IP6ADDR_STRING(bp));
 				bp += 16;
 			}
 			c = ',';
 		}
 		if (version == 2 && auth_type == VRRP_AUTH_SIMPLE) { /* simple text password */
-			ND_PRINT(" auth \"");
+			ND_PRINT(C_RESET, " auth \"");
 			/*
 			 * RFC 2338 Section 5.3.10: "If the configured authentication string
 			 * is shorter than 8 bytes, the remaining space MUST be zero-filled.
 			 */
 			nd_printjnp(ndo, bp, 8);
-			ND_PRINT("\"");
+			ND_PRINT(C_RESET, "\"");
 		}
 	}
 }

--- a/print-vsock.c
+++ b/print-vsock.c
@@ -129,24 +129,24 @@ vsock_virtio_hdr_print(netdissect_options *ndo, const struct virtio_vsock_hdr *h
 	uint32_t u32_v;
 
 	u32_v = GET_LE_U_4(hdr->len);
-	ND_PRINT("len %u", u32_v);
+	ND_PRINT(C_RESET, "len %u", u32_v);
 
 	u16_v = GET_LE_U_2(hdr->type);
-	ND_PRINT(", type %s",
+	ND_PRINT(C_RESET, ", type %s",
 		 tok2str(virtio_type, "Invalid type (%hu)", u16_v));
 
 	u16_v = GET_LE_U_2(hdr->op);
-	ND_PRINT(", op %s",
+	ND_PRINT(C_RESET, ", op %s",
 		 tok2str(virtio_op, "Invalid op (%hu)", u16_v));
 
 	u32_v = GET_LE_U_4(hdr->flags);
-	ND_PRINT(", flags %x", u32_v);
+	ND_PRINT(C_RESET, ", flags %x", u32_v);
 
 	u32_v = GET_LE_U_4(hdr->buf_alloc);
-	ND_PRINT(", buf_alloc %u", u32_v);
+	ND_PRINT(C_RESET, ", buf_alloc %u", u32_v);
 
 	u32_v = GET_LE_U_4(hdr->fwd_cnt);
-	ND_PRINT(", fwd_cnt %u", u32_v);
+	ND_PRINT(C_RESET, ", fwd_cnt %u", u32_v);
 }
 
 /*
@@ -178,9 +178,9 @@ vsock_transport_hdr_print(netdissect_options *ndo, uint16_t transport,
 	hdr = p + sizeof(struct af_vsockmon_hdr);
 	switch (transport) {
 		case AF_VSOCK_TRANSPORT_VIRTIO:
-			ND_PRINT(" (");
+			ND_PRINT(C_RESET, " (");
 			vsock_virtio_hdr_print(ndo, hdr);
-			ND_PRINT(")");
+			ND_PRINT(C_RESET, ")");
 			break;
 		default:
 			break;
@@ -199,7 +199,7 @@ vsock_hdr_print(netdissect_options *ndo, const u_char *p, const u_int caplen)
 	int ret = 0;
 
 	hdr_transport = GET_LE_U_2(hdr->transport);
-	ND_PRINT("%s",
+	ND_PRINT(C_RESET, "%s",
 		 tok2str(vsock_transport, "Invalid transport (%u)",
 			  hdr_transport));
 
@@ -207,16 +207,16 @@ vsock_hdr_print(netdissect_options *ndo, const u_char *p, const u_int caplen)
 	if (ndo->ndo_vflag) {
 		ret = vsock_transport_hdr_print(ndo, hdr_transport, p, caplen);
 		if (ret == 0)
-			ND_PRINT("\n\t");
+			ND_PRINT(C_RESET, "\n\t");
 	} else
-		ND_PRINT(" ");
+		ND_PRINT(C_RESET, " ");
 
 	hdr_src_cid = GET_LE_U_8(hdr->src_cid);
 	hdr_dst_cid = GET_LE_U_8(hdr->dst_cid);
 	hdr_src_port = GET_LE_U_4(hdr->src_port);
 	hdr_dst_port = GET_LE_U_4(hdr->dst_port);
 	hdr_op = GET_LE_U_2(hdr->op);
-	ND_PRINT("%" PRIu64 ".%u > %" PRIu64 ".%u %s, length %u",
+	ND_PRINT(C_RESET, "%" PRIu64 ".%u > %" PRIu64 ".%u %s, length %u",
 		 hdr_src_cid, hdr_src_port,
 		 hdr_dst_cid, hdr_dst_port,
 		 tok2str(vsock_op, " invalid op (%u)", hdr_op),
@@ -233,7 +233,7 @@ vsock_hdr_print(netdissect_options *ndo, const u_char *p, const u_int caplen)
 		if (caplen > total_hdr_size) {
 			const u_char *payload = p + total_hdr_size;
 
-			ND_PRINT("\n");
+			ND_PRINT(C_RESET, "\n");
 			print_unknown_data(ndo, payload, "\t",
 					   caplen - total_hdr_size);
 		} else

--- a/print-vtp.c
+++ b/print-vtp.c
@@ -133,7 +133,7 @@ vtp_print(netdissect_options *ndo,
     ND_TCHECK_LEN(tptr, VTP_HEADER_LEN);
 
     type = GET_U_1(tptr + 1);
-    ND_PRINT("VTPv%u, Message %s (0x%02x), length %u",
+    ND_PRINT(C_RESET, "VTPv%u, Message %s (0x%02x), length %u",
 	   GET_U_1(tptr),
 	   tok2str(vtp_message_type_values,"Unknown message type", type),
 	   type,
@@ -145,14 +145,14 @@ vtp_print(netdissect_options *ndo,
     }
 
     /* verbose mode print all fields */
-    ND_PRINT("\n\tDomain name: ");
+    ND_PRINT(C_RESET, "\n\tDomain name: ");
     mgmtd_len = GET_U_1(tptr + 3);
     if (mgmtd_len < 1 ||  mgmtd_len > VTP_DOMAIN_NAME_LEN) {
-	ND_PRINT(" [invalid MgmtD Len %u]", mgmtd_len);
+	ND_PRINT(C_RESET, " [invalid MgmtD Len %u]", mgmtd_len);
 	goto invalid;
     }
     nd_printjnp(ndo, tptr + 4, mgmtd_len);
-    ND_PRINT(", %s: %u",
+    ND_PRINT(C_RESET, ", %s: %u",
 	   tok2str(vtp_header_values, "Unknown", type),
 	   GET_U_1(tptr + 2));
 
@@ -182,16 +182,16 @@ vtp_print(netdissect_options *ndo,
 	 *
 	 */
 
-	ND_PRINT("\n\t  Config Rev %x, Updater %s",
+	ND_PRINT(C_RESET, "\n\t  Config Rev %x, Updater %s",
 	       GET_BE_U_4(tptr),
 	       GET_IPADDR_STRING(tptr+4));
 	tptr += 8;
-	ND_PRINT(", Timestamp 0x%08x 0x%08x 0x%08x",
+	ND_PRINT(C_RESET, ", Timestamp 0x%08x 0x%08x 0x%08x",
 	       GET_BE_U_4(tptr),
 	       GET_BE_U_4(tptr + 4),
 	       GET_BE_U_4(tptr + 8));
 	tptr += VTP_UPDATE_TIMESTAMP_LEN;
-	ND_PRINT(", MD5 digest: %08x%08x%08x%08x",
+	ND_PRINT(C_RESET, ", MD5 digest: %08x%08x%08x%08x",
 	       GET_BE_U_4(tptr),
 	       GET_BE_U_4(tptr + 4),
 	       GET_BE_U_4(tptr + 8),
@@ -221,7 +221,7 @@ vtp_print(netdissect_options *ndo,
 	 *
 	 */
 
-	ND_PRINT(", Config Rev %x", GET_BE_U_4(tptr));
+	ND_PRINT(C_RESET, ", Config Rev %x", GET_BE_U_4(tptr));
 
 	/*
 	 *  VLAN INFORMATION
@@ -250,7 +250,7 @@ vtp_print(netdissect_options *ndo,
 	    vtp_vlan = (const struct vtp_vlan_*)tptr;
 	    if (len < VTP_VLAN_INFO_FIXED_PART_LEN)
 		goto invalid;
-	    ND_PRINT("\n\tVLAN info status %s, type %s, VLAN-id %u, MTU %u, SAID 0x%08x, Name ",
+	    ND_PRINT(C_RESET, "\n\tVLAN info status %s, type %s, VLAN-id %u, MTU %u, SAID 0x%08x, Name ",
 		   tok2str(vtp_vlan_status,"Unknown",GET_U_1(vtp_vlan->status)),
 		   tok2str(vtp_vlan_type_values,"Unknown",GET_U_1(vtp_vlan->type)),
 		   GET_BE_U_2(vtp_vlan->vlanid),
@@ -285,12 +285,12 @@ vtp_print(netdissect_options *ndo,
                 type = GET_U_1(tptr);
                 tlv_len = GET_U_1(tptr + 1);
 
-                ND_PRINT("\n\t\t%s (0x%04x) TLV",
+                ND_PRINT(C_RESET, "\n\t\t%s (0x%04x) TLV",
                        tok2str(vtp_vlan_tlv_values, "Unknown", type),
                        type);
 
                 if (len < tlv_len * 2 + 2) {
-                    ND_PRINT(" (TLV goes past the end of the packet)");
+                    ND_PRINT(C_RESET, " (TLV goes past the end of the packet)");
                     goto invalid;
                 }
                 ND_TCHECK_LEN(tptr, tlv_len * 2 + 2);
@@ -300,36 +300,36 @@ vtp_print(netdissect_options *ndo,
                  * in units of 16-bit words.
                  */
                 if (tlv_len != 1) {
-                    ND_PRINT(" (invalid TLV length %u != 1)", tlv_len);
+                    ND_PRINT(C_RESET, " (invalid TLV length %u != 1)", tlv_len);
                     goto invalid;
                 } else {
                     tlv_value = GET_BE_U_2(tptr + 2);
 
                     switch (type) {
                     case VTP_VLAN_STE_HOP_COUNT:
-                        ND_PRINT(", %u", tlv_value);
+                        ND_PRINT(C_RESET, ", %u", tlv_value);
                         break;
 
                     case VTP_VLAN_PRUNING:
-                        ND_PRINT(", %s (%u)",
+                        ND_PRINT(C_RESET, ", %s (%u)",
                                tlv_value == 1 ? "Enabled" : "Disabled",
                                tlv_value);
                         break;
 
                     case VTP_VLAN_STP_TYPE:
-                        ND_PRINT(", %s (%u)",
+                        ND_PRINT(C_RESET, ", %s (%u)",
                                tok2str(vtp_stp_type_values, "Unknown", tlv_value),
                                tlv_value);
                         break;
 
                     case VTP_VLAN_BRIDGE_TYPE:
-                        ND_PRINT(", %s (%u)",
+                        ND_PRINT(C_RESET, ", %s (%u)",
                                tlv_value == 1 ? "SRB" : "SRT",
                                tlv_value);
                         break;
 
                     case VTP_VLAN_BACKUP_CRF_MODE:
-                        ND_PRINT(", %s (%u)",
+                        ND_PRINT(C_RESET, ", %s (%u)",
                                tlv_value == 1 ? "Backup" : "Not backup",
                                tlv_value);
                         break;
@@ -371,7 +371,7 @@ vtp_print(netdissect_options *ndo,
 	 *
 	 */
 
-	ND_PRINT("\n\tStart value: %u", GET_BE_U_4(tptr));
+	ND_PRINT(C_RESET, "\n\tStart value: %u", GET_BE_U_4(tptr));
 	break;
 
     case VTP_JOIN_MESSAGE:

--- a/print-vxlan-gpe.c
+++ b/print-vxlan-gpe.c
@@ -66,16 +66,16 @@ vxlan_gpe_print(netdissect_options *ndo, const u_char *bp, u_int len)
     uint32_t vni;
 
     ndo->ndo_protocol = "vxlan_gpe";
-    ND_PRINT(C_RESET, C_RESET "VXLAN-GPE, ");
+    ND_PRINT(C_RESET, "VXLAN-GPE, ");
     if (len < VXLAN_GPE_HDR_LEN) {
-        ND_PRINT(C_RESET, C_RESET " (len %u < %u)", len, VXLAN_GPE_HDR_LEN);
+        ND_PRINT(C_RESET, " (len %u < %u)", len, VXLAN_GPE_HDR_LEN);
         goto invalid;
     }
 
     flags = GET_U_1(bp);
     bp += 1;
     len -= 1;
-    ND_PRINT(C_RESET, C_RESET "flags [%s], ",
+    ND_PRINT(C_RESET, "flags [%s], ",
               bittok2str_nosep(vxlan_gpe_flags, "none", flags));
 
     /* Reserved */
@@ -116,7 +116,7 @@ vxlan_gpe_print(netdissect_options *ndo, const u_char *bp, u_int len)
         nsh_print(ndo, bp, len);
         break;
     default:
-        ND_PRINT(C_RESET, C_RESET "ERROR: unknown-next-protocol");
+        ND_PRINT(C_RESET, "ERROR: unknown-next-protocol");
         goto invalid;
     }
 

--- a/print-vxlan-gpe.c
+++ b/print-vxlan-gpe.c
@@ -66,16 +66,16 @@ vxlan_gpe_print(netdissect_options *ndo, const u_char *bp, u_int len)
     uint32_t vni;
 
     ndo->ndo_protocol = "vxlan_gpe";
-    ND_PRINT("VXLAN-GPE, ");
+    ND_PRINT(C_RESET, C_RESET "VXLAN-GPE, ");
     if (len < VXLAN_GPE_HDR_LEN) {
-        ND_PRINT(" (len %u < %u)", len, VXLAN_GPE_HDR_LEN);
+        ND_PRINT(C_RESET, C_RESET " (len %u < %u)", len, VXLAN_GPE_HDR_LEN);
         goto invalid;
     }
 
     flags = GET_U_1(bp);
     bp += 1;
     len -= 1;
-    ND_PRINT("flags [%s], ",
+    ND_PRINT(C_RESET, C_RESET "flags [%s], ",
               bittok2str_nosep(vxlan_gpe_flags, "none", flags));
 
     /* Reserved */
@@ -95,8 +95,12 @@ vxlan_gpe_print(netdissect_options *ndo, const u_char *bp, u_int len)
     bp += 1;
     len -= 1;
 
-    ND_PRINT("vni %u", vni);
-    ND_PRINT(ndo->ndo_vflag ? "\n    " : ": ");
+    ND_PRINT(C_RESET, "vni %u", vni);
+
+    if(ndo->ndo_vflag)
+        ND_PRINT(C_RESET, "\n    ");
+    else
+        ND_PRINT(C_RESET, ": ");
 
     switch (next_protocol) {
     case 0x1:
@@ -112,7 +116,7 @@ vxlan_gpe_print(netdissect_options *ndo, const u_char *bp, u_int len)
         nsh_print(ndo, bp, len);
         break;
     default:
-        ND_PRINT("ERROR: unknown-next-protocol");
+        ND_PRINT(C_RESET, C_RESET "ERROR: unknown-next-protocol");
         goto invalid;
     }
 

--- a/print-vxlan.c
+++ b/print-vxlan.c
@@ -60,7 +60,7 @@ vxlan_print(netdissect_options *ndo, const u_char *bp, u_int len)
 
     flags = GET_U_1(bp);
     bp += 1;
-    ND_PRINT(", flags [%s] (0x%02x), ",
+    ND_PRINT(C_RESET, ", flags [%s] (0x%02x), ",
              bittok2str_nosep(vxlan_flags, "invalid", flags), flags);
 
     /* 1st Reserved */
@@ -68,7 +68,7 @@ vxlan_print(netdissect_options *ndo, const u_char *bp, u_int len)
 
     vni = GET_BE_U_3(bp);
     bp += 3;
-    ND_PRINT("vni %u\n", vni);
+    ND_PRINT(C_RESET, "vni %u\n", vni);
 
     /* 2nd Reserved */
     ND_TCHECK_1(bp);

--- a/print-wb.c
+++ b/print-wb.c
@@ -203,12 +203,12 @@ wb_id(netdissect_options *ndo,
 	char c;
 	u_int nid;
 
-	ND_PRINT(" wb-id:");
+	ND_PRINT(C_RESET, " wb-id:");
 	if (len < sizeof(*id))
 		return (-1);
 	len -= sizeof(*id);
 
-	ND_PRINT(" %u/%s:%u (max %u/%s:%u) ",
+	ND_PRINT(C_RESET, " %u/%s:%u (max %u/%s:%u) ",
 	       GET_BE_U_4(id->pi_ps.slot),
 	       GET_IPADDR_STRING(id->pi_ps.page.p_sid),
 	       GET_BE_U_4(id->pi_ps.page.p_uid),
@@ -227,13 +227,13 @@ wb_id(netdissect_options *ndo,
 
 	c = '<';
 	for (i = 0; i < nid; ++io, ++i) {
-		ND_PRINT("%c%s:%u",
+		ND_PRINT(C_RESET, "%c%s:%u",
 		    c, GET_IPADDR_STRING(io->id), GET_BE_U_4(io->off));
 		c = ',';
 	}
-	ND_PRINT("> \"");
+	ND_PRINT(C_RESET, "> \"");
 	nd_printjnp(ndo, sitename, len);
-	ND_PRINT("\"");
+	ND_PRINT(C_RESET, "\"");
 	return (0);
 }
 
@@ -241,11 +241,11 @@ static int
 wb_rreq(netdissect_options *ndo,
         const struct pkt_rreq *rreq, u_int len)
 {
-	ND_PRINT(" wb-rreq:");
+	ND_PRINT(C_RESET, " wb-rreq:");
 	if (len < sizeof(*rreq))
 		return (-1);
 
-	ND_PRINT(" please repair %s %s:%u<%u:%u>",
+	ND_PRINT(C_RESET, " please repair %s %s:%u<%u:%u>",
 	       GET_IPADDR_STRING(rreq->pr_id),
 	       GET_IPADDR_STRING(rreq->pr_page.p_sid),
 	       GET_BE_U_4(rreq->pr_page.p_uid),
@@ -258,11 +258,11 @@ static int
 wb_preq(netdissect_options *ndo,
         const struct pkt_preq *preq, u_int len)
 {
-	ND_PRINT(" wb-preq:");
+	ND_PRINT(C_RESET, " wb-preq:");
 	if (len < sizeof(*preq))
 		return (-1);
 
-	ND_PRINT(" need %u/%s:%u",
+	ND_PRINT(C_RESET, " need %u/%s:%u",
 	       GET_BE_U_4(preq->pp_low),
 	       GET_IPADDR_STRING(preq->pp_page.p_sid),
 	       GET_BE_U_4(preq->pp_page.p_uid));
@@ -278,7 +278,7 @@ wb_prep(netdissect_options *ndo,
 	u_int n;
 	const struct pgstate *ps;
 
-	ND_PRINT(" wb-prep:");
+	ND_PRINT(C_RESET, " wb-prep:");
 	if (len < sizeof(*prep))
 		return (-1);
 	n = GET_BE_U_4(prep->pp_n);
@@ -287,7 +287,7 @@ wb_prep(netdissect_options *ndo,
 		const struct id_off *io, *ie;
 		char c = '<';
 
-		ND_PRINT(" %u/%s:%u",
+		ND_PRINT(C_RESET, " %u/%s:%u",
 		    GET_BE_U_4(ps->slot),
 		    GET_IPADDR_STRING(ps->page.p_sid),
 		    GET_BE_U_4(ps->page.p_uid));
@@ -295,11 +295,11 @@ wb_prep(netdissect_options *ndo,
 		ND_TCHECK_SIZE(ps);
 		io = (const struct id_off *)(ps + 1);
 		for (ie = io + GET_U_1(ps->nid); io < ie; ++io) {
-			ND_PRINT("%c%s:%u", c, GET_IPADDR_STRING(io->id),
+			ND_PRINT(C_RESET, "%c%s:%u", c, GET_IPADDR_STRING(io->id),
 			    GET_BE_U_4(io->off));
 			c = ',';
 		}
-		ND_PRINT(">");
+		ND_PRINT(C_RESET, ">");
 		ps = (const struct pgstate *)io;
 		n--;
 	}
@@ -312,18 +312,18 @@ wb_dops(netdissect_options *ndo, const struct pkt_dop *dop,
 {
 	const struct dophdr *dh = (const struct dophdr *)((const u_char *)dop + sizeof(*dop));
 
-	ND_PRINT(" <");
+	ND_PRINT(C_RESET, " <");
 	for ( ; ss <= es; ++ss) {
 		u_int t;
 
 		t = GET_U_1(dh->dh_type);
 
-		ND_PRINT(" %s", tok2str(dop_str, "dop-%u!", t));
+		ND_PRINT(C_RESET, " %s", tok2str(dop_str, "dop-%u!", t));
 		if (t == DT_SKIP || t == DT_HOLE) {
 			uint32_t ts = GET_BE_U_4(dh->dh_ts);
-			ND_PRINT("%u", ts - ss + 1);
+			ND_PRINT(C_RESET, "%u", ts - ss + 1);
 			if (ss > ts || ts > es) {
-				ND_PRINT("[|]");
+				ND_PRINT(C_RESET, "[|]");
 				if (ts < ss)
 					return;
 			}
@@ -331,7 +331,7 @@ wb_dops(netdissect_options *ndo, const struct pkt_dop *dop,
 		}
 		dh = DOP_NEXT(dh);
 	}
-	ND_PRINT(" >");
+	ND_PRINT(C_RESET, " >");
 }
 
 static int
@@ -340,12 +340,12 @@ wb_rrep(netdissect_options *ndo,
 {
 	const struct pkt_dop *dop = &rrep->pr_dop;
 
-	ND_PRINT(" wb-rrep:");
+	ND_PRINT(C_RESET, " wb-rrep:");
 	if (len < sizeof(*rrep))
 		return (-1);
 	len -= sizeof(*rrep);
 
-	ND_PRINT(" for %s %s:%u<%u:%u>",
+	ND_PRINT(C_RESET, " for %s %s:%u<%u:%u>",
 	    GET_IPADDR_STRING(rrep->pr_id),
 	    GET_IPADDR_STRING(dop->pd_page.p_sid),
 	    GET_BE_U_4(dop->pd_page.p_uid),
@@ -363,12 +363,12 @@ static int
 wb_drawop(netdissect_options *ndo,
           const struct pkt_dop *dop, u_int len)
 {
-	ND_PRINT(" wb-dop:");
+	ND_PRINT(C_RESET, " wb-dop:");
 	if (len < sizeof(*dop))
 		return (-1);
 	len -= sizeof(*dop);
 
-	ND_PRINT(" %s:%u<%u:%u>",
+	ND_PRINT(C_RESET, " %s:%u<%u:%u>",
 	    GET_IPADDR_STRING(dop->pd_page.p_sid),
 	    GET_BE_U_4(dop->pd_page.p_uid),
 	    GET_BE_U_4(dop->pd_sseq),
@@ -400,12 +400,12 @@ wb_print(netdissect_options *ndo,
 	len -= sizeof(*ph);
 
 	if (GET_U_1(ph->ph_flags))
-		ND_PRINT("*");
+		ND_PRINT(C_RESET, "*");
 	type = GET_U_1(ph->ph_type);
 	switch (type) {
 
 	case PT_KILL:
-		ND_PRINT(" wb-kill");
+		ND_PRINT(C_RESET, " wb-kill");
 		return;
 
 	case PT_ID:
@@ -433,7 +433,7 @@ wb_print(netdissect_options *ndo,
 		break;
 
 	default:
-		ND_PRINT(" wb-%u!", type);
+		ND_PRINT(C_RESET, " wb-%u!", type);
 		print_result = -1;
 	}
 	if (print_result < 0)

--- a/print-zep.c
+++ b/print-zep.c
@@ -75,7 +75,7 @@ static void zep_print_ts(netdissect_options *ndo, const u_char *p)
 	ff = (float) (ff / FMAXINT); /* shift radix point by 32 bits */
 	f = (uint32_t) (ff * 1000000000.0);  /* treat fraction as parts per
 						billion */
-	ND_PRINT("%u.%09d", i, f);
+	ND_PRINT(C_RESET, "%u.%09d", i, f);
 
 #ifdef HAVE_STRFTIME
 	/*
@@ -88,7 +88,7 @@ static void zep_print_ts(netdissect_options *ndo, const u_char *p)
 
 		tm = localtime(&seconds);
 		strftime(time_buf, sizeof (time_buf), "%Y/%m/%d %H:%M:%S", tm);
-		ND_PRINT(" (%s)", time_buf);
+		ND_PRINT(C_RESET, " (%s)", time_buf);
 	}
 #endif
 }
@@ -110,28 +110,28 @@ zep_print(netdissect_options *ndo,
 
 	/* Preamble Code (must be "EX") */
 	if (GET_U_1(bp) != 'E' || GET_U_1(bp + 1) != 'X') {
-		ND_PRINT(" [Preamble Code: ");
+		ND_PRINT(C_RESET, " [Preamble Code: ");
 		fn_print_char(ndo, GET_U_1(bp));
 		fn_print_char(ndo, GET_U_1(bp + 1));
-		ND_PRINT("]");
+		ND_PRINT(C_RESET, "]");
 		nd_print_invalid(ndo);
 		return;
 	}
 
 	version = GET_U_1(bp + 2);
-	ND_PRINT("v%u ", version);
+	ND_PRINT(C_RESET, "v%u ", version);
 
 	if (version == 1) {
 		/* ZEP v1 packet. */
 		ND_ICHECK_U(len, <, 16);
-		ND_PRINT("Channel ID %u, Device ID 0x%04x, ",
+		ND_PRINT(C_RESET, "Channel ID %u, Device ID 0x%04x, ",
 			 GET_U_1(bp + 3), GET_BE_U_2(bp + 4));
 		if (GET_U_1(bp + 6))
-			ND_PRINT("CRC, ");
+			ND_PRINT(C_RESET, "CRC, ");
 		else
-			ND_PRINT("LQI %u, ", GET_U_1(bp + 7));
+			ND_PRINT(C_RESET, "LQI %u, ", GET_U_1(bp + 7));
 		inner_len = GET_U_1(bp + 15);
-		ND_PRINT("inner len = %u", inner_len);
+		ND_PRINT(C_RESET, "inner len = %u", inner_len);
 
 		bp += 16;
 		len -= 16;
@@ -141,25 +141,25 @@ zep_print(netdissect_options *ndo,
 			/* ZEP v2 ack. */
 			ND_ICHECK_U(len, <, 8);
 			seq_no = GET_BE_U_4(bp + 4);
-			ND_PRINT("ACK, seq# = %u", seq_no);
+			ND_PRINT(C_RESET, "ACK, seq# = %u", seq_no);
 			inner_len = 0;
 			bp += 8;
 			len -= 8;
 		} else {
 			/* ZEP v2 data, or some other. */
 			ND_ICHECK_U(len, <, 32);
-			ND_PRINT("Type %u, Channel ID %u, Device ID 0x%04x, ",
+			ND_PRINT(C_RESET, "Type %u, Channel ID %u, Device ID 0x%04x, ",
 				 GET_U_1(bp + 3), GET_U_1(bp + 4),
 				 GET_BE_U_2(bp + 5));
 			if (GET_U_1(bp + 7))
-				ND_PRINT("CRC, ");
+				ND_PRINT(C_RESET, "CRC, ");
 			else
-				ND_PRINT("LQI %u, ", GET_U_1(bp + 8));
+				ND_PRINT(C_RESET, "LQI %u, ", GET_U_1(bp + 8));
 
 			zep_print_ts(ndo, bp + 9);
 			seq_no = GET_BE_U_4(bp + 17);
 			inner_len = GET_U_1(bp + 31);
-			ND_PRINT(", seq# = %u, inner len = %u",
+			ND_PRINT(C_RESET, ", seq# = %u, inner len = %u",
 				 seq_no, inner_len);
 			bp += 32;
 			len -= 32;
@@ -168,7 +168,7 @@ zep_print(netdissect_options *ndo,
 
 	if (inner_len != 0) {
 		/* Call 802.15.4 dissector. */
-		ND_PRINT("\n\t");
+		ND_PRINT(C_RESET, "\n\t");
 		if (ieee802_15_4_print(ndo, bp, inner_len)) {
 			ND_TCHECK_LEN(bp, len);
 			bp += len;

--- a/print-zephyr.c
+++ b/print-zephyr.c
@@ -140,7 +140,7 @@ str_to_lower(const char *string)
 }
 
 #define ZEPHYR_PRINT(str1,str2) \
-{ ND_PRINT("%s", (str1)); fn_print_str(ndo, (const u_char *)(str2)); }
+{ ND_PRINT(C_RESET, C_RESET "%s", (str1)); fn_print_str(ndo, (const u_char *)(str2)); }
 
 void
 zephyr_print(netdissect_options *ndo, const u_char *cp, u_int length)
@@ -211,13 +211,13 @@ zephyr_print(netdissect_options *ndo, const u_char *cp, u_int length)
     if (lose)
 	goto invalid;
 
-    ND_PRINT(" zephyr");
+    ND_PRINT(C_RESET, C_RESET " zephyr");
     if (strncmp(z.version+4, "0.2", 3)) {
 	ZEPHYR_PRINT(" v", z.version+4)
 	return;
     }
 
-    ND_PRINT(" %s", tok2str(z_types, "type %d", z.kind));
+    ND_PRINT(C_RESET, C_RESET " %s", tok2str(z_types, "type %d", z.kind));
     if (z.kind == Z_PACKET_SERVACK) {
 	/* Initialization to silence warnings */
 	const char *ackdata = NULL;
@@ -229,9 +229,9 @@ zephyr_print(netdissect_options *ndo, const u_char *cp, u_int length)
 
     if (!strcmp(z.class, "USER_LOCATE")) {
 	if (!strcmp(z.opcode, "USER_HIDE"))
-	    ND_PRINT(" hide");
+	    ND_PRINT(C_RESET, C_RESET " hide");
 	else if (!strcmp(z.opcode, "USER_UNHIDE"))
-	    ND_PRINT(" unhide");
+	    ND_PRINT(C_RESET, C_RESET " unhide");
 	else
 	    ZEPHYR_PRINT(" locate ", z.inst);
 	return;
@@ -248,7 +248,7 @@ zephyr_print(netdissect_options *ndo, const u_char *cp, u_int length)
 		!strcmp(z.opcode, "SUBSCRIBE_NODEFS") ||
 		!strcmp(z.opcode, "UNSUBSCRIBE")) {
 
-		ND_PRINT(" %ssub%s", strcmp(z.opcode, "SUBSCRIBE") ? "un" : "",
+		ND_PRINT(C_RESET, C_RESET " %ssub%s", strcmp(z.opcode, "SUBSCRIBE") ? "un" : "",
 				   strcmp(z.opcode, "SUBSCRIBE_NODEFS") ? "" :
 								   "-nodefs");
 		if (z.kind != Z_PACKET_SERVACK) {
@@ -263,17 +263,17 @@ zephyr_print(netdissect_options *ndo, const u_char *cp, u_int length)
 	    }
 
 	    if (!strcmp(z.opcode, "GIMME")) {
-		ND_PRINT(" ret");
+		ND_PRINT(C_RESET, C_RESET " ret");
 		return;
 	    }
 
 	    if (!strcmp(z.opcode, "GIMMEDEFS")) {
-		ND_PRINT(" gimme-defs");
+		ND_PRINT(C_RESET, C_RESET " gimme-defs");
 		return;
 	    }
 
 	    if (!strcmp(z.opcode, "CLEARSUB")) {
-		ND_PRINT(" clear-subs");
+		ND_PRINT(C_RESET, C_RESET " clear-subs");
 		return;
 	    }
 
@@ -288,13 +288,13 @@ zephyr_print(netdissect_options *ndo, const u_char *cp, u_int length)
 
 	if (!strcmp(z.inst, "REALM")) {
 	    if (!strcmp(z.opcode, "ADD_SUBSCRIBE"))
-		ND_PRINT(" realm add-subs");
+		ND_PRINT(C_RESET, C_RESET " realm add-subs");
 	    if (!strcmp(z.opcode, "REQ_SUBSCRIBE"))
-		ND_PRINT(" realm req-subs");
+		ND_PRINT(C_RESET, C_RESET " realm req-subs");
 	    if (!strcmp(z.opcode, "RLM_SUBSCRIBE"))
-		ND_PRINT(" realm rlm-sub");
+		ND_PRINT(C_RESET, C_RESET " realm rlm-sub");
 	    if (!strcmp(z.opcode, "RLM_UNSUBSCRIBE"))
-		ND_PRINT(" realm rlm-unsub");
+		ND_PRINT(C_RESET, C_RESET " realm rlm-unsub");
 	    return;
 	}
     }
@@ -307,7 +307,7 @@ zephyr_print(netdissect_options *ndo, const u_char *cp, u_int length)
 
     if (!strcmp(z.class, "HM_STAT")) {
 	if (!strcmp(z.inst, "HMST_CLIENT") && !strcmp(z.opcode, "GIMMESTATS")) {
-	    ND_PRINT(" get-client-stats");
+	    ND_PRINT(C_RESET, C_RESET " get-client-stats");
 	    return;
 	}
     }
@@ -320,7 +320,7 @@ zephyr_print(netdissect_options *ndo, const u_char *cp, u_int length)
 
     if (!strcmp(z.class, "LOGIN")) {
 	if (!strcmp(z.opcode, "USER_FLUSH")) {
-	    ND_PRINT(" flush_locs");
+	    ND_PRINT(C_RESET, C_RESET " flush_locs");
 	    return;
 	}
 

--- a/print-zephyr.c
+++ b/print-zephyr.c
@@ -140,7 +140,7 @@ str_to_lower(const char *string)
 }
 
 #define ZEPHYR_PRINT(str1,str2) \
-{ ND_PRINT(C_RESET, C_RESET "%s", (str1)); fn_print_str(ndo, (const u_char *)(str2)); }
+{ ND_PRINT(C_RESET, "%s", (str1)); fn_print_str(ndo, (const u_char *)(str2)); }
 
 void
 zephyr_print(netdissect_options *ndo, const u_char *cp, u_int length)
@@ -211,13 +211,13 @@ zephyr_print(netdissect_options *ndo, const u_char *cp, u_int length)
     if (lose)
 	goto invalid;
 
-    ND_PRINT(C_RESET, C_RESET " zephyr");
+    ND_PRINT(C_RESET, " zephyr");
     if (strncmp(z.version+4, "0.2", 3)) {
 	ZEPHYR_PRINT(" v", z.version+4)
 	return;
     }
 
-    ND_PRINT(C_RESET, C_RESET " %s", tok2str(z_types, "type %d", z.kind));
+    ND_PRINT(C_RESET, " %s", tok2str(z_types, "type %d", z.kind));
     if (z.kind == Z_PACKET_SERVACK) {
 	/* Initialization to silence warnings */
 	const char *ackdata = NULL;
@@ -229,9 +229,9 @@ zephyr_print(netdissect_options *ndo, const u_char *cp, u_int length)
 
     if (!strcmp(z.class, "USER_LOCATE")) {
 	if (!strcmp(z.opcode, "USER_HIDE"))
-	    ND_PRINT(C_RESET, C_RESET " hide");
+	    ND_PRINT(C_RESET, " hide");
 	else if (!strcmp(z.opcode, "USER_UNHIDE"))
-	    ND_PRINT(C_RESET, C_RESET " unhide");
+	    ND_PRINT(C_RESET, " unhide");
 	else
 	    ZEPHYR_PRINT(" locate ", z.inst);
 	return;
@@ -248,7 +248,7 @@ zephyr_print(netdissect_options *ndo, const u_char *cp, u_int length)
 		!strcmp(z.opcode, "SUBSCRIBE_NODEFS") ||
 		!strcmp(z.opcode, "UNSUBSCRIBE")) {
 
-		ND_PRINT(C_RESET, C_RESET " %ssub%s", strcmp(z.opcode, "SUBSCRIBE") ? "un" : "",
+		ND_PRINT(C_RESET, " %ssub%s", strcmp(z.opcode, "SUBSCRIBE") ? "un" : "",
 				   strcmp(z.opcode, "SUBSCRIBE_NODEFS") ? "" :
 								   "-nodefs");
 		if (z.kind != Z_PACKET_SERVACK) {
@@ -263,17 +263,17 @@ zephyr_print(netdissect_options *ndo, const u_char *cp, u_int length)
 	    }
 
 	    if (!strcmp(z.opcode, "GIMME")) {
-		ND_PRINT(C_RESET, C_RESET " ret");
+		ND_PRINT(C_RESET, " ret");
 		return;
 	    }
 
 	    if (!strcmp(z.opcode, "GIMMEDEFS")) {
-		ND_PRINT(C_RESET, C_RESET " gimme-defs");
+		ND_PRINT(C_RESET, " gimme-defs");
 		return;
 	    }
 
 	    if (!strcmp(z.opcode, "CLEARSUB")) {
-		ND_PRINT(C_RESET, C_RESET " clear-subs");
+		ND_PRINT(C_RESET, " clear-subs");
 		return;
 	    }
 
@@ -288,13 +288,13 @@ zephyr_print(netdissect_options *ndo, const u_char *cp, u_int length)
 
 	if (!strcmp(z.inst, "REALM")) {
 	    if (!strcmp(z.opcode, "ADD_SUBSCRIBE"))
-		ND_PRINT(C_RESET, C_RESET " realm add-subs");
+		ND_PRINT(C_RESET, " realm add-subs");
 	    if (!strcmp(z.opcode, "REQ_SUBSCRIBE"))
-		ND_PRINT(C_RESET, C_RESET " realm req-subs");
+		ND_PRINT(C_RESET, " realm req-subs");
 	    if (!strcmp(z.opcode, "RLM_SUBSCRIBE"))
-		ND_PRINT(C_RESET, C_RESET " realm rlm-sub");
+		ND_PRINT(C_RESET, " realm rlm-sub");
 	    if (!strcmp(z.opcode, "RLM_UNSUBSCRIBE"))
-		ND_PRINT(C_RESET, C_RESET " realm rlm-unsub");
+		ND_PRINT(C_RESET, " realm rlm-unsub");
 	    return;
 	}
     }
@@ -307,7 +307,7 @@ zephyr_print(netdissect_options *ndo, const u_char *cp, u_int length)
 
     if (!strcmp(z.class, "HM_STAT")) {
 	if (!strcmp(z.inst, "HMST_CLIENT") && !strcmp(z.opcode, "GIMMESTATS")) {
-	    ND_PRINT(C_RESET, C_RESET " get-client-stats");
+	    ND_PRINT(C_RESET, " get-client-stats");
 	    return;
 	}
     }
@@ -320,7 +320,7 @@ zephyr_print(netdissect_options *ndo, const u_char *cp, u_int length)
 
     if (!strcmp(z.class, "LOGIN")) {
 	if (!strcmp(z.opcode, "USER_FLUSH")) {
-	    ND_PRINT(C_RESET, C_RESET " flush_locs");
+	    ND_PRINT(C_RESET, " flush_locs");
 	    return;
 	}
 

--- a/print-zeromq.c
+++ b/print-zeromq.c
@@ -91,18 +91,18 @@ zmtp1_print_frame(netdissect_options *ndo, const u_char *cp, const u_char *ep)
 	uint64_t body_len_declared, body_len_captured, header_len;
 	uint8_t flags;
 
-	ND_PRINT("\n\t");
+	ND_PRINT(C_RESET, "\n\t");
 
 	if (GET_U_1(cp) != 0xFF) {	/* length/0xFF */
 		header_len = 1; /* length */
 		body_len_declared = GET_U_1(cp);
-		ND_PRINT(" frame flags+body  (8-bit) length %" PRIu64, body_len_declared);
+		ND_PRINT(C_RESET, " frame flags+body  (8-bit) length %" PRIu64, body_len_declared);
 	} else {
 		header_len = 1 + 8; /* 0xFF, length */
-		ND_PRINT(" frame flags+body (64-bit) length");
+		ND_PRINT(C_RESET, " frame flags+body (64-bit) length");
 		ND_TCHECK_LEN(cp, header_len); /* 0xFF, length */
 		body_len_declared = GET_BE_U_8(cp + 1);
-		ND_PRINT(" %" PRIu64, body_len_declared);
+		ND_PRINT(C_RESET, " %" PRIu64, body_len_declared);
 	}
 	if (body_len_declared == 0)
 		return cp + header_len; /* skip to the next frame */
@@ -111,17 +111,17 @@ zmtp1_print_frame(netdissect_options *ndo, const u_char *cp, const u_char *ep)
 
 	body_len_captured = ep - cp - header_len;
 	if (body_len_declared > body_len_captured)
-		ND_PRINT(" (%" PRIu64 " captured)", body_len_captured);
-	ND_PRINT(", flags 0x%02x", flags);
+		ND_PRINT(C_RESET, " (%" PRIu64 " captured)", body_len_captured);
+	ND_PRINT(C_RESET, ", flags 0x%02x", flags);
 
 	if (ndo->ndo_vflag) {
 		uint64_t body_len_printed = ND_MIN(body_len_captured, body_len_declared);
 
-		ND_PRINT(" (%s)", bittok2str(flags_bm, "none", flags));
+		ND_PRINT(C_RESET, " (%s)", bittok2str(flags_bm, "none", flags));
 		if (ndo->ndo_vflag == 1)
 			body_len_printed = ND_MIN(VBYTES + 1, body_len_printed);
 		if (body_len_printed > 1) {
-			ND_PRINT(", first %" PRIu64 " byte(s) of body:", body_len_printed - 1);
+			ND_PRINT(C_RESET, ", first %" PRIu64 " byte(s) of body:", body_len_printed - 1);
 			hex_and_ascii_print(ndo, "\n\t ", cp + header_len + 1, body_len_printed - 1);
 		}
 	}
@@ -146,7 +146,7 @@ zmtp1_print(netdissect_options *ndo, const u_char *cp, u_int len)
 	const u_char *ep = ND_MIN(ndo->ndo_snapend, cp + len);
 
 	ndo->ndo_protocol = "zmtp1";
-	ND_PRINT(": ZMTP/1.0");
+	ND_PRINT(C_RESET, ": ZMTP/1.0");
 	while (cp < ep)
 		cp = zmtp1_print_frame(ndo, cp, ep);
 }
@@ -174,29 +174,29 @@ zmtp1_print_intermediate_part(netdissect_options *ndo, const u_char *cp, const u
 	u_int remaining_len;
 
 	frame_offset = GET_BE_U_2(cp);
-	ND_PRINT("\n\t frame offset 0x%04x", frame_offset);
+	ND_PRINT(C_RESET, "\n\t frame offset 0x%04x", frame_offset);
 	cp += 2;
 	remaining_len = ND_BYTES_AVAILABLE_AFTER(cp); /* without the frame length */
 
 	if (frame_offset == 0xFFFF)
 		frame_offset = len - 2; /* always within the declared length */
 	else if (2 + frame_offset > len) {
-		ND_PRINT(" (exceeds datagram declared length)");
+		ND_PRINT(C_RESET, " (exceeds datagram declared length)");
 		goto trunc;
 	}
 
 	/* offset within declared length of the datagram */
 	if (frame_offset) {
-		ND_PRINT("\n\t frame intermediate part, %u bytes", frame_offset);
+		ND_PRINT(C_RESET, "\n\t frame intermediate part, %u bytes", frame_offset);
 		if (frame_offset > remaining_len)
-			ND_PRINT(" (%u captured)", remaining_len);
+			ND_PRINT(C_RESET, " (%u captured)", remaining_len);
 		if (ndo->ndo_vflag) {
 			u_int len_printed = ND_MIN(frame_offset, remaining_len);
 
 			if (ndo->ndo_vflag == 1)
 				len_printed = ND_MIN(VBYTES, len_printed);
 			if (len_printed > 1) {
-				ND_PRINT(", first %u byte(s):", len_printed);
+				ND_PRINT(C_RESET, ", first %u byte(s):", len_printed);
 				hex_and_ascii_print(ndo, "\n\t ", cp, len_printed);
 			}
 		}

--- a/print.c
+++ b/print.c
@@ -329,46 +329,46 @@ pretty_print_packet(netdissect_options *ndo, const struct pcap_pkthdr *h,
 #endif
 
 	if (ndo->ndo_packet_number)
-		ND_PRINT("%5u  ", packets_captured);
+		ND_PRINT(C_RESET, "%5u  ", packets_captured);
 
 	/* Sanity checks on packet length / capture length */
 	if (h->caplen == 0) {
 		invalid_header = 1;
-		ND_PRINT("[Invalid header: caplen==0");
+		ND_PRINT(C_RESET, "[Invalid header: caplen==0");
 	}
 	if (h->len == 0) {
 		if (!invalid_header) {
 			invalid_header = 1;
-			ND_PRINT("[Invalid header:");
+			ND_PRINT(C_RESET, "[Invalid header:");
 		} else
-			ND_PRINT(",");
-		ND_PRINT(" len==0");
+			ND_PRINT(C_RESET, ",");
+		ND_PRINT(C_RESET, " len==0");
 	} else if (h->len < h->caplen) {
 		if (!invalid_header) {
 			invalid_header = 1;
-			ND_PRINT("[Invalid header:");
+			ND_PRINT(C_RESET, "[Invalid header:");
 		} else
-			ND_PRINT(",");
-		ND_PRINT(" len(%u) < caplen(%u)", h->len, h->caplen);
+			ND_PRINT(C_RESET, ",");
+		ND_PRINT(C_RESET, " len(%u) < caplen(%u)", h->len, h->caplen);
 	}
 	if (h->caplen > MAXIMUM_SNAPLEN) {
 		if (!invalid_header) {
 			invalid_header = 1;
-			ND_PRINT("[Invalid header:");
+			ND_PRINT(C_RESET, "[Invalid header:");
 		} else
-			ND_PRINT(",");
-		ND_PRINT(" caplen(%u) > %u", h->caplen, MAXIMUM_SNAPLEN);
+			ND_PRINT(C_RESET, ",");
+		ND_PRINT(C_RESET, " caplen(%u) > %u", h->caplen, MAXIMUM_SNAPLEN);
 	}
 	if (h->len > MAXIMUM_SNAPLEN) {
 		if (!invalid_header) {
 			invalid_header = 1;
-			ND_PRINT("[Invalid header:");
+			ND_PRINT(C_RESET, "[Invalid header:");
 		} else
-			ND_PRINT(",");
-		ND_PRINT(" len(%u) > %u", h->len, MAXIMUM_SNAPLEN);
+			ND_PRINT(C_RESET, ",");
+		ND_PRINT(C_RESET, " len(%u) > %u", h->len, MAXIMUM_SNAPLEN);
 	}
 	if (invalid_header) {
-		ND_PRINT("]\n");
+		ND_PRINT(C_RESET, "]\n");
 		return;
 	}
 
@@ -495,7 +495,7 @@ pretty_print_packet(netdissect_options *ndo, const struct pcap_pkthdr *h,
 		}
 	}
 
-	ND_PRINT("\n");
+	ND_PRINT(C_RESET, "\n");
 	nd_free_all(ndo);
 }
 

--- a/signature.c
+++ b/signature.c
@@ -191,7 +191,7 @@ signature_verify(netdissect_options *ndo, const u_char *pptr, u_int plen,
     } else {
         /* No - print the computed signature. */
         for (i = 0; i < sizeof(sig); ++i) {
-            ND_PRINT("%02x", sig[i]);
+            ND_PRINT(C_RESET, "%02x", sig[i]);
         }
 
         return (SIGNATURE_INVALID);

--- a/smbutil.c
+++ b/smbutil.c
@@ -290,38 +290,38 @@ smb_data_print(netdissect_options *ndo, const u_char *buf, u_int len)
 
     if (len == 0)
 	return;
-    ND_PRINT("[%03X] ", i);
+    ND_PRINT(C_RESET, "[%03X] ", i);
     for (i = 0; i < len; /*nothing*/) {
-	ND_PRINT("%02X ", GET_U_1(buf + i) & 0xff);
+	ND_PRINT(C_RESET, "%02X ", GET_U_1(buf + i) & 0xff);
 	i++;
 	if (i%8 == 0)
-	    ND_PRINT(" ");
+	    ND_PRINT(C_RESET, " ");
 	if (i % 16 == 0) {
 	    print_asc(ndo, buf + i - 16, 8);
-	    ND_PRINT(" ");
+	    ND_PRINT(C_RESET, " ");
 	    print_asc(ndo, buf + i - 8, 8);
-	    ND_PRINT("\n");
+	    ND_PRINT(C_RESET, "\n");
 	    if (i < len)
-		ND_PRINT("[%03X] ", i);
+		ND_PRINT(C_RESET, "[%03X] ", i);
 	}
     }
     if (i % 16) {
 	int n;
 
 	n = 16 - (i % 16);
-	ND_PRINT(" ");
+	ND_PRINT(C_RESET, " ");
 	if (n>8)
-	    ND_PRINT(" ");
+	    ND_PRINT(C_RESET, " ");
 	while (n--)
-	    ND_PRINT("   ");
+	    ND_PRINT(C_RESET, "   ");
 
 	n = ND_MIN(8, i % 16);
 	print_asc(ndo, buf + i - (i % 16), n);
-	ND_PRINT(" ");
+	ND_PRINT(C_RESET, " ");
 	n = (i % 16) - n;
 	if (n > 0)
 	    print_asc(ndo, buf + i - n, n);
-	ND_PRINT("\n");
+	ND_PRINT(C_RESET, "\n");
     }
 }
 
@@ -336,7 +336,7 @@ write_bits(netdissect_options *ndo,
     while ((p = strchr(fmt, '|'))) {
 	u_int l = ND_BYTES_BETWEEN(p, fmt);
 	if (l && (val & (1 << i)))
-	    ND_PRINT("%.*s ", (int)l, fmt);
+	    ND_PRINT(C_RESET, "%.*s ", (int)l, fmt);
 	fmt = p + 1;
 	i++;
     }
@@ -524,7 +524,7 @@ smb_fdata1(netdissect_options *ndo,
 	  {
 	    unsigned int x;
 	    x = GET_U_1(buf);
-	    ND_PRINT("%u (0x%x)", x, x);
+	    ND_PRINT(C_RESET, "%u (0x%x)", x, x);
 	    buf += 1;
 	    fmt++;
 	    break;
@@ -534,7 +534,7 @@ smb_fdata1(netdissect_options *ndo,
 	    int x;
 	    x = reverse ? GET_BE_S_2(buf) :
 			  GET_LE_S_2(buf);
-	    ND_PRINT("%d (0x%x)", x, x);
+	    ND_PRINT(C_RESET, "%d (0x%x)", x, x);
 	    buf += 2;
 	    fmt++;
 	    break;
@@ -544,7 +544,7 @@ smb_fdata1(netdissect_options *ndo,
 	    int x;
 	    x = reverse ? GET_BE_S_4(buf) :
 			  GET_LE_S_4(buf);
-	    ND_PRINT("%d (0x%x)", x, x);
+	    ND_PRINT(C_RESET, "%d (0x%x)", x, x);
 	    buf += 4;
 	    fmt++;
 	    break;
@@ -554,7 +554,7 @@ smb_fdata1(netdissect_options *ndo,
 	    uint64_t x;
 	    x = reverse ? GET_BE_U_8(buf) :
 			  GET_LE_U_8(buf);
-	    ND_PRINT("%" PRIu64 " (0x%" PRIx64 ")", x, x);
+	    ND_PRINT(C_RESET, "%" PRIu64 " (0x%" PRIx64 ")", x, x);
 	    buf += 8;
 	    fmt++;
 	    break;
@@ -564,7 +564,7 @@ smb_fdata1(netdissect_options *ndo,
 	    unsigned int x;
 	    x = reverse ? GET_BE_U_2(buf) :
 			  GET_LE_U_2(buf);
-	    ND_PRINT("%u (0x%x)", x, x);
+	    ND_PRINT(C_RESET, "%u (0x%x)", x, x);
 	    buf += 2;
 	    fmt++;
 	    break;
@@ -574,7 +574,7 @@ smb_fdata1(netdissect_options *ndo,
 	    unsigned int x;
 	    x = reverse ? GET_BE_U_4(buf) :
 			  GET_LE_U_4(buf);
-	    ND_PRINT("%u (0x%x)", x, x);
+	    ND_PRINT(C_RESET, "%u (0x%x)", x, x);
 	    buf += 4;
 	    fmt++;
 	    break;
@@ -590,7 +590,7 @@ smb_fdata1(netdissect_options *ndo,
 	    x2 = reverse ? GET_BE_U_4(buf + 4) :
 			   GET_LE_U_4(buf + 4);
 	    x = (((uint64_t)x1) << 32) | x2;
-	    ND_PRINT("%" PRIu64 " (0x%" PRIx64 ")", x, x);
+	    ND_PRINT(C_RESET, "%" PRIu64 " (0x%" PRIx64 ")", x, x);
 	    buf += 8;
 	    fmt++;
 	    break;
@@ -599,7 +599,7 @@ smb_fdata1(netdissect_options *ndo,
 	  {
 	    unsigned int x;
 	    x = GET_U_1(buf);
-	    ND_PRINT("0x%X", x);
+	    ND_PRINT(C_RESET, "0x%X", x);
 	    buf += 1;
 	    fmt++;
 	    break;
@@ -609,7 +609,7 @@ smb_fdata1(netdissect_options *ndo,
 	    unsigned int x;
 	    x = reverse ? GET_BE_U_2(buf) :
 			  GET_LE_U_2(buf);
-	    ND_PRINT("0x%X", x);
+	    ND_PRINT(C_RESET, "0x%X", x);
 	    buf += 2;
 	    fmt++;
 	    break;
@@ -619,7 +619,7 @@ smb_fdata1(netdissect_options *ndo,
 	    unsigned int x;
 	    x = reverse ? GET_BE_U_4(buf) :
 			  GET_LE_U_4(buf);
-	    ND_PRINT("0x%X", x);
+	    ND_PRINT(C_RESET, "0x%X", x);
 	    buf += 4;
 	    fmt++;
 	    break;
@@ -632,7 +632,7 @@ smb_fdata1(netdissect_options *ndo,
 	    case 'b':
 		stringlen = GET_U_1(buf);
 		stringlen_is_set = 1;
-		ND_PRINT("%u", stringlen);
+		ND_PRINT(C_RESET, "%u", stringlen);
 		buf += 1;
 		break;
 
@@ -641,7 +641,7 @@ smb_fdata1(netdissect_options *ndo,
 		stringlen = reverse ? GET_BE_U_2(buf) :
 				      GET_LE_U_2(buf);
 		stringlen_is_set = 1;
-		ND_PRINT("%u", stringlen);
+		ND_PRINT(C_RESET, "%u", stringlen);
 		buf += 2;
 		break;
 
@@ -650,7 +650,7 @@ smb_fdata1(netdissect_options *ndo,
 		stringlen = reverse ? GET_BE_U_4(buf) :
 				      GET_LE_U_4(buf);
 		stringlen_is_set = 1;
-		ND_PRINT("%u", stringlen);
+		ND_PRINT(C_RESET, "%u", stringlen);
 		buf += 4;
 		break;
 	    }
@@ -662,7 +662,7 @@ smb_fdata1(netdissect_options *ndo,
 	  {
 	    /*XXX unistr() */
 	    buf = unistr(ndo, &strbuf, buf, 0, 1, (*fmt == 'R') ? 0 : unicodestr);
-	    ND_PRINT("%s", strbuf);
+	    ND_PRINT(C_RESET, "%s", strbuf);
 	    if (buf == NULL)
 		goto trunc;
 	    fmt++;
@@ -672,11 +672,11 @@ smb_fdata1(netdissect_options *ndo,
 	case 'Y':	/* like 'Z', but always ASCII */
 	  {
 	    if (GET_U_1(buf) != 4 && GET_U_1(buf) != 2) {
-		ND_PRINT("Error! ASCIIZ buffer of type %u", GET_U_1(buf));
+		ND_PRINT(C_RESET, "Error! ASCIIZ buffer of type %u", GET_U_1(buf));
 		return maxbuf;	/* give up */
 	    }
 	    buf = unistr(ndo, &strbuf, buf + 1, 0, 1, (*fmt == 'Y') ? 0 : unicodestr);
-	    ND_PRINT("%s", strbuf);
+	    ND_PRINT(C_RESET, "%s", strbuf);
 	    if (buf == NULL)
 		goto trunc;
 	    fmt++;
@@ -686,7 +686,7 @@ smb_fdata1(netdissect_options *ndo,
 	  {
 	    int l = atoi(fmt + 1);
 	    ND_TCHECK_LEN(buf, l);
-	    ND_PRINT("%-*.*s", l, l, buf);
+	    ND_PRINT(C_RESET, "%-*.*s", l, l, buf);
 	    buf += l;
 	    fmt++;
 	    while (ND_ASCII_ISDIGIT(*fmt))
@@ -696,11 +696,11 @@ smb_fdata1(netdissect_options *ndo,
 	case 'c':
 	  {
             if (!stringlen_is_set) {
-                ND_PRINT("{stringlen not set}");
+                ND_PRINT(C_RESET, "{stringlen not set}");
                 goto trunc;
             }
 	    ND_TCHECK_LEN(buf, stringlen);
-	    ND_PRINT("%-*.*s", (int)stringlen, (int)stringlen, buf);
+	    ND_PRINT(C_RESET, "%-*.*s", (int)stringlen, (int)stringlen, buf);
 	    buf += stringlen;
 	    fmt++;
 	    while (ND_ASCII_ISDIGIT(*fmt))
@@ -710,11 +710,11 @@ smb_fdata1(netdissect_options *ndo,
 	case 'C':
 	  {
             if (!stringlen_is_set) {
-                ND_PRINT("{stringlen not set}");
+                ND_PRINT(C_RESET, "{stringlen not set}");
                 goto trunc;
             }
 	    buf = unistr(ndo, &strbuf, buf, stringlen, 0, unicodestr);
-	    ND_PRINT("%s", strbuf);
+	    ND_PRINT(C_RESET, "%s", strbuf);
 	    if (buf == NULL)
 		goto trunc;
 	    fmt++;
@@ -725,7 +725,7 @@ smb_fdata1(netdissect_options *ndo,
 	    int l = atoi(fmt + 1);
 	    ND_TCHECK_LEN(buf, l);
 	    while (l--) {
-		ND_PRINT("%02x", GET_U_1(buf));
+		ND_PRINT(C_RESET, "%02x", GET_U_1(buf));
 		buf++;
 	    }
 	    fmt++;
@@ -750,12 +750,12 @@ smb_fdata1(netdissect_options *ndo,
 		if (len < 0)
 		    goto trunc;
 		buf += len;
-		ND_PRINT("%-15.15s NameType=0x%02X (%s)", nbuf, name_type,
+		ND_PRINT(C_RESET, "%-15.15s NameType=0x%02X (%s)", nbuf, name_type,
 		    name_type_str(name_type));
 		break;
 	    case 2:
 		name_type = GET_U_1(buf + 15);
-		ND_PRINT("%-15.15s NameType=0x%02X (%s)", buf, name_type,
+		ND_PRINT(C_RESET, "%-15.15s NameType=0x%02X (%s)", buf, name_type,
 		    name_type_str(name_type));
 		buf += 16;
 		break;
@@ -806,21 +806,21 @@ smb_fdata1(netdissect_options *ndo,
 		    tstring = "(Can't convert time)\n";
 	    } else
 		tstring = "NULL\n";
-	    ND_PRINT("%s", tstring);
+	    ND_PRINT(C_RESET, "%s", tstring);
 	    fmt++;
 	    while (ND_ASCII_ISDIGIT(*fmt))
 		fmt++;
 	    break;
 	  }
 	default:
-	    ND_PRINT("%c", *fmt);
+	    ND_PRINT(C_RESET, "%c", *fmt);
 	    fmt++;
 	    break;
 	}
     }
 
     if (buf >= maxbuf && *fmt)
-	ND_PRINT("END OF BUFFER\n");
+	ND_PRINT(C_RESET, "END OF BUFFER\n");
 
     return(buf);
 
@@ -857,7 +857,7 @@ smb_fdata(netdissect_options *ndo,
 		 * have format strings with that level of nesting.
 		 */
 		if (depth == 10) {
-			ND_PRINT("(too many nested levels, not recursing)");
+			ND_PRINT(C_RESET, "(too many nested levels, not recursing)");
 			buf2 = buf;
 		} else
 			buf2 = smb_fdata(ndo, buf, fmt, maxbuf, unicodestr);
@@ -921,7 +921,7 @@ smb_fdata(netdissect_options *ndo,
 		 * get stuff in the middle of the line.
 		 */
 		if (*fmt == '\n')
-		    ND_PRINT("\n");
+		    ND_PRINT(C_RESET, "\n");
 		return(NULL);
 	    }
 	    break;
@@ -930,14 +930,14 @@ smb_fdata(netdissect_options *ndo,
 	    /*
 	     * Not a formatting character, so just print it.
 	     */
-	    ND_PRINT("%c", *fmt);
+	    ND_PRINT(C_RESET, "%c", *fmt);
 	    fmt++;
 	    break;
 	}
     }
     if (!depth && buf < maxbuf) {
 	u_int len = ND_BYTES_BETWEEN(maxbuf, buf);
-	ND_PRINT("Data: (%u bytes)\n", len);
+	ND_PRINT(C_RESET, "Data: (%u bytes)\n", len);
 	smb_data_print(ndo, buf, len);
 	return(buf + len);
     }

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -692,6 +692,7 @@ show_remote_devices_and_exit(void)
 #define OPTION_FP_TYPE			135
 #define OPTION_COUNT			136
 #define OPTION_PRINT_SAMPLING		137
+#define OPTION_COLOR	138
 
 static const struct option longopts[] = {
 #if defined(HAVE_PCAP_CREATE) || defined(_WIN32)
@@ -741,6 +742,7 @@ static const struct option longopts[] = {
 	{ "print", no_argument, NULL, OPTION_PRINT },
 	{ "print-sampling", required_argument, NULL, OPTION_PRINT_SAMPLING },
 	{ "version", no_argument, NULL, OPTION_VERSION },
+	{ "color", no_argument, NULL, OPTION_COLOR },
 	{ NULL, 0, NULL, 0 }
 };
 
@@ -1993,6 +1995,10 @@ main(int argc, char **argv)
 
 		case OPTION_COUNT:
 			count_mode = 1;
+			break;
+
+		case OPTION_COLOR:
+			++ndo->ndo_color;
 			break;
 
 		default:
@@ -3292,4 +3298,6 @@ print_usage(FILE *f)
 #endif
 	(void)fprintf(f,
 "\t\t[ -z postrotate-command ] [ -Z user ] [ expression ]\n");
+	(void)fprintf(f,
+"\t\t[ --color ]\n");
 }


### PR DESCRIPTION
Add `--color` arg that makes tcpdump print stuff using colors. The end goal is to make the output more readable.

As of now, only the ability to change colors is added, the colors themselves aren't changed.

<b>Before:</b>
```
ND_PRINT("foo %d, 123");
```
<b>After:</b>
```
ND_PRINT(C_RED, "foo %d, 123"); // prints in red
```


`C_RESET` macro in each `ND_PRINT(...)` ought to be changed to the desired colors' macro defined in `colors.h`. There are roughly 6k invocations of `ND_PRINT` so it wasn't in my scope alone to change the colors. If the idea sounds good, then I'd love to contribute further to provide colorful coverage over all outputs.

I do realize that tcpdump uses other ways than `ND_PRINT` to output stuff but gotta start from somewhere atleast :|