### PR TITLE
Don't touch groups with -Z root.

### DIFF
--- a/tcpdump.c
+++ b/tcpdump.c
@@ -724,7 +724,10 @@ droproot(const char *username, const char *chroot_dir)
 				fprintf(stderr, "dropped privs to %s\n", username);
 		}
 #else
-		if (initgroups(pw->pw_name, pw->pw_gid) != 0 ||
+
+		if ((pw->pw_gid == 0) && (pw->pw_uid == 0))
+			fprintf(stderr, "requested to not drop privs\n");
+		else if (initgroups(pw->pw_name, pw->pw_gid) != 0 ||
 		    setgid(pw->pw_gid) != 0 || setuid(pw->pw_uid) != 0)
 			error("Couldn't change to '%.32s' uid=%lu gid=%lu: %s",
 				username,


### PR DESCRIPTION
In single-user namespaces, calling initgroups() is forbidden. This enables tcpdump to be compiled with forced privilege separation while keeping the ability to actually run in an isolated environment where the privilege separation is already done by other means.