### PR TITLE
Cirrus CI: Avoid perl warnings about setting locale, Linux task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -40,6 +40,7 @@ linux_task:
   env:
     DEBIAN_FRONTEND: noninteractive
     MAKEFLAGS: -j 5
+    LANG: C
   script:
     - apt-get -qy update >/dev/null
     - apt-get -qy install git autoconf make cmake clang gcc bc >/dev/null


### PR DESCRIPTION
The warnings were like:
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
	LANGUAGE = (unset),
	LC_ALL = (unset),
	LANG = "en_US.UTF-8"
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").