### PR TITLE
MSDP: Modernize packet parsing

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -42,7 +42,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       Remove unused missing/snprintf.c.
       Remove unused missing/strdup.c.
       (FIXME: somebody please wrap the line below just before the release)
-      AODV, AppleTalk, BOOTP, CHDLC, DCCP, EAP, EGP, EIGRP, ForCES, Geneve, GRE, ICMP, Juniper, L2TP, mobile, NetFlow, NFLOG, NTP, OLSR, pflog, PGM, RADIUS, RIP, RSVP, SCTP, SNMP, TCP, UDP, vsock: Modernize packet parsing style
+      AODV, AppleTalk, BOOTP, CHDLC, DCCP, EAP, EGP, EIGRP, ForCES, Geneve, GRE, ICMP, Juniper, L2TP, mobile, MSDP, NetFlow, NFLOG, NTP, OLSR, pflog, PGM, RADIUS, RIP, RSVP, SCTP, SNMP, TCP, UDP, vsock: Modernize packet parsing style
       DCCP, EGP: Replace custom code with tok2str()
       UDP: Clean up address and port printing.
       AppleTalk: Declutter appletalk.h.


### PR DESCRIPTION
Use ND_ICHECK_U() in length/type tests and add an 'invalid' label. Remove the 'trunc' label.
Move '#define ND_LONGJMP_FROM_TCHECK' just before '#include "netdissect.h"' as for all other uses.