### PR TITLE
pflog: the default rulenr is "-1"

### DIFF
--- a/print-pflog.c
+++ b/print-pflog.c
@@ -108,9 +108,12 @@ pflog_print(netdissect_options *ndo, const struct pfloghdr *hdr)
 	ndo->ndo_protocol = "pflog";
 	rulenr = GET_BE_U_4(hdr->rulenr);
 	subrulenr = GET_BE_U_4(hdr->subrulenr);
-	if (subrulenr == (uint32_t)-1)
-		ND_PRINT("rule %u/", rulenr);
-	else {
+	if (subrulenr == (uint32_t)-1) {
+		if (rulenr == (uint32_t)-1)
+			ND_PRINT("rule %d/", -1);
+		else
+			ND_PRINT("rule %u/", rulenr);
+	} else {
 		ND_PRINT("rule %u.", rulenr);
 		nd_printjnp(ndo, (const u_char*)hdr->ruleset, PFLOG_RULESET_NAME_SIZE);
 		ND_PRINT(".%u/", subrulenr);


### PR DESCRIPTION
As reported by an OPNsense user doing a security scan pf/pflog can drop e.g. invalid length packets under the default rule which also uses a -1 value like subrulenr.

Transform the displayed value from "4294967295" to "-1" in this case because it is more correct (although both are suboptimal for processing).

FreeBSD: https://cgit.freebsd.org/src/tree/sys/netpfil/pf/pf_ioctl.c?id=3347078000c078f2e67214ef1ba2e0bffe1aea4f#n349
OpenBSD: https://github.com/openbsd/src/blob/142580dd4dc788acb41545aca79c845e04d1cb7d/sys/net/pf_ioctl.c#L242

See also: https://github.com/opnsense/core/issues/6800