### PR TITLE
decode full 12 tcp flag bits, add exp1 tcp option

### DIFF
--- a/print-tcp.c
+++ b/print-tcp.c
@@ -135,6 +135,7 @@ static const struct tok tcp_option_values[] = {
         { TCPOPT_TCPAO, "tcp-ao" },
         { TCPOPT_MPTCP, "mptcp" },
         { TCPOPT_FASTOPEN, "tfo" },
+        { TCPOPT_EXPERIMENT1, "exp1" },
         { TCPOPT_EXPERIMENT2, "exp" },
         { 0, NULL }
 };
@@ -166,7 +167,7 @@ tcp_print(netdissect_options *ndo,
 {
         const struct tcphdr *tp;
         const struct ip *ip;
-        u_char flags;
+        uint16_t flags;
         u_int hlen;
         char ch;
         uint16_t sport, dport, win, urp;
@@ -248,7 +249,7 @@ tcp_print(netdissect_options *ndo,
                 return;
         }
 
-        flags = GET_U_1(tp->th_flags);
+        flags = TH_FLAGS(tp);
         ND_PRINT("Flags [%s]", bittok2str_nosep(tcp_flag_values, "none", flags));
 
         if (!ndo->ndo_Sflag && (flags & TH_ACK)) {

--- a/tcp.h
+++ b/tcp.h
@@ -50,6 +50,8 @@ struct tcphdr {
 };
 
 #define TH_OFF(th)	((GET_U_1((th)->th_offx2) & 0xf0) >> 4)
+#define TH_FLAGS(th)	(((GET_U_1((th)->th_offx2) & 0x0f) << 8) | \
+			((GET_U_1((th)->th_flags))))
 
 /* TCP flags */
 #define	TH_FIN     0x01
@@ -58,8 +60,8 @@ struct tcphdr {
 #define	TH_PUSH	   0x08
 #define	TH_ACK	   0x10
 #define	TH_URG	   0x20
-#define TH_ECNECHO 0x40	/* ECN Echo */
-#define TH_CWR	   0x80	/* ECN Cwnd Reduced */
+#define	TH_ECNECHO 0x40	/* ECN Echo */
+#define	TH_CWR	   0x80	/* ECN Cwnd Reduced */
 extern const struct tok tcp_flag_values[];
 
 
@@ -87,6 +89,7 @@ extern const struct tok tcp_flag_values[];
 #define TCPOPT_TCPAO		29	/* TCP authentication option (rfc5925) */
 #define	TCPOPT_MPTCP		30	/* MPTCP options */
 #define TCPOPT_FASTOPEN		34	/* TCP Fast Open (rfc7413) */
+#define TCPOPT_EXPERIMENT1	253	/* experimental headers (rfc4727) */
 #define TCPOPT_EXPERIMENT2	254	/* experimental headers (rfc4727) */
 
 #define TCPOPT_TSTAMP_HDR	\


### PR DESCRIPTION
Adjacent patch to [libpcap](https://github.com/the-tcpdump-group/libpcap/pull/1210), to have access to all 12 TCP header Flag bits.
Also add the 2nd experimental option ID from RFC4727
Minor whitespace change to align TH_ECNECHO and TH_CWR with the other TCP flag definitions in a colored diff printout.