### PR TITLE
tcpdump.1.in: Delete Linux 2.0 references

### DIFF
--- a/tcpdump.1.in
+++ b/tcpdump.1.in
@@ -2052,24 +2052,6 @@ in the tcpdump source tree root.
 NIT doesn't let you watch your own outbound traffic, BPF will.
 We recommend that you use the latter.
 .LP
-On Linux systems with 2.0[.x] kernels:
-.IP
-packets on the loopback device will be seen twice;
-.IP
-packet filtering cannot be done in the kernel, so that all packets must
-be copied from the kernel in order to be filtered in user mode;
-.IP
-all of a packet, not just the part that's within the snapshot length,
-will be copied from the kernel (the 2.0[.x] packet capture mechanism, if
-asked to copy only part of a packet to userspace, will not report the
-true length of the packet; this would cause most IP packets to get an
-error from
-.BR tcpdump );
-.IP
-capturing on some PPP devices won't work correctly.
-.LP
-We recommend that you upgrade to a 2.2 or later kernel.
-.LP
 Some attempt should be made to reassemble IP fragments or, at least
 to compute the right length for the higher level protocol.
 .LP


### PR DESCRIPTION
Delete Linux 2.0 bugs from bug list.

Linux 2.0.x releases are from 1996-2004. The man page recommended upgrading to Linux 2.2, released in 1999.

https://en.wikipedia.org/wiki/Linux_kernel_version_history#Releases_up_to_2.6.0

I'm assuming these >20 year old bug references aren't that useful now.