### PR TITLE
Makefile.in: don't remove configure and config.h.in in make distclean.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -453,9 +453,9 @@ lint:
 clean:
 	rm -f $(CLEANFILES) $(PROG)-`cat ${srcdir}/VERSION`.tar.gz
 
-distclean:
-	rm -f $(CLEANFILES) Makefile config.cache config.log config.status \
-	    config.h config.h.in config.h.in~ configure configure~ configure.ac~ \
+distclean: clean
+	rm -f Makefile config.cache config.log config.status \
+	    config.h config.h.in~ configure~ configure.ac~ \
 	    os-proto.h stamp-h stamp-h.in $(PROG).1 \
 	    libnetdissect.a tests/.failed tests/.passed \
 	    tests/failure-outputs.txt


### PR DESCRIPTION
In the GNU makefile standards, "make distclean" removes everything that's not part of the source distribution; this does *not* include the configure script or the config.h.in file, as those are in the release tarball, so that building from a source tarball doesn't require having autoconf.  This allows somebody building from the source tarball to do a "make distclean" and then reconfigure.

Do, however, remove any release tarball in make distclean, by having distclean depend on clean.