### PR TITLE
Make illumos build warning-free.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -41,6 +41,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       Remove all remaining support for BSD/OS, IRIX, {OSF/1, Digital Unix,
         Tru64 Unix}, SINIX and Ultrix.
       Fix compiling on GNU/Hurd.
+      Make illumos build warning-free.
 
 DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
   Summary for 4.99.5 tcpdump release (so far!)

--- a/build.sh
+++ b/build.sh
@@ -35,13 +35,7 @@ print_cc_version
 # later warnings in the same matrix subset trigger an error.
 
 case `cc_id`/`os_id` in
-clang-*/SunOS-5.11)
-    # (Clang 9 on OpenIndiana, Clang 11 on OmniOS)
-    # tcpdump.c:2312:51: warning: this function declaration is not a prototype
-    #   [-Wstrict-prototypes]
-    # tcpdump.c:2737:11: warning: this function declaration is not a prototype
-    #   [-Wstrict-prototypes]
-    [ "`uname -o`" = illumos ] && TCPDUMP_TAINTED=yes
+*)
     ;;
 esac
 

--- a/diag-control.h
+++ b/diag-control.h
@@ -119,6 +119,19 @@
     #define DIAG_ON_C11_EXTENSIONS \
       DIAG_DO_PRAGMA(clang diagnostic pop)
   #endif
+
+  /*
+   * When Clang correctly detects an old-style function prototype after
+   * preprocessing, the warning can be irrelevant to this source tree because
+   * the prototype comes from a system header macro.
+   */
+  #if ND_IS_AT_LEAST_CLANG_VERSION(5,0)
+    #define DIAG_OFF_STRICT_PROTOTYPES \
+      DIAG_DO_PRAGMA(clang diagnostic push) \
+      DIAG_DO_PRAGMA(clang diagnostic ignored "-Wstrict-prototypes")
+    #define DIAG_ON_STRICT_PROTOTYPES \
+      DIAG_DO_PRAGMA(clang diagnostic pop)
+  #endif
 #elif ND_IS_AT_LEAST_GNUC_VERSION(4,2)
   /* GCC apparently doesn't complain about ORing enums together. */
 
@@ -159,6 +172,9 @@
   /*
    * GCC supports -Wc99-c11-compat since version 5.1.0, but the warning does
    * not trigger for now, so let's just leave it be.
+   *
+   * GCC does not currently generate any -Wstrict-prototypes warnings that
+   * would need silencing as is done for Clang above.
    */
 #endif
 
@@ -205,6 +221,12 @@
 #endif
 #ifndef DIAG_ON_C11_EXTENSIONS
 #define DIAG_ON_C11_EXTENSIONS
+#endif
+#ifndef DIAG_OFF_STRICT_PROTOTYPES
+#define DIAG_OFF_STRICT_PROTOTYPES
+#endif
+#ifndef DIAG_ON_STRICT_PROTOTYPES
+#define DIAG_ON_STRICT_PROTOTYPES
 #endif
 #ifndef ND_UNREACHABLE
 #define ND_UNREACHABLE


### PR DESCRIPTION
To the best of my understanding, the approach is correct. If you find that `-Wstrict-prototypes` should use a macro of its own instead of piggy-backing on `DIAG_OFF_DEPRECATION`, please make your point before long.