### PR TITLE
Fix Memory Leak and Improve Error Handling in `find_interface_by_number` Function

### DIFF
--- a/tcpdump.c
+++ b/tcpdump.c
@@ -1164,12 +1164,12 @@ _U_
 #endif
         status = pcap_findalldevs(&devlist, ebuf);
         if (status < 0) {
-		      if (devlist != NULL) {
-			        pcap_freealldevs(devlist);
-		      }
-		      error("%s", ebuf);
-	        return NULL;
-      }
+  		      if (devlist != NULL) {
+	  		        pcap_freealldevs(devlist);
+		        }
+		        error("%s", ebuf);
+	          return NULL;
+        }
 
 	/*
 	 * Look for the devnum-th entry in the list of devices (1-based).

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -1162,15 +1162,14 @@ _U_
 		free(host_url);
 	} else
 #endif
-      status = pcap_findalldevs(&devlist, ebuf);
-
-    if (status < 0) {
-		  if (devlist != NULL) {
-			  pcap_freealldevs(devlist);
-		  }
-		error("%s", ebuf);
-		return NULL;
-	}
+        status = pcap_findalldevs(&devlist, ebuf);
+        if (status < 0) {
+		        if (devlist != NULL) {
+			          pcap_freealldevs(devlist);
+		        }
+		        error("%s", ebuf);
+		        return NULL;
+	      }
 
 	/*
 	 * Look for the devnum-th entry in the list of devices (1-based).

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -1162,7 +1162,7 @@ _U_
 		free(host_url);
 	} else
 #endif
-    status = pcap_findalldevs(&devlist, ebuf);
+      status = pcap_findalldevs(&devlist, ebuf);
 
     if (status < 0) {
 		  if (devlist != NULL) {

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -1162,17 +1162,27 @@ _U_
 		free(host_url);
 	} else
 #endif
-	status = pcap_findalldevs(&devlist, ebuf);
-	if (status < 0)
+    status = pcap_findalldevs(&devlist, ebuf);
+
+    if (status < 0) {
+		  if (devlist != NULL) {
+			  pcap_freealldevs(devlist);
+		  }
 		error("%s", ebuf);
+		return NULL;
+	}
+
 	/*
 	 * Look for the devnum-th entry in the list of devices (1-based).
 	 */
-	for (i = 0, dev = devlist; i < devnum-1 && dev != NULL;
-	    i++, dev = dev->next)
-		;
-	if (dev == NULL)
+
+	for (i = 0, dev = devlist; i < devnum - 1 && dev != NULL; i++, dev = dev->next);
+	if (dev == NULL) {
+		pcap_freealldevs(devlist);
 		error("Invalid adapter index");
+		return NULL;
+	}
+
 	device = strdup(dev->name);
 	pcap_freealldevs(devlist);
 	return (device);

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -1164,12 +1164,12 @@ _U_
 #endif
         status = pcap_findalldevs(&devlist, ebuf);
         if (status < 0) {
-		        if (devlist != NULL) {
-			          pcap_freealldevs(devlist);
-		        }
-		        error("%s", ebuf);
-		        return NULL;
-	      }
+		      if (devlist != NULL) {
+			        pcap_freealldevs(devlist);
+		      }
+		      error("%s", ebuf);
+	        return NULL;
+      }
 
 	/*
 	 * Look for the devnum-th entry in the list of devices (1-based).


### PR DESCRIPTION
## What and Why

This pull request addresses a potential memory leak and improves error handling in the `find_interface_by_number` function within `tcpdump.c`. The issue was identified when the `pcap_findalldevs` or `pcap_findalldevs_ex` function call failed, leading to an early exit without freeing the allocated memory for the device list (`devlist`). This pull request ensures proper memory management by freeing resources before exiting the function on error.

