### PR TITLE
tcpdump.c: Fix a warning when HAVE_FORK and HAVE_VFORK are not defined

### DIFF
--- a/tcpdump.c
+++ b/tcpdump.c
@@ -222,7 +222,9 @@ static int64_t parse_int64(const char *argname, const char *string,
     char **endp, int64_t minval, int64_t maxval, int base);
 static void (*setsignal (int sig, void (*func)(int)))(int);
 static void cleanup(int);
+#if defined(HAVE_FORK) || defined(HAVE_VFORK)
 static void child_cleanup(int);
+#endif
 static void print_version(FILE *);
 static void print_usage(FILE *);
 


### PR DESCRIPTION
The warning was:
tcpdump.c:226:13: warning: unused function 'child_cleanup'
  [-Wunused-function] static void child_cleanup(int);