### PR TITLE
Fix warnings when building for 32-bit and defining _TIME_BITS=64

### DIFF
--- a/util-print.c
+++ b/util-print.c
@@ -249,8 +249,8 @@ ts_date_hmsfrac_print(netdissect_options *ndo, const struct timeval *tv,
 	char timebuf[32];
 	const char *timestr;
 
-	if ((unsigned)tv->tv_sec & 0x80000000) {
-		ND_PRINT("[Error converting time]");
+	if (tv->tv_sec < 0) {
+		ND_PRINT("[timestamp < 1970-01-01 00:00:00 UTC]");
 		return;
 	}
 
@@ -277,8 +277,8 @@ ts_date_hmsfrac_print(netdissect_options *ndo, const struct timeval *tv,
 static void
 ts_unix_print(netdissect_options *ndo, const struct timeval *tv)
 {
-	if ((unsigned)tv->tv_sec & 0x80000000) {
-		ND_PRINT("[Error converting time]");
+	if (tv->tv_sec < 0) {
+		ND_PRINT("[timestamp < 1970-01-01 00:00:00 UTC]");
 		return;
 	}
 


### PR DESCRIPTION
The warnings, given by clang with -Wshorten-64-to-32, were:

```
./util-print.c:306:48: warning: implicit conversion loses integer
precision: 'const __suseconds64_t' (aka 'const long long') to 'long'
[-Wshorten-64-to-32]
        ts_date_hmsfrac_print(ndo, tvp->tv_sec, tvp->tv_usec,
        ~~~~~~~~~~~~~~~~~~~~~                   ~~~~~^~~~~~~
./util-print.c:306:35: warning: implicit conversion loses integer
precision: 'const __time64_t' (aka 'const long long') to 'long'
[-Wshorten-64-to-32]
        ts_date_hmsfrac_print(ndo, tvp->tv_sec, tvp->tv_usec,
        ~~~~~~~~~~~~~~~~~~~~~      ~~~~~^~~~~~
./util-print.c:315:40: warning: implicit conversion loses integer
precision: 'const __suseconds64_t' (aka 'const long long') to 'long'
[-Wshorten-64-to-32]
        ts_unix_print(ndo, tvp->tv_sec, tvp->tv_usec);
        ~~~~~~~~~~~~~                   ~~~~~^~~~~~~
./util-print.c:315:27: warning: implicit conversion loses integer
precision: 'const __time64_t' (aka 'const long long') to 'long'
[-Wshorten-64-to-32]
        ts_unix_print(ndo, tvp->tv_sec, tvp->tv_usec);
        ~~~~~~~~~~~~~      ~~~~~^~~~~~
./util-print.c:346:58: warning: implicit conversion loses integer
precision: '__suseconds64_t' (aka 'long long') to 'long'
[-Wshorten-64-to-32]
        ts_date_hmsfrac_print(ndo, tv_result.tv_sec, tv_result.tv_usec,
        ~~~~~~~~~~~~~~~~~~~~~                        ~~~~~~~~~~^~~~~~~
./util-print.c:346:40: warning: implicit conversion loses integer
precision: '__time64_t' (aka 'long long') to 'long'
[-Wshorten-64-to-32]
        ts_date_hmsfrac_print(ndo, tv_result.tv_sec, tv_result.tv_usec,
        ~~~~~~~~~~~~~~~~~~~~~      ~~~~~~~~~~^~~~~~
./util-print.c:355:48: warning: implicit conversion loses integer
precision: 'const __suseconds64_t' (aka 'const long long') to 'long'
[-Wshorten-64-to-32]
        ts_date_hmsfrac_print(ndo, tvp->tv_sec, tvp->tv_usec,
        ~~~~~~~~~~~~~~~~~~~~~                   ~~~~~^~~~~~~
./util-print.c:355:35: warning: implicit conversion loses integer
precision: 'const __time64_t' (aka 'const long long') to 'long'
[-Wshorten-64-to-32]
        ts_date_hmsfrac_print(ndo, tvp->tv_sec, tvp->tv_usec,
        ~~~~~~~~~~~~~~~~~~~~~      ~~~~~^~~~~~
```