### PR TITLE
ICMP: Modernize packet parsing

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -26,7 +26,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       Remove unused missing/snprintf.c.
       Remove unused missing/strdup.c.
       (FIXME: somebody please wrap the line below just before the release)
-      AODV, AppleTalk, BOOTP, CHDLC, DCCP, EAP, EGP, EIGRP, ForCES, Geneve, GRE, Juniper, L2TP, mobile, NetFlow, NTP, OLSR, PGM, RADIUS, RIP, RSVP, SCTP, SNMP, TCP, UDP, vsock: Modernize packet parsing style
+      AODV, AppleTalk, BOOTP, CHDLC, DCCP, EAP, EGP, EIGRP, ForCES, Geneve, GRE, ICMP, Juniper, L2TP, mobile, NetFlow, NTP, OLSR, PGM, RADIUS, RIP, RSVP, SCTP, SNMP, TCP, UDP, vsock: Modernize packet parsing style
       DCCP, EGP: Replace custom code with tok2str()
       UDP: Clean up address and port printing.
       AppleTalk: Declutter appletalk.h.

--- a/netdissect.h
+++ b/netdissect.h
@@ -657,7 +657,7 @@ extern void hncp_print(netdissect_options *, const u_char *, u_int);
 extern void hsrp_print(netdissect_options *, const u_char *, u_int);
 extern void http_print(netdissect_options *, const u_char *, u_int);
 extern void icmp6_print(netdissect_options *, const u_char *, u_int, const u_char *, int);
-extern void icmp_print(netdissect_options *, const u_char *, u_int, const u_char *, int);
+extern void icmp_print(netdissect_options *, const u_char *, u_int, int);
 extern u_int ieee802_11_radio_print(netdissect_options *, const u_char *, u_int, u_int);
 extern u_int ieee802_15_4_print(netdissect_options *, const u_char *, u_int);
 extern void igmp_print(netdissect_options *, const u_char *, u_int);

--- a/print-ip-demux.c
+++ b/print-ip-demux.c
@@ -104,7 +104,7 @@ again:
 
 	case IPPROTO_ICMP:
 		if (ver == 4)
-			icmp_print(ndo, bp, length, iph, fragmented);
+			icmp_print(ndo, bp, length, fragmented);
 		else {
 			ND_PRINT("[%s requires IPv4]",
 				 tok2str(ipproto_values,"unknown",nh));


### PR DESCRIPTION
Remove the icmp_print() unused parameter 'bp2'.
Enable ND_LONGJMP_FROM_TCHECK and remove a 'trunc' label. Remove some redundant ND_TCHECK_*().
Reduce the scope of some variables.
Fix some indentations.
Remove some extra blank lines.