### PR TITLE
Disregard setlinebuf(3), always use setvbuf(3).

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -42,6 +42,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       IEEE 802.11: Simplify handle_action().
       Provide GET_ macros for 4-byte and 8-byte floating-point numbers
         and use them rather than custom code
+      Disregard setlinebuf(3), always use setvbuf(3).
     Building and testing:
       autoconf: Update install-sh script to the latest available version.
       autoconf: Remove detection of early IPv6 stacks.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -485,7 +485,6 @@ tcpdump would not work correctly even if it managed to compile."
 endif()
 
 check_function_exists(getopt_long HAVE_GETOPT_LONG)
-check_function_exists(setlinebuf HAVE_SETLINEBUF)
 #
 # For Windows,  don't need to waste time checking for fork() or vfork().
 #

--- a/cmakeconfig.h.in
+++ b/cmakeconfig.h.in
@@ -162,9 +162,6 @@
 /* Define to 1 if you have the <rpc/rpc.h> header file. */
 #cmakedefine HAVE_RPC_RPC_H 1
 
-/* Define to 1 if you have the `setlinebuf' function. */
-#cmakedefine HAVE_SETLINEBUF 1
-
 /* Define to 1 if you have the <stdint.h> header file. */
 #cmakedefine HAVE_STDINT_H 1
 

--- a/configure.ac
+++ b/configure.ac
@@ -283,7 +283,6 @@ AC_LBL_LIBRARY_NET
 
 AC_REPLACE_FUNCS(strlcat strlcpy strsep getservent getopt_long)
 AC_CHECK_FUNCS(fork vfork)
-AC_CHECK_FUNCS(setlinebuf)
 
 #
 # Make sure we have snprintf(); we require it.

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -1781,11 +1781,7 @@ main(int argc, char **argv)
 			 */
 			setvbuf(stdout, NULL, _IONBF, 0);
 #else /* _WIN32 */
-#ifdef HAVE_SETLINEBUF
-			setlinebuf(stdout);
-#else
 			setvbuf(stdout, NULL, _IOLBF, 0);
-#endif
 #endif /* _WIN32 */
 			lflag = 1;
 			break;


### PR DESCRIPTION
Let's confirm this passes CI as expected.