### PR TITLE
Update ND_BYTES_BETWEEN() and ND_BYTES_AVAILABLE_AFTER() macros for better accuracy

### DIFF
--- a/netdissect.h
+++ b/netdissect.h
@@ -391,7 +391,7 @@ nd_trunc_longjmp(netdissect_options *ndo)
  * Number of bytes remaining in the captured data, starting at the
  * byte pointed to by the argument.
  */
-#define ND_BYTES_AVAILABLE_AFTER(p) ND_BYTES_BETWEEN((p), ndo->ndo_snapend)
+#define ND_BYTES_AVAILABLE_AFTER(p) ((const u_char *)(p) < ndo->ndo_packetp ? 0 : ND_BYTES_BETWEEN((p), ndo->ndo_snapend))
 
 /*
  * Check (expression_1 operator expression_2) for invalid packet with

--- a/netdissect.h
+++ b/netdissect.h
@@ -385,13 +385,13 @@ nd_trunc_longjmp(netdissect_options *ndo)
 /*
  * Number of bytes between two pointers.
  */
-#define ND_BYTES_BETWEEN(p1, p2) ((u_int)(((const uint8_t *)(p1)) - (const uint8_t *)(p2)))
+#define ND_BYTES_BETWEEN(p1, p2) ((const u_char *)(p1) >= (const u_char *)(p2) ? 0 : ((u_int)(((const u_char *)(p2)) - (const u_char *)(p1))))
 
 /*
  * Number of bytes remaining in the captured data, starting at the
  * byte pointed to by the argument.
  */
-#define ND_BYTES_AVAILABLE_AFTER(p) ND_BYTES_BETWEEN(ndo->ndo_snapend, (p))
+#define ND_BYTES_AVAILABLE_AFTER(p) ND_BYTES_BETWEEN((p), ndo->ndo_snapend)
 
 /*
  * Check (expression_1 operator expression_2) for invalid packet with

--- a/print-ascii.c
+++ b/print-ascii.c
@@ -67,7 +67,7 @@ ascii_print(netdissect_options *ndo,
 	int truncated = FALSE;
 
 	ndo->ndo_protocol = "ascii";
-	caplength = (ndo->ndo_snapend > cp) ? ND_BYTES_AVAILABLE_AFTER(cp) : 0;
+	caplength = ND_BYTES_AVAILABLE_AFTER(cp);
 	if (length > caplength) {
 		length = caplength;
 		truncated = TRUE;
@@ -113,7 +113,7 @@ hex_and_ascii_print_with_offset(netdissect_options *ndo, const char *indent,
 	char hexstuff[HEXDUMP_SHORTS_PER_LINE*HEXDUMP_HEXSTUFF_PER_SHORT+1], *hsp;
 	char asciistuff[ASCII_LINELENGTH+1], *asp;
 
-	caplength = (ndo->ndo_snapend > cp) ? ND_BYTES_AVAILABLE_AFTER(cp) : 0;
+	caplength = ND_BYTES_AVAILABLE_AFTER(cp);
 	if (length > caplength) {
 		length = caplength;
 		truncated = TRUE;
@@ -181,7 +181,7 @@ hex_print_with_offset(netdissect_options *ndo,
 	u_int nshorts;
 	int truncated = FALSE;
 
-	caplength = (ndo->ndo_snapend > cp) ? ND_BYTES_AVAILABLE_AFTER(cp) : 0;
+	caplength = ND_BYTES_AVAILABLE_AFTER(cp);
 	if (length > caplength) {
 		length = caplength;
 		truncated = TRUE;

--- a/print-bgp.c
+++ b/print-bgp.c
@@ -2346,8 +2346,10 @@ bgp_attr_print(netdissect_options *ndo,
             ND_PRINT(", no SNPA");
         }
 
-        add_path4 = check_add_path(ndo, tptr, (len-ND_BYTES_BETWEEN(tptr, pptr)), 32);
-        add_path6 = check_add_path(ndo, tptr, (len-ND_BYTES_BETWEEN(tptr, pptr)), 128);
+        add_path4 = check_add_path(ndo, tptr,
+                                   (len-ND_BYTES_BETWEEN(pptr, tptr)), 32);
+        add_path6 = check_add_path(ndo, tptr,
+                                   (len-ND_BYTES_BETWEEN(pptr, tptr)), 128);
 
         while (tptr < pptr + len) {
             advance = bgp_nlri_print(ndo, af, safi, tptr, len, buf, sizeof(buf),
@@ -2373,8 +2375,10 @@ bgp_attr_print(netdissect_options *ndo,
 
         tptr += 3;
 
-        add_path4 = check_add_path(ndo, tptr, (len-ND_BYTES_BETWEEN(tptr, pptr)), 32);
-        add_path6 = check_add_path(ndo, tptr, (len-ND_BYTES_BETWEEN(tptr, pptr)), 128);
+        add_path4 = check_add_path(ndo, tptr,
+                                   (len-ND_BYTES_BETWEEN(pptr, tptr)), 32);
+        add_path6 = check_add_path(ndo, tptr,
+                                   (len-ND_BYTES_BETWEEN(pptr, tptr)), 128);
 
         while (tptr < pptr + len) {
             advance = bgp_nlri_print(ndo, af, safi, tptr, len, buf, sizeof(buf),

--- a/print-isoclns.c
+++ b/print-isoclns.c
@@ -1126,9 +1126,10 @@ clnp_print(netdissect_options *ndo,
 
         default:
             /* dump the PDU specific data */
-            if (length > ND_BYTES_BETWEEN(pptr, optr)) {
+            if (length > ND_BYTES_BETWEEN(optr, pptr)) {
                 ND_PRINT("\n\t  undecoded non-header data, length %u", length-li);
-                print_unknown_data(ndo, pptr, "\n\t  ", length - ND_BYTES_BETWEEN(pptr, optr));
+                print_unknown_data(ndo, pptr, "\n\t  ",
+                                   length - ND_BYTES_BETWEEN(optr, pptr));
             }
         }
 

--- a/print-lwres.c
+++ b/print-lwres.c
@@ -267,7 +267,7 @@ lwres_printaddr(netdissect_options *ndo,
 		}
 	}
 
-	return ND_BYTES_BETWEEN(p, p0);
+	return ND_BYTES_BETWEEN(p0, p);
 }
 
 void
@@ -548,7 +548,7 @@ lwres_print(netdissect_options *ndo,
 		ND_PRINT(" [len: %u != %u]", GET_BE_U_4(np->length),
 			  length);
 	}
-	if (!unsupported && ND_BYTES_BETWEEN(s, bp) < GET_BE_U_4(np->length))
+	if (!unsupported && ND_BYTES_BETWEEN(bp, s) < GET_BE_U_4(np->length))
 		ND_PRINT("[extra]");
 	return;
 

--- a/print-resp.c
+++ b/print-resp.c
@@ -306,7 +306,7 @@ resp_print_string_error_integer(netdissect_options *ndo, const u_char *bp, int l
      * preceding the \r\n.  That includes the opcode, so don't print
      * that.
      */
-    len = ND_BYTES_BETWEEN(bp_ptr, bp);
+    len = ND_BYTES_BETWEEN(bp, bp_ptr);
     RESP_PRINT_SEGMENT(ndo, bp, len);
     ret_len = 1 /*<opcode>*/ + len /*<string>*/ + 2 /*<CRLF>*/;
 
@@ -431,7 +431,7 @@ resp_print_inline(netdissect_options *ndo, const u_char *bp, int length) {
      * Found it; bp_ptr points to the \r or \n, so bp_ptr - bp is the
      * Length of the line text that precedes it.  Print it.
      */
-    len = ND_BYTES_BETWEEN(bp_ptr, bp);
+    len = ND_BYTES_BETWEEN(bp, bp_ptr);
     RESP_PRINT_SEGMENT(ndo, bp, len);
 
     /*

--- a/print-smb.c
+++ b/print-smb.c
@@ -414,7 +414,8 @@ print_negprot(netdissect_options *ndo,
 	smb_fdata(ndo, words + 1, f1, ND_MIN(words + 1 + wct * 2, maxbuf),
 	    unicodestr);
     else
-	smb_data_print(ndo, words + 1, ND_MIN(wct * 2, ND_BYTES_BETWEEN(maxbuf, words + 1)));
+	smb_data_print(ndo, words + 1,
+                       ND_MIN(wct * 2, ND_BYTES_BETWEEN(words + 1, maxbuf)));
 
     bcc = GET_LE_U_2(data);
     ND_PRINT("smb_bcc=%u\n", bcc);
@@ -424,7 +425,7 @@ print_negprot(netdissect_options *ndo,
                                              maxbuf), unicodestr);
 	else
 	    smb_data_print(ndo, data + 2,
-                           ND_MIN(GET_LE_U_2(data), ND_BYTES_BETWEEN(maxbuf, data + 2)));
+                           ND_MIN(GET_LE_U_2(data), ND_BYTES_BETWEEN(data + 2, maxbuf)));
     }
 }
 
@@ -454,7 +455,8 @@ print_sesssetup(netdissect_options *ndo,
 	smb_fdata(ndo, words + 1, f1, ND_MIN(words + 1 + wct * 2, maxbuf),
 	    unicodestr);
     else
-	smb_data_print(ndo, words + 1, ND_MIN(wct * 2, ND_BYTES_BETWEEN(maxbuf, words + 1)));
+	smb_data_print(ndo, words + 1,
+                       ND_MIN(wct * 2, ND_BYTES_BETWEEN(words + 1, maxbuf)));
 
     bcc = GET_LE_U_2(data);
     ND_PRINT("smb_bcc=%u\n", bcc);
@@ -464,7 +466,7 @@ print_sesssetup(netdissect_options *ndo,
                                              maxbuf), unicodestr);
 	else
 	    smb_data_print(ndo, data + 2,
-                           ND_MIN(GET_LE_U_2(data), ND_BYTES_BETWEEN(maxbuf, data + 2)));
+                           ND_MIN(GET_LE_U_2(data), ND_BYTES_BETWEEN(data + 2, maxbuf)));
     }
 }
 
@@ -499,7 +501,7 @@ print_lockingandx(netdissect_options *ndo,
                                              maxbuf), unicodestr);
 	else
 	    smb_data_print(ndo, data + 2,
-                           ND_MIN(GET_LE_U_2(data), ND_BYTES_BETWEEN(maxbuf, data + 2)));
+                           ND_MIN(GET_LE_U_2(data), ND_BYTES_BETWEEN(data + 2, maxbuf)));
     }
 }
 
@@ -871,7 +873,8 @@ print_smb(netdissect_options *ndo,
 	    } else {
 		if (bcc > 0) {
 		    ND_PRINT("smb_buf[]=\n");
-		    smb_data_print(ndo, data + 2, ND_MIN(bcc, ND_BYTES_BETWEEN(maxbuf, data + 2)));
+		    smb_data_print(ndo, data + 2,
+                                   ND_MIN(bcc, ND_BYTES_BETWEEN(data + 2, maxbuf)));
 		}
 	    }
 	}
@@ -1194,7 +1197,8 @@ nbt_udp137_print(netdissect_options *ndo,
 		} else {
 		    if (p >= maxbuf)
 		        goto out;
-		    smb_data_print(ndo, p, ND_MIN(rdlen, length - ND_BYTES_BETWEEN(p, data)));
+		    smb_data_print(ndo, p,
+                                   ND_MIN(rdlen, length - ND_BYTES_BETWEEN(data, p)));
 		    p += rdlen;
 		}
 	    }

--- a/smbutil.c
+++ b/smbutil.c
@@ -251,7 +251,7 @@ name_len(netdissect_options *ndo,
 	s += GET_U_1(s) + 1;
 	ND_TCHECK_1(s);
     }
-    return(ND_BYTES_BETWEEN(s, s0) + 1);
+    return(ND_BYTES_BETWEEN(s0, s) + 1);
 
 trunc:
     return(-1);	/* name goes past the end of the buffer */
@@ -334,7 +334,7 @@ write_bits(netdissect_options *ndo,
     u_int i = 0;
 
     while ((p = strchr(fmt, '|'))) {
-	u_int l = ND_BYTES_BETWEEN(p, fmt);
+	u_int l = ND_BYTES_BETWEEN(fmt, p);
 	if (l && (val & (1 << i)))
 	    ND_PRINT("%.*s ", (int)l, fmt);
 	fmt = p + 1;
@@ -493,7 +493,7 @@ smb_fdata1(netdissect_options *ndo,
 	    u_int l;
 
 	    p = strchr(++fmt, '}');
-	    l = ND_BYTES_BETWEEN(p, fmt);
+	    l = ND_BYTES_BETWEEN(fmt, p);
 
 	    if (l > sizeof(bitfmt) - 1)
 		l = sizeof(bitfmt)-1;
@@ -742,8 +742,9 @@ smb_fdata1(netdissect_options *ndo,
 
 	    switch (t) {
 	    case 1:
-		name_type = name_extract(ndo, startbuf, ND_BYTES_BETWEEN(buf, startbuf),
-		    maxbuf, nbuf);
+		name_type = name_extract(ndo, startbuf,
+                                         ND_BYTES_BETWEEN(startbuf, buf),
+                                         maxbuf, nbuf);
 		if (name_type < 0)
 		    goto trunc;
 		len = name_len(ndo, buf, maxbuf);
@@ -933,7 +934,7 @@ smb_fdata(netdissect_options *ndo,
 	}
     }
     if (!depth && buf < maxbuf) {
-	u_int len = ND_BYTES_BETWEEN(maxbuf, buf);
+	u_int len = ND_BYTES_BETWEEN(buf, maxbuf);
 	ND_PRINT("Data: (%u bytes)\n", len);
 	smb_data_print(ndo, buf, len);
 	return(buf + len);


### PR DESCRIPTION
1)
Update ND_BYTES_BETWEEN() macro for better accuracy

Update the macro that computes how many bytes are present, starting
at the first argument and running up to (but not including) the second
argument, and returns that as a u_int (cutting it to 32 bits on LP64
and LLP64 platforms).

This reverses, for reasons of readability, the order of the arguments
which was based on old SMB's PTR_DIFF().

With this change the number of bytes "between" given by the macro is 0
when the first argument is greater than or equal to the second argument.

This is a follow-up to f9c2c905b118b69a0b102549c1b25cca871947b5.

2)
Update ND_BYTES_AVAILABLE_AFTER() macro for better accuracy

With this change the number of bytes available in the captured data
given by the macro is 0 when the argument is greater than or equal
to ndo_snapend or less than ndo_packetp (e.g. pointer underflow).
 
i.e.:
If p is like p3, the macro gives 0.
If p is like p1, the macro gives 0.
```
|------------------|-----------------------|-----------------|
     p1  <   ndo_packetp  <=  p2  <  ndo_snapend   <=   p3 
 ```
Update the ascii_print(), hex_and_ascii_print_with_offset() and 
hex_print_with_offset() functions accordingly.
