### PR TITLE
Simplify the checks for snprintf().

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -501,17 +501,6 @@ endif(STDLIBS_HAVE_GETSERVENT)
 cmake_pop_check_state()
 
 #
-# Make sure we have snprintf(); we require it.
-# We use check_symbol_exists(), as it isn't necessarily an external
-# function - in Visual Studio, for example, it is an inline function
-# calling an external function.
-#
-check_symbol_exists(snprintf "stdio.h" HAVE_SNPRINTF)
-if(NOT HAVE_SNPRINTF)
-    message(FATAL_ERROR "snprintf() is required but wasn't found")
-endif()
-
-#
 # Require a proof of suitable snprintf(3), same as in Autoconf.
 #
 include(CheckCSourceRuns)

--- a/configure.ac
+++ b/configure.ac
@@ -446,12 +446,6 @@ AC_CHECK_FUNCS(fork vfork)
 AC_CHECK_FUNCS(setlinebuf)
 
 #
-# Make sure we have snprintf(); we require it.
-#
-AC_CHECK_FUNC(snprintf,,
-    AC_MSG_ERROR([snprintf() is required but wasn't found]))
-
-#
 # It became apparent at some point that using a suitable C99 compiler does not
 # automatically mean snprintf(3) implementation in the libc supports all the
 # modifiers and specifiers used in the project, so let's test that before the


### PR DESCRIPTION
Do not check that the function is just available: first, it is in C99, so the check almost certainly is a waste of time; second, the source requires the function unconditionally; third, the subsequent "snprintf() is suitable" check implies the "snprintf() is available" part anyway.

(cherry picked from commit e1bcb7941d916285e5e502ff84dff5a15ec0b498)