### PR TITLE
ICMPv6: Fix duplicate type printing for Node Information Queries

### DIFF
--- a/print-icmp6.c
+++ b/print-icmp6.c
@@ -115,11 +115,7 @@ struct icmp6_hdr {
 
 #define ICMP6_ROUTER_RENUMBERING	138	/* router renumbering */
 
-#define ICMP6_WRUREQUEST		139	/* who are you request */
-#define ICMP6_WRUREPLY			140	/* who are you reply */
-#define ICMP6_FQDN_QUERY		139	/* FQDN query */
-#define ICMP6_FQDN_REPLY		140	/* FQDN reply */
-#define ICMP6_NI_QUERY			139	/* node information request - RFC 4620 */
+#define ICMP6_NI_QUERY			139	/* node information query - RFC 4620 */
 #define ICMP6_NI_REPLY			140	/* node information reply - RFC 4620 */
 #define IND_SOLICIT			141	/* inverse neighbor solicitation */
 #define IND_ADVERT			142	/* inverse neighbor advertisement */
@@ -661,8 +657,6 @@ static const struct tok icmp6_type_values[] = {
     { ICMP6_HADISCOV_REPLY, "ha discovery reply"},
     { ICMP6_MOBILEPREFIX_SOLICIT, "mobile router solicitation"},
     { ICMP6_MOBILEPREFIX_ADVERT, "mobile router advertisement"},
-    { ICMP6_WRUREQUEST, "who-are-you request"},
-    { ICMP6_WRUREPLY, "who-are-you reply"},
     { ICMP6_NI_QUERY, "node information query"},
     { ICMP6_NI_REPLY, "node information reply"},
     { MLD6_MTRACE, "mtrace message"},
@@ -1712,7 +1706,6 @@ icmp6_nodeinfo_print(netdissect_options *ndo, u_int icmp6len, const u_char *bp, 
 			ND_PRINT(" who-are-you request");
 			break;
 		}
-		ND_PRINT(" node information query");
 
 		ND_TCHECK_LEN(dp, sizeof(*ni6));
 		ni6 = (const struct icmp6_nodeinfo *)dp;
@@ -1824,7 +1817,6 @@ icmp6_nodeinfo_print(netdissect_options *ndo, u_int icmp6len, const u_char *bp, 
 
 		ND_TCHECK_LEN(dp, sizeof(*ni6));
 		ni6 = (const struct icmp6_nodeinfo *)dp;
-		ND_PRINT(" node information reply");
 		ND_PRINT(" (");	/*)*/
 		switch (GET_U_1(ni6->ni_code)) {
 		case ICMP6_NI_SUCCESS:

--- a/tests/icmp6_nodeinfo_oobr.out
+++ b/tests/icmp6_nodeinfo_oobr.out
@@ -1,1 +1,1 @@
-    1  2014-11-10 03:32:08.002213 IP6 a072:7f00:1:7f00:1:e01a:17:6785 > c903::a002:8018:fe30:0:204: ICMP6, who-are-you reply [|icmp6], length 4
+    1  2014-11-10 03:32:08.002213 IP6 a072:7f00:1:7f00:1:e01a:17:6785 > c903::a002:8018:fe30:0:204: ICMP6, node information reply [|icmp6], length 4

--- a/tests/icmpv6-ni-flags.out
+++ b/tests/icmpv6-ni-flags.out
@@ -1,5 +1,5 @@
-    1  2022-09-06 13:56:00.443595 IP6 fe80::5054:ff:fe43:2ca8 > fe80::5054:ff:fe2c:3629: ICMP6, who-are-you request node information query (node addresses [A], subject=fe80::5054:ff:fe2c:3629), length 32
-    2  2022-09-06 13:56:46.614177 IP6 fe80::5054:ff:fe43:2ca8 > fe80::5054:ff:fe2c:3629: ICMP6, who-are-you request node information query (node addresses [C], subject=fe80::5054:ff:fe2c:3629), length 32
-    3  2022-09-06 13:57:14.854456 IP6 fe80::5054:ff:fe43:2ca8 > fe80::5054:ff:fe2c:3629: ICMP6, who-are-you request node information query (node addresses [L], subject=fe80::5054:ff:fe2c:3629), length 32
-    4  2022-09-06 13:57:22.010951 IP6 fe80::5054:ff:fe43:2ca8 > fe80::5054:ff:fe2c:3629: ICMP6, who-are-you request node information query (node addresses [S], subject=fe80::5054:ff:fe2c:3629), length 32
-    5  2022-09-06 13:57:41.727114 IP6 fe80::5054:ff:fe43:2ca8 > fe80::5054:ff:fe2c:3629: ICMP6, who-are-you request node information query (node addresses [G], subject=fe80::5054:ff:fe2c:3629), length 32
+    1  2022-09-06 13:56:00.443595 IP6 fe80::5054:ff:fe43:2ca8 > fe80::5054:ff:fe2c:3629: ICMP6, node information query (node addresses [A], subject=fe80::5054:ff:fe2c:3629), length 32
+    2  2022-09-06 13:56:46.614177 IP6 fe80::5054:ff:fe43:2ca8 > fe80::5054:ff:fe2c:3629: ICMP6, node information query (node addresses [C], subject=fe80::5054:ff:fe2c:3629), length 32
+    3  2022-09-06 13:57:14.854456 IP6 fe80::5054:ff:fe43:2ca8 > fe80::5054:ff:fe2c:3629: ICMP6, node information query (node addresses [L], subject=fe80::5054:ff:fe2c:3629), length 32
+    4  2022-09-06 13:57:22.010951 IP6 fe80::5054:ff:fe43:2ca8 > fe80::5054:ff:fe2c:3629: ICMP6, node information query (node addresses [S], subject=fe80::5054:ff:fe2c:3629), length 32
+    5  2022-09-06 13:57:41.727114 IP6 fe80::5054:ff:fe43:2ca8 > fe80::5054:ff:fe2c:3629: ICMP6, node information query (node addresses [G], subject=fe80::5054:ff:fe2c:3629), length 32


### PR DESCRIPTION
Delete some duplicate macros, keeping macros with names similar to the RFC 4620 names.

Update the outputs of two tests.