### PR TITLE
LDP: outstanding work to display additional TLVs and Message Types

### DIFF
--- a/print-ldp.c
+++ b/print-ldp.c
@@ -554,8 +554,7 @@ ldp_tlv_print(netdissect_options *ndo,
 	    ND_PRINT(", causing Message ID: 0x%08x", ui);
 	ui = GET_BE_U_2(tptr);
 	if (ui)
-	    ND_PRINT(", Message ID: %s", tok2str(ldp_msg_values, "Unknown", ui));
-
+	    ND_PRINT(", Message Type: %s", tok2str(ldp_msg_values, "Unknown", ui));
 	break;
 
     case LDP_TLV_FT_SESSION:

--- a/print-ldp.c
+++ b/print-ldp.c
@@ -142,6 +142,7 @@ static const struct tok ldp_msg_values[] = {
 #define	LDP_TLV_ATM_SESSION_PARM     0x0501
 #define	LDP_TLV_FR_SESSION_PARM      0x0502
 #define LDP_TLV_FT_SESSION	     0x0503
+#define LDP_TLV_TYPED_WC_FEC_CAP     0x050b /* rfc 5918 */
 #define	LDP_TLV_LABEL_REQUEST_MSG_ID 0x0600
 #define LDP_TLV_MTU                  0x0601 /* rfc 3988 */
 #define LDP_TLV_DUAL_STACK_CAP       0x0701 /* rfc 7552 */
@@ -166,6 +167,7 @@ static const struct tok ldp_tlv_values[] = {
     { LDP_TLV_ATM_SESSION_PARM,      "ATM Session Parameters" },
     { LDP_TLV_FR_SESSION_PARM,       "Frame-Relay Session Parameters" },
     { LDP_TLV_FT_SESSION,            "Fault-Tolerant Session Parameters" },
+    { LDP_TLV_TYPED_WC_FEC_CAP,      "Typed Wildcard FEC Capability" },
     { LDP_TLV_LABEL_REQUEST_MSG_ID,  "Label Request Message ID" },
     { LDP_TLV_MTU,                   "MTU" },
     { LDP_TLV_DUAL_STACK_CAP,        "Dual-Stack Capability" },
@@ -557,6 +559,11 @@ ldp_tlv_print(netdissect_options *ndo,
 	ui = GET_BE_U_4(tptr);
 	if (ui)
 	    ND_PRINT(", Recovery Time: %ums", ui);
+	break;
+
+    case LDP_TLV_TYPED_WC_FEC_CAP:
+	TLV_TCHECK(1);
+	ND_PRINT("\n\t      %s", GET_U_1(tptr)&0x80 ? "Support" : "No Support");
 	break;
 
     case LDP_TLV_MTU:

--- a/print-ldp.c
+++ b/print-ldp.c
@@ -172,6 +172,37 @@ static const struct tok ldp_tlv_values[] = {
     { 0, NULL}
 };
 
+static const struct tok ldp_status_code_values[] = {
+    /* rfc 5036 */
+    { 0x00000000, "Success" },
+    { 0x00000001, "Bad LDP Identifier" },
+    { 0x00000002, "Bad Protocol Version" },
+    { 0x00000003, "Bad PDU Length" },
+    { 0x00000004, "Unknown Message Type" },
+    { 0x00000005, "Bad Message Length" },
+    { 0x00000006, "Unknown TLV" },
+    { 0x00000007, "Bad TLV Length" },
+    { 0x00000008, "Malformted TLV Value" },
+    { 0x00000009, "Hold Timer Expired" },
+    { 0x0000000A, "Shutdown" },
+    { 0x0000000B, "Loop Detected" },
+    { 0x0000000C, "Unknown FEC" },
+    { 0x0000000D, "No Route" },
+    { 0x0000000E, "No Label Resources" },
+    { 0x0000000F, "Label Resources/Available" },
+    { 0x00000010, "Session Rejected/No Hello" },
+    { 0x00000011, "Session Rejected/Parameters Advertisement Mode" },
+    { 0x00000012, "Session Rejected/Parameters Max PDU Length" },
+    { 0x00000013, "Session Rejected/Parameters Label Range" },
+    { 0x00000014, "KeepAlive Timer Expired" },
+    { 0x00000015, "Label Request Aborted" },
+    { 0x00000016, "Missing Message Parameters" },
+    { 0x00000017, "Unsupported Address Family" },
+    { 0x00000018, "Session Rejected/Bad KeepAlive Time" },
+    { 0x00000019, "Internal Error" },
+    { 0, NULL}
+};
+
 #define LDP_FEC_WILDCARD	0x01
 #define LDP_FEC_PREFIX		0x02
 #define LDP_FEC_HOSTADDRESS	0x03
@@ -491,17 +522,21 @@ ldp_tlv_print(netdissect_options *ndo,
 	break;
 
     case LDP_TLV_STATUS:
-	TLV_TCHECK(8);
+	TLV_TCHECK(10);
 	ui = GET_BE_U_4(tptr);
 	tptr+=4;
-	ND_PRINT("\n\t      Status: 0x%02x, Flags: [%s and %s forward]",
-	       ui&0x3fffffff,
-	       ui&0x80000000 ? "Fatal error" : "Advisory Notification",
-	       ui&0x40000000 ? "do" : "don't");
+	ND_PRINT("\n\t      Status Code: %s, Flags: [%s and %s forward]",
+		 tok2str(ldp_status_code_values, "Unknown", ui&0x3fffffff),
+		 ui&0x80000000 ? "Fatal error" : "Advisory Notification",
+		 ui&0x40000000 ? "do" : "don't");
 	ui = GET_BE_U_4(tptr);
 	tptr+=4;
 	if (ui)
 	    ND_PRINT(", causing Message ID: 0x%08x", ui);
+	ui = GET_BE_U_2(tptr);
+	if (ui)
+	    ND_PRINT(", Message ID: %s", tok2str(ldp_msg_values, "Unknown", ui));
+
 	break;
 
     case LDP_TLV_FT_SESSION:

--- a/print-ldp.c
+++ b/print-ldp.c
@@ -372,6 +372,23 @@ ldp_tlv_print(netdissect_options *ndo,
         }
 	break;
 
+    case LDP_TLV_HOP_COUNT:
+	TLV_TCHECK(1);
+	ND_PRINT("\n\t      Hop Count: %u", GET_U_1(tptr));
+	break;
+
+    case LDP_TLV_PATH_VECTOR:
+	TLV_TCHECK(4);
+	ND_PRINT("\n\t      Path Vector: %s", GET_IPADDR_STRING(tptr));
+	tptr += 4;
+	tlv_tlen -= 4;
+	while (tlv_tlen >= 4) {
+	    ND_PRINT(", %s", GET_IPADDR_STRING(tptr));
+	    tptr += 4;
+	    tlv_tlen -= 4;
+	}
+	break;
+
     case LDP_TLV_COMMON_SESSION:
 	TLV_TCHECK(14);
 	ND_PRINT("\n\t      Version: %u, Keepalive: %us, Flags: [Downstream %s, Loop Detection %s]",
@@ -586,8 +603,6 @@ ldp_tlv_print(netdissect_options *ndo,
      *  you are welcome to contribute code ;-)
      */
 
-    case LDP_TLV_HOP_COUNT:
-    case LDP_TLV_PATH_VECTOR:
     case LDP_TLV_ATM_LABEL:
     case LDP_TLV_FR_LABEL:
     case LDP_TLV_EXTD_STATUS:

--- a/tests/ldp-common-session.out
+++ b/tests/ldp-common-session.out
@@ -3,7 +3,7 @@
 	LDP, Label-Space-ID: 192.168.0.2:0, pdu-length: 28
 	  Notification Message (0x0001), length: 18, Message ID: 0xfffffff9, Flags: [ignore if unknown]
 	    Status TLV (0x0300), length: 10, Flags: [ignore and don't forward if unknown]
-	      Status: 0x0a, Flags: [Fatal error and don't forward]
+	      Status Code: Shutdown, Flags: [Fatal error and don't forward]
     2  12:23:59.828114 IP (tos 0xc0, ttl 255, id 1499, offset 0, flags [none], proto TCP (6), length 40)
     192.168.0.2.58320 > 192.168.0.1.646: Flags [F.], cksum 0x7d76 (correct), seq 32, ack 1, win 2990, length 0
     3  12:24:00.018513 IP (tos 0xc0, ttl 1, id 0, offset 0, flags [none], proto UDP (17), length 70)
@@ -126,7 +126,7 @@
 	    Generic Label TLV (0x0200), length: 4, Flags: [ignore and don't forward if unknown]
 	      Label: 20066
 	    Status TLV (0x0300), length: 10, Flags: [ignore and don't forward if unknown]
-	      Status: 0x0b, Flags: [Advisory Notification and don't forward], causing Message ID: 0x0000000f
+	      Status Code: Loop Detected, Flags: [Advisory Notification and don't forward], causing Message ID: 0x0000000f, Message ID: Label Mapping
 	LDP, Label-Space-ID: 192.168.0.2:0, pdu-length: 48
 	  Label Release Message (0x0403), length: 38, Message ID: 0x0000000b, Flags: [ignore if unknown]
 	    FEC TLV (0x0100), length: 8, Flags: [ignore and don't forward if unknown]
@@ -134,7 +134,7 @@
 	    Generic Label TLV (0x0200), length: 4, Flags: [ignore and don't forward if unknown]
 	      Label: 20066
 	    Status TLV (0x0300), length: 10, Flags: [ignore and don't forward if unknown]
-	      Status: 0x0b, Flags: [Advisory Notification and don't forward], causing Message ID: 0x00000010
+	      Status Code: Loop Detected, Flags: [Advisory Notification and don't forward], causing Message ID: 0x00000010, Message ID: Label Mapping
 	LDP, Label-Space-ID: 192.168.0.2:0, pdu-length: 48
 	  Label Release Message (0x0403), length: 38, Message ID: 0x0000000c, Flags: [ignore if unknown]
 	    FEC TLV (0x0100), length: 8, Flags: [ignore and don't forward if unknown]
@@ -142,7 +142,7 @@
 	    Generic Label TLV (0x0200), length: 4, Flags: [ignore and don't forward if unknown]
 	      Label: 20066
 	    Status TLV (0x0300), length: 10, Flags: [ignore and don't forward if unknown]
-	      Status: 0x0b, Flags: [Advisory Notification and don't forward], causing Message ID: 0x00000011
+	      Status Code: Loop Detected, Flags: [Advisory Notification and don't forward], causing Message ID: 0x00000011, Message ID: Label Mapping
 	LDP, Label-Space-ID: 192.168.0.2:0, pdu-length: 48
 	  Label Release Message (0x0403), length: 38, Message ID: 0x0000000d, Flags: [ignore if unknown]
 	    FEC TLV (0x0100), length: 8, Flags: [ignore and don't forward if unknown]
@@ -150,7 +150,7 @@
 	    Generic Label TLV (0x0200), length: 4, Flags: [ignore and don't forward if unknown]
 	      Label: 20066
 	    Status TLV (0x0300), length: 10, Flags: [ignore and don't forward if unknown]
-	      Status: 0x0b, Flags: [Advisory Notification and don't forward], causing Message ID: 0x00000012
+	      Status Code: Loop Detected, Flags: [Advisory Notification and don't forward], causing Message ID: 0x00000012, Message ID: Label Mapping
 	LDP, Label-Space-ID: 192.168.0.2:0, pdu-length: 48
 	  Label Release Message (0x0403), length: 38, Message ID: 0x0000000e, Flags: [ignore if unknown]
 	    FEC TLV (0x0100), length: 8, Flags: [ignore and don't forward if unknown]
@@ -158,7 +158,7 @@
 	    Generic Label TLV (0x0200), length: 4, Flags: [ignore and don't forward if unknown]
 	      Label: 20066
 	    Status TLV (0x0300), length: 10, Flags: [ignore and don't forward if unknown]
-	      Status: 0x0b, Flags: [Advisory Notification and don't forward], causing Message ID: 0x00000013
+	      Status Code: Loop Detected, Flags: [Advisory Notification and don't forward], causing Message ID: 0x00000013, Message ID: Label Mapping
    13  12:24:12.831754 IP (tos 0xc0, ttl 255, id 1520, offset 0, flags [none], proto TCP (6), length 415)
     192.168.0.2.58321 > 192.168.0.1.646: Flags [P.], cksum 0xef2a (correct), seq 666:1041, ack 813, win 3000, length 375
 	LDP, Label-Space-ID: 192.168.0.2:0, pdu-length: 371

--- a/tests/ldp-common-session.out
+++ b/tests/ldp-common-session.out
@@ -14,8 +14,8 @@
 	      Hold Time: 15s, Flags: [Link Hello]
 	    IPv4 Transport Address TLV (0x0401), length: 4, Flags: [ignore and don't forward if unknown]
 	      IPv4 Transport Address: 172.168.0.2
-	    Unknown TLV (0x0701), length: 4, Flags: [continue processing and don't forward if unknown]
-	      0x0000:  4000 0000
+	    Dual-Stack Capability TLV (0x0701), length: 4, Flags: [continue processing and don't forward if unknown]
+	      Transport Connection Preference: IPv4
     4  12:24:05.058942 IP (tos 0xc0, ttl 1, id 0, offset 0, flags [none], proto UDP (17), length 70)
     12.1.3.2.646 > 224.0.0.2.646: 
 	LDP, Label-Space-ID: 172.168.0.2:0, pdu-length: 38
@@ -24,8 +24,8 @@
 	      Hold Time: 15s, Flags: [Link Hello]
 	    IPv4 Transport Address TLV (0x0401), length: 4, Flags: [ignore and don't forward if unknown]
 	      IPv4 Transport Address: 172.168.0.2
-	    Unknown TLV (0x0701), length: 4, Flags: [continue processing and don't forward if unknown]
-	      0x0000:  4000 0000
+	    Dual-Stack Capability TLV (0x0701), length: 4, Flags: [continue processing and don't forward if unknown]
+	      Transport Connection Preference: IPv4
     5  12:24:08.049677 IP (tos 0xc0, ttl 1, id 0, offset 0, flags [none], proto UDP (17), length 70)
     12.0.0.2.646 > 224.0.0.2.646: 
 	LDP, Label-Space-ID: 192.168.0.2:0, pdu-length: 38
@@ -34,8 +34,8 @@
 	      Hold Time: 15s, Flags: [Link Hello]
 	    IPv4 Transport Address TLV (0x0401), length: 4, Flags: [ignore and don't forward if unknown]
 	      IPv4 Transport Address: 192.168.0.2
-	    Unknown TLV (0x0701), length: 4, Flags: [continue processing and don't forward if unknown]
-	      0x0000:  4000 0000
+	    Dual-Stack Capability TLV (0x0701), length: 4, Flags: [continue processing and don't forward if unknown]
+	      Transport Connection Preference: IPv4
     6  12:24:10.017949 IP (tos 0xc0, ttl 1, id 0, offset 0, flags [none], proto UDP (17), length 70)
     12.1.3.2.646 > 224.0.0.2.646: 
 	LDP, Label-Space-ID: 172.168.0.2:0, pdu-length: 38
@@ -44,8 +44,8 @@
 	      Hold Time: 15s, Flags: [Link Hello]
 	    IPv4 Transport Address TLV (0x0401), length: 4, Flags: [ignore and don't forward if unknown]
 	      IPv4 Transport Address: 172.168.0.2
-	    Unknown TLV (0x0701), length: 4, Flags: [continue processing and don't forward if unknown]
-	      0x0000:  4000 0000
+	    Dual-Stack Capability TLV (0x0701), length: 4, Flags: [continue processing and don't forward if unknown]
+	      Transport Connection Preference: IPv4
     7  12:24:11.046122 IP (tos 0x0, ttl 255, id 1505, offset 0, flags [none], proto TCP (6), length 48)
     192.168.0.2.58321 > 192.168.0.1.646: Flags [S], cksum 0x6df9 (correct), seq 110236, win 65535, options [mss 1420,nop,wscale 5], length 0
     8  12:24:11.046149 IP (tos 0xc0, ttl 255, id 1506, offset 0, flags [none], proto TCP (6), length 81)
@@ -121,29 +121,44 @@
     192.168.0.2.58321 > 192.168.0.1.646: Flags [P.], cksum 0xbffe (correct), seq 406:666, ack 813, win 3000, length 260
 	LDP, Label-Space-ID: 192.168.0.2:0, pdu-length: 48
 	  Label Release Message (0x0403), length: 38, Message ID: 0x0000000a, Flags: [ignore if unknown]
-	  0x0000:  0100 0008 0200 0120 c0a8 0002 0200 0004
-	  0x0010:  0000 4e62 0300 000a 0000 000b 0000 000f
-	  0x0020:  0400
+	    FEC TLV (0x0100), length: 8, Flags: [ignore and don't forward if unknown]
+	      Prefix FEC (0x02): IPv4 prefix 192.168.0.2/32
+	    Generic Label TLV (0x0200), length: 4, Flags: [ignore and don't forward if unknown]
+	      Label: 20066
+	    Status TLV (0x0300), length: 10, Flags: [ignore and don't forward if unknown]
+	      Status: 0x0b, Flags: [Advisory Notification and don't forward], causing Message ID: 0x0000000f
 	LDP, Label-Space-ID: 192.168.0.2:0, pdu-length: 48
 	  Label Release Message (0x0403), length: 38, Message ID: 0x0000000b, Flags: [ignore if unknown]
-	  0x0000:  0100 0008 0200 0120 c0a8 0102 0200 0004
-	  0x0010:  0000 4e62 0300 000a 0000 000b 0000 0010
-	  0x0020:  0400
+	    FEC TLV (0x0100), length: 8, Flags: [ignore and don't forward if unknown]
+	      Prefix FEC (0x02): IPv4 prefix 192.168.1.2/32
+	    Generic Label TLV (0x0200), length: 4, Flags: [ignore and don't forward if unknown]
+	      Label: 20066
+	    Status TLV (0x0300), length: 10, Flags: [ignore and don't forward if unknown]
+	      Status: 0x0b, Flags: [Advisory Notification and don't forward], causing Message ID: 0x00000010
 	LDP, Label-Space-ID: 192.168.0.2:0, pdu-length: 48
 	  Label Release Message (0x0403), length: 38, Message ID: 0x0000000c, Flags: [ignore if unknown]
-	  0x0000:  0100 0008 0200 0120 c0a8 0202 0200 0004
-	  0x0010:  0000 4e62 0300 000a 0000 000b 0000 0011
-	  0x0020:  0400
+	    FEC TLV (0x0100), length: 8, Flags: [ignore and don't forward if unknown]
+	      Prefix FEC (0x02): IPv4 prefix 192.168.2.2/32
+	    Generic Label TLV (0x0200), length: 4, Flags: [ignore and don't forward if unknown]
+	      Label: 20066
+	    Status TLV (0x0300), length: 10, Flags: [ignore and don't forward if unknown]
+	      Status: 0x0b, Flags: [Advisory Notification and don't forward], causing Message ID: 0x00000011
 	LDP, Label-Space-ID: 192.168.0.2:0, pdu-length: 48
 	  Label Release Message (0x0403), length: 38, Message ID: 0x0000000d, Flags: [ignore if unknown]
-	  0x0000:  0100 0008 0200 0120 c0a8 0302 0200 0004
-	  0x0010:  0000 4e62 0300 000a 0000 000b 0000 0012
-	  0x0020:  0400
+	    FEC TLV (0x0100), length: 8, Flags: [ignore and don't forward if unknown]
+	      Prefix FEC (0x02): IPv4 prefix 192.168.3.2/32
+	    Generic Label TLV (0x0200), length: 4, Flags: [ignore and don't forward if unknown]
+	      Label: 20066
+	    Status TLV (0x0300), length: 10, Flags: [ignore and don't forward if unknown]
+	      Status: 0x0b, Flags: [Advisory Notification and don't forward], causing Message ID: 0x00000012
 	LDP, Label-Space-ID: 192.168.0.2:0, pdu-length: 48
 	  Label Release Message (0x0403), length: 38, Message ID: 0x0000000e, Flags: [ignore if unknown]
-	  0x0000:  0100 0008 0200 0120 c0a8 0402 0200 0004
-	  0x0010:  0000 4e62 0300 000a 0000 000b 0000 0013
-	  0x0020:  0400
+	    FEC TLV (0x0100), length: 8, Flags: [ignore and don't forward if unknown]
+	      Prefix FEC (0x02): IPv4 prefix 192.168.4.2/32
+	    Generic Label TLV (0x0200), length: 4, Flags: [ignore and don't forward if unknown]
+	      Label: 20066
+	    Status TLV (0x0300), length: 10, Flags: [ignore and don't forward if unknown]
+	      Status: 0x0b, Flags: [Advisory Notification and don't forward], causing Message ID: 0x00000013
    13  12:24:12.831754 IP (tos 0xc0, ttl 255, id 1520, offset 0, flags [none], proto TCP (6), length 415)
     192.168.0.2.58321 > 192.168.0.1.646: Flags [P.], cksum 0xef2a (correct), seq 666:1041, ack 813, win 3000, length 375
 	LDP, Label-Space-ID: 192.168.0.2:0, pdu-length: 371
@@ -225,8 +240,8 @@
 	      Hold Time: 15s, Flags: [Link Hello]
 	    IPv4 Transport Address TLV (0x0401), length: 4, Flags: [ignore and don't forward if unknown]
 	      IPv4 Transport Address: 192.168.0.2
-	    Unknown TLV (0x0701), length: 4, Flags: [continue processing and don't forward if unknown]
-	      0x0000:  4000 0000
+	    Dual-Stack Capability TLV (0x0701), length: 4, Flags: [continue processing and don't forward if unknown]
+	      Transport Connection Preference: IPv4
    15  12:24:13.058561 IP (tos 0xc0, ttl 255, id 1524, offset 0, flags [none], proto TCP (6), length 40)
     192.168.0.2.58321 > 192.168.0.1.646: Flags [.], cksum 0x2e0b (correct), ack 1263, win 2986, length 0
    16  12:24:13.833287 IP (tos 0xc0, ttl 255, id 1530, offset 0, flags [none], proto TCP (6), length 255)
@@ -285,8 +300,8 @@
 	      Hold Time: 15s, Flags: [Link Hello]
 	    IPv4 Transport Address TLV (0x0401), length: 4, Flags: [ignore and don't forward if unknown]
 	      IPv4 Transport Address: 172.168.0.2
-	    Unknown TLV (0x0701), length: 4, Flags: [continue processing and don't forward if unknown]
-	      0x0000:  4000 0000
+	    Dual-Stack Capability TLV (0x0701), length: 4, Flags: [continue processing and don't forward if unknown]
+	      Transport Connection Preference: IPv4
    18  12:24:18.042950 IP (tos 0xc0, ttl 1, id 0, offset 0, flags [none], proto UDP (17), length 70)
     12.0.0.2.646 > 224.0.0.2.646: 
 	LDP, Label-Space-ID: 192.168.0.2:0, pdu-length: 38
@@ -295,8 +310,8 @@
 	      Hold Time: 15s, Flags: [Link Hello]
 	    IPv4 Transport Address TLV (0x0401), length: 4, Flags: [ignore and don't forward if unknown]
 	      IPv4 Transport Address: 192.168.0.2
-	    Unknown TLV (0x0701), length: 4, Flags: [continue processing and don't forward if unknown]
-	      0x0000:  4000 0000
+	    Dual-Stack Capability TLV (0x0701), length: 4, Flags: [continue processing and don't forward if unknown]
+	      Transport Connection Preference: IPv4
    19  12:24:20.052540 IP (tos 0xc0, ttl 1, id 0, offset 0, flags [none], proto UDP (17), length 70)
     12.1.3.2.646 > 224.0.0.2.646: 
 	LDP, Label-Space-ID: 172.168.0.2:0, pdu-length: 38
@@ -305,8 +320,8 @@
 	      Hold Time: 15s, Flags: [Link Hello]
 	    IPv4 Transport Address TLV (0x0401), length: 4, Flags: [ignore and don't forward if unknown]
 	      IPv4 Transport Address: 172.168.0.2
-	    Unknown TLV (0x0701), length: 4, Flags: [continue processing and don't forward if unknown]
-	      0x0000:  4000 0000
+	    Dual-Stack Capability TLV (0x0701), length: 4, Flags: [continue processing and don't forward if unknown]
+	      Transport Connection Preference: IPv4
    20  12:24:21.030795 IP (tos 0xc0, ttl 255, id 1534, offset 0, flags [none], proto TCP (6), length 58)
     192.168.0.2.58321 > 192.168.0.1.646: Flags [P.], cksum 0x6a3d (correct), seq 1256:1274, ack 1263, win 2986, length 18
    21  12:24:21.087477 IP (tos 0xc0, ttl 255, id 1535, offset 0, flags [none], proto TCP (6), length 40)
@@ -319,5 +334,5 @@
 	      Hold Time: 15s, Flags: [Link Hello]
 	    IPv4 Transport Address TLV (0x0401), length: 4, Flags: [ignore and don't forward if unknown]
 	      IPv4 Transport Address: 192.168.0.2
-	    Unknown TLV (0x0701), length: 4, Flags: [continue processing and don't forward if unknown]
-	      0x0000:  4000 0000
+	    Dual-Stack Capability TLV (0x0701), length: 4, Flags: [continue processing and don't forward if unknown]
+	      Transport Connection Preference: IPv4

--- a/tests/ldp-common-session.out
+++ b/tests/ldp-common-session.out
@@ -55,8 +55,8 @@
 	    Common Session Parameters TLV (0x0500), length: 14, Flags: [ignore and don't forward if unknown]
 	      Version: 1, Keepalive: 30s, Flags: [Downstream Unsolicited, Loop Detection Enabled]
 	      Path Vector Limit 32, Max-PDU length: 0, Receiver Label-Space-ID 192.168.0.1:0
-	    Unknown TLV (0x050b), length: 1, Flags: [continue processing and don't forward if unknown]
-	      0x0000:  80
+	    Typed Wildcard FEC Capability TLV (0x050b), length: 1, Flags: [continue processing and don't forward if unknown]
+	      Support
     9  12:24:11.052281 IP (tos 0xc0, ttl 255, id 1507, offset 0, flags [none], proto TCP (6), length 58)
     192.168.0.2.58321 > 192.168.0.1.646: Flags [P.], cksum 0x73a6 (correct), seq 41:59, ack 60, win 3023, length 18
    10  12:24:11.103231 IP (tos 0xc0, ttl 255, id 1508, offset 0, flags [none], proto TCP (6), length 387)

--- a/tests/ldp-common-session.out
+++ b/tests/ldp-common-session.out
@@ -126,7 +126,7 @@
 	    Generic Label TLV (0x0200), length: 4, Flags: [ignore and don't forward if unknown]
 	      Label: 20066
 	    Status TLV (0x0300), length: 10, Flags: [ignore and don't forward if unknown]
-	      Status Code: Loop Detected, Flags: [Advisory Notification and don't forward], causing Message ID: 0x0000000f, Message ID: Label Mapping
+	      Status Code: Loop Detected, Flags: [Advisory Notification and don't forward], causing Message ID: 0x0000000f, Message Type: Label Mapping
 	LDP, Label-Space-ID: 192.168.0.2:0, pdu-length: 48
 	  Label Release Message (0x0403), length: 38, Message ID: 0x0000000b, Flags: [ignore if unknown]
 	    FEC TLV (0x0100), length: 8, Flags: [ignore and don't forward if unknown]
@@ -134,7 +134,7 @@
 	    Generic Label TLV (0x0200), length: 4, Flags: [ignore and don't forward if unknown]
 	      Label: 20066
 	    Status TLV (0x0300), length: 10, Flags: [ignore and don't forward if unknown]
-	      Status Code: Loop Detected, Flags: [Advisory Notification and don't forward], causing Message ID: 0x00000010, Message ID: Label Mapping
+	      Status Code: Loop Detected, Flags: [Advisory Notification and don't forward], causing Message ID: 0x00000010, Message Type: Label Mapping
 	LDP, Label-Space-ID: 192.168.0.2:0, pdu-length: 48
 	  Label Release Message (0x0403), length: 38, Message ID: 0x0000000c, Flags: [ignore if unknown]
 	    FEC TLV (0x0100), length: 8, Flags: [ignore and don't forward if unknown]
@@ -142,7 +142,7 @@
 	    Generic Label TLV (0x0200), length: 4, Flags: [ignore and don't forward if unknown]
 	      Label: 20066
 	    Status TLV (0x0300), length: 10, Flags: [ignore and don't forward if unknown]
-	      Status Code: Loop Detected, Flags: [Advisory Notification and don't forward], causing Message ID: 0x00000011, Message ID: Label Mapping
+	      Status Code: Loop Detected, Flags: [Advisory Notification and don't forward], causing Message ID: 0x00000011, Message Type: Label Mapping
 	LDP, Label-Space-ID: 192.168.0.2:0, pdu-length: 48
 	  Label Release Message (0x0403), length: 38, Message ID: 0x0000000d, Flags: [ignore if unknown]
 	    FEC TLV (0x0100), length: 8, Flags: [ignore and don't forward if unknown]
@@ -150,7 +150,7 @@
 	    Generic Label TLV (0x0200), length: 4, Flags: [ignore and don't forward if unknown]
 	      Label: 20066
 	    Status TLV (0x0300), length: 10, Flags: [ignore and don't forward if unknown]
-	      Status Code: Loop Detected, Flags: [Advisory Notification and don't forward], causing Message ID: 0x00000012, Message ID: Label Mapping
+	      Status Code: Loop Detected, Flags: [Advisory Notification and don't forward], causing Message ID: 0x00000012, Message Type: Label Mapping
 	LDP, Label-Space-ID: 192.168.0.2:0, pdu-length: 48
 	  Label Release Message (0x0403), length: 38, Message ID: 0x0000000e, Flags: [ignore if unknown]
 	    FEC TLV (0x0100), length: 8, Flags: [ignore and don't forward if unknown]
@@ -158,7 +158,7 @@
 	    Generic Label TLV (0x0200), length: 4, Flags: [ignore and don't forward if unknown]
 	      Label: 20066
 	    Status TLV (0x0300), length: 10, Flags: [ignore and don't forward if unknown]
-	      Status Code: Loop Detected, Flags: [Advisory Notification and don't forward], causing Message ID: 0x00000013, Message ID: Label Mapping
+	      Status Code: Loop Detected, Flags: [Advisory Notification and don't forward], causing Message ID: 0x00000013, Message Type: Label Mapping
    13  12:24:12.831754 IP (tos 0xc0, ttl 255, id 1520, offset 0, flags [none], proto TCP (6), length 415)
     192.168.0.2.58321 > 192.168.0.1.646: Flags [P.], cksum 0xef2a (correct), seq 666:1041, ack 813, win 3000, length 375
 	LDP, Label-Space-ID: 192.168.0.2:0, pdu-length: 371

--- a/tests/ldp-common-session.out
+++ b/tests/ldp-common-session.out
@@ -76,45 +76,45 @@
 	    Generic Label TLV (0x0200), length: 4, Flags: [ignore and don't forward if unknown]
 	      Label: 3
 	    Hop Count TLV (0x0103), length: 1, Flags: [ignore and don't forward if unknown]
-	      0x0000:  01
+	      Hop Count: 1
 	    Path Vector TLV (0x0104), length: 4, Flags: [ignore and don't forward if unknown]
-	      0x0000:  c0a8 0002
+	      Path Vector: 192.168.0.2
 	  Label Mapping Message (0x0400), length: 37, Message ID: 0x00000006, Flags: [ignore if unknown]
 	    FEC TLV (0x0100), length: 8, Flags: [ignore and don't forward if unknown]
 	      Prefix FEC (0x02): IPv4 prefix 192.168.1.2/32
 	    Generic Label TLV (0x0200), length: 4, Flags: [ignore and don't forward if unknown]
 	      Label: 3
 	    Hop Count TLV (0x0103), length: 1, Flags: [ignore and don't forward if unknown]
-	      0x0000:  01
+	      Hop Count: 1
 	    Path Vector TLV (0x0104), length: 4, Flags: [ignore and don't forward if unknown]
-	      0x0000:  c0a8 0002
+	      Path Vector: 192.168.0.2
 	  Label Mapping Message (0x0400), length: 37, Message ID: 0x00000007, Flags: [ignore if unknown]
 	    FEC TLV (0x0100), length: 8, Flags: [ignore and don't forward if unknown]
 	      Prefix FEC (0x02): IPv4 prefix 192.168.2.2/32
 	    Generic Label TLV (0x0200), length: 4, Flags: [ignore and don't forward if unknown]
 	      Label: 3
 	    Hop Count TLV (0x0103), length: 1, Flags: [ignore and don't forward if unknown]
-	      0x0000:  01
+	      Hop Count: 1
 	    Path Vector TLV (0x0104), length: 4, Flags: [ignore and don't forward if unknown]
-	      0x0000:  c0a8 0002
+	      Path Vector: 192.168.0.2
 	  Label Mapping Message (0x0400), length: 37, Message ID: 0x00000008, Flags: [ignore if unknown]
 	    FEC TLV (0x0100), length: 8, Flags: [ignore and don't forward if unknown]
 	      Prefix FEC (0x02): IPv4 prefix 192.168.3.2/32
 	    Generic Label TLV (0x0200), length: 4, Flags: [ignore and don't forward if unknown]
 	      Label: 3
 	    Hop Count TLV (0x0103), length: 1, Flags: [ignore and don't forward if unknown]
-	      0x0000:  01
+	      Hop Count: 1
 	    Path Vector TLV (0x0104), length: 4, Flags: [ignore and don't forward if unknown]
-	      0x0000:  c0a8 0002
+	      Path Vector: 192.168.0.2
 	  Label Mapping Message (0x0400), length: 37, Message ID: 0x00000009, Flags: [ignore if unknown]
 	    FEC TLV (0x0100), length: 8, Flags: [ignore and don't forward if unknown]
 	      Prefix FEC (0x02): IPv4 prefix 192.168.4.2/32
 	    Generic Label TLV (0x0200), length: 4, Flags: [ignore and don't forward if unknown]
 	      Label: 3
 	    Hop Count TLV (0x0103), length: 1, Flags: [ignore and don't forward if unknown]
-	      0x0000:  01
+	      Hop Count: 1
 	    Path Vector TLV (0x0104), length: 4, Flags: [ignore and don't forward if unknown]
-	      0x0000:  c0a8 0002
+	      Path Vector: 192.168.0.2
    11  12:24:11.929655 IP (tos 0xc0, ttl 255, id 1509, offset 0, flags [none], proto TCP (6), length 40)
     192.168.0.2.58321 > 192.168.0.1.646: Flags [.], cksum 0x34ab (correct), ack 168, win 3020, length 0
    12  12:24:11.929679 IP (tos 0xc0, ttl 255, id 1510, offset 0, flags [none], proto TCP (6), length 300)
@@ -168,45 +168,45 @@
 	    Generic Label TLV (0x0200), length: 4, Flags: [ignore and don't forward if unknown]
 	      Label: 20065
 	    Hop Count TLV (0x0103), length: 1, Flags: [ignore and don't forward if unknown]
-	      0x0000:  02
+	      Hop Count: 2
 	    Path Vector TLV (0x0104), length: 8, Flags: [ignore and don't forward if unknown]
-	      0x0000:  c0a8 0001 c0a8 0002
+	      Path Vector: 192.168.0.1, 192.168.0.2
 	  Label Mapping Message (0x0400), length: 41, Message ID: 0x00000010, Flags: [ignore if unknown]
 	    FEC TLV (0x0100), length: 8, Flags: [ignore and don't forward if unknown]
 	      Prefix FEC (0x02): IPv4 prefix 192.168.1.1/32
 	    Generic Label TLV (0x0200), length: 4, Flags: [ignore and don't forward if unknown]
 	      Label: 20065
 	    Hop Count TLV (0x0103), length: 1, Flags: [ignore and don't forward if unknown]
-	      0x0000:  02
+	      Hop Count: 2
 	    Path Vector TLV (0x0104), length: 8, Flags: [ignore and don't forward if unknown]
-	      0x0000:  c0a8 0001 c0a8 0002
+	      Path Vector: 192.168.0.1, 192.168.0.2
 	  Label Mapping Message (0x0400), length: 41, Message ID: 0x00000011, Flags: [ignore if unknown]
 	    FEC TLV (0x0100), length: 8, Flags: [ignore and don't forward if unknown]
 	      Prefix FEC (0x02): IPv4 prefix 192.168.2.1/32
 	    Generic Label TLV (0x0200), length: 4, Flags: [ignore and don't forward if unknown]
 	      Label: 20065
 	    Hop Count TLV (0x0103), length: 1, Flags: [ignore and don't forward if unknown]
-	      0x0000:  02
+	      Hop Count: 2
 	    Path Vector TLV (0x0104), length: 8, Flags: [ignore and don't forward if unknown]
-	      0x0000:  c0a8 0001 c0a8 0002
+	      Path Vector: 192.168.0.1, 192.168.0.2
 	  Label Mapping Message (0x0400), length: 41, Message ID: 0x00000012, Flags: [ignore if unknown]
 	    FEC TLV (0x0100), length: 8, Flags: [ignore and don't forward if unknown]
 	      Prefix FEC (0x02): IPv4 prefix 192.168.3.1/32
 	    Generic Label TLV (0x0200), length: 4, Flags: [ignore and don't forward if unknown]
 	      Label: 20065
 	    Hop Count TLV (0x0103), length: 1, Flags: [ignore and don't forward if unknown]
-	      0x0000:  02
+	      Hop Count: 2
 	    Path Vector TLV (0x0104), length: 8, Flags: [ignore and don't forward if unknown]
-	      0x0000:  c0a8 0001 c0a8 0002
+	      Path Vector: 192.168.0.1, 192.168.0.2
 	  Label Mapping Message (0x0400), length: 41, Message ID: 0x00000013, Flags: [ignore if unknown]
 	    FEC TLV (0x0100), length: 8, Flags: [ignore and don't forward if unknown]
 	      Prefix FEC (0x02): IPv4 prefix 192.168.4.1/32
 	    Generic Label TLV (0x0200), length: 4, Flags: [ignore and don't forward if unknown]
 	      Label: 20065
 	    Hop Count TLV (0x0103), length: 1, Flags: [ignore and don't forward if unknown]
-	      0x0000:  02
+	      Hop Count: 2
 	    Path Vector TLV (0x0104), length: 8, Flags: [ignore and don't forward if unknown]
-	      0x0000:  c0a8 0001 c0a8 0002
+	      Path Vector: 192.168.0.1, 192.168.0.2
 	  Label Withdraw Message (0x0402), length: 24, Message ID: 0x00000014, Flags: [ignore if unknown]
 	    FEC TLV (0x0100), length: 8, Flags: [ignore and don't forward if unknown]
 	      Prefix FEC (0x02): IPv4 prefix 192.168.0.3/32
@@ -253,45 +253,45 @@
 	    Generic Label TLV (0x0200), length: 4, Flags: [ignore and don't forward if unknown]
 	      Label: 20066
 	    Hop Count TLV (0x0103), length: 1, Flags: [ignore and don't forward if unknown]
-	      0x0000:  00
+	      Hop Count: 0
 	    Path Vector TLV (0x0104), length: 4, Flags: [ignore and don't forward if unknown]
-	      0x0000:  c0a8 0002
+	      Path Vector: 192.168.0.2
 	  Label Mapping Message (0x0400), length: 37, Message ID: 0x0000001a, Flags: [ignore if unknown]
 	    FEC TLV (0x0100), length: 8, Flags: [ignore and don't forward if unknown]
 	      Prefix FEC (0x02): IPv4 prefix 192.168.1.3/32
 	    Generic Label TLV (0x0200), length: 4, Flags: [ignore and don't forward if unknown]
 	      Label: 20066
 	    Hop Count TLV (0x0103), length: 1, Flags: [ignore and don't forward if unknown]
-	      0x0000:  00
+	      Hop Count: 0
 	    Path Vector TLV (0x0104), length: 4, Flags: [ignore and don't forward if unknown]
-	      0x0000:  c0a8 0002
+	      Path Vector: 192.168.0.2
 	  Label Mapping Message (0x0400), length: 37, Message ID: 0x0000001b, Flags: [ignore if unknown]
 	    FEC TLV (0x0100), length: 8, Flags: [ignore and don't forward if unknown]
 	      Prefix FEC (0x02): IPv4 prefix 192.168.2.3/32
 	    Generic Label TLV (0x0200), length: 4, Flags: [ignore and don't forward if unknown]
 	      Label: 20066
 	    Hop Count TLV (0x0103), length: 1, Flags: [ignore and don't forward if unknown]
-	      0x0000:  00
+	      Hop Count: 0
 	    Path Vector TLV (0x0104), length: 4, Flags: [ignore and don't forward if unknown]
-	      0x0000:  c0a8 0002
+	      Path Vector: 192.168.0.2
 	  Label Mapping Message (0x0400), length: 37, Message ID: 0x0000001c, Flags: [ignore if unknown]
 	    FEC TLV (0x0100), length: 8, Flags: [ignore and don't forward if unknown]
 	      Prefix FEC (0x02): IPv4 prefix 192.168.3.3/32
 	    Generic Label TLV (0x0200), length: 4, Flags: [ignore and don't forward if unknown]
 	      Label: 20066
 	    Hop Count TLV (0x0103), length: 1, Flags: [ignore and don't forward if unknown]
-	      0x0000:  00
+	      Hop Count: 0
 	    Path Vector TLV (0x0104), length: 4, Flags: [ignore and don't forward if unknown]
-	      0x0000:  c0a8 0002
+	      Path Vector: 192.168.0.2
 	  Label Mapping Message (0x0400), length: 37, Message ID: 0x0000001d, Flags: [ignore if unknown]
 	    FEC TLV (0x0100), length: 8, Flags: [ignore and don't forward if unknown]
 	      Prefix FEC (0x02): IPv4 prefix 192.168.4.3/32
 	    Generic Label TLV (0x0200), length: 4, Flags: [ignore and don't forward if unknown]
 	      Label: 20066
 	    Hop Count TLV (0x0103), length: 1, Flags: [ignore and don't forward if unknown]
-	      0x0000:  00
+	      Hop Count: 0
 	    Path Vector TLV (0x0104), length: 4, Flags: [ignore and don't forward if unknown]
-	      0x0000:  c0a8 0002
+	      Path Vector: 192.168.0.2
    17  12:24:15.036359 IP (tos 0xc0, ttl 1, id 0, offset 0, flags [none], proto UDP (17), length 70)
     12.1.3.2.646 > 224.0.0.2.646: 
 	LDP, Label-Space-ID: 172.168.0.2:0, pdu-length: 38


### PR DESCRIPTION
This is to complete support for all the yet unsupported messages/TLVs as per the ldp-common-session.pcap testfile.
testfile output has been updated.