### PR TITLE
Make nd_trunc_longjmp() not static inline.

### DIFF
--- a/netdissect.c
+++ b/netdissect.c
@@ -299,3 +299,17 @@ nd_pop_all_packet_info(netdissect_options *ndo)
 	while (ndo->ndo_packet_info_stack != NULL)
 		nd_pop_packet_info(ndo);
 }
+
+NORETURN void
+nd_trunc_longjmp(netdissect_options *ndo)
+{
+	longjmp(ndo->ndo_early_end, ND_TRUNCATED);
+#ifdef _AIX
+	/*
+	 * In AIX <setjmp.h> decorates longjmp() with "#pragma leaves", which tells
+	 * XL C that the function is noreturn, but GCC remains unaware of that and
+	 * yields a "'noreturn' function does return" warning.
+	 */
+	ND_UNREACHABLE
+#endif /* _AIX */
+}

--- a/netdissect.h
+++ b/netdissect.h
@@ -272,19 +272,10 @@ extern void nd_change_snaplen(netdissect_options *, const u_char *, const u_int)
 extern void nd_pop_packet_info(netdissect_options *);
 extern void nd_pop_all_packet_info(netdissect_options *);
 
-static inline NORETURN void
-nd_trunc_longjmp(netdissect_options *ndo)
-{
-	longjmp(ndo->ndo_early_end, ND_TRUNCATED);
-#ifdef _AIX
-	/*
-	 * In AIX <setjmp.h> decorates longjmp() with "#pragma leaves", which tells
-	 * XL C that the function is noreturn, but GCC remains unaware of that and
-	 * yields a "'noreturn' function does return" warning.
-	 */
-	ND_UNREACHABLE
-#endif /* _AIX */
-}
+/*
+ * Report a packet truncation with a longjmp().
+ */
+NORETURN void nd_trunc_longjmp(netdissect_options *ndo);
 
 #define PT_VAT		1	/* Visual Audio Tool */
 #define PT_WB		2	/* distributed White Board */


### PR DESCRIPTION
It should rarely be called (if it's called, either the packet was cut short by snapshot-based slicing or it's malformed, or the dissector has a bug), so inlining it doesn't help much, and, as it calls longjmp(), which often expands to a call to __builtin_longjmp(), GCC won't inline it anyway (see "An Inline Function is As Fast As a Macro" in the GCC documentation), and Apple clang version 14.0.3 (clang-1403.0.22.14.1), at least, doesn't inline it, either, so you get a bunch of inlined definitions of it throughout the generated code.

Just make it a regular routine.