### PR TITLE
Use C99 macros to define 64-bit constants and maximum 64-bit values.

### DIFF
--- a/extract.h
+++ b/extract.h
@@ -414,7 +414,7 @@ EXTRACT_IPV4_TO_NETWORK_ORDER(const void *p)
 	             ((uint64_t)(*((const uint8_t *)(p) + 2)) << 16) | \
 	             ((uint64_t)(*((const uint8_t *)(p) + 3)) << 8) | \
 	             ((uint64_t)(*((const uint8_t *)(p) + 4)) << 0))) : \
-	  ((int64_t)(INT64_T_CONSTANT(0xFFFFFF0000000000U) | \
+	  ((int64_t)(UINT64_C(0xFFFFFF0000000000) | \
 	             ((uint64_t)(*((const uint8_t *)(p) + 0)) << 32) | \
 	             ((uint64_t)(*((const uint8_t *)(p) + 1)) << 24) | \
 	             ((uint64_t)(*((const uint8_t *)(p) + 2)) << 16) | \
@@ -437,7 +437,7 @@ EXTRACT_IPV4_TO_NETWORK_ORDER(const void *p)
 	              ((uint64_t)(*((const uint8_t *)(p) + 3)) << 16) | \
 	              ((uint64_t)(*((const uint8_t *)(p) + 4)) << 8) | \
 	              ((uint64_t)(*((const uint8_t *)(p) + 5)) << 0))) : \
-	  ((int64_t)(INT64_T_CONSTANT(0xFFFFFFFF00000000U) | \
+	  ((int64_t)(UINT64_C(0xFFFFFFFF00000000) | \
 	              ((uint64_t)(*((const uint8_t *)(p) + 0)) << 40) | \
 	              ((uint64_t)(*((const uint8_t *)(p) + 1)) << 32) | \
 	              ((uint64_t)(*((const uint8_t *)(p) + 2)) << 24) | \
@@ -463,7 +463,7 @@ EXTRACT_IPV4_TO_NETWORK_ORDER(const void *p)
 	             ((uint64_t)(*((const uint8_t *)(p) + 4)) << 16) | \
 	             ((uint64_t)(*((const uint8_t *)(p) + 5)) << 8) | \
 	             ((uint64_t)(*((const uint8_t *)(p) + 6)) << 0))) : \
-	    ((int64_t)(INT64_T_CONSTANT(0xFFFFFFFFFF000000U) | \
+	    ((int64_t)(UINT64_C(0xFFFFFFFFFF000000) | \
 	             ((uint64_t)(*((const uint8_t *)(p) + 0)) << 48) | \
 	             ((uint64_t)(*((const uint8_t *)(p) + 1)) << 40) | \
 	             ((uint64_t)(*((const uint8_t *)(p) + 2)) << 32) | \

--- a/netdissect-stdinc.h
+++ b/netdissect-stdinc.h
@@ -139,11 +139,6 @@
    * strtoint64_t().
    */
   #define strtoint64_t	strtoll
-
-  /*
-   * And we have LL as a suffix for constants, so use that.
-   */
-  #define INT64_T_CONSTANT(constant)	(constant##LL)
 #else
   /*
    * Non-Microsoft compiler.
@@ -151,11 +146,6 @@
    * XXX - should we use strtoll or should we use _strtoi64()?
    */
   #define strtoint64_t		strtoll
-
-  /*
-   * Assume LL works.
-   */
-  #define INT64_T_CONSTANT(constant)	(constant##LL)
 #endif
 
 #ifdef _MSC_VER
@@ -246,11 +236,6 @@ typedef char *caddr_t;
  * Assume all UN*Xes have strtoll(), and use it for strtoint64_t().
  */
 #define strtoint64_t	strtoll
-
-/*
- * Assume LL works.
- */
-#define INT64_T_CONSTANT(constant)	(constant##LL)
 #endif /* _WIN32 */
 
 /*

--- a/ntp.c
+++ b/ntp.c
@@ -26,7 +26,7 @@
 
 #include "extract.h"
 
-#define	JAN_1970	INT64_T_CONSTANT(2208988800)	/* 1970 - 1900 in seconds */
+#define	JAN_1970	INT64_C(2208988800)	/* 1970 - 1900 in seconds */
 
 void
 p_ntp_time_fmt(netdissect_options *ndo, const char *fmt,

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -1728,7 +1728,7 @@ main(int argc, char **argv)
 			 * Will multiplying it by multiplier overflow?
 			 */
 #ifdef HAVE_PCAP_DUMP_FTELL64
-			if (Cflag > INT64_T_CONSTANT(0x7fffffffffffffff) / Cflagmult)
+			if (Cflag > INT64_MAX / Cflagmult)
 #else
 			if (Cflag > LONG_MAX / Cflagmult)
 #endif


### PR DESCRIPTION
We require C99 support, so don't roll our own versions.