### PR TITLE
autotools: don't put anything before -I and -L flags for local libpcap.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -733,10 +733,14 @@ AC_ARG_WITH(crypto,
 
 		#
 		# Put the subdirectories of the libcrypto root directory
-		# at the front of the header and library search path.
+		# at the end of the header and library search path, to
+		# make sure they come after any -I or -L flags for
+		# a local libpcap - those must take precedence of any
+		# directory that might contain an installed version of
+		# libpcap.
 		#
-		V_INCLS="-I$withval/include $V_INCLS"
-		LIBS="-L$withval/lib $LIBS"
+		V_INCLS="$V_INCLS -I$withval/include"
+		LIBS="$LIBS -L$withval/lib"
 	fi
 ],[
 	#


### PR DESCRIPTION
Those might point to a directory with headers and libraries for an installed version of libpcap; if we've already decided to use a local version in the source tree next to us, don't put -I and -L flags from --with-crypto in front of them, put those flags *after* what's already in V_INCLS and LIBS.