### PR TITLE
crypto.tests: Remove an useless option

### DIFF
--- a/tests/crypto.tests
+++ b/tests/crypto.tests
@@ -52,7 +52,7 @@ $testlist = [
         name => 'espudp1',
         input => 'espudp1.pcap',
         output => 'espudp1.out',
-        args   => '-nnnn -E "file @TESTDIR@/esp-secrets.txt"',
+        args   => '-E "file @TESTDIR@/esp-secrets.txt"',
     },
 
     {


### PR DESCRIPTION
'-nnnn' is useless because '-n' is already used in TESTrun. Valid values for ndo_nflag are 0 or 1.