### PR TITLE
Configure check for MD5_Init instead of DES_cbc_encrypt

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -868,8 +868,8 @@ if test "$want_libcrypto" != "no"; then
 	#
 	AC_CHECK_HEADER(openssl/crypto.h,
 	[
-		AC_CHECK_LIB(crypto, DES_cbc_encrypt)
-		if test "$ac_cv_lib_crypto_DES_cbc_encrypt" = "yes"; then
+		AC_CHECK_LIB(crypto, AES_cbc_encrypt)
+		if test "$ac_cv_lib_crypto_AES_cbc_encrypt" = "yes"; then
 			AC_CHECK_HEADERS(openssl/evp.h)
 			#
 			# OK, then:

--- a/configure.ac
+++ b/configure.ac
@@ -868,8 +868,8 @@ if test "$want_libcrypto" != "no"; then
 	#
 	AC_CHECK_HEADER(openssl/crypto.h,
 	[
-		AC_CHECK_LIB(crypto, AES_cbc_encrypt)
-		if test "$ac_cv_lib_crypto_AES_cbc_encrypt" = "yes"; then
+		AC_CHECK_LIB(crypto, MD5_Init)
+		if test "$ac_cv_lib_crypto_MD5_Init" = "yes"; then
 			AC_CHECK_HEADERS(openssl/evp.h)
 			#
 			# OK, then:


### PR DESCRIPTION
With this configure-script patch, tcpdump successfully builds and (with [a few other small changes](https://github.com/aws/aws-lc/pull/1351)) tests pass using AWS-LC as the libcrypto.
   * Related PR for AWS-LC is here: [#1351](https://github.com/aws/aws-lc/pull/1351)
   * AWS-LC doesn't have a `DES_cbc_encrypt` function, but it supports the ciphers required for ESP in the tests.
   * `MD5_Init` appears to be supported by other libcrypto implementations (e.g., [OpenSSL](https://www.openssl.org/docs/man1.1.1/man3/MD5_Init.html) and [LibreSSL](https://man.openbsd.org/MD5_Init)).