### PR TITLE
Autoconf: Use V_INCLS to update the list of include search paths

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -735,7 +735,7 @@ AC_ARG_WITH(crypto,
 		# Put the subdirectories of the libcrypto root directory
 		# at the front of the header and library search path.
 		#
-		CFLAGS="-I$withval/include $CFLAGS"
+		V_INCLS="-I$withval/include $V_INCLS"
 		LIBS="-L$withval/lib $LIBS"
 	fi
 ],[


### PR DESCRIPTION
This is the one used in the Makefile depend target via INCLS.