### PR TITLE
Fix sub-second packet timestamp printing

### DIFF
--- a/util-print.c
+++ b/util-print.c
@@ -215,11 +215,11 @@ ts_frac_print(netdissect_options *ndo, const struct timeval *tv)
 	switch (ndo->ndo_tstamp_precision) {
 
 	case PCAP_TSTAMP_PRECISION_MICRO:
-		ND_PRINT(".%06u", (unsigned)tv->tv_usec);
+		ND_PRINT(".%06d", (int32_t)tv->tv_usec);
 		break;
 
 	case PCAP_TSTAMP_PRECISION_NANO:
-		ND_PRINT(".%09u", (unsigned)tv->tv_usec);
+		ND_PRINT(".%09d", (int32_t)tv->tv_usec);
 		break;
 
 	default:
@@ -227,7 +227,7 @@ ts_frac_print(netdissect_options *ndo, const struct timeval *tv)
 		break;
 	}
 #else
-	ND_PRINT(".%06u", (unsigned)tv->tv_usec);
+	ND_PRINT(".%06d", (int32_t)tv->tv_usec);
 #endif
 }
 


### PR DESCRIPTION
The '(unsigned)' cast and the '%u' format mask some invalid timestamp
e.g. when the sub-second part (microsecond or nanosecond) is negative.

The sub-second part could be:
long (64-bit) on 64-bit build.
long (32-bit) on 32-bit build.
long long (64-bit) on 32-bit build with 64-bit time_t.

In the packet header, the sub-second value is 32-bit. To get only the
last 32-bit, cast with '(int32_t)' and print using '%d' format.