### PR TITLE
netdissect-stdinc: get rid of an extra definition of strdup.

### DIFF
--- a/netdissect-stdinc.h
+++ b/netdissect-stdinc.h
@@ -166,7 +166,6 @@
    */
   #define isatty _isatty
   #define stat _stat
-  #define strdup _strdup
   #define open _open
   #define read _read
   #define close _close


### PR DESCRIPTION
We first unconditionally define it, and then later only define it if it's already defined.  Microsoft defines it for us, but has deprecated that definition because it pollutes the ISO C namespace with a POSIXism; try just doing the conditional definition.