### PR TITLE
Include <net/if.h> unconditionally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -344,7 +344,6 @@ cmake_pop_check_state()
 # Header files.
 #
 check_include_file(rpc/rpc.h HAVE_RPC_RPC_H)
-check_include_file(net/if.h HAVE_NET_IF_H)
 if(HAVE_RPC_RPC_H)
     check_include_files("rpc/rpc.h;rpc/rpcent.h" HAVE_RPC_RPCENT_H)
 endif(HAVE_RPC_RPC_H)

--- a/cmakeconfig.h.in
+++ b/cmakeconfig.h.in
@@ -60,9 +60,6 @@
 /* Define to 1 if you have the `rpc' library (-lrpc). */
 #cmakedefine HAVE_LIBRPC 1
 
-/* Define to 1 if you have the <net/if.h> header file. */
-#cmakedefine HAVE_NET_IF_H 1
-
 /* Define to 1 if you have the `openat' function. */
 #cmakedefine HAVE_OPENAT 1
 

--- a/configure.ac
+++ b/configure.ac
@@ -30,7 +30,7 @@ if test "$ac_cv_prog_cc_c99" = "no"; then
 fi
 AC_LBL_C_INIT(V_CCOPT, V_INCLS)
 
-AC_CHECK_HEADERS(rpc/rpc.h rpc/rpcent.h net/if.h)
+AC_CHECK_HEADERS(rpc/rpc.h rpc/rpcent.h)
 #
 # Get the size of a void *, to know whether this is a 32-bit or 64-bit build.
 #

--- a/print-sll.c
+++ b/print-sll.c
@@ -23,14 +23,12 @@
 
 #include <config.h>
 
-#ifdef HAVE_NET_IF_H
 /*
  * Include diag-control.h before <net/if.h>, which too defines a macro
  * named ND_UNREACHABLE.
  */
 #include "diag-control.h"
 #include <net/if.h>
-#endif
 
 #include "netdissect-stdinc.h"
 
@@ -408,21 +406,17 @@ sll2_if_print(netdissect_options *ndo, const struct pcap_pkthdr *h, const u_char
 	u_short ether_type;
 	int llc_hdrlen;
 	u_int hdrlen;
-#ifdef HAVE_NET_IF_H
 	uint32_t if_index;
 	char ifname[IF_NAMESIZE];
-#endif
 
 	ndo->ndo_protocol = "sll2";
 	ND_TCHECK_LEN(p, SLL2_HDR_LEN);
 
 	sllp = (const struct sll2_header *)p;
-#ifdef HAVE_NET_IF_H
 	if_index = GET_BE_U_4(sllp->sll2_if_index);
 	if (!if_indextoname(if_index, ifname))
 		strncpy(ifname, "?", 2);
 	ND_PRINT("%-5s ", ifname);
-#endif
 
 	ND_PRINT("%-3s ",
 		 tok2str(sll_pkttype_values, "?", GET_U_1(sllp->sll2_pkttype)));


### PR DESCRIPTION
It is used for if_indextoname() which is in POSIX.1-2001, POSIX.1-2008.

libpcap has included <net/if.h> unconditionally since at least 1999.