### PR TITLE
Add macros to fetch big-endian 4-byte and 8-byte IEEE floating point.

### DIFF
--- a/extract.h
+++ b/extract.h
@@ -746,6 +746,36 @@ get_he_s_4(netdissect_options *ndo, const u_char *p)
 	return EXTRACT_HE_S_4(p);
 }
 
+/* get_be_f_N */
+
+static inline float
+get_be_f_4(netdissect_options *ndo, const u_char *p)
+{
+	union { /* int to float conversion buffer */
+		float f;
+		uint32_t i;
+	} buf;
+
+	if (!ND_TTEST_4(p))
+		nd_trunc_longjmp(ndo);
+	buf.i = EXTRACT_BE_U_4(p);
+	return buf.f;
+}
+
+static inline double
+get_be_f_8(netdissect_options *ndo, const u_char *p)
+{
+	union { /* int to float conversion buffer */
+		double f;
+		uint64_t i;
+	} buf;
+
+	if (!ND_TTEST_8(p))
+		nd_trunc_longjmp(ndo);
+	buf.i = EXTRACT_BE_U_8(p);
+	return buf.f;
+}
+
 /* get_le_u_N */
 
 static inline uint16_t
@@ -882,6 +912,9 @@ get_cpy_bytes(netdissect_options *ndo, u_char *dst, const u_char *p, size_t len)
 #define GET_BE_S_6(p) get_be_s_6(ndo, (const u_char *)(p))
 #define GET_BE_S_7(p) get_be_s_7(ndo, (const u_char *)(p))
 #define GET_BE_S_8(p) get_be_s_8(ndo, (const u_char *)(p))
+
+#define GET_BE_F_4(p) get_be_f_4(ndo, (const u_char *)(p))
+#define GET_BE_F_8(p) get_be_f_8(ndo, (const u_char *)(p))
 
 #define GET_HE_U_2(p) get_he_u_2(ndo, (const u_char *)(p))
 #define GET_HE_U_4(p) get_he_u_4(ndo, (const u_char *)(p))

--- a/print-bgp.c
+++ b/print-bgp.c
@@ -894,10 +894,7 @@ static void
 bgp_extended_community_print(netdissect_options *ndo,
                              const u_char *pptr)
 {
-    union { /* copy buffer for bandwidth values */
-        float f;
-        uint32_t i;
-    } bw;
+    float bw;
     /* allocate space for the largest possible string */
     char astostr[AS_STR_SIZE];
 
@@ -929,9 +926,9 @@ bgp_extended_community_print(netdissect_options *ndo,
             break;
 
     case BGP_EXT_COM_LINKBAND:
-            bw.i = GET_BE_U_4(pptr + 4);
+            bw = GET_BE_F_4(pptr + 4);
             ND_PRINT("bandwidth: %.3f Mbps",
-                     bw.f*8/1000000);
+                     bw*8/1000000);
             break;
 
     case BGP_EXT_COM_OVS:

--- a/print-isoclns.c
+++ b/print-isoclns.c
@@ -1950,10 +1950,7 @@ isis_print_ext_is_reach(netdissect_options *ndo,
     u_int subtlv_type,subtlv_len,subtlv_sum_len;
     int proc_bytes = 0; /* how many bytes did we process ? */
     u_int te_class,priority_level,gmpls_switch_cap;
-    union { /* int to float conversion buffer for several subTLVs */
-        float f;
-        uint32_t i;
-    } bw;
+    float bw;
 
     ND_TCHECK_LEN(tptr, NODE_ID_LEN);
     if (tlv_remaining < NODE_ID_LEN)
@@ -2041,18 +2038,18 @@ isis_print_ext_is_reach(netdissect_options *ndo,
             case ISIS_SUBTLV_EXT_IS_REACH_MAX_LINK_BW :
             case ISIS_SUBTLV_EXT_IS_REACH_RESERVABLE_BW:
                 if (subtlv_len >= 4) {
-                    bw.i = GET_BE_U_4(tptr);
-                    ND_PRINT(", %.3f Mbps", bw.f * 8 / 1000000);
+                    bw = GET_BE_F_4(tptr);
+                    ND_PRINT(", %.3f Mbps", bw * 8 / 1000000);
                 }
                 break;
             case ISIS_SUBTLV_EXT_IS_REACH_UNRESERVED_BW :
                 if (subtlv_len >= 32) {
                     for (te_class = 0; te_class < 8; te_class++) {
-                        bw.i = GET_BE_U_4(tptr);
+                        bw = GET_BE_F_4(tptr);
                         ND_PRINT("%s  TE-Class %u: %.3f Mbps",
                                   indent,
                                   te_class,
-                                  bw.f * 8 / 1000000);
+                                  bw * 8 / 1000000);
                         tptr += 4;
                         subtlv_len -= 4;
                         subtlv_sum_len -= 4;
@@ -2076,11 +2073,11 @@ isis_print_ext_is_reach(netdissect_options *ndo,
                 for (te_class = 0; subtlv_len != 0; te_class++) {
                     if (subtlv_len < 4)
                         break;
-                    bw.i = GET_BE_U_4(tptr);
+                    bw = GET_BE_F_4(tptr);
                     ND_PRINT("%s  Bandwidth constraint CT%u: %.3f Mbps",
                               indent,
                               te_class,
-                              bw.f * 8 / 1000000);
+                              bw * 8 / 1000000);
                     tptr += 4;
                     subtlv_len -= 4;
                     subtlv_sum_len -= 4;
@@ -2136,11 +2133,11 @@ isis_print_ext_is_reach(netdissect_options *ndo,
                     proc_bytes += 4;
                     ND_PRINT("%s  Max LSP Bandwidth:", indent);
                     for (priority_level = 0; priority_level < 8; priority_level++) {
-                        bw.i = GET_BE_U_4(tptr);
+                        bw = GET_BE_F_4(tptr);
                         ND_PRINT("%s    priority level %u: %.3f Mbps",
                                   indent,
                                   priority_level,
-                                  bw.f * 8 / 1000000);
+                                  bw * 8 / 1000000);
                         tptr += 4;
                         subtlv_len -= 4;
                         subtlv_sum_len -= 4;
@@ -2153,16 +2150,16 @@ isis_print_ext_is_reach(netdissect_options *ndo,
                     case GMPLS_PSC4:
                         if (subtlv_len < 6)
                             break;
-                        bw.i = GET_BE_U_4(tptr);
-                        ND_PRINT("%s  Min LSP Bandwidth: %.3f Mbps", indent, bw.f * 8 / 1000000);
+                        bw = GET_BE_F_4(tptr);
+                        ND_PRINT("%s  Min LSP Bandwidth: %.3f Mbps", indent, bw * 8 / 1000000);
                         ND_PRINT("%s  Interface MTU: %u", indent,
                                  GET_BE_U_2(tptr + 4));
                         break;
                     case GMPLS_TSC:
                         if (subtlv_len < 8)
                             break;
-                        bw.i = GET_BE_U_4(tptr);
-                        ND_PRINT("%s  Min LSP Bandwidth: %.3f Mbps", indent, bw.f * 8 / 1000000);
+                        bw = GET_BE_F_4(tptr);
+                        ND_PRINT("%s  Min LSP Bandwidth: %.3f Mbps", indent, bw * 8 / 1000000);
                         ND_PRINT("%s  Indication %s", indent,
                                   tok2str(gmpls_switch_cap_tsc_indication_values, "Unknown (%u)", GET_U_1((tptr + 4))));
                         break;

--- a/print-lmp.c
+++ b/print-lmp.c
@@ -362,11 +362,7 @@ lmp_print_data_link_subobjs(netdissect_options *ndo, const u_char *obj_tptr,
 {
     int hexdump = FALSE;
     int subobj_type, subobj_len;
-
-    union { /* int to float conversion buffer */
-        float f;
-        uint32_t i;
-    } bw;
+    float bw;
 
     while (total_subobj_len > 0 && hexdump == FALSE ) {
 	subobj_type = GET_U_1(obj_tptr + offset);
@@ -401,12 +397,12 @@ lmp_print_data_link_subobjs(netdissect_options *ndo, const u_char *obj_tptr,
 			"Unknown",
 			GET_U_1(obj_tptr + offset + 3)),
 		GET_U_1(obj_tptr + offset + 3));
-	    bw.i = GET_BE_U_4(obj_tptr + offset + 4);
+	    bw = GET_BE_F_4(obj_tptr + offset + 4);
 	    ND_PRINT("\n\t      Min Reservable Bandwidth: %.3f Mbps",
-                bw.f*8/1000000);
-	    bw.i = GET_BE_U_4(obj_tptr + offset + 8);
+                bw*8/1000000);
+	    bw = GET_BE_F_4(obj_tptr + offset + 8);
 	    ND_PRINT("\n\t      Max Reservable Bandwidth: %.3f Mbps",
-                bw.f*8/1000000);
+                bw*8/1000000);
 	    break;
 	case WAVELENGTH_SUBOBJ:
 	    ND_PRINT("\n\t      Wavelength: %u",
@@ -433,11 +429,7 @@ lmp_print(netdissect_options *ndo,
     int hexdump;
     u_int offset;
     u_int link_type;
-
-    union { /* int to float conversion buffer */
-        float f;
-        uint32_t i;
-    } bw;
+    float bw;
 
     ndo->ndo_protocol = "lmp";
     tptr=pptr;
@@ -803,8 +795,8 @@ lmp_print(netdissect_options *ndo,
 			GET_BE_U_2(obj_tptr + 10),
 			GET_BE_U_2(obj_tptr + 10),
 			GET_BE_U_2(obj_tptr + 10)&8000 ? " (Payload test messages capable)" : "");
-                bw.i = GET_BE_U_4(obj_tptr + 12);
-		ND_PRINT("\n\t    Transmission Rate: %.3f Mbps",bw.f*8/1000000);
+                bw = GET_BE_F_4(obj_tptr + 12);
+		ND_PRINT("\n\t    Transmission Rate: %.3f Mbps",bw*8/1000000);
 		ND_PRINT("\n\t    Wavelength: %u",
 			GET_BE_U_4(obj_tptr + 16));
 		break;

--- a/print-ospf.c
+++ b/print-ospf.c
@@ -329,10 +329,7 @@ ospf_te_lsa_print(netdissect_options *ndo,
 {
     u_int tlv_type, tlv_length, subtlv_type, subtlv_length;
     u_int priority_level, te_class, count_srlg;
-    union { /* int to float conversion buffer for several subTLVs */
-        float f;
-        uint32_t i;
-    } bw;
+    float bw;
 
     while (ls_length != 0) {
         ND_TCHECK_4(tptr);
@@ -426,8 +423,8 @@ ospf_te_lsa_print(netdissect_options *ndo,
 			ND_PRINT(" != 4");
 			goto invalid;
 		    }
-                    bw.i = GET_BE_U_4(tptr);
-                    ND_PRINT(", %.3f Mbps", bw.f * 8 / 1000000);
+                    bw = GET_BE_F_4(tptr);
+                    ND_PRINT(", %.3f Mbps", bw * 8 / 1000000);
                     break;
                 case LS_OPAQUE_TE_LINK_SUBTLV_UNRES_BW:
 		    if (subtlv_length != 32) {
@@ -435,10 +432,10 @@ ospf_te_lsa_print(netdissect_options *ndo,
 			goto invalid;
 		    }
                     for (te_class = 0; te_class < 8; te_class++) {
-                        bw.i = GET_BE_U_4(tptr + te_class * 4);
+                        bw = GET_BE_F_4(tptr + te_class * 4);
                         ND_PRINT("\n\t\tTE-Class %u: %.3f Mbps",
                                te_class,
-                               bw.f * 8 / 1000000);
+                               bw * 8 / 1000000);
                     }
                     break;
                 case LS_OPAQUE_TE_LINK_SUBTLV_BW_CONSTRAINTS:
@@ -460,10 +457,10 @@ ospf_te_lsa_print(netdissect_options *ndo,
 		    }
                     /* decode BCs until the subTLV ends */
                     for (te_class = 0; te_class < (subtlv_length-4)/4; te_class++) {
-                        bw.i = GET_BE_U_4(tptr + 4 + te_class * 4);
+                        bw = GET_BE_F_4(tptr + 4 + te_class * 4);
                         ND_PRINT("\n\t\t  Bandwidth constraint CT%u: %.3f Mbps",
                                te_class,
-                               bw.f * 8 / 1000000);
+                               bw * 8 / 1000000);
                     }
                     break;
                 case LS_OPAQUE_TE_LINK_SUBTLV_TE_METRIC:
@@ -493,10 +490,10 @@ ospf_te_lsa_print(netdissect_options *ndo,
                     ND_PRINT("\n\t\tLSP Encoding: %s\n\t\tMax LSP Bandwidth:",
                            tok2str(gmpls_encoding_values, "Unknown", GET_U_1((tptr + 1))));
                     for (priority_level = 0; priority_level < 8; priority_level++) {
-                        bw.i = GET_BE_U_4(tptr + 4 + (priority_level * 4));
+                        bw = GET_BE_F_4(tptr + 4 + (priority_level * 4));
                         ND_PRINT("\n\t\t  priority level %u: %.3f Mbps",
                                priority_level,
-                               bw.f * 8 / 1000000);
+                               bw * 8 / 1000000);
                     }
                     break;
                 case LS_OPAQUE_TE_LINK_SUBTLV_LINK_TYPE:
@@ -518,8 +515,7 @@ ospf_te_lsa_print(netdissect_options *ndo,
                     if (count_srlg != 0)
                         ND_PRINT("\n\t\t  Shared risk group: ");
                     while (count_srlg > 0) {
-                        bw.i = GET_BE_U_4(tptr);
-                        ND_PRINT("%u", bw.i);
+                        ND_PRINT("%u", GET_BE_U_4(tptr));
                         tptr+=4;
                         count_srlg--;
                         if (count_srlg > 0)

--- a/print-rsvp.c
+++ b/print-rsvp.c
@@ -514,10 +514,7 @@ rsvp_intserv_print(netdissect_options *ndo,
                    const u_char *tptr, u_int obj_tlen)
 {
     u_int parameter_id,parameter_length;
-    union {
-	float f;
-	uint32_t i;
-    } bw;
+    float bw;
 
     ND_ICHECK_U(obj_tlen, <, 4);
     parameter_id = GET_U_1(tptr);
@@ -554,8 +551,8 @@ rsvp_intserv_print(netdissect_options *ndo,
         * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
         */
         if (parameter_length == 4) {
-            bw.i = GET_BE_U_4(tptr + 4);
-            ND_PRINT("\n\t\tPath b/w estimate: %.10g Mbps", bw.f / 125000);
+            bw = GET_BE_F_4(tptr + 4);
+            ND_PRINT("\n\t\tPath b/w estimate: %.10g Mbps", bw / 125000);
         }
         break;
 
@@ -607,12 +604,12 @@ rsvp_intserv_print(netdissect_options *ndo,
         */
 
         if (parameter_length == 20) {
-            bw.i = GET_BE_U_4(tptr + 4);
-            ND_PRINT("\n\t\tToken Bucket Rate: %.10g Mbps", bw.f / 125000);
-            bw.i = GET_BE_U_4(tptr + 8);
-            ND_PRINT("\n\t\tToken Bucket Size: %.10g bytes", bw.f);
-            bw.i = GET_BE_U_4(tptr + 12);
-            ND_PRINT("\n\t\tPeak Data Rate: %.10g Mbps", bw.f / 125000);
+            bw = GET_BE_F_4(tptr + 4);
+            ND_PRINT("\n\t\tToken Bucket Rate: %.10g Mbps", bw / 125000);
+            bw = GET_BE_F_4(tptr + 8);
+            ND_PRINT("\n\t\tToken Bucket Size: %.10g bytes", bw);
+            bw = GET_BE_F_4(tptr + 12);
+            ND_PRINT("\n\t\tPeak Data Rate: %.10g Mbps", bw / 125000);
             ND_PRINT("\n\t\tMinimum Policed Unit: %u bytes",
                      GET_BE_U_4(tptr + 16));
             ND_PRINT("\n\t\tMaximum Packet Size: %u bytes",
@@ -632,8 +629,8 @@ rsvp_intserv_print(netdissect_options *ndo,
         */
 
         if (parameter_length == 8) {
-            bw.i = GET_BE_U_4(tptr + 4);
-            ND_PRINT("\n\t\tRate: %.10g Mbps", bw.f / 125000);
+            bw = GET_BE_F_4(tptr + 4);
+            ND_PRINT("\n\t\tRate: %.10g Mbps", bw / 125000);
             ND_PRINT("\n\t\tSlack Term: %u", GET_BE_U_4(tptr + 8));
         }
         break;
@@ -687,10 +684,7 @@ rsvp_obj_print(netdissect_options *ndo,
     u_int obj_tlen,intserv_serv_tlen;
     int hexdump;
     u_int processed,padbytes,error_code,error_value,i,sigcheck;
-    union {
-	float f;
-	uint32_t i;
-    } bw;
+    float bw;
     u_int namelen;
 
     u_int action, subchannel;
@@ -1547,13 +1541,13 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_1: /* new style */
                 if (obj_tlen < sizeof(struct rsvp_obj_frr_t))
                     goto obj_tooshort;
-                bw.i = GET_BE_U_4(obj_ptr.rsvp_obj_frr->bandwidth);
+                bw = GET_BE_F_4(obj_ptr.rsvp_obj_frr->bandwidth);
                 ND_PRINT("%s  Setup Priority: %u, Holding Priority: %u, Hop-limit: %u, Bandwidth: %.10g Mbps",
                        indent,
                        obj_ptr.rsvp_obj_frr->setup_prio,
                        obj_ptr.rsvp_obj_frr->hold_prio,
                        obj_ptr.rsvp_obj_frr->hop_limit,
-                       bw.f * 8 / 1000000);
+                       bw * 8 / 1000000);
                 ND_PRINT("%s  Include-any: 0x%08x, Exclude-any: 0x%08x, Include-all: 0x%08x",
                        indent,
                        GET_BE_U_4(obj_ptr.rsvp_obj_frr->include_any),
@@ -1566,13 +1560,13 @@ rsvp_obj_print(netdissect_options *ndo,
             case RSVP_CTYPE_TUNNEL_IPV4: /* old style */
                 if (obj_tlen < 16)
                     goto obj_tooshort;
-                bw.i = GET_BE_U_4(obj_ptr.rsvp_obj_frr->bandwidth);
+                bw = GET_BE_F_4(obj_ptr.rsvp_obj_frr->bandwidth);
                 ND_PRINT("%s  Setup Priority: %u, Holding Priority: %u, Hop-limit: %u, Bandwidth: %.10g Mbps",
                        indent,
                        obj_ptr.rsvp_obj_frr->setup_prio,
                        obj_ptr.rsvp_obj_frr->hold_prio,
                        obj_ptr.rsvp_obj_frr->hop_limit,
-                       bw.f * 8 / 1000000);
+                       bw * 8 / 1000000);
                 ND_PRINT("%s  Include Colors: 0x%08x, Exclude Colors: 0x%08x",
                        indent,
                        GET_BE_U_4(obj_ptr.rsvp_obj_frr->include_any),


### PR DESCRIPTION
Bury the union-of-float-and-unsigned-int hack inside inline functions and define macros to call them, rather than doing the same trick in several dissectors.