### PR TITLE
tcpdump: show error message for PCAP_ERROR_CAPTURE_NOTSUP.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -96,6 +96,8 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       PTP: Fix management packet fields.
     User interface:
       Warn that options -A, -x[x] and -X[X] are mutually exclusive.
+      For PCAP_ERROR_CAPTURE_NOTSUP, show the error message provided
+        by libpcap for that error if it's non-empty.
     Source code:
       Fix '-tt' option printing when time > 2106-02-07T06:28:15Z.
       Add sub-second packet timestamp checks for invalid micro/nano.

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -1346,6 +1346,11 @@ open_interface(const char *device, netdissect_options *ndo, char *ebuf)
 		} else if (status == PCAP_ERROR_PERM_DENIED && *cp != '\0')
 			error("%s: %s\n(%s)", device,
 			    pcap_statustostr(status), cp);
+#ifdef PCAP_ERROR_CAPTURE_NOTSUP
+		else if (status == PCAP_ERROR_CAPTURE_NOTSUP && *cp != '\0')
+			error("%s: %s\n(%s)", device,
+			    pcap_statustostr(status), cp);
+#endif
 #ifdef __FreeBSD__
 		else if (status == PCAP_ERROR_RFMON_NOTSUP &&
 		    strncmp(device, "wlan", 4) == 0) {


### PR DESCRIPTION
If an attempt to open a capture device failed because capturing isn't supported on that device, check whether an error message with a further explanation was provided and, if so, report it.