### PR TITLE
Makefile.in: Use a local libpcap in the releasecheck target

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -39,6 +39,7 @@ linux_task:
   script:
     - apt-get -qy update >/dev/null
     - apt-get -qy install autoconf make gcc libpcap-dev >/dev/null # for "./configure"
+    - apt-get -qy install flex bison libdbus-1-dev libbluetooth-dev libnl-genl-3-dev libibverbs-dev >/dev/null # for libpcap
     - apt-get -qy install cmake git binutils-dev >/dev/null # for "make releasecheck"
     - apt-get -qy install shellcheck >/dev/null
     - ./autogen.sh

--- a/Makefile.in
+++ b/Makefile.in
@@ -493,6 +493,22 @@ releasecheck: releasetar
 	INSTALL_DIR=/tmp/install_"$$TAG"_$$$$ && \
 	DIR=`pwd` && \
 	cd /tmp && \
+	rm -rf libpcap && \
+	rm -rf install_libpcap && \
+	echo "[$@] $$ git clone [...] libpcap.git" && \
+	git clone --depth 3 --quiet https://github.com/the-tcpdump-group/libpcap.git && \
+	echo "[$@] $$ cd libpcap" && \
+	cd libpcap && \
+	echo "[$@] $$ ./autogen.sh" && \
+	./autogen.sh && \
+	echo "[$@] $$ ./configure --quiet --prefix=/tmp/install_libpcap" && \
+	./configure --quiet --prefix=/tmp/install_libpcap && \
+	echo "[$@] $$ make -s " && \
+	make -s && \
+	echo "[$@] $$ make -s install" && \
+	make -s install && \
+	echo "[$@] $$ cd .." && \
+	cd .. && \
 	rm -rf "$$TAG" && \
 	rm -rf "$$INSTALL_DIR" && \
 	tar xf "$$DIR"/"$$TAG".tar.gz && \
@@ -514,6 +530,8 @@ releasecheck: releasetar
 	touch .devel && \
 	mkdir build && \
 	cd build && \
+	echo "[$@] $$ export PKG_CONFIG_PATH=/tmp/install_libpcap/lib/pkgconfig" && \
+	export PKG_CONFIG_PATH=/tmp/install_libpcap/lib/pkgconfig && \
 	echo '[$@] $$ cmake -DENABLE_SMB=yes [...] ..' && \
 	cmake -DENABLE_SMB=yes \
 	    -DCMAKE_INSTALL_PREFIX="$$INSTALL_DIR" \
@@ -528,6 +546,8 @@ releasecheck: releasetar
 	cd ../.. && \
 	rm -rf "$$TAG" && \
 	rm -rf "$$INSTALL_DIR" && \
+	rm -rf install_libpcap && \
+	rm -rf libpcap && \
 	echo '[$@] Done.'
 
 whitespacecheck:


### PR DESCRIPTION
This may avoid errors in make check, depending on the system's libpcap version.

Update the Cirrus CI configuration, linux_task, accordingly.