### PR TITLE
Add support for no-capture and no-inject device flags.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -66,6 +66,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       Fix "ip broadcast" netmask byte order with the -f flag.
       Remove pcap-missing.h.
       Remove the ".exe" from the program name in Windows error messages.
+      Add support for no-capture and no-inject device flags.
     Building and testing:
       Autoconf: Remove detection of early IPv6 stacks.
       Detect OS IPv6 support using AF_INET6 only.

--- a/tcpdump.1.in
+++ b/tcpdump.1.in
@@ -20,7 +20,7 @@
 .\" WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
 .\" MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 .\"
-.TH TCPDUMP 1  "31 July 2026"
+.TH TCPDUMP 1  "10 September 2026"
 .SH NAME
 tcpdump \- dump traffic on a network
 .SH SYNOPSIS
@@ -364,13 +364,14 @@ Dump packet-matching code as decimal numbers (preceded with a count).
 .TP
 .B \-\-list\-interfaces
 .PD
-Print the list of the network interfaces available on the system and on
-which
+Print the list of libpcap devices (regular and pseudo network interfaces,
+802.11/Bluetooth/USB monitors, DAG/D-Bus/netfilter/RDMA/SNF devices etc.)
+available for
 .I tcpdump
-can capture packets.  For each network interface, a number and an
-interface name, possibly followed by a text description of the
-interface, are printed.  The interface name or the number can be supplied
-to the
+use.  For each device print a name, a text description (if available)
+and a set of flags.  Also print a number unless libpcap indicates that the
+device does not support packet capture.  The interface name or the number
+can be supplied to the
 .B \-i
 flag to specify an interface on which to capture.
 .IP

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -289,6 +289,12 @@ static const struct tok status_flags[] = {
 #ifdef PCAP_IF_WIRELESS
 	{ PCAP_IF_WIRELESS, "Wireless" },
 #endif
+#ifdef PCAP_IF_NO_INJECT
+	{ PCAP_IF_NO_INJECT, "NoInject" },
+#endif
+#ifdef PCAP_IF_NO_CAPTURE
+	{ PCAP_IF_NO_CAPTURE, "NoCapture" },
+#endif
 	{ 0, NULL }
 };
 
@@ -501,8 +507,25 @@ show_devices_and_exit(void)
 
 	if (pcap_findalldevs(&devlist, ebuf) < 0)
 		error("%s", ebuf);
-	for (i = 0, dev = devlist; dev != NULL; i++, dev = dev->next) {
-		printf("%d.%s", i+1, dev->name);
+
+	for (i = 0, dev = devlist; dev != NULL; dev = dev->next) {
+		/*
+		 * If PCAP_IF_NO_CAPTURE is set, do not count the device and
+		 * print it without a number.
+		 */
+#ifdef PCAP_IF_NO_CAPTURE
+		if (dev->flags & PCAP_IF_NO_CAPTURE)
+			printf("%s %s",
+			    i > 999  ? "    " :
+			    i > 99  ? "   " :
+			    i > 9 ? "  " :
+			    " ",
+			    dev->name
+			);
+		else
+#endif // PCAP_IF_NO_CAPTURE
+			printf("%d.%s", i + 1, dev->name);
+
 		if (dev->description != NULL)
 			printf(" (%s)", dev->description);
 		if (dev->flags != 0) {
@@ -550,6 +573,11 @@ show_devices_and_exit(void)
 			printf("]");
 		}
 		printf("\n");
+#ifdef PCAP_IF_NO_CAPTURE
+		if (dev->flags & PCAP_IF_NO_CAPTURE)
+			continue;
+#endif // PCAP_IF_NO_CAPTURE
+		i++;
 	}
 	pcap_freealldevs(devlist);
 	exit_tcpdump(S_SUCCESS);
@@ -1226,10 +1254,18 @@ _U_
 		error("no interfaces available for capture");
 	/*
 	 * Look for the devnum-th entry in the list of devices (1-based).
+	 * Do not count devices that have PCAP_IF_NO_CAPTURE set, consistently
+	 * with show_devices_and_exit().
 	 */
-	for (i = 0, dev = devlist; i < devnum-1 && dev != NULL;
-	    i++, dev = dev->next)
-		;
+	for (i = 0, dev = devlist; dev != NULL; dev = dev->next) {
+#ifdef PCAP_IF_NO_CAPTURE
+		if (dev->flags & PCAP_IF_NO_CAPTURE)
+			continue;
+#endif // PCAP_IF_NO_CAPTURE
+		if (i == devnum - 1)
+			break;
+		i++;
+	}
 	if (dev == NULL) {
 		pcap_freealldevs(devlist);
 		error("Invalid adapter index %ld: only %ld interface%s found",


### PR DESCRIPTION
This is one of the possible uses of the device flags in the-tcpdump-group/libpcap#1388, it may require more work.