### PR TITLE
Autoconf: Use AC_SYS_YEAR2038_RECOMMENDED when possible

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,6 +1,7 @@
 #!/bin/sh -e
 
 : "${AUTORECONF:=autoreconf}"
+: "${BUILD_YEAR2038:=no}"
 
 AUTORECONFVERSION=`$AUTORECONF --version 2>&1 | grep "^autoreconf" | sed 's/.*) *//'`
 
@@ -22,6 +23,27 @@ if [ "$maj" = "" ] || [ "$min" = "" ] || \
 fi
 
 echo "$AUTORECONF identification: $AUTORECONFVERSION"
+
+# On Linux, if Autoconf version >= 2.72 and GNU C Library version >= 2.34,
+# s/AC_SYS_LARGEFILE/AC_SYS_YEAR2038_RECOMMENDED/ to ensure time_t
+# is Y2038-safe.
+if [ "$BUILD_YEAR2038" = yes ] && [ "`uname -s`" = Linux ]; then
+	if [ "$maj" -gt 2 ] || { [ "$maj" -eq 2 ] && [ "$min" -ge 72 ]; }; then
+		GLIBC_VERSION=`ldd --version|head -1|grep GLIBC|sed 's/.* //'`
+		maj_glibc=`echo "$GLIBC_VERSION" | cut -d. -f1`
+		min_glibc=`echo "$GLIBC_VERSION" | cut -d. -f2`
+		if [ "$maj_glibc" -gt 2 ] || { [ "$maj_glibc" -eq 2 ] && \
+		   [ "$min_glibc" -ge 34 ]; }; then
+			CONFIGURE_AC_NEW="configure.ac.new$$"
+			sed 's/^# \(AC_SYS_YEAR2038_RECOMMENDED\)/\1/' \
+				<configure.ac >"$CONFIGURE_AC_NEW"
+			cmp -s configure.ac "$CONFIGURE_AC_NEW" || \
+			cat "$CONFIGURE_AC_NEW" >configure.ac
+			rm -f "$CONFIGURE_AC_NEW"
+			echo 'Setup to ensure time_t is Y2038-safe.'
+		fi
+	fi
+fi
 
 # configure.ac is an Autoconf 2.69 file, but it works as expected even with
 # Autoconf 2.72.  However, in Autoconf versions 2.70 and later obsolete

--- a/configure.ac
+++ b/configure.ac
@@ -45,6 +45,10 @@ AC_LBL_C_INIT(V_CCOPT, V_INCLS)
 #
 AC_CHECK_HEADERS(rpc/rpc.h rpc/rpcent.h)
 
+# On Linux, if Autoconf version >= 2.72 and GNU C Library version >= 2.34,
+# uncomment AC_SYS_YEAR2038_RECOMMENDED to ensure time_t is Y2038-safe.
+# (Can be done by autogen.sh)
+# AC_SYS_YEAR2038_RECOMMENDED
 #
 # Get the size of a void *, to know whether this is a 32-bit or 64-bit build.
 #


### PR DESCRIPTION
On Linux, if the environment variable BUILD_YEAR2038=yes, Autoconf version >= 2.72 and GNU C Library version >= 2.34, uncomment AC_SYS_YEAR2038_RECOMMENDED to ensure time_t is Y2038-safe.

Tested with: BUILD_YEAR2038=yes MATRIX_CMAKE=no ./build_matrix.sh
on linux-armv7l because currently CMake build don't have year 2038 support.