### PR TITLE
NTP: Update a field name with the RFC 5905 name

### DIFF
--- a/print-ntp.c
+++ b/print-ntp.c
@@ -66,7 +66,7 @@
  * |                                                               |
  * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  * |                                                               |
- * |                   Originate Timestamp (64)                    |
+ * |                     Origin Timestamp (64)                     |
  * |                                                               |
  * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  * |                                                               |
@@ -309,7 +309,7 @@ ntp_time_print(netdissect_options *ndo,
 	ND_PRINT("\n\t  Reference Timestamp:  ");
 	p_ntp_time(ndo, &(bp->ref_timestamp));
 
-	ND_PRINT("\n\t  Originator Timestamp: ");
+	ND_PRINT("\n\t  Origin Timestamp:     ");
 	p_ntp_time(ndo, &(bp->org_timestamp));
 
 	ND_PRINT("\n\t  Receive Timestamp:    ");

--- a/tests/ntp-time--v.out
+++ b/tests/ntp-time--v.out
@@ -3,7 +3,7 @@
 	Leap indicator: clock unsynchronized (192), Stratum 0 (unspecified), poll 8 (256s), precision 0
 	Root Delay: 0.000000, Root dispersion: 0.000000, Reference-ID: (unspec)
 	  Reference Timestamp:  0.000000000
-	  Originator Timestamp: 0.000000000
+	  Origin Timestamp:     0.000000000
 	  Receive Timestamp:    0.000000000
 	  Transmit Timestamp:   3712483316.928478999 (2017-08-23T13:21:56Z)
 	    Originator - Receive Timestamp:  0.000000000
@@ -13,7 +13,7 @@
 	Leap indicator:  (0), Stratum 2 (secondary reference), poll 8 (256s), precision -24
 	Root Delay: 0.000320, Root dispersion: 0.036407, Reference-ID: 0x84c707c9
 	  Reference Timestamp:  3712482106.337741360 (2017-08-23T13:01:46Z)
-	  Originator Timestamp: 3712483316.928478999 (2017-08-23T13:21:56Z)
+	  Origin Timestamp:     3712483316.928478999 (2017-08-23T13:21:56Z)
 	  Receive Timestamp:    3712483316.929920629 (2017-08-23T13:21:56Z)
 	  Transmit Timestamp:   3712483316.929948437 (2017-08-23T13:21:56Z)
 	    Originator - Receive Timestamp:  +0.001441629

--- a/tests/ntp-time-ef--v.out
+++ b/tests/ntp-time-ef--v.out
@@ -3,7 +3,7 @@
 	Leap indicator:  (0), Stratum 0 (unspecified), poll 6 (64s), precision 32
 	Root Delay: 0.000000, Root dispersion: 0.000000, Reference-ID: (unspec)
 	  Reference Timestamp:  0.000000000
-	  Originator Timestamp: 0.000000000
+	  Origin Timestamp:     0.000000000
 	  Receive Timestamp:    0.000000000
 	  Transmit Timestamp:   3656702015.307509582 (2015-11-16T22:33:35Z)
 	    Originator - Receive Timestamp:  0.000000000
@@ -18,7 +18,7 @@
 	Leap indicator:  (0), Stratum 3 (secondary reference), poll 6 (64s), precision -25
 	Root Delay: 0.017074, Root dispersion: 0.000732, Reference-ID: 0x0a1f0880
 	  Reference Timestamp:  3869212959.224956389 (2022-08-11T13:22:39Z)
-	  Originator Timestamp: 3656702015.307509582 (2015-11-16T22:33:35Z)
+	  Origin Timestamp:     3656702015.307509582 (2015-11-16T22:33:35Z)
 	  Receive Timestamp:    3869213010.188058000 (2022-08-11T13:23:30Z)
 	  Transmit Timestamp:   3869213010.188123546 (2022-08-11T13:23:30Z)
 	    Originator - Receive Timestamp:  +212510994.880548417

--- a/tests/ntp-time-ef--vvv.out
+++ b/tests/ntp-time-ef--vvv.out
@@ -3,7 +3,7 @@
 	Leap indicator:  (0), Stratum 0 (unspecified), poll 6 (64s), precision 32
 	Root Delay: 0.000000, Root dispersion: 0.000000, Reference-ID: (unspec)
 	  Reference Timestamp:  0.000000000
-	  Originator Timestamp: 0.000000000
+	  Origin Timestamp:     0.000000000
 	  Receive Timestamp:    0.000000000
 	  Transmit Timestamp:   3656702015.307509582 (2015-11-16T22:33:35Z)
 	    Originator - Receive Timestamp:  0.000000000
@@ -37,7 +37,7 @@
 	Leap indicator:  (0), Stratum 3 (secondary reference), poll 6 (64s), precision -25
 	Root Delay: 0.017074, Root dispersion: 0.000732, Reference-ID: 0x0a1f0880
 	  Reference Timestamp:  3869212959.224956389 (2022-08-11T13:22:39Z)
-	  Originator Timestamp: 3656702015.307509582 (2015-11-16T22:33:35Z)
+	  Origin Timestamp:     3656702015.307509582 (2015-11-16T22:33:35Z)
 	  Receive Timestamp:    3869213010.188058000 (2022-08-11T13:23:30Z)
 	  Transmit Timestamp:   3869213010.188123546 (2022-08-11T13:23:30Z)
 	    Originator - Receive Timestamp:  +212510994.880548417

--- a/tests/ntp-v.out
+++ b/tests/ntp-v.out
@@ -3,7 +3,7 @@
 	Leap indicator:  (0), Stratum 0 (unspecified), poll 0 (1s), precision 32
 	Root Delay: 0.000000, Root dispersion: 0.000000, Reference-ID: (unspec)
 	  Reference Timestamp:  0.000000000
-	  Originator Timestamp: 0.000000000
+	  Origin Timestamp:     0.000000000
 	  Receive Timestamp:    0.000000000
 	  Transmit Timestamp:   2763234513.007738396 (1987-07-25T21:08:33Z)
 	    Originator - Receive Timestamp:  0.000000000
@@ -15,7 +15,7 @@
 	Leap indicator: clock unsynchronized (192), Stratum 0 (unspecified), poll 3 (8s), precision -23
 	Root Delay: 0.000000, Root dispersion: 0.001373, Reference-ID: STEP
 	  Reference Timestamp:  0.000000000
-	  Originator Timestamp: 2763234513.007738396 (1987-07-25T21:08:33Z)
+	  Origin Timestamp:     2763234513.007738396 (1987-07-25T21:08:33Z)
 	  Receive Timestamp:    3706870329.516015118 (2017-06-19T14:12:09Z)
 	  Transmit Timestamp:   3706870329.516074047 (2017-06-19T14:12:09Z)
 	    Originator - Receive Timestamp:  +943635816.508276721
@@ -26,7 +26,7 @@
 	Leap indicator:  (0), Stratum 0 (unspecified), poll 0 (1s), precision 32
 	Root Delay: 0.000000, Root dispersion: 0.000000, Reference-ID: (unspec)
 	  Reference Timestamp:  0.000000000
-	  Originator Timestamp: 3706870757.473833108 (2017-06-19T14:19:17Z)
+	  Origin Timestamp:     3706870757.473833108 (2017-06-19T14:19:17Z)
 	  Receive Timestamp:    1802554105.693999877 (2093-03-22T03:56:41Z)
 	  Transmit Timestamp:   2929527464.107565978 (1992-10-31T13:37:44Z)
 	    Originator - Receive Timestamp:  -1904316651.779833231
@@ -38,7 +38,7 @@
 	Leap indicator:  (0), Stratum 2 (secondary reference), poll 0 (1s), precision -23
 	Root Delay: 0.155502, Root dispersion: 0.001571, Reference-ID: 0x0a051b0a
 	  Reference Timestamp:  3706870757.720418353 (2017-06-19T14:19:17Z)
-	  Originator Timestamp: 2929527464.107565978 (1992-10-31T13:37:44Z)
+	  Origin Timestamp:     2929527464.107565978 (1992-10-31T13:37:44Z)
 	  Receive Timestamp:    3706870758.494427815 (2017-06-19T14:19:18Z)
 	  Transmit Timestamp:   3706870758.494546877 (2017-06-19T14:19:18Z)
 	    Originator - Receive Timestamp:  +777343294.386861836
@@ -50,7 +50,7 @@
 	Leap indicator: clock unsynchronized (192), Stratum 0 (unspecified), poll 3 (8s), precision -6
 	Root Delay: 1.000000, Root dispersion: 1.000000, Reference-ID: (unspec)
 	  Reference Timestamp:  0.000000000
-	  Originator Timestamp: 0.000000000
+	  Origin Timestamp:     0.000000000
 	  Receive Timestamp:    0.000000000
 	  Transmit Timestamp:   3706870974.488488492 (2017-06-19T14:22:54Z)
 	    Originator - Receive Timestamp:  0.000000000
@@ -60,7 +60,7 @@
 	Leap indicator:  (0), Stratum 2 (secondary reference), poll 3 (8s), precision -23
 	Root Delay: 0.155456, Root dispersion: 0.001007, Reference-ID: 0x0a051b0a
 	  Reference Timestamp:  3706870972.021018556 (2017-06-19T14:22:52Z)
-	  Originator Timestamp: 3706870974.488488492 (2017-06-19T14:22:54Z)
+	  Origin Timestamp:     3706870974.488488492 (2017-06-19T14:22:54Z)
 	  Receive Timestamp:    3706870974.488540573 (2017-06-19T14:22:54Z)
 	  Transmit Timestamp:   3706870974.488665335 (2017-06-19T14:22:54Z)
 	    Originator - Receive Timestamp:  +0.000052081
@@ -70,7 +70,7 @@
 	Leap indicator: clock unsynchronized (192), Stratum 0 (unspecified), poll 6 (64s), precision -25
 	Root Delay: 0.000000, Root dispersion: 0.000000, Reference-ID: INIT
 	  Reference Timestamp:  0.000000000
-	  Originator Timestamp: 0.000000000
+	  Origin Timestamp:     0.000000000
 	  Receive Timestamp:    0.000000000
 	  Transmit Timestamp:   3706872432.800841171 (2017-06-19T14:47:12Z)
 	    Originator - Receive Timestamp:  0.000000000
@@ -82,7 +82,7 @@
 	Leap indicator:  (0), Stratum 2 (secondary reference), poll 6 (64s), precision -23
 	Root Delay: 0.116577, Root dispersion: 0.001739, Reference-ID: 0x0a0ba0ee
 	  Reference Timestamp:  3706872421.265296222 (2017-06-19T14:47:01Z)
-	  Originator Timestamp: 3706872432.800841171 (2017-06-19T14:47:12Z)
+	  Origin Timestamp:     3706872432.800841171 (2017-06-19T14:47:12Z)
 	  Receive Timestamp:    3706872432.799168336 (2017-06-19T14:47:12Z)
 	  Transmit Timestamp:   3706872432.799217265 (2017-06-19T14:47:12Z)
 	    Originator - Receive Timestamp:  -0.001672834


### PR DESCRIPTION
s/Originate Timestamp/Origin Timestamp/
s/Originator Timestamp/Origin Timestamp/

Originate Timestamp: Obsoleted.
Originator Timestamp: Never used.