### PR TITLE
SLL2: Translate interface indices to names on Linux only.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -26,6 +26,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
         advance the packet data pointer
       OSPF: Print more truncation indications
       OSPF: Add more length checks
+      SLL2: Translate interface indices to names on Linux only.
       TCP: Add support for the AE (AccECN) flag.
     User interface:
       Add optional unit suffix on -C file size.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -344,7 +344,6 @@ cmake_pop_check_state()
 # Header files.
 #
 check_include_file(rpc/rpc.h HAVE_RPC_RPC_H)
-check_include_file(net/if.h HAVE_NET_IF_H)
 if(HAVE_RPC_RPC_H)
     check_include_files("rpc/rpc.h;rpc/rpcent.h" HAVE_RPC_RPCENT_H)
 endif(HAVE_RPC_RPC_H)

--- a/addrtoname.c
+++ b/addrtoname.c
@@ -75,11 +75,6 @@
   #endif /* what declares ether_ntohost() */
 
   #ifdef NEED_NETINET_IF_ETHER_H
-    /*
-     * Include diag-control.h before <net/if.h>, which too defines a macro
-     * named ND_UNREACHABLE.
-     */
-    #include "diag-control.h"
     #include <net/if.h>		/* Needed on some platforms */
     #include <netinet/in.h>	/* Needed on some platforms */
     #include <netinet/if_ether.h>

--- a/cmakeconfig.h.in
+++ b/cmakeconfig.h.in
@@ -60,9 +60,6 @@
 /* Define to 1 if you have the `rpc' library (-lrpc). */
 #cmakedefine HAVE_LIBRPC 1
 
-/* Define to 1 if you have the <net/if.h> header file. */
-#cmakedefine HAVE_NET_IF_H 1
-
 /* Define to 1 if you have the `openat' function. */
 #cmakedefine HAVE_OPENAT 1
 

--- a/configure.ac
+++ b/configure.ac
@@ -30,7 +30,7 @@ if test "$ac_cv_prog_cc_c99" = "no"; then
 fi
 AC_LBL_C_INIT(V_CCOPT, V_INCLS)
 
-AC_CHECK_HEADERS(rpc/rpc.h rpc/rpcent.h net/if.h)
+AC_CHECK_HEADERS(rpc/rpc.h rpc/rpcent.h)
 #
 # Get the size of a void *, to know whether this is a 32-bit or 64-bit build.
 #

--- a/extract.h
+++ b/extract.h
@@ -37,7 +37,6 @@
  */
 #include "funcattrs.h"
 #include "netdissect.h"
-#include "diag-control.h"
 
 /*
  * If we have versions of GCC or Clang that support an __attribute__

--- a/netdissect.c
+++ b/netdissect.c
@@ -34,6 +34,10 @@
 #include <smi.h>
 #endif
 
+#ifdef _AIX
+#include "diag-control.h"
+#endif /* _AIX */
+
 /*
  * Initialize anything that must be initialized before dissecting
  * packets.

--- a/netdissect.h
+++ b/netdissect.h
@@ -33,7 +33,6 @@
 #include <time.h>
 #include "status-exit-codes.h"
 #include "funcattrs.h" /* for PRINTFLIKE_FUNCPTR() */
-#include "diag-control.h" /* for ND_UNREACHABLE */
 
 /*
  * Data types corresponding to multi-byte integral values within data

--- a/print-sll.c
+++ b/print-sll.c
@@ -23,7 +23,7 @@
 
 #include <config.h>
 
-#ifdef HAVE_NET_IF_H
+#ifdef __linux__
 #include <net/if.h>
 #endif
 
@@ -403,7 +403,7 @@ sll2_if_print(netdissect_options *ndo, const struct pcap_pkthdr *h, const u_char
 	u_short ether_type;
 	int llc_hdrlen;
 	u_int hdrlen;
-#ifdef HAVE_NET_IF_H
+#ifdef __linux__
 	uint32_t if_index;
 	char ifname[IF_NAMESIZE];
 #endif
@@ -412,7 +412,7 @@ sll2_if_print(netdissect_options *ndo, const struct pcap_pkthdr *h, const u_char
 	ND_TCHECK_LEN(p, SLL2_HDR_LEN);
 
 	sllp = (const struct sll2_header *)p;
-#ifdef HAVE_NET_IF_H
+#ifdef __linux__
 	if_index = GET_BE_U_4(sllp->sll2_if_index);
 	if (!if_indextoname(if_index, ifname))
 		strncpy(ifname, "?", 2);

--- a/print-sll.c
+++ b/print-sll.c
@@ -24,11 +24,6 @@
 #include <config.h>
 
 #ifdef HAVE_NET_IF_H
-/*
- * Include diag-control.h before <net/if.h>, which too defines a macro
- * named ND_UNREACHABLE.
- */
-#include "diag-control.h"
 #include <net/if.h>
 #endif
 

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -2166,7 +2166,7 @@ main(int argc, char **argv)
 				pcap_datalink_val_to_description(dlt));
 		}
 		fprintf(stderr, ", snapshot length %d\n", pcap_snapshot(pd));
-#ifdef DLT_LINUX_SLL2
+#if defined(DLT_LINUX_SLL2) && defined(__linux__)
 		if (dlt == DLT_LINUX_SLL2)
 			fprintf(stderr, "Warning: interface names might be incorrect\n");
 #endif


### PR DESCRIPTION
As discussed in pull request #1161.