### PR TITLE
Makefile.in: Fix the depend target / mkdep: Exit with a non-zero status if a command fails

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -559,8 +559,8 @@ testlist:
 	echo $(TEST_DIST)
 
 depend:
-	@echo $(MKDEP) -c "$(CC)" -m "$(DEPENDENCY_CFLAG)" -s "$(srcdir)" $(DEFS) $(INCLS) $(SRC) '<libnetdissect src list>'
-	@$(MKDEP) -c "$(CC)" -m "$(DEPENDENCY_CFLAG)" -s "$(srcdir)" $(DEFS) $(INCLS) $(SRC) $(LIBNETDISSECT_SRC)
+	@echo $(MKDEP) -c $(CC) -m "$(DEPENDENCY_CFLAG)" -s "$(srcdir)" $(DEFS) $(INCLS) $(SRC) '<libnetdissect src list>'
+	@$(MKDEP) -c $(CC) -m "$(DEPENDENCY_CFLAG)" -s "$(srcdir)" $(DEFS) $(INCLS) $(SRC) $(LIBNETDISSECT_SRC)
 
 shellcheck:
 	shellcheck -f gcc -e SC2006 autogen.sh build.sh build_matrix.sh build_common.sh mkdep .ci-coverity-scan-build.sh

--- a/mkdep
+++ b/mkdep
@@ -1,4 +1,4 @@
-#!/bin/sh -
+#!/bin/sh -e
 #
 # Copyright (c) 1994, 1996
 #	The Regents of the University of California.  All rights reserved.


### PR DESCRIPTION
```
Fix an error on Solaris 10 like:
./mkdep: /opt/solarisstudio12.3/bin/cc -D_STDC_C99=: not found

When configure get some compiler option like:
checking for /opt/solarisstudio12.3/bin/cc option to accept ISO C99...
-D_STDC_C99=
Makefile will contain:
CC = /opt/solarisstudio12.3/bin/cc -D_STDC_C99=

And if we use '-c "$(CC)"' mkdep will set and try to run:
CC="/opt/solarisstudio12.3/bin/cc -D_STDC_C99=", which is incorrect.

Remove the quotes to allow mkdep to set CC with the compiler name and
set flags with the option.
```