### PR TITLE
IP: Use ND_TTEST_LEN() instead of a custom bounds check

### DIFF
--- a/print-ip.c
+++ b/print-ip.c
@@ -426,7 +426,7 @@ ip_print(netdissect_options *ndo,
                 ND_PRINT(")");
             }
 
-	    if (!ndo->ndo_Kflag && (const u_char *)ip + hlen <= ndo->ndo_snapend) {
+	    if (!ndo->ndo_Kflag && ND_TTEST_LEN((const u_char *)ip, hlen)) {
 	        vec[0].ptr = (const uint8_t *)(const void *)ip;
 	        vec[0].len = hlen;
 	        sum = in_cksum(vec, 1);


### PR DESCRIPTION
```
This avoids an invalid-pointer-pair AddressSanitizer error with options
-fsanitize=address -fsanitize=pointer-compare
and
ASAN_OPTIONS=detect_invalid_pointer_pairs=1

The error was:
    ip_printroute_asan                      : TEST FAILED[...]

reading from file ip_printroute_asan.pcap, link-type EN10MB (Ethernet),
  snapshot length 60
=================================================================
==ERROR: AddressSanitizer: invalid-pointer-pair: 0x60600000006a
  0x60600000005c
    #0 0x558ce1cddb0b in ip_print
      /home/cpe/soft-origin/tcpdump/my-tcpdump/print-ip.c:429:55

0x60600000006a is located 14 bytes after 60-byte region
  [0x606000000020,0x60600000005c)
allocated by thread T0 here:
    #0 0x558ce1c5390e in malloc
      (/home/cpe/soft-origin/tcpdump/my-tcpdump/tcpdump+0x1fd90e)
    #1 0x558ce1efbba3 in pcap_check_header
      /home/cpe/soft-origin/tcpdump/my-libpcap/sf-pcap.c:480:14

0x60600000005c is located 0 bytes after 60-byte region
  [0x606000000020,0x60600000005c)
allocated by thread T0 here:
    #0 0x558ce1c5390e in malloc
      (/home/cpe/soft-origin/tcpdump/my-tcpdump/tcpdump+0x1fd90e)
    #1 0x558ce1efbba3 in pcap_check_header
      /home/cpe/soft-origin/tcpdump/my-libpcap/sf-pcap.c:480:14

SUMMARY: AddressSanitizer: invalid-pointer-pair
  /home/cpe/soft-origin/tcpdump/my-tcpdump/print-ip.c:429:55 in ip_print
```