### PR TITLE
Group AFNUM needs to be extracted before moving bp pointer

### DIFF
--- a/print-pgm.c
+++ b/print-pgm.c
@@ -329,6 +329,7 @@ pgm_print(netdissect_options *ndo,
 	case PGM_NCF: {
 	    const struct pgm_nak *nak;
 	    char source_buf[INET6_ADDRSTRLEN], group_buf[INET6_ADDRSTRLEN];
+	    unsigned afnum;
 
 	    nak = (const struct pgm_nak *)(pgm + 1);
 	    ND_TCHECK_SIZE(nak);
@@ -358,8 +359,9 @@ pgm_print(netdissect_options *ndo,
 	     * Skip past the group, saving info along the way
 	     * and stopping if we don't have enough.
 	     */
+	    afnum = GET_BE_U_2(bp);
 	    bp += (2 * sizeof(uint16_t));
-	    switch (GET_BE_U_2(bp)) {
+	    switch (afnum) {
 	    case AFNUM_INET:
 		ND_TCHECK_LEN(bp, sizeof(nd_ipv4));
 		addrtostr(bp, group_buf, sizeof(group_buf));


### PR DESCRIPTION
When parsing PGM NCF packet type, the group AFNUM is extracted too late to be correct. In the switch in print-pgm.c under PGM_NCF option, when all the pointers are set, the pointers point to following:
```
struct pgm_header {                         <------ pgm points to the main PGM header
    nd_uint16_t pgm_sport;
    nd_uint16_t pgm_dport;
    nd_uint8_t  pgm_type;
    nd_uint8_t  pgm_options;
    nd_uint16_t pgm_sum;
    nd_byte     pgm_gsid[6];
    nd_uint16_t pgm_length;
};

struct pgm_nak {                     <----- nak points to (pgm + 1) that means it skips the main header and points here
    nd_uint32_t pgmn_seq;
    nd_uint16_t pgmn_source_afi;
    nd_uint16_t pgmn_reserved;
    /* ... uint8_t      pgmn_source[0]; */ <---- bp points to (nak + 1) so right after the first reserved part of the NAK header
    /* ... uint16_t     pgmn_group_afi */
    /* ... uint16_t     pgmn_reserved2; */
    /* ... uint8_t      pgmn_group[0]; */
    /* ... options */   
}
```
And then when the header is parsed, the pgmn_source is parsed, bp moves to pgmn_group_afi which is the value for the next switch but bp is again moved two bytes ahead before the group AFI can be extracted ( bp += (2 * sizeof(uint16_t)); ). 'switch (GET_BE_U_2(bp)) {' will be taking the value from pgmn_reserved2.
