### PR TITLE
CMake/CRYPTO - set CMAKE_REQUIRED_INCLUDES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -828,7 +828,8 @@ if(WITH_CRYPTO)
         #
         # Check for some headers and functions.
         #
-        check_include_file(openssl/evp.h HAVE_OPENSSL_EVP_H)
+        set(CMAKE_REQUIRED_INCLUDES "${CRYPTO_INCLUDE_DIR}")
+        check_include_file("openssl/evp.h" HAVE_OPENSSL_EVP_H)
 
         #
         # 1) do we have EVP_CIPHER_CTX_new?


### PR DESCRIPTION
When using a custom CRYPTO library, that library's include path should be set to the [`CMAKE_REQUIRED_INCLUDES` prior to `check_include_file`](https://cmake.org/cmake/help/latest/module/CheckIncludeFile.html).

> CMAKE_REQUIRED_INCLUDES
>         A [;-list](https://cmake.org/cmake/help/latest/manual/cmake-language.7.html#cmake-language-lists) of header search paths to pass to the compiler. These will be the only header search paths used--the contents of the [INCLUDE_DIRECTORIES](https://cmake.org/cmake/help/latest/prop_dir/INCLUDE_DIRECTORIES.html#prop_dir:INCLUDE_DIRECTORIES) directory property will be ignored.

## Testing
* Setup
```
cd `mktemp -d`
git clone https://github.com/aws/aws-lc.git
git clone https://github.com/the-tcpdump-group/tcpdump.git
# Then... change branch or apply this PR as a patch to tcpdump
```
* Build/Install AWS-LC
```
mkdir aws-lc-build aws-lc-install
cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=./aws-lc-install -B ./aws-lc-build -S ./aws-lc
cmake --build ./aws-lc-build --target install -j 4
```
* Build tcpdump  -- ([`CMAKE_PREFIX_PATH`](https://cmake.org/cmake/help/latest/variable/CMAKE_PREFIX_PATH.html) needs to be set to an absolute path.)
```
mkdir -p tcpdump-build
cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=`pwd`/aws-lc-install -S ./tcpdump -B ./tcpdump-build
cmake --build ./tcpdump-build --target tcpdump
cmake --build ./tcpdump-build --target check
```

Several tests may fail until [PR #1351](https://github.com/aws/aws-lc/pull/1351) is merged.