### PR TITLE
TCP: Print notes about Urgent Pointer and Acknowledgment Number in some cases

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -65,6 +65,8 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
   Summary for 4.99.6 tcpdump release (so far!)
     Refine protocol decoding for:
       IPv6: Add a missing comma and remove a colon in the output.
+      TCP: Note if the Urgent Pointer is non-zero while URG flag not set,
+           if the verbose level is > 1 (option -vv and more).
 
 Friday, August 30, 2024 / The Tcpdump Group
   Summary for 4.99.5 tcpdump release

--- a/CHANGES
+++ b/CHANGES
@@ -67,6 +67,8 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       IPv6: Add a missing comma and remove a colon in the output.
       TCP: Note if the Urgent Pointer is non-zero while URG flag not set,
            if the verbose level is > 1 (option -vv and more).
+      TCP: Note if the Acknowledgment Number is non-zero while ACK flag not set,
+           if the verbose level is > 1 (option -vv and more).
 
 Friday, August 30, 2024 / The Tcpdump Group
   Summary for 4.99.5 tcpdump release

--- a/print-tcp.c
+++ b/print-tcp.c
@@ -425,9 +425,11 @@ tcp_print(netdissect_options *ndo,
                 }
         }
 
-        if (flags & TH_ACK) {
+        if (flags & TH_ACK)
                 ND_PRINT(", ack %u", ack);
-        }
+        else
+                if (ndo->ndo_vflag > 1 && ack != 0)
+                        ND_PRINT(", [ack %u != 0 while ACK flag not set]", ack);
 
         ND_PRINT(", win %u", win);
 

--- a/print-tcp.c
+++ b/print-tcp.c
@@ -433,6 +433,9 @@ tcp_print(netdissect_options *ndo,
 
         if (flags & TH_URG)
                 ND_PRINT(", urg %u", urp);
+        else
+                if (ndo->ndo_vflag > 1 && urp != 0)
+                        ND_PRINT(", [urg %u != 0 while URG flag not set]", urp);
         /*
          * Handle any options.
          */

--- a/tests/TESTLIST
+++ b/tests/TESTLIST
@@ -783,6 +783,7 @@ rsvp_uni-oobr-1	rsvp_uni-oobr-1.pcap	rsvp_uni-oobr-1.out	-v
 rsvp_uni-oobr-2	rsvp_uni-oobr-2.pcap	rsvp_uni-oobr-2.out	-v
 rsvp_uni-oobr-3	rsvp_uni-oobr-3.pcap	rsvp_uni-oobr-3.out	-v
 rpki-rtr-oobr		rpki-rtr-oobr.pcap	rpki-rtr-oobr.out	-v
+rpki-rtr-oobr-vv	rpki-rtr-oobr.pcap	rpki-rtr-oobr-vv.out	-vv
 lldp_8023_mtu-oobr	lldp_8023_mtu-oobr.pcap	lldp_8023_mtu-oobr.out	-v
 bgp_vpn_rt-oobr	bgp_vpn_rt-oobr.pcap	bgp_vpn_rt-oobr.out	-v -c1
 cfm_sender_id-oobr	cfm_sender_id-oobr.pcap	cfm_sender_id-oobr.out	-v

--- a/tests/geneve-gcp.out
+++ b/tests/geneve-gcp.out
@@ -1,4 +1,4 @@
     1  2022-03-21 10:31:03.250708 IP (tos 0x0, ttl 2, id 0, offset 0, flags [DF], proto UDP (17), length 116)
     192.168.100.254.62974 > 192.168.100.3.6081: [no cksum] Geneve, Flags [none], vni 0x0, options [class Google (0x132) type 0x1 len 8 data 800000d1, class Google (0x132) type 0x2 len 20 data 0800000d c0a86402 00000000 00000000, class Google (0x132) type 0x3 len 12 data 00000000 00001234]
 	IP (tos 0x0, ttl 64, id 55620, offset 0, flags [none], proto TCP (6), length 40)
-    192.168.100.2.2905 > 192.168.100.1.8080: Flags [none], cksum 0xf547 (correct), seq 760929856, win 512, length 0
+    192.168.100.2.2905 > 192.168.100.1.8080: Flags [none], cksum 0xf547 (correct), seq 760929856, [ack 2028584922 != 0 while ACK flag not set], win 512, length 0

--- a/tests/rpki-rtr-oobr-vv.out
+++ b/tests/rpki-rtr-oobr-vv.out
@@ -1,0 +1,3 @@
+    1  1975-04-27 03:20:48.134349590 IP [total length 62 > length 50] (invalid) (tos 0x0, ttl 254, id 13327, offset 0, flags [+, DF, rsvd], proto TCP (6), length 62, bad cksum 8e7f (->c283)!)
+    19.128.128.20.323 > 76.19.6.127.49600: Flags [e], seq 2684354563:2684354585, win 28672, [urg 770 != 0 while URG flag not set], length 22
+	RPKI-RTRv171 (unknown)

--- a/tests/rpki-rtr-oobr-vv.out
+++ b/tests/rpki-rtr-oobr-vv.out
@@ -1,3 +1,3 @@
     1  1975-04-27 03:20:48.134349590 IP [total length 62 > length 50] (invalid) (tos 0x0, ttl 254, id 13327, offset 0, flags [+, DF, rsvd], proto TCP (6), length 62, bad cksum 8e7f (->c283)!)
-    19.128.128.20.323 > 76.19.6.127.49600: Flags [e], seq 2684354563:2684354585, win 28672, [urg 770 != 0 while URG flag not set], length 22
+    19.128.128.20.323 > 76.19.6.127.49600: Flags [e], seq 2684354563:2684354585, [ack 3892371968 != 0 while ACK flag not set], win 28672, [urg 770 != 0 while URG flag not set], length 22
 	RPKI-RTRv171 (unknown)


### PR DESCRIPTION
1) Note if the Urgent Pointer is non-zero while URG flag not set.
If verbose level is > 1 (option -vv and more).
Add a test case (existing pcap printed with -vv).

2) Note if the Acknowledgment Number is non-zero while ACK flag not set.
If verbose level is > 1 (option -vv and more).
Update the outputs of 2 tests accordingly.

Like tshark/wireshark.