### PR TITLE
Use a less cryptic message for packet timestamp overflow

### DIFF
--- a/util-print.c
+++ b/util-print.c
@@ -254,7 +254,7 @@ ts_date_hmsfrac_print(netdissect_options *ndo, const struct timeval *tv,
 #endif
 
 	if (tv->tv_sec < 0) {
-		ND_PRINT("[timestamp < 1970-01-01 00:00:00 UTC]");
+		ND_PRINT("[timestamp overflow]");
 		return;
 	}
 
@@ -295,7 +295,7 @@ static void
 ts_unix_print(netdissect_options *ndo, const struct timeval *tv)
 {
 	if (tv->tv_sec < 0) {
-		ND_PRINT("[timestamp < 1970-01-01 00:00:00 UTC]");
+		ND_PRINT("[timestamp overflow]");
 		return;
 	}
 


### PR DESCRIPTION
In ts_date_hmsfrac_print() and ts_unix_print() replace
"[timestamp < 1970-01-01 00:00:00 UTC]"
by
"[timestamp overflow]".

(Wikipedia "Year 2038 problem" uses "overflow".)