### PR TITLE
DHCP: Fix a comment about formats for (un)signed longs/shorts data

### DIFF
--- a/print-bootp.c
+++ b/print-bootp.c
@@ -518,7 +518,7 @@ static const struct tok tag2str[] = {
 	{ TAG_TZ_STRING,	"aTZSTR" },
 	{ TAG_FQDN_OPTION,	"bFQDNS" },	/* XXX 'b' */
 	{ TAG_AUTH,		"bAUTH" },	/* XXX 'b' */
-	{ TAG_CLIENT_LAST_TRANSACTION_TIME, "LLast-Transaction-Time" },
+	{ TAG_CLIENT_LAST_TRANSACTION_TIME, "lLast-Transaction-Time" },
 	{ TAG_ASSOCIATED_IP,	"iAssociated-IP" },
 	{ TAG_CLIENT_ARCH,	"sARCH" },
 	{ TAG_CLIENT_NDI,	"bNDI" },	/* XXX 'b' */


### PR DESCRIPTION
l - unsigned longs (32 bits)
L - longs (32 bits)
s - unsigned shorts (16 bits)

Also:
DHCP: Fix print format for client-last-transaction-time option