### PR TITLE
Update the ND_ICHECKMSG_U and ND_ICHECKMSG_ZU macro definitions

### DIFF
--- a/netdissect.h
+++ b/netdissect.h
@@ -410,10 +410,12 @@ NORETURN void nd_trunc_longjmp(netdissect_options *ndo);
  * a custom message, format %u
  */
 #define ND_ICHECKMSG_U(message, expression_1, operator, expression_2) \
+do { \
 if ((expression_1) operator (expression_2)) { \
 ND_PRINT(" [%s %u %s %u]", (message), (expression_1), (#operator), (expression_2)); \
 goto invalid; \
-}
+} \
+} while (0)
 
 /*
  * Check (expression_1 operator expression_2) for invalid packet with
@@ -427,10 +429,12 @@ ND_ICHECKMSG_U((#expression_1), (expression_1), operator, (expression_2))
  * a custom message, format %zu
  */
 #define ND_ICHECKMSG_ZU(message, expression_1, operator, expression_2) \
+do { \
 if ((expression_1) operator (expression_2)) { \
 ND_PRINT(" [%s %u %s %zu]", (message), (expression_1), (#operator), (expression_2)); \
 goto invalid; \
-}
+} \
+} while (0)
 
 /*
  * Check (expression_1 operator expression_2) for invalid packet with


### PR DESCRIPTION
Avoid errors such as in the following case:
```
        if (...)
                ND_ICHECKMSG_U(...);
	else

source.c:X:9: error: 'else' without a previous 'if'
    X |         else
      |         ^~~~
```
with gcc, or "error: expected expression" with clang.

This avoids the need to use explicit braces (dangling else).

Same for ND_ICHECK_U, ND_ICHECKMSG_ZU and ND_ICHECK_ZU.