### PR TITLE
Include <config.h> unconditionally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,8 +280,6 @@ file(STRINGS ${tcpdump_SOURCE_DIR}/VERSION
 # Project settings
 ######################################
 
-add_definitions(-DHAVE_CONFIG_H)
-
 include_directories(
     ${CMAKE_CURRENT_BINARY_DIR}
     ${tcpdump_SOURCE_DIR}

--- a/addrtoname.c
+++ b/addrtoname.c
@@ -22,9 +22,7 @@
  *  and address to string conversion routines
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #ifdef HAVE_CASPER
 #include <libcasper.h>

--- a/addrtostr.c
+++ b/addrtostr.c
@@ -36,9 +36,7 @@
  * SUCH DAMAGE.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 #include "addrtostr.h"

--- a/af.c
+++ b/af.c
@@ -15,9 +15,7 @@
  * Original code by Hannes Gredler (hannes@gredler.at)
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 #include "netdissect.h"

--- a/bpf_dump.c
+++ b/bpf_dump.c
@@ -19,9 +19,7 @@
  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/checksum.c
+++ b/checksum.c
@@ -17,9 +17,7 @@
  * Original code by Hannes Gredler (hannes@gredler.at)
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/cpack.c
+++ b/cpack.c
@@ -27,9 +27,7 @@
  * OF SUCH DAMAGE.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <stdlib.h>
 #include <string.h>

--- a/gmpls.c
+++ b/gmpls.c
@@ -13,9 +13,7 @@
  * Original code by Hannes Gredler (hannes@gredler.at)
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/in_cksum.c
+++ b/in_cksum.c
@@ -35,9 +35,7 @@
  *	@(#)in_cksum.c	8.1 (Berkeley) 6/10/93
  */
 
-#ifdef HAVE_CONFIG_H
 # include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/ipproto.c
+++ b/ipproto.c
@@ -13,9 +13,7 @@
  * Original code by Hannes Gredler (hannes@gredler.at)
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/l2vpn.c
+++ b/l2vpn.c
@@ -13,9 +13,7 @@
  * Original code by Hannes Gredler (hannes@gredler.at)
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 #include "netdissect.h"

--- a/missing/datalinks.c
+++ b/missing/datalinks.c
@@ -31,9 +31,7 @@
  * SUCH DAMAGE.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <netdissect-stdinc.h>
 

--- a/missing/dlnames.c
+++ b/missing/dlnames.c
@@ -31,9 +31,7 @@
  * SUCH DAMAGE.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <netdissect-stdinc.h>
 

--- a/missing/getservent.c
+++ b/missing/getservent.c
@@ -34,9 +34,7 @@
  * SUCH DAMAGE.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <netdissect-stdinc.h>
 #include <getservent.h>

--- a/missing/strlcat.c
+++ b/missing/strlcat.c
@@ -28,9 +28,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <netdissect-stdinc.h>
 

--- a/missing/strlcpy.c
+++ b/missing/strlcpy.c
@@ -28,9 +28,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <netdissect-stdinc.h>
 

--- a/missing/strsep.c
+++ b/missing/strsep.c
@@ -31,9 +31,7 @@
  * SUCH DAMAGE.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <netdissect-stdinc.h>
 

--- a/netdissect-alloc.c
+++ b/netdissect-alloc.c
@@ -14,9 +14,7 @@
  * FOR A PARTICULAR PURPOSE.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <stdlib.h>
 #include "netdissect-alloc.h"

--- a/netdissect.c
+++ b/netdissect.c
@@ -22,9 +22,7 @@
  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 #include "netdissect.h"

--- a/nlpid.c
+++ b/nlpid.c
@@ -13,9 +13,7 @@
  * Original code by Hannes Gredler (hannes@gredler.at)
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 #include "netdissect.h"

--- a/ntp.c
+++ b/ntp.c
@@ -20,9 +20,7 @@
  *
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "ntp.h"
 

--- a/oui.c
+++ b/oui.c
@@ -13,9 +13,7 @@
  * Original code by Hannes Gredler (hannes@gredler.at)
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 #include "netdissect.h"

--- a/parsenfsfh.c
+++ b/parsenfsfh.c
@@ -40,9 +40,7 @@
  * Western Research Laboratory
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-802_11.c
+++ b/print-802_11.c
@@ -22,9 +22,7 @@
 
 /* \summary: IEEE 802.11 printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-802_15_4.c
+++ b/print-802_15_4.c
@@ -22,9 +22,7 @@
 
 /* \summary: IEEE 802.15.4 printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-ah.c
+++ b/print-ah.c
@@ -23,9 +23,7 @@
 
 /* \summary: IPSEC Authentication Header printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-ahcp.c
+++ b/print-ahcp.c
@@ -29,9 +29,7 @@
 
 /* Based on draft-chroboczek-ahcp-00 and source code of ahcpd-0.53 */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-aodv.c
+++ b/print-aodv.c
@@ -33,9 +33,7 @@
 /* \summary: Ad hoc On-Demand Distance Vector (AODV) Routing printer */
 /* specification: RFC 3561 */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-aoe.c
+++ b/print-aoe.c
@@ -31,9 +31,7 @@
  * https://web.archive.org/web/20161025044402/http://brantleycoilecompany.com/AoEr11.pdf
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-ap1394.c
+++ b/print-ap1394.c
@@ -21,9 +21,7 @@
 
 /* \summary: Apple IP-over-IEEE 1394 printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-arcnet.c
+++ b/print-arcnet.c
@@ -23,9 +23,7 @@
 
 /* \summary: Attached Resource Computer NETwork (ARCNET) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-arista.c
+++ b/print-arista.c
@@ -2,9 +2,7 @@
 
 /* \summary: EtherType protocol for Arista Networks printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-arp.c
+++ b/print-arp.c
@@ -21,9 +21,7 @@
 
 /* \summary: Address Resolution Protocol (ARP) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-ascii.c
+++ b/print-ascii.c
@@ -38,9 +38,7 @@
 
 /* \summary: ASCII packet dump printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-atalk.c
+++ b/print-atalk.c
@@ -21,9 +21,7 @@
 
 /* \summary: AppleTalk printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-atm.c
+++ b/print-atm.c
@@ -21,9 +21,7 @@
 
 /* \summary: Asynchronous Transfer Mode (ATM) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-babel.c
+++ b/print-babel.c
@@ -37,9 +37,7 @@
  * draft-ietf-babel-source-specific-0
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-bcm-li.c
+++ b/print-bcm-li.c
@@ -21,9 +21,7 @@
 
 /* \summary: Broadcom LI Printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-beep.c
+++ b/print-beep.c
@@ -11,9 +11,7 @@
 
 /* \summary: Blocks Extensible Exchange Protocol (BEEP) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-bfd.c
+++ b/print-bfd.c
@@ -20,9 +20,7 @@
  * RFC 5880 for version 1, and RFC 5881
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-bgp.c
+++ b/print-bgp.c
@@ -34,9 +34,7 @@
 
 /* specification: RFC 4271 */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-bootp.c
+++ b/print-bootp.c
@@ -21,9 +21,7 @@
 
 /* \summary: BOOTP and IPv4 DHCP printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-brcmtag.c
+++ b/print-brcmtag.c
@@ -21,9 +21,7 @@
 
 /* \summary: Broadcom Ethernet switches tag (4 bytes) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-bt.c
+++ b/print-bt.c
@@ -19,9 +19,7 @@
 
 /* \summary: Bluetooth printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-calm-fast.c
+++ b/print-calm-fast.c
@@ -17,9 +17,7 @@
 
 /* \summary: Communication access for land mobiles (CALM) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-carp.c
+++ b/print-carp.c
@@ -36,9 +36,7 @@
 
 /* \summary: Common Address Redundancy Protocol (CARP) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-cdp.c
+++ b/print-cdp.c
@@ -26,9 +26,7 @@
 
 /* \summary: Cisco Discovery Protocol (CDP) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-cfm.c
+++ b/print-cfm.c
@@ -17,9 +17,7 @@
 
 /* \summary: IEEE 802.1ag Connectivity Fault Management (CFM) protocols printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-chdlc.c
+++ b/print-chdlc.c
@@ -21,9 +21,7 @@
 
 /* \summary: Cisco HDLC printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-cip.c
+++ b/print-cip.c
@@ -22,9 +22,7 @@
 
 /* \summary: Linux Classical IP over ATM printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <string.h>
 

--- a/print-cnfp.c
+++ b/print-cnfp.c
@@ -40,9 +40,7 @@
  *    https://www.cisco.com/c/en/us/td/docs/net_mgmt/netflow_collection_engine/3-6/user/guide/format.html#wp1005892
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-dccp.c
+++ b/print-dccp.c
@@ -11,9 +11,7 @@
 
 /* specification: RFC 4340 */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-decnet.c
+++ b/print-decnet.c
@@ -21,9 +21,7 @@
 
 /* \summary: DECnet printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-dhcp6.c
+++ b/print-dhcp6.c
@@ -43,9 +43,7 @@
  *  RFC6334: Dual-Stack Lite option,
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-domain.c
+++ b/print-domain.c
@@ -21,9 +21,7 @@
 
 /* \summary: Domain Name System (DNS) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-dsa.c
+++ b/print-dsa.c
@@ -21,9 +21,7 @@
 
 /* \summary: Marvell (Ethertype) Distributed Switch Architecture printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-dtp.c
+++ b/print-dtp.c
@@ -17,9 +17,7 @@
 
 /* \summary: Dynamic Trunking Protocol (DTP) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-dvmrp.c
+++ b/print-dvmrp.c
@@ -21,9 +21,7 @@
 
 /* \summary: Distance Vector Multicast Routing Protocol printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-eap.c
+++ b/print-eap.c
@@ -20,9 +20,7 @@
 
 /* \summary: Extensible Authentication Protocol (EAP) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-egp.c
+++ b/print-egp.c
@@ -22,9 +22,7 @@
 
 /* specification: RFC 827 */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-eigrp.c
+++ b/print-eigrp.c
@@ -23,9 +23,7 @@
  * RFC 7868
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-enc.c
+++ b/print-enc.c
@@ -23,9 +23,7 @@
 
 /* \summary: OpenBSD IPsec encapsulation BPF layer printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-erspan.c
+++ b/print-erspan.c
@@ -32,9 +32,7 @@
  * Specifications: I-D draft-foschiano-erspan-03.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-esp.c
+++ b/print-esp.c
@@ -23,9 +23,7 @@
 
 /* \summary: IPSEC Encapsulating Security Payload (ESP) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-ether.c
+++ b/print-ether.c
@@ -21,9 +21,7 @@
 
 /* \summary: Ethernet printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-fddi.c
+++ b/print-fddi.c
@@ -21,9 +21,7 @@
 
 /* \summary: Fiber Distributed Data Interface (FDDI) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-forces.c
+++ b/print-forces.c
@@ -18,9 +18,7 @@
 
 /* specification: RFC 5810 */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-fr.c
+++ b/print-fr.c
@@ -21,9 +21,7 @@
 
 /* \summary: Frame Relay printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-frag6.c
+++ b/print-frag6.c
@@ -21,9 +21,7 @@
 
 /* \summary: IPv6 fragmentation header printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-ftp.c
+++ b/print-ftp.c
@@ -13,9 +13,7 @@
 
 /* \summary: File Transfer Protocol (FTP) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-geneve.c
+++ b/print-geneve.c
@@ -18,9 +18,7 @@
 /* \summary: Generic Network Virtualization Encapsulation (Geneve) printer */
 /* specification: RFC 8926 */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-geonet.c
+++ b/print-geonet.c
@@ -17,9 +17,7 @@
 
 /* \summary: ISO CALM FAST and ETSI GeoNetworking printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-gre.c
+++ b/print-gre.c
@@ -44,9 +44,7 @@
  * Virtual Subnet ID (VSID) and an 8-bit FlowID.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-hncp.c
+++ b/print-hncp.c
@@ -28,9 +28,7 @@
 
 /* \summary: Home Networking Control Protocol (HNCP) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-hsrp.c
+++ b/print-hsrp.c
@@ -31,9 +31,7 @@
 
 /* specification: RFC 2281 for version 1 */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-http.c
+++ b/print-http.c
@@ -13,9 +13,7 @@
 
 /* \summary: Hypertext Transfer Protocol (HTTP) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-icmp.c
+++ b/print-icmp.c
@@ -21,9 +21,7 @@
 
 /* \summary: Internet Control Message Protocol (ICMP) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-icmp6.c
+++ b/print-icmp6.c
@@ -21,9 +21,7 @@
 
 /* \summary: IPv6 Internet Control Message Protocol (ICMPv6) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-igmp.c
+++ b/print-igmp.c
@@ -29,9 +29,7 @@
  *	draft-asaeda-mboned-mtrace-v2 for the mtrace message
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-igrp.c
+++ b/print-igrp.c
@@ -23,9 +23,7 @@
 
 /* \summary: Interior Gateway Routing Protocol (IGRP) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-ip-demux.c
+++ b/print-ip-demux.c
@@ -21,9 +21,7 @@
 
 /* \summary: IPv4/IPv6 payload printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-ip.c
+++ b/print-ip.c
@@ -21,9 +21,7 @@
 
 /* \summary: IP printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-ip6.c
+++ b/print-ip6.c
@@ -21,9 +21,7 @@
 
 /* \summary: IPv6 printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-ip6opts.c
+++ b/print-ip6opts.c
@@ -29,9 +29,7 @@
 
 /* \summary: IPv6 header option printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-ipcomp.c
+++ b/print-ipcomp.c
@@ -21,9 +21,7 @@
 
 /* \summary: IP Payload Compression Protocol (IPComp) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-ipfc.c
+++ b/print-ipfc.c
@@ -23,9 +23,7 @@
 
 /* specification: RFC 2625 */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-ipnet.c
+++ b/print-ipnet.c
@@ -1,8 +1,6 @@
 /* \summary: Solaris DLT_IPNET printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-ipoib.c
+++ b/print-ipoib.c
@@ -25,9 +25,7 @@
 
 /* \summary: IP-over-InfiniBand (IPoIB) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-ipx.c
+++ b/print-ipx.c
@@ -23,9 +23,7 @@
 
 /* \summary: Novell IPX printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-isakmp.c
+++ b/print-isakmp.c
@@ -32,9 +32,7 @@
 
 /* specification: RFC 2407, RFC 2408, RFC 5996 */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 /* The functions from print-esp.c used in this file are only defined when both
  * OpenSSL and evp.h are detected. Employ the same preprocessor device here.

--- a/print-isoclns.c
+++ b/print-isoclns.c
@@ -34,9 +34,7 @@
  * IS-IS: ISO 10589
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-juniper.c
+++ b/print-juniper.c
@@ -22,9 +22,7 @@
 __RCSID("NetBSD: print-juniper.c,v 1.3 2007/07/25 06:31:32 dogcow Exp ");
 #endif
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-krb.c
+++ b/print-krb.c
@@ -23,9 +23,7 @@
 
 /* \summary: Kerberos printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-l2tp.c
+++ b/print-l2tp.c
@@ -25,9 +25,7 @@
 
 /* specification: RFC 2661 */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-lane.c
+++ b/print-lane.c
@@ -22,9 +22,7 @@
 
 /* \summary: ATM LANE printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-ldp.c
+++ b/print-ldp.c
@@ -16,9 +16,7 @@
 
 /* \summary: Label Distribution Protocol (LDP) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-lisp.c
+++ b/print-lisp.c
@@ -94,9 +94,7 @@
  *  +-> +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 #include "netdissect.h"

--- a/print-llc.c
+++ b/print-llc.c
@@ -24,9 +24,7 @@
 
 /* \summary: IEEE 802.2 LLC printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-lldp.c
+++ b/print-lldp.c
@@ -19,9 +19,7 @@
 
 /* \summary: IEEE 802.1ab Link Layer Discovery Protocol (LLDP) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-lmp.c
+++ b/print-lmp.c
@@ -20,9 +20,7 @@
 /* specification: RFC 4204 */
 /* OIF UNI 1.0: https://web.archive.org/web/20160401194747/http://www.oiforum.com/public/documents/OIF-UNI-01.0.pdf */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-loopback.c
+++ b/print-loopback.c
@@ -33,9 +33,7 @@
  * https://web.archive.org/web/20060919181108/http://www.mit.edu/people/jhawk/ctp.pdf
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-lspping.c
+++ b/print-lspping.c
@@ -17,9 +17,7 @@
 
 /* specification: RFC 4379 */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-lwapp.c
+++ b/print-lwapp.c
@@ -19,9 +19,7 @@
 
 /* specification: RFC 5412 */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-lwres.c
+++ b/print-lwres.c
@@ -29,9 +29,7 @@
 
 /* \summary: BIND9 Lightweight Resolver protocol printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-m3ua.c
+++ b/print-m3ua.c
@@ -26,9 +26,7 @@
 
 /* RFC 4666 */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-macsec.c
+++ b/print-macsec.c
@@ -21,9 +21,7 @@
 
 /* \summary: MACsec printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-mobile.c
+++ b/print-mobile.c
@@ -38,9 +38,7 @@
 
 /* \summary: IPv4 mobility printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-mobility.c
+++ b/print-mobility.c
@@ -30,9 +30,7 @@
 /* \summary: IPv6 mobility printer */
 /* RFC 3775 */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-mpcp.c
+++ b/print-mpcp.c
@@ -17,9 +17,7 @@
 
 /* \summary: IEEE 802.3ah Multi-Point Control Protocol (MPCP) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-mpls.c
+++ b/print-mpls.c
@@ -28,9 +28,7 @@
 
 /* \summary: Multi-Protocol Label Switching (MPLS) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-mptcp.c
+++ b/print-mptcp.c
@@ -36,9 +36,7 @@
 
 /* specification: RFC 6824 */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-msdp.c
+++ b/print-msdp.c
@@ -18,9 +18,7 @@
 
 /* \summary: Multicast Source Discovery Protocol (MSDP) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-msnlb.c
+++ b/print-msnlb.c
@@ -28,9 +28,7 @@
 
 /* \summary: MS Network Load Balancing's (NLB) heartbeat printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-nflog.c
+++ b/print-nflog.c
@@ -27,9 +27,7 @@
 
 /* \summary: DLT_NFLOG printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-nfs.c
+++ b/print-nfs.c
@@ -21,9 +21,7 @@
 
 /* \summary: Network File System (NFS) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-nhrp.c
+++ b/print-nhrp.c
@@ -23,9 +23,7 @@
  * I-D draft-detienne-dmvpn-01 (expired)
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-nsh.c
+++ b/print-nsh.c
@@ -25,9 +25,7 @@
 
 /* specification: RFC 8300 */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-ntp.c
+++ b/print-ntp.c
@@ -32,9 +32,7 @@
  * RFC 5905 - NTPv4
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-null.c
+++ b/print-null.c
@@ -21,9 +21,7 @@
 
 /* \summary: BSD loopback device printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-olsr.c
+++ b/print-olsr.c
@@ -21,9 +21,7 @@
 
 /* specification: RFC 3626 */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-openflow-1.0.c
+++ b/print-openflow-1.0.c
@@ -59,9 +59,7 @@
 
 /* \summary: OpenFlow protocol version 1.0 printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-openflow-1.3.c
+++ b/print-openflow-1.3.c
@@ -33,9 +33,7 @@
 
 /* \summary: OpenFlow protocol version 1.3 printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-openflow.c
+++ b/print-openflow.c
@@ -32,9 +32,7 @@
 
 /* \summary: version-independent OpenFlow printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-ospf.c
+++ b/print-ospf.c
@@ -23,9 +23,7 @@
 
 /* \summary: Open Shortest Path First (OSPF) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-ospf6.c
+++ b/print-ospf6.c
@@ -23,9 +23,7 @@
 
 /* \summary: IPv6 Open Shortest Path First (OSPFv3) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-otv.c
+++ b/print-otv.c
@@ -17,9 +17,7 @@
 
 /* specification: draft-hasmit-otv-04 */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-pflog.c
+++ b/print-pflog.c
@@ -21,9 +21,7 @@
 
 /* \summary: *BSD/Darwin packet filter log file printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-pgm.c
+++ b/print-pgm.c
@@ -47,9 +47,7 @@
 
    */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-pim.c
+++ b/print-pim.c
@@ -21,9 +21,7 @@
 
 /* \summary: Protocol Independent Multicast (PIM) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-pktap.c
+++ b/print-pktap.c
@@ -21,9 +21,7 @@
 
 /* \summary: Apple's DLT_PKTAP printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-ppi.c
+++ b/print-ppi.c
@@ -9,9 +9,7 @@
  * https://web.archive.org/web/20160328114748/http://www.cacetech.com/documents/PPI%20Header%20format%201.0.7.pdf
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-ppp.c
+++ b/print-ppp.c
@@ -31,9 +31,7 @@
  * o BAP support
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-pppoe.c
+++ b/print-pppoe.c
@@ -23,9 +23,7 @@
 
 /* \summary: PPP-over-Ethernet (PPPoE) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-pptp.c
+++ b/print-pptp.c
@@ -25,9 +25,7 @@
 
 /* specification: RFC 2637 */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-ptp.c
+++ b/print-ptp.c
@@ -17,9 +17,7 @@
 
 /* specification: https://standards.ieee.org/findstds/standard/1588-2008.html*/
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 #include "netdissect.h"

--- a/print-quic.c
+++ b/print-quic.c
@@ -23,9 +23,7 @@
 /* \summary: QUIC Protocol printer */
 /* specification: https://www.rfc-editor.org/rfc/rfc9000.txt */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 #include "netdissect-alloc.h"

--- a/print-radius.c
+++ b/print-radius.c
@@ -82,9 +82,7 @@
  * TODO: Among other things to print ok MacIntosh and Vendor values
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-raw.c
+++ b/print-raw.c
@@ -21,9 +21,7 @@
 
 /* \summary: Raw IP printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-realtek.c
+++ b/print-realtek.c
@@ -25,9 +25,7 @@
 
 /* \summary: printer for various Realtek protocols */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-resp.c
+++ b/print-resp.c
@@ -29,9 +29,7 @@
 
 /* \summary: REdis Serialization Protocol (RESP) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 #include "netdissect.h"

--- a/print-rip.c
+++ b/print-rip.c
@@ -23,9 +23,7 @@
 
 /* specification: RFC 1058, RFC 2453, RFC 4822 */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-ripng.c
+++ b/print-ripng.c
@@ -23,9 +23,7 @@
 
 /* specification: RFC 2080 */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-rpki-rtr.c
+++ b/print-rpki-rtr.c
@@ -19,9 +19,7 @@
 
 /* specification: RFC 6810 */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-rsvp.c
+++ b/print-rsvp.c
@@ -19,9 +19,7 @@
 
 /* specification: RFC 2205 */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-rt6.c
+++ b/print-rt6.c
@@ -21,9 +21,7 @@
 
 /* \summary: IPv6 routing header printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-rtsp.c
+++ b/print-rtsp.c
@@ -13,9 +13,7 @@
 
 /* \summary: Real Time Streaming Protocol (RTSP) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-rx.c
+++ b/print-rx.c
@@ -35,9 +35,7 @@
  * Ken Hornstein <kenh@cmf.nrl.navy.mil>
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <stdio.h>
 #include <string.h>

--- a/print-sctp.c
+++ b/print-sctp.c
@@ -35,9 +35,7 @@
 
 /* \summary: Stream Control Transmission Protocol (SCTP) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-sflow.c
+++ b/print-sflow.c
@@ -21,9 +21,7 @@
 
 /* specification: https://sflow.org/developers/specifications.php */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-sip.c
+++ b/print-sip.c
@@ -17,9 +17,7 @@
 
 /* \summary: Session Initiation Protocol (SIP) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-sl.c
+++ b/print-sl.c
@@ -21,9 +21,7 @@
 
 /* \summary: Compressed Serial Line Internet Protocol printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-sll.c
+++ b/print-sll.c
@@ -21,9 +21,7 @@
 
 /* \summary: Linux cooked sockets capture printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #ifdef HAVE_NET_IF_H
 /*

--- a/print-slow.c
+++ b/print-slow.c
@@ -20,9 +20,7 @@
 
 /* \summary: IEEE "slow protocols" (802.3ad/802.3ah) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-smb.c
+++ b/print-smb.c
@@ -8,9 +8,7 @@
 
 /* \summary: SMB/CIFS printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-smtp.c
+++ b/print-smtp.c
@@ -13,9 +13,7 @@
 
 /* \summary: Simple Mail Transfer Protocol (SMTP) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-snmp.c
+++ b/print-snmp.c
@@ -58,9 +58,7 @@
 
 /* \summary: Simple Network Management Protocol (SNMP) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-someip.c
+++ b/print-someip.c
@@ -15,9 +15,7 @@
 
 /* \summary: Autosar SOME/IP Protocol printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 #include "netdissect.h"

--- a/print-ssh.c
+++ b/print-ssh.c
@@ -13,9 +13,7 @@
 
 /* \summary: Secure Shell (SSH) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 #include "netdissect-ctype.h"

--- a/print-stp.c
+++ b/print-stp.c
@@ -10,9 +10,7 @@
 
 /* \summary: IEEE 802.1d Spanning Tree Protocol (STP) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-sunatm.c
+++ b/print-sunatm.c
@@ -32,9 +32,7 @@
 
 /* \summary: SunATM DLPI capture printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-sunrpc.c
+++ b/print-sunrpc.c
@@ -21,9 +21,7 @@
 
 /* \summary: Sun Remote Procedure Call printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 /*
  * At least on HP-UX:

--- a/print-symantec.c
+++ b/print-symantec.c
@@ -21,9 +21,7 @@
 
 /* \summary: Symantec Enterprise Firewall printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-syslog.c
+++ b/print-syslog.c
@@ -17,9 +17,7 @@
 /* \summary: Syslog protocol printer */
 /* specification: RFC 3164 (not RFC 5424) */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-tcp.c
+++ b/print-tcp.c
@@ -30,9 +30,7 @@
 __RCSID("$NetBSD: print-tcp.c,v 1.8 2007/07/24 11:53:48 drochner Exp $");
 #endif
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-telnet.c
+++ b/print-telnet.c
@@ -47,9 +47,7 @@
 
 /* \summary: Telnet option printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-tftp.c
+++ b/print-tftp.c
@@ -21,9 +21,7 @@
 
 /* \summary: Trivial File Transfer Protocol (TFTP) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-timed.c
+++ b/print-timed.c
@@ -23,9 +23,7 @@
 
 /* specification: https://docs.freebsd.org/44doc/smm/12.timed/paper.pdf */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-tipc.c
+++ b/print-tipc.c
@@ -27,9 +27,7 @@
  *     https://web.archive.org/web/20161025110514/http://tipc.sourceforge.net/doc/tipc_message_formats.html
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-token.c
+++ b/print-token.c
@@ -26,9 +26,7 @@
 
 /* \summary: Token Ring printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-udld.c
+++ b/print-udld.c
@@ -19,9 +19,7 @@
 
 /* specification: RFC 5171 */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-udp.c
+++ b/print-udp.c
@@ -21,9 +21,7 @@
 
 /* \summary: UDP printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-unsupported.c
+++ b/print-unsupported.c
@@ -16,9 +16,7 @@
 
 /* \summary: unsupported link-layer protocols printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-usb.c
+++ b/print-usb.c
@@ -21,9 +21,7 @@
 
 /* \summary: USB printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-vjc.c
+++ b/print-vjc.c
@@ -23,9 +23,7 @@
 
 /* specification: RFC 1144 */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-vqp.c
+++ b/print-vqp.c
@@ -17,9 +17,7 @@
 
 /* \summary: Cisco VLAN Query Protocol (VQP) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-vrrp.c
+++ b/print-vrrp.c
@@ -25,9 +25,7 @@
 
 /* \summary: Virtual Router Redundancy Protocol (VRRP) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-vsock.c
+++ b/print-vsock.c
@@ -23,9 +23,7 @@
 
 /* \summary: Linux vsock printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 #include <stddef.h>

--- a/print-vtp.c
+++ b/print-vtp.c
@@ -21,9 +21,7 @@
 
 /* \summary: Cisco VLAN Trunking Protocol (VTP) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-vxlan-gpe.c
+++ b/print-vxlan-gpe.c
@@ -25,9 +25,7 @@
 
 /* specification: draft-ietf-nvo3-vxlan-gpe-12 */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-vxlan.c
+++ b/print-vxlan.c
@@ -17,9 +17,7 @@
 
 /* specification: RFC 7348 */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-wb.c
+++ b/print-wb.c
@@ -21,9 +21,7 @@
 
 /* \summary: White Board printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-whois.c
+++ b/print-whois.c
@@ -15,9 +15,7 @@
 
 /* RFC 3912 */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-zep.c
+++ b/print-zep.c
@@ -21,9 +21,7 @@
 
 /* \summary: ZigBee Encapsulation Protocol (ZEP) printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-zephyr.c
+++ b/print-zephyr.c
@@ -22,9 +22,7 @@
 
 /* \summary: Zephyr printer */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print-zeromq.c
+++ b/print-zeromq.c
@@ -28,9 +28,7 @@
 /* \summary: ZeroMQ Message Transport Protocol (ZMTP) printer */
 /* specification: https://rfc.zeromq.org/spec/13/ */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/print.c
+++ b/print.c
@@ -25,9 +25,7 @@
  *	Seth Webster <swebster@sst.ll.mit.edu>
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <stdlib.h>
 #include <string.h>

--- a/signature.c
+++ b/signature.c
@@ -15,9 +15,7 @@
  * Original code by Hannes Gredler (hannes@gredler.at)
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/smbutil.c
+++ b/smbutil.c
@@ -6,9 +6,7 @@
  * or later
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 

--- a/strtoaddr.c
+++ b/strtoaddr.c
@@ -15,9 +15,7 @@
  * OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 #include <stddef.h>

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -33,9 +33,7 @@
  * combined efforts of Van, Steve McCanne and Craig Leres of LBL.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 /*
  * Some older versions of Mac OS X ship pcap.h from libpcap 0.6 with a

--- a/util-print.c
+++ b/util-print.c
@@ -35,9 +35,7 @@
  * FOR A PARTICULAR PURPOSE.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "netdissect-stdinc.h"
 


### PR DESCRIPTION
Builds using Autotools or CMake generate config.h, thus remove the '#ifdef HAVE_CONFIG_H'/'#endif'.

Remove also the 'add_definitions(-DHAVE_CONFIG_H)' in CMakeLists.txt.