### PR TITLE
build_common: fix missing ldd on Haiku

### DIFF
--- a/build_common.sh
+++ b/build_common.sh
@@ -248,6 +248,9 @@ print_so_deps() {
     Darwin-*)
         run_after_echo otool -L "${1:?}"
         ;;
+    Haiku-*)
+        run_after_echo objdump -p "${1:?}"
+        ;;
     *)
         run_after_echo ldd "${1:?}"
         ;;


### PR DESCRIPTION
Haiku does not have an `ldd` script. This change allows us to get at least some successful cases from the build matrix by using `objdump` instead of `ldd`. Should help with #996.