### PR TITLE
Address build and test errors with recent LibreSSL (GH #1175).

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -60,6 +60,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       Make illumos build warning-free.
       Makefile.in: Update the .c.o build rule (Remove hacks for old SunOS 4).
       Autoconf: fix buggy tests for ether_ntohost().
+      Address build and test errors with recent LibreSSL (GH #1175).
 
 DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
   Summary for 4.99.5 tcpdump release (so far!)

--- a/print-esp.c
+++ b/print-esp.c
@@ -684,7 +684,11 @@ static void esp_init(netdissect_options *ndo _U_)
 #if !defined(OPENSSL_API_COMPAT) || OPENSSL_API_COMPAT < 0x10100000L
 	OpenSSL_add_all_algorithms();
 #endif
+
+	// Does not exist since LibreSSL 3.9.0.
+#ifndef LIBRESSL_VERSION_NUMBER
 	EVP_add_cipher_alias(SN_des_ede3_cbc, "3des");
+#endif
 }
 DIAG_ON_DEPRECATION
 

--- a/tests/crypto.tests
+++ b/tests/crypto.tests
@@ -3,7 +3,7 @@
 # Only attempt OpenSSL-specific tests when compiled with the library.
 # Reading the secret(s) from a file does not work with Capsicum.
 
-$testlist = [
+$testlist_3des = [
     {
         config_set => 'HAVE_LIBCRYPTO',
         name => 'esp1',
@@ -40,18 +40,20 @@ $testlist = [
     {
         config_set   => 'HAVE_LIBCRYPTO',
         config_unset => 'HAVE_CAPSICUM',
-        name => 'esp5',
-        input => '08-sunrise-sunset-aes.pcap',
-        output => 'esp5.out',
-        args   => '-E "file @TESTDIR@/esp-secrets.txt"',
-    },
-
-    {
-        config_set   => 'HAVE_LIBCRYPTO',
-        config_unset => 'HAVE_CAPSICUM',
         name => 'espudp1',
         input => 'espudp1.pcap',
         output => 'espudp1.out',
+        args   => '-E "file @TESTDIR@/esp-secrets.txt"',
+    },
+];
+
+$testlist_other = [
+    {
+        config_set   => 'HAVE_LIBCRYPTO',
+        config_unset => 'HAVE_CAPSICUM',
+        name => 'esp5',
+        input => '08-sunrise-sunset-aes.pcap',
+        output => 'esp5.out',
         args   => '-E "file @TESTDIR@/esp-secrets.txt"',
     },
 
@@ -110,5 +112,19 @@ $testlist = [
     },
 
 ];
+
+$testlist = [];
+
+# On OpenBSD skip, with appropriate reason, all tests that use 3DES because
+# tcpdump 3DES support depends on EVP_add_cipher_alias(), which LibreSSL no
+# longer supports, and on OpenBSD libcrypto is LibreSSL by default.
+foreach(@$testlist_3des) {
+    if($^O eq "openbsd") {
+        $_->{config_unset} = 'IS_OPENBSD';
+    }
+    push(@$testlist, ($_));
+}
+
+push(@$testlist, @$testlist_other);
 
 1;


### PR DESCRIPTION
Buildbot builders now do not define `MATRIX_CRYPTO=no` on OpenBSD, let's see if these changes pass as expected.