### PR TITLE
Cirrus CI: drop FreeBSD 12.4 and add FreeBSD 14.0

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,10 +9,10 @@ freebsd_task:
     # FreeBSD fails to start with 1 GB. 8 CPUs max concurrency.
     # The number of CPU cores must be either 1 or a multiple of 2.
     matrix:
-      - image_family: freebsd-12-4
+      - image_family: freebsd-13-2
         cpu: 2
         memory: 2G
-      - image_family: freebsd-13-2
+      - image_family: freebsd-14-0
         cpu: 2
         memory: 2G
   env:


### PR DESCRIPTION
FreeBSD 12.4 is EOL at the end of 2023, and FreeBSD 14.0 was released recently.