### PR TITLE
Detect OS IPv6 support using AF_INET6 only.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -48,6 +48,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       At build time require a proof of suitable snprintf(3) implementation in
         libc (and document Solaris 9 as unsupported because of that).
       Autoconf: Remove detection of early IPv6 stacks.
+      Detect OS IPv6 support using AF_INET6 only.
 
 DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
   Summary for 4.99.4 tcpdump release (so far!)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -633,22 +633,10 @@ cmake_pop_check_state()
 #
 
 #
-# Check for IPv6 support.
-# We just check for AF_INET6 and struct in6_addr.
+# FIXME: This check does not influence the build logic, but without it CMake
+# 3.18.4 fails trying to make the next check_type_size() check later on.
 #
-cmake_push_check_state()
-if(WIN32)
-    set(CMAKE_EXTRA_INCLUDE_FILES sys/types.h ws2tcpip.h)
-    check_symbol_exists(AF_INET6 "sys/types.h;ws2tcpip.h" HAVE_AF_INET6)
-else(WIN32)
-    set(CMAKE_EXTRA_INCLUDE_FILES sys/types.h sys/socket.h netinet/in.h)
-    check_symbol_exists(AF_INET6 "sys/types.h;sys/socket.h;netinet/in.h" HAVE_AF_INET6)
-endif(WIN32)
 check_type_size("struct in6_addr" HAVE_STRUCT_IN6_ADDR)
-cmake_pop_check_state()
-if(HAVE_AF_INET6 AND HAVE_STRUCT_IN6_ADDR)
-    set(HAVE_OS_IPV6_SUPPORT TRUE)
-endif(HAVE_AF_INET6 AND HAVE_STRUCT_IN6_ADDR)
 
 ######################################
 # External dependencies

--- a/addrtoname.c
+++ b/addrtoname.c
@@ -148,14 +148,15 @@ win32_gethostbyaddr(const char *addr, int len, int type)
 	static struct hostent host;
 	static char hostbuf[NI_MAXHOST];
 	char hname[NI_MAXHOST];
-	struct sockaddr_in6 addr6;
 
 	host.h_name = hostbuf;
 	switch (type) {
 	case AF_INET:
 		return gethostbyaddr(addr, len, type);
 		break;
-	case AF_INET6:
+#ifdef AF_INET6
+	case AF_INET6: {
+		struct sockaddr_in6 addr6;
 		memset(&addr6, 0, sizeof(addr6));
 		addr6.sin6_family = AF_INET6;
 		memcpy(&addr6.sin6_addr, addr, len);
@@ -167,6 +168,8 @@ win32_gethostbyaddr(const char *addr, int len, int type)
 			return &host;
 		}
 		break;
+	}
+#endif /* AF_INET6 */
 	default:
 		return NULL;
 	}
@@ -358,6 +361,7 @@ ip6addr_string(netdissect_options *ndo, const u_char *ap)
 	/*
 	 * Do not print names if -n was given.
 	 */
+#ifdef AF_INET6
 	if (!ndo->ndo_nflag) {
 #ifdef HAVE_CASPER
 		if (capdns != NULL) {
@@ -383,6 +387,7 @@ ip6addr_string(netdissect_options *ndo, const u_char *ap)
 			return (p->name);
 		}
 	}
+#endif /* AF_INET6 */
 	cp = addrtostr6(ap, ntop_buf, sizeof(ntop_buf));
 	p->name = strdup(cp);
 	if (p->name == NULL)

--- a/cmakeconfig.h.in
+++ b/cmakeconfig.h.in
@@ -78,9 +78,6 @@
 /* Define to 1 if you have the <openssl/evp.h> header file. */
 #cmakedefine HAVE_OPENSSL_EVP_H 1
 
-/* define if the OS provides AF_INET6 and struct in6_addr */
-#cmakedefine HAVE_OS_IPV6_SUPPORT 1
-
 /* if there's an os_proto.h for this platform, to use additional prototypes */
 #cmakedefine HAVE_OS_PROTO_H 1
 

--- a/configure.ac
+++ b/configure.ac
@@ -261,47 +261,6 @@ fi
 #
 AC_LBL_LIBRARY_NET
 
-#
-# Check whether AF_INET6 and struct in6_addr are defined.
-# If they aren't both defined, we don't have sufficient OS
-# support for IPv6, so we don't look for IPv6 support libraries,
-# and we define AF_INET6 and struct in6_addr ourselves.
-#
-AC_MSG_CHECKING([whether the operating system supports IPv6])
-AC_COMPILE_IFELSE(
-    [
-      AC_LANG_SOURCE(
-	[[
-#include <string.h>
-/* AF_INET6 available check */
-#include <sys/types.h>
-#ifdef _WIN32
-#include <ws2tcpip.h>
-#else
-#include <sys/socket.h>
-#include <netinet/in.h>
-#endif
-#ifdef AF_INET6
-void
-foo(struct in6_addr *addr)
-{
- memset(addr, 0, sizeof (struct in6_addr));
-}
-#else
-#error "AF_INET6 not defined"
-#endif
-	]])
-    ],
-    [
-	AC_MSG_RESULT(yes)
-	AC_DEFINE(HAVE_OS_IPV6_SUPPORT, 1,
-	    [define if the OS provides AF_INET6 and struct in6_addr])
-    ],
-    [
-	AC_MSG_RESULT(no)
-    ]
-)
-
 AC_REPLACE_FUNCS(strlcat strlcpy strsep getservent getopt_long)
 AC_CHECK_FUNCS(fork vfork)
 AC_CHECK_FUNCS(setlinebuf)

--- a/netdissect-stdinc.h
+++ b/netdissect-stdinc.h
@@ -202,10 +202,6 @@
 #define inline __inline
 #endif
 
-#if defined(AF_INET6) && !defined(HAVE_OS_IPV6_SUPPORT)
-#define HAVE_OS_IPV6_SUPPORT
-#endif
-
 #ifndef INET6_ADDRSTRLEN
 #define INET6_ADDRSTRLEN 46
 #endif
@@ -317,28 +313,6 @@ typedef char *caddr_t;
             : "=q" (x) : "0" (x));
     return (x);
   }
-#endif
-
-/*
- * If the OS doesn't define AF_INET6 and struct in6_addr:
- *
- * define AF_INET6, so we can use it internally as a "this is an
- * IPv6 address" indication;
- *
- * define struct in6_addr so that we can use it for IPv6 addresses.
- */
-#ifndef HAVE_OS_IPV6_SUPPORT
-#ifndef AF_INET6
-#define AF_INET6	24
-
-struct in6_addr {
-	union {
-		__uint8_t   __u6_addr8[16];
-		__uint16_t  __u6_addr16[8];
-		__uint32_t  __u6_addr32[4];
-	} __u6_addr;			/* 128-bit IP6 address */
-};
-#endif
 #endif
 
 #ifndef NI_MAXHOST

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -916,6 +916,7 @@ capdns_setup(void)
 	if (cap_dns_type_limit(capdnsloc, types, 1) < 0)
 		error("unable to limit access to system.dns service");
 	families[0] = AF_INET;
+	/* Casper is a feature of FreeBSD, which defines AF_INET6. */
 	families[1] = AF_INET6;
 	if (cap_dns_family_limit(capdnsloc, families, 2) < 0)
 		error("unable to limit access to system.dns service");


### PR DESCRIPTION
Let's see if this passes CI cleanly. A couple additional notes:
* There's one call to `cmake_pop_check_state()` missing from `CMakeLists.txt`, I guess it should be just before "Check for various functions in libpcap/WinPcap/Npcap.", but this discrepancy is old and seems to be irrelevant to this commit.
* The pre-existing `check_type_size("struct in6_addr" HAVE_STRUCT_IN6_ADDR)` line remains because without it my CMake fails to configure as shown below without an apparent reason. I tried to debug it, but both with and without the line the value of `CMAKE_REQUIRED_LIBRARIES` seems to be the same, so I cannot explain this failure, but it reproduces steadily.
```
-- Looking for sys/types.h
CMake Error (dev) at /usr/share/cmake-3.18/Modules/CheckIncludeFile.cmake:80 (message):
  Policy CMP0075 is not set: Include file check macros honor
  CMAKE_REQUIRED_LIBRARIES.  Run "cmake --help-policy CMP0075" for policy
  details.  Use the cmake_policy command to set the policy and suppress this
  warning.

  CMAKE_REQUIRED_LIBRARIES is set to:

    /usr/lib/x86_64-linux-gnu/libpcap.so

  For compatibility with CMake 3.11 and below this check is ignoring it.
Call Stack (most recent call first):
  /usr/share/cmake-3.18/Modules/CheckTypeSize.cmake:230 (check_include_file)
  CMakeLists.txt:764 (check_type_size)
This error is for project developers. Use -Wno-error=dev to suppress it.

-- Configuring incomplete, errors occurred!
```