### PR TITLE
Fix incompatible pointer types with time functions calls on Windows

### DIFF
--- a/util-print.c
+++ b/util-print.c
@@ -249,16 +249,32 @@ ts_date_hmsfrac_print(netdissect_options *ndo, const struct timeval *tv,
 	struct tm *tm;
 	char timebuf[32];
 	const char *timestr;
+#ifdef _WIN32
+	time_t sec;
+#endif
 
 	if (tv->tv_sec < 0) {
 		ND_PRINT("[timestamp overflow]");
 		return;
 	}
 
+#ifdef _WIN32
+	/* on Windows tv->tv_sec is a long not a 64-bit time_t. */
+	sec = tv->tv_sec;
+#endif
+
 	if (time_flag == LOCAL_TIME)
+#ifdef _WIN32
+		tm = localtime(&sec);
+#else
 		tm = localtime(&tv->tv_sec);
+#endif
 	else
+#ifdef _WIN32
+		tm = gmtime(&sec);
+#else
 		tm = gmtime(&tv->tv_sec);
+#endif
 
 	if (date_flag == WITH_DATE) {
 		timestr = nd_format_time(timebuf, sizeof(timebuf),


### PR DESCRIPTION
On Windows in a struct timestamp, tv_sec is a long not a 64-bit time_t.
```
The problem shows:
listening on \Device\NPF_Loopback, link-type NULL (BSD loopback), snapshot length 262144 bytes
    1  [localtime() or gmtime() couldn't convert the date and time].052255
       IP 10.0.0.10 > 224.0.0.251: igmp v2 report 224.0.0.251
    2  [localtime() or gmtime() couldn't convert the date and time].792000
       IP 10.0.0.10.138 > 10.0.0.255.138: NBT UDP PACKET(138)

The warnings with clang-cl were:
util-print.c(253,18): warning: incompatible pointer types passing
  'const long *' to parameter of type 'const time_t *'
      (aka 'const long long *') [-Wincompatible-pointer-types]
  253 |                 tm = localtime(&tv->tv_sec);
      |                                ^~~~~~~~~~~

util-print.c(255,15): warning: incompatible pointer types passing
  'const long *' to parameter of type 'const time_t *'
      (aka 'const long long *') [-Wincompatible-pointer-types]
  255 |                 tm = gmtime(&tv->tv_sec);
      |                             ^~~~~~~~~~~
```
(cherry picked from commit dab871e8be7a30e511487ef0a5d401ab5657d314)