### PR TITLE
frag6: Add a bounds check in non-verbose mode

### DIFF
--- a/print-frag6.c
+++ b/print-frag6.c
@@ -25,6 +25,7 @@
 
 #include "netdissect-stdinc.h"
 
+#define ND_LONGJMP_FROM_TCHECK
 #include "netdissect.h"
 #include "extract.h"
 
@@ -43,6 +44,8 @@ frag6_print(netdissect_options *ndo, const u_char *bp, const u_char *bp2)
 	ND_PRINT("frag (");
 	if (ndo->ndo_vflag)
 		ND_PRINT("0x%08x:", GET_BE_U_4(dp->ip6f_ident));
+	else
+		ND_TCHECK_4(dp->ip6f_ident);
 	ND_PRINT("%u|", GET_BE_U_2(dp->ip6f_offlg) & IP6F_OFF_MASK);
 	if ((bp - bp2) + sizeof(struct ip6_frag) >
 	    sizeof(struct ip6_hdr) + GET_BE_U_2(ip6->ip6_plen))

--- a/tests/TESTLIST
+++ b/tests/TESTLIST
@@ -773,7 +773,8 @@ pim_header_asan		pim_header_asan.pcap		pim_header_asan.out	-v
 pim_header_asan-2	pim_header_asan-2.pcap		pim_header_asan-2.out	-v
 pim_header_asan-3	pim_header_asan-3.pcap		pim_header_asan-3.out	-v
 pim_header_asan-4	pim_header_asan-4.pcap		pim_header_asan-4.out	-v
-ip6_frag_asan		ip6_frag_asan.pcap		ip6_frag_asan.out	-v
+ip6_frag_asan		ip6_frag_asan.pcap		ip6_frag_asan.out
+ip6_frag_asan-v		ip6_frag_asan.pcap		ip6_frag_asan-v.out	-v
 radius_attr_asan	radius_attr_asan.pcap		radius_attr_asan.out	-v
 ospf6_decode_v3_asan	ospf6_decode_v3_asan.pcap	ospf6_decode_v3_asan.out -v
 ip_ts_opts_asan		ip_ts_opts_asan.pcap		ip_ts_opts_asan.out	-v

--- a/tests/ip6_frag_asan-v.out
+++ b/tests/ip6_frag_asan-v.out
@@ -1,0 +1,1 @@
+    1  2038-01-01 00:00:00.000000 IP6 (class 0x51, flowlabel 0xb2100, hlim 16, next-header Fragment (44), payload length 27136) 452:22:19:0:41a:e4ff:10ff:484d > 2243:80:1400:100:19:ffff:ffff:fffb: frag ( [|frag6]

--- a/tests/ip6_frag_asan.out
+++ b/tests/ip6_frag_asan.out
@@ -1,1 +1,1 @@
-    1  2038-01-01 00:00:00.000000 IP6 (class 0x51, flowlabel 0xb2100, hlim 16, next-header Fragment (44), payload length 27136) 452:22:19:0:41a:e4ff:10ff:484d > 2243:80:1400:100:19:ffff:ffff:fffb: frag ( [|frag6]
+    1  2038-01-01 00:00:00.000000 IP6 452:22:19:0:41a:e4ff:10ff:484d > 2243:80:1400:100:19:ffff:ffff:fffb: frag ( [|frag6]


### PR DESCRIPTION
Define ND_LONGJMP_FROM_TCHECK.

Rename a test and its output, with "-v" in the names.
Add a test case (same pcap printed without "-v").