### PR TITLE
OLSR: Fix invalid-pointer-pair AddressSanitizer errors

### DIFF
--- a/print-olsr.c
+++ b/print-olsr.c
@@ -341,7 +341,7 @@ olsr_print(netdissect_options *ndo,
         return;
     }
 
-    while (tptr < (pptr+length)) {
+    while (tptr - pptr < length) {
         union
         {
             const struct olsr_msg4 *v4;
@@ -679,7 +679,7 @@ olsr_print(netdissect_options *ndo,
             break;
         } /* switch (msg_type) */
         tptr += msg_len;
-    } /* while (tptr < (pptr+length)) */
+    } /* while (tptr - pptr < length) */
 
     return;
 


### PR DESCRIPTION
```
Avoid adding a length value to a pointer. The result could be located
in an invalid (freed) region or could give a wild pointer.

The errors were:
1)
    olsr-oobr-1                             : TEST FAILED[...]

reading from file tests/olsr-oobr-1.pcap, link-type EN10MB (Ethernet),
  snapshot length 61
=================================================================
==ERROR: AddressSanitizer: invalid-pointer-pair: 0x60600000004e
  0x606000000852
    #0 0x555555c32d61 in olsr_print [...]/print-olsr.c:346:17

0x60600000004e is located 46 bytes inside of 61-byte region
  [0x606000000020,0x60600000005d)
allocated by thread T0 here:
    #0 0x5555558d18ee in malloc ([...]/tcpdump+0x37d8ee)
    #1 0x555555cf37dc in pcap_check_header [...]/sf-pcap.c:480:14

0x606000000852 is located 1938 bytes after 64-byte region
  [0x606000000080,0x6060000000c0)
freed by thread T0 here:
    #0 0x5555558d1646 in __interceptor_free ([...]/tcpdump+0x37d646)
    #1 0x555555cd3144 in pcap_compile [...]/gencode.c:1009:3

previously allocated by thread T0 here:
    #0 0x5555558d18ee in malloc ([...]/tcpdump+0x37d8ee)
    #1 0x555555cf76d0 in pcap_alloc [...]/scanner.c:5588:9
    #2 0x555555cf76d0 in pcap__scan_buffer [...]/scanner.c:5177:24

SUMMARY: AddressSanitizer: invalid-pointer-pair [...]/print-olsr.c:346:17
  in olsr_print

2)
    olsr-oobr-2                             : TEST FAILED[...]

reading from file tests/olsr-oobr-2.pcap, link-type EN10MB (Ethernet),
  snapshot length 81
=================================================================
==ERROR: AddressSanitizer: invalid-pointer-pair: 0x608000000062
  0x60800000156f
    #0 0x555555c32d61 in olsr_print [...]/print-olsr.c:346:17

0x608000000062 is located 66 bytes inside of 81-byte region
  [0x608000000020,0x608000000071)
allocated by thread T0 here:
    #0 0x5555558d18ee in malloc ([...]/tcpdump+0x37d8ee)
    #1 0x555555cf37dc in pcap_check_header [...]/sf-pcap.c:480:14

Address 0x60800000156f is a wild pointer inside of access range of size
  0x000000000001.
SUMMARY: AddressSanitizer: invalid-pointer-pair [...]/print-olsr.c:346:17
  in olsr_print
```