### PR TITLE
Print NTP kiss codes for NTP debugging

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -24,6 +24,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       NetFlow: Use tcp_flag_values[] for TCP flags.
       NTP: Check that the entire extension field is in the capture even
         if it isn't printed
+      NTP: Print kiss codes relevant for NTP debugging.
       MPTCP: parse MPC data_len field, print flags from MP_CAPABLE option.
       OSPF: Fix printing of Traffic Engineering Link TLVs to correctly
         advance the packet data pointer

--- a/tests/ntp-v.out
+++ b/tests/ntp-v.out
@@ -13,7 +13,7 @@
     2  2017-06-19 14:12:10.231082 IP (tos 0xb8, ttl 64, id 24722, offset 0, flags [DF], proto UDP (17), length 80)
     192.168.100.1.123 > 192.168.100.2.58054: NTPv4, Server, length 52
 	Leap indicator: clock unsynchronized (192), Stratum 0 (unspecified), poll 3 (8s), precision -23
-	Root Delay: 0.000000, Root dispersion: 0.001373, Reference-ID: (unspec)
+	Root Delay: 0.000000, Root dispersion: 0.001373, Reference-ID: STEP
 	  Reference Timestamp:  0.000000000
 	  Originator Timestamp: 2763234513.007738396 (1987-07-25T21:08:33Z)
 	  Receive Timestamp:    3706870329.516015118 (2017-06-19T14:12:09Z)
@@ -68,7 +68,7 @@
     7  2017-06-19 14:47:12.800853 IP (tos 0xc0, ttl 64, id 4575, offset 0, flags [DF], proto UDP (17), length 96)
     192.168.100.2.123 > 192.168.100.1.123: NTPv4, Client, length 68
 	Leap indicator: clock unsynchronized (192), Stratum 0 (unspecified), poll 6 (64s), precision -25
-	Root Delay: 0.000000, Root dispersion: 0.000000, Reference-ID: (unspec)
+	Root Delay: 0.000000, Root dispersion: 0.000000, Reference-ID: INIT
 	  Reference Timestamp:  0.000000000
 	  Originator Timestamp: 0.000000000
 	  Receive Timestamp:    0.000000000


### PR DESCRIPTION
NTPv4 (RFC 5905, section 7.4) and SNTPv4 (RFC 4330, section 8) formalize that if the stratum value is zero, the refid _may_ contain a printable ("designed for character displays and log files"), left justified, zero filled ASCII string for status reporting and debugging ("kiss code"). Some kiss codes are defined in the RFCs, but the list may be modified or extended in the future, and unregistered kiss codes, e.g., for experimentation and development, are possible (and are being seen in the field).

Thus, if the stratum value is zero AND the refid field begins with a printable character, assume the refid field contains a kiss code and print it.