### PR TITLE
Remove an unneeded include

### DIFF
--- a/util-print.c
+++ b/util-print.c
@@ -41,9 +41,6 @@
 
 #include <sys/stat.h>
 
-#ifdef HAVE_FCNTL_H
-#include <fcntl.h>
-#endif
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdlib.h>


### PR DESCRIPTION
Remove <fcntl.h> conditional include from util-print.c.

Historically read_infile() was in util.c and used open(), so needed it. When part of util.c became util-print.c without read_infile(), the include was left without need.