### PR TITLE
CI: Add TinyCC (aka TCC) support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -35,6 +35,12 @@ print_cc_version
 # later warnings in the same matrix subset trigger an error.
 
 case `cc_id`/`os_id` in
+tcc-*/*)
+    # print-802_11.c:3317: warning: assignment discards qualifiers from pointer
+    #   target type
+    # print-esp.c:373: warning: function might return no value: 'ldp_pdu_print'
+    TCPDUMP_TAINTED=yes
+    ;;
 *)
     ;;
 esac

--- a/build_common.sh
+++ b/build_common.sh
@@ -63,7 +63,7 @@ print_sysinfo() {
 cc_version_nocache() {
     : "${CC:?}"
     case `basename "$CC"` in
-    gcc*|egcc*|clang*)
+    gcc*|egcc*|clang*|tcc*)
         # GCC and Clang recognize --version, print to stdout and exit with 0.
         "$CC" --version
         ;;
@@ -151,6 +151,17 @@ cc_id_nocache() {
         return
     fi
 
+    # Examples of installed packages:
+    # "tcc version 0.9.27 (x86_64 Linux)"
+    # "tcc version 0.9.27 2023-07-05 mob@5b28165 (x86_64 OpenBSD)"
+    # Example of a development version:
+    # "tcc version 0.9.28rc 2024-04-28 mob@0aca8611 (x86_64 Linux)"
+    cc_id_guessed=`echo "$cc_id_firstline" | sed 's/^.*tcc version \([0-9\.rc]*\).*$/tcc-\1/'`
+    if [ "$cc_id_firstline" != "$cc_id_guessed" ]; then
+        echo "$cc_id_guessed"
+        return
+    fi
+
     # OpenBSD default GCC:
     # "gcc (GCC) 4.2.1 20070719"
     # RedHat GCC:
@@ -187,7 +198,7 @@ discard_cc_cache() {
 # warnings as errors.
 cc_werr_cflags() {
     case `cc_id` in
-    gcc-*|clang-*)
+    gcc-*|clang-*|tcc-*)
         echo '-Werror'
         ;;
     xlc-*)

--- a/funcattrs.h
+++ b/funcattrs.h
@@ -52,13 +52,14 @@
     || ND_IS_AT_LEAST_GNUC_VERSION(2,5) \
     || ND_IS_AT_LEAST_SUNC_VERSION(5,9) \
     || ND_IS_AT_LEAST_XL_C_VERSION(10,1) \
-    || ND_IS_AT_LEAST_HP_C_VERSION(6,10)
+    || ND_IS_AT_LEAST_HP_C_VERSION(6,10) \
+    || __TINYC__
   /*
    * Compiler with support for __attribute((noreturn)), or GCC 2.5 and
    * later, or some compiler asserting compatibility with GCC 2.5 and
    * later, or Solaris Studio 12 (Sun C 5.9) and later, or IBM XL C 10.1
    * and later (do any earlier versions of XL C support this?), or HP aCC
-   * A.06.10 and later.
+   * A.06.10 and later, or current TinyCC.
    */
   #define NORETURN __attribute((noreturn))
 


### PR DESCRIPTION
Identification examples: tcc-0.9.27, tcc-0.9.28rc

There are currently warnings such as:
print-802_11.c:3317: warning: assignment discards qualifiers from pointer target type
print-esp.c:373: warning: function might return no value: 'hexdigit'
So use: TCPDUMP_TAINTED=yes

Works on linux-amd64.
Does not work on linux-armv7l with BUILD_LIBPCAP=yes / CMAKE=yes
(Segmentation fault, libpcap dynamically linked). Works with 0.9.28rc.

TinyCC can be found at https://bellard.org/tcc/,
https://repo.or.cz/r/tinycc.git or as package on some distros.