### PR TITLE
Sun C fixups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1031,7 +1031,13 @@ if(EXISTS ${CMAKE_SOURCE_DIR}/.devel OR EXISTS ${CMAKE_BINARY_DIR}/.devel)
         check_and_add_compiler_option(-Wmissing-prototypes)
         check_and_add_compiler_option(-Wmissing-variable-declarations)
         check_and_add_compiler_option(-Wold-style-definition)
-        check_and_add_compiler_option(-Wpedantic)
+        if(NOT CMAKE_C_COMPILER_ID MATCHES "Sun")
+            # In Sun C versions that implement GCC compatibility "-Wpedantic"
+            # means the same as "-pedantic".  The latter is mutually exclusive
+            # with several other options.  One of those is "-xc99", which has
+            # already been set for Sun C above.
+            check_and_add_compiler_option(-Wpedantic)
+        endif()
         check_and_add_compiler_option(-Wpointer-arith)
         check_and_add_compiler_option(-Wpointer-sign)
         check_and_add_compiler_option(-Wshadow)

--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ tcpdump compiles and works on at least the following platforms:
 * FreeBSD
 * [Haiku](./doc/README.haiku.md)
 * HP-UX 11i
-* illumos (OmniOS, OpenIndiana)
+* [illumos](./doc/README.solaris.md) (OmniOS, OpenIndiana)
 * GNU/Hurd
 * GNU/Linux
 * {Mac} OS X / macOS
 * [NetBSD](./doc/README.NetBSD.md)
 * OpenBSD
-* [Solaris and related OSes](./doc/README.solaris.md)
+* [Solaris](./doc/README.solaris.md)
 * [Windows](./doc/README.Win32.md) (requires WinPcap or Npcap, and Visual
   Studio with CMake)
 

--- a/diag-control.h
+++ b/diag-control.h
@@ -176,6 +176,14 @@
    * GCC does not currently generate any -Wstrict-prototypes warnings that
    * would need silencing as is done for Clang above.
    */
+#elif ND_IS_AT_LEAST_SUNC_VERSION(5,5)
+  /*
+   * Suppress deprecation warnings.
+   */
+  #define DIAG_OFF_DEPRECATION \
+    DIAG_DO_PRAGMA(error_messages(off,E_DEPRECATED_ATT))
+  #define DIAG_ON_DEPRECATION \
+    DIAG_DO_PRAGMA(error_messages(default,E_DEPRECATED_ATT))
 #endif
 
 /*

--- a/doc/README.solaris.md
+++ b/doc/README.solaris.md
@@ -37,16 +37,18 @@ developer/clang-90
 ENDOFTEXT
 ```
 
-## Oracle Solaris 11.4.42/AMD64
+## Oracle Solaris CBE (11.4.42.111.0)/AMD64
 
 * Both system and local libpcap are suitable.
+* CMake 3.21.0 works.
 * GCC 11.2 and Clang 11.0 work.
+* Sun C 5.15 works.
 
-For reference, the tests were done on a VM booted from `sol-11_4-vbox.ova`
-and updated to 11.4.42.111.0 plus the following packages:
+For reference, the tests were done using the following packages:
 ```shell
 xargs -L1 pkg install <<ENDOFTEXT
 developer/build/autoconf
+developer/build/cmake
 developer/gcc
 developer/llvm/clang
 ENDOFTEXT

--- a/print-802_15_4.c
+++ b/print-802_15_4.c
@@ -513,20 +513,16 @@ ieee802_15_4_addr_len(uint16_t addr_type)
 	switch (addr_type) {
 	case FC_ADDRESSING_MODE_NONE: /* None. */
 		return 0;
-		break;
 	case FC_ADDRESSING_MODE_RESERVED: /* Reserved, there used to be 8-bit
 					   * address type in one amendment, but
 					   * that and the feature using it was
 					   * removed during 802.15.4-2015
 					   * maintenance process. */
 		return -1;
-		break;
 	case FC_ADDRESSING_MODE_SHORT: /* Short. */
 		return 2;
-		break;
 	case FC_ADDRESSING_MODE_LONG: /* Extended. */
 		return 8;
-		break;
 	}
 	return 0;
 }
@@ -1388,8 +1384,6 @@ ieee802_15_4_print_mpx_ie(netdissect_options *ndo,
 			}
 		}
 		return;
-		/* NOTREACHED */
-		break;
 	case 0x03: /* Reserved */
 	case 0x05: /* Reserved */
 	case 0x07: /* Reserved */
@@ -1554,7 +1548,6 @@ ieee802_15_4_print_aux_sec_header(netdissect_options *ndo,
 			ND_PRINT("Implicit");
 		}
 		return len;
-		break;
 	case 0x01: /* Key Index, nothing to print here. */
 		break;
 	case 0x02: /* PAN and Short address Key Source, and Key Index. */
@@ -1632,7 +1625,7 @@ ieee802_15_4_print_command_data(netdissect_options *ndo,
 				  "Allocate address, " : ""));
 			return caplen;
 		}
-		break;
+		/* NOTREACHED */
 	case 0x02: /* Association Response */
 		if (caplen != 3) {
 			ND_PRINT("Invalid Association response command length");
@@ -1663,7 +1656,7 @@ ieee802_15_4_print_command_data(netdissect_options *ndo,
 			}
 			return caplen;
 		}
-		break;
+		/* NOTREACHED */
 	case 0x03: /* Disassociation Notification command */
 		if (caplen != 1) {
 			ND_PRINT("Invalid Disassociation Notification command length");
@@ -1723,7 +1716,7 @@ ieee802_15_4_print_command_data(netdissect_options *ndo,
 			ieee802_15_4_print_addr(ndo, p + 5, 2);
 			return caplen;
 		}
-		break;
+		/* NOTREACHED */
 	case 0x09: /* GTS Request command */
 		if (caplen != 1) {
 			ND_PRINT("Invalid GTS Request command length");
@@ -1740,7 +1733,7 @@ ieee802_15_4_print_command_data(netdissect_options *ndo,
 				  "GTS allocation" : "GTS deallocations"));
 			return caplen;
 		}
-		break;
+		/* NOTREACHED */
 	case 0x13: /* DSME Association Request command */
 		/* XXX Not implemented */
 	case 0x14: /* DSME Association Response command */
@@ -2493,19 +2486,14 @@ ieee802_15_4_print(netdissect_options *ndo,
 	case 0x02: /* Acknowledgement */
 	case 0x03: /* MAC Command */
 		return ieee802_15_4_std_frames(ndo, p, caplen, fc);
-		break;
 	case 0x04: /* Reserved */
 		return 0;
-		break;
 	case 0x05: /* Multipurpose */
 		return ieee802_15_4_mp_frame(ndo, p, caplen, fc);
-		break;
 	case 0x06: /* Fragment or Frak */
 		return ieee802_15_4_frag_frame(ndo, p, caplen, fc);
-		break;
 	case 0x07: /* Extended */
 		return 0;
-		break;
 	}
 	return 0;
 }

--- a/print-bgp.c
+++ b/print-bgp.c
@@ -2250,7 +2250,6 @@ bgp_attr_print(netdissect_options *ndo,
                     tlen -= tnhlen;
                     tnhlen = 0;
                     goto done;
-                    break;
                 }
             }
         }

--- a/print-dccp.c
+++ b/print-dccp.c
@@ -392,7 +392,6 @@ dccp_print(netdissect_options *ndo, const u_char *bp, const u_char *data2,
 		break;
 	default:
 		goto invalid;
-		break;
 	}
 
 	if ((DCCPH_TYPE(dh) != DCCP_PKT_DATA) &&
@@ -596,7 +595,6 @@ dccp_print_option(netdissect_options *ndo, const u_char *bp, u_int hlen)
 			default:
 				ND_PRINT(" [optlen != 6 or 8 or 10]");
 				goto invalid;
-				break;
 			}
 			break;
 		case DCCP_OPTION_ELAPSED_TIME:

--- a/print-juniper.c
+++ b/print-juniper.c
@@ -1166,7 +1166,6 @@ juniper_ppp_heuristic_guess(netdissect_options *ndo,
 
     default:
         return 0; /* did not find a ppp header */
-        break;
     }
     return 1; /* we printed a ppp packet */
 }
@@ -1210,7 +1209,6 @@ ip_heuristic_guess(netdissect_options *ndo,
         break;
     default:
         return 0; /* did not find a ip header */
-        break;
     }
     return 1; /* we printed an v4/v6 packet */
 }

--- a/print-lisp.c
+++ b/print-lisp.c
@@ -320,7 +320,6 @@ lisp_print(netdissect_options *ndo, const u_char *bp, u_int length)
 			 * No support for LCAF right now.
 			 */
 			return;
-			break;
 		}
 
 		ND_PRINT(" %u locator(s)", loc_count);

--- a/print-mobility.c
+++ b/print-mobility.c
@@ -319,7 +319,6 @@ mobility_print(netdissect_options *ndo,
 	default:
 		ND_PRINT(" len=%u", GET_U_1(mh->ip6m_len));
 		return(mhlen);
-		break;
 	}
 	if (ndo->ndo_vflag)
 		if (mobility_opt_print(ndo, bp + hlen, mhlen - hlen))

--- a/print-pgm.c
+++ b/print-pgm.c
@@ -274,7 +274,6 @@ pgm_print(netdissect_options *ndo,
 		break;
 	    default:
 		goto invalid;
-		break;
 	    }
 
 	    ND_PRINT("SPM seq %u trail %u lead %u nla %s",
@@ -306,7 +305,6 @@ pgm_print(netdissect_options *ndo,
 		break;
 	    default:
 		goto invalid;
-		break;
 	    }
 
 	    ivl = GET_BE_U_4(bp);
@@ -384,7 +382,6 @@ pgm_print(netdissect_options *ndo,
 		break;
 	    default:
 		goto invalid;
-		break;
 	    }
 
 	    /*
@@ -405,7 +402,6 @@ pgm_print(netdissect_options *ndo,
 		break;
 	    default:
 		goto invalid;
-		break;
 	    }
 
 	    /*
@@ -630,7 +626,6 @@ pgm_print(netdissect_options *ndo,
 			break;
 		    default:
 			goto invalid;
-			break;
 		    }
 
 		    ND_PRINT(" REDIRECT %s",  nla_buf);
@@ -787,7 +782,6 @@ pgm_print(netdissect_options *ndo,
 			break;
 		    default:
 			goto invalid;
-			break;
 		    }
 
 		    ND_PRINT(" PGMCC DATA %u %s", offset, nla_buf);
@@ -830,7 +824,6 @@ pgm_print(netdissect_options *ndo,
 			break;
 		    default:
 			goto invalid;
-			break;
 		    }
 
 		    ND_PRINT(" PGMCC FEEDBACK %u %s", offset, nla_buf);

--- a/print-pim.c
+++ b/print-pim.c
@@ -584,7 +584,6 @@ pimv2_addr_print(netdissect_options *ndo,
 			break;
 		default:
 			return -1;
-			break;
 		}
 		hdrlen = 0;
 	}
@@ -813,7 +812,6 @@ pimv2_print(netdissect_options *ndo,
 					ND_PRINT("[option length %u != 4]", olen);
 					nd_print_invalid(ndo);
 					return;
-					break;
 				}
 				break;
 

--- a/print-resp.c
+++ b/print-resp.c
@@ -183,6 +183,9 @@ static int resp_get_length(netdissect_options *, const u_char *, int, const u_ch
  * TEST_RET_LEN
  * If ret_len is < 0, jump to the trunc tag which returns (-1)
  * and 'bubbles up' to printing tstr. Otherwise, return ret_len.
+ *
+ * Note that using this macro with a semicolon at the end emits a warning from
+ * Sun C about an unreachable statement (the semicolon is the statement).
  */
 #define TEST_RET_LEN(rl) \
     if (rl < 0) { goto trunc; } else { return rl; }
@@ -260,7 +263,7 @@ resp_parse(netdissect_options *ndo, const u_char *bp, int length)
      * including invalid packet errors; that's what we want, as
      * we have to give up on further parsing in that case.
      */
-    TEST_RET_LEN(ret_len);
+    TEST_RET_LEN(ret_len) // without a semicolon
 
 trunc:
     return (-1);
@@ -310,7 +313,7 @@ resp_print_string_error_integer(netdissect_options *ndo, const u_char *bp, int l
     RESP_PRINT_SEGMENT(ndo, bp, len);
     ret_len = 1 /*<opcode>*/ + len /*<string>*/ + 2 /*<CRLF>*/;
 
-    TEST_RET_LEN(ret_len);
+    TEST_RET_LEN(ret_len) // without a semicolon
 
 trunc:
     return (-1);

--- a/print-rt6.c
+++ b/print-rt6.c
@@ -165,7 +165,6 @@ rt6_print(netdissect_options *ndo, const u_char *bp, const u_char *bp2 _U_)
 		/*(*/
 		ND_PRINT(") ");
 		return((GET_U_1(dp0->ip6r0_len) + 1) << 3);
-		break;
 	case IPV6_RTHDR_TYPE_4:
 		srh = (const struct ip6_srh *)dp;
 		last_entry = GET_U_1(srh->srh_last_ent);
@@ -195,7 +194,6 @@ rt6_print(netdissect_options *ndo, const u_char *bp, const u_char *bp2 _U_)
 		/*(*/
 		ND_PRINT(") ");
 		return((GET_U_1(srh->srh_len) + 1) << 3);
-		break;
 	default:
 		ND_PRINT(" (unknown type)");
 		goto invalid;

--- a/smbutil.c
+++ b/smbutil.c
@@ -891,7 +891,6 @@ smb_fdata(netdissect_options *ndo,
 	     */
 	    fmt++;
 	    return(buf);
-	    break;
 
 	case '[':
 	    /*

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -1740,7 +1740,7 @@ main(int argc, char **argv)
 		case 'h':
 			print_usage(stdout);
 			exit_tcpdump(S_SUCCESS);
-			break;
+			/* NOTREACHED */
 
 		case 'H':
 			++ndo->ndo_Hflag;
@@ -1988,7 +1988,7 @@ main(int argc, char **argv)
 		case OPTION_VERSION:
 			print_version(stdout);
 			exit_tcpdump(S_SUCCESS);
-			break;
+			/* NOTREACHED */
 
 #ifdef HAVE_PCAP_SET_TSTAMP_PRECISION
 		case OPTION_TSTAMP_PRECISION:
@@ -2068,7 +2068,7 @@ main(int argc, char **argv)
 
 	default: /* Not supported */
 		error("only -t, -tt, -ttt, -tttt and -ttttt are supported");
-		break;
+		/* NOTREACHED */
 	}
 
 	if (ndo->ndo_fflag != 0 && (VFileName != NULL || RFileName != NULL))


### PR DESCRIPTION
With these changes tcpdump passes a complete build matrix on Solaris CBE using Sun C, GCC and Clang. In theory, these changes are not supposed to break anything else.