### PR TITLE
CMake: check for pcap_findalldevs_ex.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -760,6 +760,7 @@ if(NOT APPLE OR NOT
    (PCAP_LIBRARIES MATCHES "/usr/lib/.*" OR
     PCAP_LIBRARIES MATCHES "/Application/Xcode.app/.*"))
     check_function_exists(pcap_open HAVE_PCAP_OPEN)
+    check_function_exists(pcap_findalldevs_ex HAVE_PCAP_FINDALLDEVS_EX)
 endif()
 
 #


### PR DESCRIPTION
We do so for autotools, and we currently have separate ifdefs for pcap_open and pcap_findalldevs_ex, rather than treating the presence of pcap_open as an indication that we have the entire remote capture API (the latter is what Wireshark does).