### PR TITLE
ip: set the snapshot length for the payload correctly.

### DIFF
--- a/print-ip.c
+++ b/print-ip.c
@@ -358,9 +358,11 @@ ip_print(netdissect_options *ndo,
 
 	ND_TCHECK_SIZE(ip);
 	/*
-	 * Cut off the snapshot length to the end of the IP payload.
+	 * Cut off the snapshot length to the end of the IP payload
+	 * or the end of the data in which it's contained, whichever
+	 * comes first.
 	 */
-	if (!nd_push_snaplen(ndo, bp, len)) {
+	if (!nd_push_snaplen(ndo, bp, ND_MIN(length, len))) {
 		(*ndo->ndo_error)(ndo, S_ERR_ND_MEM_ALLOC,
 			"%s: can't push snaplen on buffer stack", __func__);
 	}


### PR DESCRIPTION
Cut off the snapshot length to the end of the IP payload or the end of the data in which it's contained, whichever comes first.