### PR TITLE
CI: install coreutils with Homebrew on macOS. [skip appveyor]

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -57,6 +57,10 @@ macos_task:
   script:
     - brew update >/dev/null
     - brew install libsmi | grep -v '%'
+    # We need coreutils so that building, checking, and installing
+    # libpcap works, as *that* requires coreutils in order to
+    # install the timeout command in macOS.
+    - brew install coreutils
     - echo '$ git clone [...] libpcap.git'
     - git -C .. clone --depth ${CIRRUS_CLONE_DEPTH} --branch=master --quiet ${LIBPCAP_GIT}
     - ./build_matrix.sh


### PR DESCRIPTION
We need it because we do an install of libpcap, including "make check", and "make check" requires Homebrew's coreutils in order to get the timeout command.

(cherry picked from commit 673a2fedf68a562ccf4612b467f373168b85552b)