### PR TITLE
BOOTP: Use an uint16_t variable to get the result of a GET_BE_U_2()

### DIFF
--- a/print-bootp.c
+++ b/print-bootp.c
@@ -1006,22 +1006,24 @@ rfc1048_print(netdissect_options *ndo,
 				 * URI: URI of the SZTP bootstrap server.
 				 */
 				while (len >= 2) {
-					suboptlen = GET_BE_U_2(bp);
+					uint16_t suboptlen2;
+
+					suboptlen2 = GET_BE_U_2(bp);
 					bp += 2;
 					len -= 2;
 					ND_PRINT("\n\t	    ");
-					ND_PRINT("length %u: ", suboptlen);
-					if (len < suboptlen) {
+					ND_PRINT("length %u: ", suboptlen2);
+					if (len < suboptlen2) {
 						ND_PRINT("length goes past end of option");
 						bp += len;
 						len = 0;
 						break;
 					}
 					ND_PRINT("\"");
-					nd_printjn(ndo, bp, suboptlen);
+					nd_printjn(ndo, bp, suboptlen2);
 					ND_PRINT("\"");
-					len -= suboptlen;
-					bp += suboptlen;
+					len -= suboptlen2;
+					bp += suboptlen2;
 				}
 				if (len != 0) {
 					ND_PRINT("[ERROR: length < 2 bytes]");


### PR DESCRIPTION
This will fix this Visual Studio warning:
print-bootp.c(1009,18): warning C4242: =: conversion from uint16_t to uint8_t, possible loss of data