### PR TITLE
Always warning on ip checksum zero

### DIFF
--- a/print-ip.c
+++ b/print-ip.c
@@ -442,11 +442,11 @@ ip_print(netdissect_options *ndo,
 	        vec[0].ptr = (const uint8_t *)(const void *)ip;
 	        vec[0].len = hlen;
 	        sum = in_cksum(vec, 1);
-		if (sum != 0) {
-		    ip_sum = GET_BE_U_2(ip->ip_sum);
-		    ND_PRINT(", bad cksum %x (->%x)!", ip_sum,
-			     in_cksum_shouldbe(ip_sum, sum));
-		}
+
+	        ip_sum = GET_BE_U_2(ip->ip_sum);
+	        ND_PRINT(", bad cksum %x (->%x)!", ip_sum,
+		         in_cksum_shouldbe(ip_sum, sum));
+
 	    }
 
 	    ND_PRINT(")\n    ");


### PR DESCRIPTION
#1009 

IP checksum zero is a value that could be delivered. For modern nic, tso or tx checksum offloading is usually available. However, if some flag got written wrong, the checksum would be set to zero and delivered out. Warning should be necessary.

Signed-off-by: junka <wan.junjie@foxmail.com>