### PR TITLE
esp: don't use EVP_add_cipher_alias().

### DIFF
--- a/print-esp.c
+++ b/print-esp.c
@@ -425,6 +425,7 @@ espprint_decode_encalgo(netdissect_options *ndo,
 	const EVP_CIPHER *evp;
 	int authlen = 0;
 	char *colon, *p;
+	const char *real_decode;
 
 	colon = strchr(decode, ':');
 	if (colon == NULL) {
@@ -445,10 +446,23 @@ espprint_decode_encalgo(netdissect_options *ndo,
 		p = strstr(decode, "-cbc");
 		*p = '\0';
 	}
-	evp = EVP_get_cipherbyname(decode);
+	/*
+	 * Not all versions of libcrypto support calls to add aliases
+	 * to ciphers - newer versions of libressl don't - so, instead
+	 * of making "3des" an alias for "des_ede3_cbc", if attempting
+	 * to get the cipher fails and the name is "3des", we try
+	 * "des_ede3_cbc".
+	 */
+	real_decode = decode;
+	if (strcmp(real_decode, "3des") == 0)
+		real_decode = "des-ede3-cbc";
+	evp = EVP_get_cipherbyname(real_decode);
 
 	if (!evp) {
-		(*ndo->ndo_warning)(ndo, "failed to find cipher algo %s\n", decode);
+		if (decode != real_decode)
+			(*ndo->ndo_warning)(ndo, "failed to find cipher algo %s (%s)\n", real_decode, decode);
+		else
+			(*ndo->ndo_warning)(ndo, "failed to find cipher algo %s\n", decode);
 		sa->evp = NULL;
 		sa->authlen = 0;
 		sa->ivlen = 0;
@@ -684,7 +698,6 @@ static void esp_init(netdissect_options *ndo _U_)
 #if !defined(OPENSSL_API_COMPAT) || OPENSSL_API_COMPAT < 0x10100000L
 	OpenSSL_add_all_algorithms();
 #endif
-	EVP_add_cipher_alias(SN_des_ede3_cbc, "3des");
 }
 DIAG_ON_DEPRECATION
 


### PR DESCRIPTION
It's described in
https://github.com/openssl/openssl/issues/11715#issuecomment-2164442688 as being one of several routines that "are internal macros and not really suitable for the Brave New Provider World", and the bug in question complains that they're not documented.

Instead, just map "3des" to "des-ede3-cbc" ourselves.

This should fix #1175.