### PR TITLE
Print "invalid option -- z" when it is

### DIFF
--- a/tcpdump.1.in
+++ b/tcpdump.1.in
@@ -1034,6 +1034,8 @@ or
 .B \-z bzip2
 will compress each savefile using gzip or bzip2.
 .IP
+This option can only be used if fork subprocess is implemented (e.g. not on Windows systems).
+.IP
 Note that tcpdump will run the command in parallel to the capture, using
 the lowest priority so that this doesn't disturb the capture process.
 .IP

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -616,7 +616,15 @@ show_remote_devices_and_exit(void)
 #define m_FLAG_USAGE "[ -m module ] ..."
 #endif
 
-#define SHORTOPTS "aAbB:c:C:dDeE:fF:G:hHi:I" j_FLAG J_FLAG "KlLm:M:nNOpqQ:r:s:StT:uUvV:w:W:xXy:Yz:Z:#"
+#if defined(HAVE_FORK) || defined(HAVE_VFORK)
+#define z_FLAG		"z:"
+#define z_FLAG_USAGE    "[ -z postrotate-command ] "
+#else
+#define z_FLAG
+#define z_FLAG_USAGE
+#endif
+
+#define SHORTOPTS "aAbB:c:C:dDeE:fF:G:hHi:I" j_FLAG J_FLAG "KlLm:M:nNOpqQ:r:s:StT:uUvV:w:W:xXy:Y" z_FLAG "Z:#"
 
 /*
  * Long options.
@@ -2014,13 +2022,12 @@ main(int argc, char **argv)
 			}
 			break;
 #endif
-		case 'z':
+
 #if defined(HAVE_FORK) || defined(HAVE_VFORK)
+		case 'z':
 			zflag = optarg;
-#else
-			error("-z cannot be used. Fork subprocess not implemented.");
-#endif
 			break;
+#endif
 
 		case 'Z':
 			username = optarg;
@@ -3484,5 +3491,5 @@ print_usage(FILE *f)
 "\t\t[ --time-stamp-precision precision ] [ --micro ] [ --nano ]\n");
 #endif
 	(void)fprintf(f,
-"\t\t[ -z postrotate-command ] [ -Z user ] [ expression ]\n");
+"\t\t" z_FLAG_USAGE "[ -Z user ] [ expression ]\n");
 }


### PR DESCRIPTION
It can only be used if defined(HAVE_FORK) || defined(HAVE_VFORK).
e.g. not on Windows systems.

Update print_usage().

Update the man page.