### PR TITLE
Use symmetrical quotation characters in error messages

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -80,6 +80,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
     User interface:
       Print the supported time stamp types (-J) to stdout instead of stderr.
       Print the list of data link types (-L) to stdout instead of stderr.
+      Use symmetrical quotation characters in error messages.
     Source code:
       tcpdump: Fix a memory leak.
       child_cleanup: reap as many child processes as possible.

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -1801,7 +1801,7 @@ main(int argc, char **argv)
 				if (nd_load_smi_module(optarg, ebuf, sizeof(ebuf)) == -1)
 					error("%s", ebuf);
 			} else {
-				(void)fprintf(stderr, "%s: ignoring option `-m %s' ",
+				(void)fprintf(stderr, "%s: ignoring option '-m %s' ",
 					      program_name, optarg);
 				(void)fprintf(stderr, "(no libsmi support)\n");
 			}
@@ -1845,7 +1845,7 @@ main(int argc, char **argv)
 			else if (ascii_strcasecmp(optarg, "inout") == 0)
 				Qflag = PCAP_D_INOUT;
 			else
-				error("unknown capture direction `%s'", optarg);
+				error("unknown capture direction '%s'", optarg);
 			break;
 #endif /* HAVE_PCAP_SETDIRECTION */
 
@@ -1913,7 +1913,7 @@ main(int argc, char **argv)
 			else if (ascii_strcasecmp(optarg, "quic") == 0)
 				ndo->ndo_packettype = PT_QUIC;
 			else
-				error("unknown packet type `%s'", optarg);
+				error("unknown packet type '%s'", optarg);
 			break;
 
 		case 'u':


### PR DESCRIPTION
Symmetrical quoting looks better.

Thus s/`/'/

See '5.10 Quote Characters' in GNU Coding Standards:

https://www.gnu.org/prep/standards/standards.html#Quote-Characters

[skip ci]