### PR TITLE
Update --version option to print 32/64-bit build and time_t size

### DIFF
--- a/tcpdump.c
+++ b/tcpdump.c
@@ -3341,6 +3341,8 @@ print_version(FILE *f)
 	(void)fprintf (f, "Compiled with MemorySanitizer/Clang.\n");
 #  endif
 #endif /* __SANITIZE_ADDRESS__ or __has_feature */
+	(void)fprintf (f, "%zu-bit build, %zu-bit time_t\n",
+		       sizeof(void *) * 8, sizeof(time_t) * 8);
 }
 DIAG_ON_DEPRECATION
 


### PR DESCRIPTION
Use only sizeof() and not SIZEOF_VOID_P/SIZEOF_TIME_T because these
macros could have invalid values in some macOS fat builds (See commit
170cbc8c6d484387ec7ae19ef9f4bd14dd0845e7).

This method should be future proof.

With this change we know:
whether this is a 32-bit or 64-bit build ;
whether the time_t size is 32-bit or 64-bit.