### PR TITLE
esp: mark unreached code as such.

### DIFF
--- a/print-esp.c
+++ b/print-esp.c
@@ -368,6 +368,7 @@ static u_int hexdigit(netdissect_options *ndo, char hex)
 	else {
 		(*ndo->ndo_error)(ndo, S_ERR_ND_ESP_SECRET,
 				  "invalid hex digit %c in espsecret\n", hex);
+		/* NOTREACHED */
 	}
 }
 


### PR DESCRIPTION
Some compilers might not understand the declaration of the ndo_error member of an netdissect_options as pointing to a function that never returns; add a /* NOTREACHED */ comment in case they recognize that as a hint.