### PR TITLE
CI: expand the matrix for AppVeyor and fix issues that finds.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,15 +17,19 @@ environment:
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       GENERATOR: "Visual Studio 14 2015"
+      PLATFORM: Win32
       SDK: npcap-sdk-1.13
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: "Visual Studio 14 2015 Win64"
+      GENERATOR: "Visual Studio 14 2015"
+      PLATFORM: x64
       SDK: npcap-sdk-1.13
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       GENERATOR: "Visual Studio 15 2017"
+      PLATFORM: Win32
       SDK: npcap-sdk-1.13
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      GENERATOR: "Visual Studio 15 2017 Win64"
+      GENERATOR: "Visual Studio 15 2017"
+      PLATFORM: x64
       SDK: npcap-sdk-1.13
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       GENERATOR: "Visual Studio 16 2019"
@@ -35,6 +39,10 @@ environment:
       GENERATOR: "Visual Studio 16 2019"
       PLATFORM: x64
       SDK: npcap-sdk-1.13
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      GENERATOR: "Visual Studio 16 2019"
+      PLATFORM: ARM64
+      SDK: npcap-sdk-1.13
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
       GENERATOR: "Visual Studio 17 2022"
       PLATFORM: Win32
@@ -42,6 +50,10 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
       GENERATOR: "Visual Studio 17 2022"
       PLATFORM: x64
+      SDK: npcap-sdk-1.13
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+      GENERATOR: "Visual Studio 17 2022"
+      PLATFORM: ARM64
       SDK: npcap-sdk-1.13
 
 build_script:
@@ -52,6 +64,5 @@ build_script:
   - type NUL >.devel
   - md build
   - cd build
-  - if NOT DEFINED PLATFORM cmake -DPCAP_ROOT=c:\projects\libpcap\Win32\%SDK% -G"%GENERATOR%" ..
-  - if DEFINED PLATFORM cmake -DPCAP_ROOT=c:\projects\libpcap\Win32\%SDK% -G"%GENERATOR%" -A %PLATFORM% ..
+  - cmake -DPCAP_ROOT=c:\projects\libpcap\Win32\%SDK% -G"%GENERATOR%" -A %PLATFORM% ..
   - msbuild /m /nologo /p:Configuration=Release tcpdump.sln

--- a/cmake/Modules/FindPCAP.cmake
+++ b/cmake/Modules/FindPCAP.cmake
@@ -29,18 +29,27 @@ if(WIN32)
   #
   find_path(PCAP_INCLUDE_DIR pcap.h)
 
-  # The 64-bit Packet.lib is located under /x64
-  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+  if(CMAKE_GENERATOR_PLATFORM STREQUAL "Win32")
+    #
+    # 32-bit x86; no need to look in subdirectories of the SDK's
+    # Lib directory for the libraries, as the libraries are in
+    # the Lib directory
+    #
+  else()
+    #
+    # Platform other than 32-bit x86.
     #
     # For the WinPcap and Npcap SDKs, the Lib subdirectory of the top-level
-    # directory contains 32-bit libraries; the 64-bit libraries are in the
-    # Lib/x64 directory.
+    # directory contains 32-bit x86 libraries; the libraries for other
+    # platforms are in subdirectories of the Lib directory whose names
+    # are the names of the supported platforms.
     #
-    # The only way to *FORCE* CMake to look in the Lib/x64 directory
-    # without searching in the Lib directory first appears to be to set
-    # CMAKE_LIBRARY_ARCHITECTURE to "x64".
+    # The only way to *FORCE* CMake to look in the appropriate
+    # subdirectory of Lib for libraries without searching in the
+    # Lib directory first appears to be to set
+    # CMAKE_LIBRARY_ARCHITECTURE to the name of the subdirectory.
     #
-    set(CMAKE_LIBRARY_ARCHITECTURE "x64")
+    set(CMAKE_LIBRARY_ARCHITECTURE "${CMAKE_GENERATOR_PLATFORM}")
   endif()
   find_library(PCAP_LIBRARY NAMES pcap wpcap)
 


### PR DESCRIPTION
Add ARM64 builds for VS 2019 and VS 2022.

Fix cmake/Modules/FindPCAP.cmake to look in the right directory for pcap
libraries if the build isn't being done for 32-bit or 64-bit x86.

Use the -A flag for all generators; according to the CMake
documentation, they're supported for all generators in CMake 3.1 and
later and, on Windows, we require CMake 3.12 or later.  That ensures
that CMAKE_GENERATOR_PLATFORM will be set, so that we can use it to
determine the right directory in which to look for pcap libraries.