### PR TITLE
NFS: Fix a MemorySanitizer error

### DIFF
--- a/parsenfsfh.c
+++ b/parsenfsfh.c
@@ -48,6 +48,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <limits.h>
 
 #include "netdissect-ctype.h"
 
@@ -389,6 +390,7 @@ Parse_fh(netdissect_options *ndo, const unsigned char *fh, u_int len,
 	    (void)fprintf(stderr, "\n");
 #endif
 	    /* Save the actual handle, so it can be display with -u */
+	    /* XXX really ? When -u is used this function is not called */
 	    for (i = 0; i < len*4 && i*2 < sizeof(fsidp->Opaque_Handle) - 1; i++)
 		(void)snprintf(&(fsidp->Opaque_Handle[i*2]), 3, "%.2X",
 			       GET_U_1(fhp + i));
@@ -396,11 +398,12 @@ Parse_fh(netdissect_options *ndo, const unsigned char *fh, u_int len,
 
 	    /* XXX for now, give "bogus" values to aid debugging */
 	    fsidp->fsid_code = 0;
-	    fsidp->Fsid_dev.Minor = 257;
-	    fsidp->Fsid_dev.Major = 257;
+	    fsidp->Fsid_dev.Minor = UINT_MAX;
+	    fsidp->Fsid_dev.Major = UINT_MAX;
 	    *inop = 1;
 
-	    /* display will show this string instead of (257,257) */
+	    /* display will show this string instead of (UINT_MAX,UINT_MAX) */
+	    /* XXX really ? */
 	    if (fsnamep)
 		*fsnamep = "Unknown";
 

--- a/print-nfs.c
+++ b/print-nfs.c
@@ -904,7 +904,7 @@ nfs_printfh(netdissect_options *ndo,
 			     fsid.Fsid_dev.Major, fsid.Fsid_dev.Minor);
 	}
 
-	if(fsid.Fsid_dev.Minor == 257)
+	if(fsid.Fsid_dev.Minor == UINT_MAX && fsid.Fsid_dev.Major == UINT_MAX)
 		/* Print the undecoded handle */
 		fn_print_str(ndo, (const u_char *)fsid.Opaque_Handle);
 	else


### PR DESCRIPTION
In parsenfsfh.c, Parse_fh(), switch (fhtype), case FHT_SUNOS5, the Fsid_dev.Minor can be 257.

Thus using 257 as a flag value ("bogus") in case FHT_UNKNOWN when Opaque_Handle[] is initialized is incorrect. This value is tested in nfs_printfh() to print or not Opaque_Handle[]. This can result in a case of use-of-uninitialized-value.

To avoid this, use UINT_MAX as flag values for Fsid_dev.Minor and Fsid_dev.Major and test the two variables in nfs_printfh().

The error was:
==9391==WARNING: MemorySanitizer: use-of-uninitialized-value [...]
MemorySanitizer: use-of-uninitialized-value util-print.c:91:2 in fn_print_str

Add two XXX comments with questions.

follow-up to commit b5353b62c2c58d3ac7c8c84b2df041f5c1602b6b.