### PR TITLE
Avoid -E and -M options inconsistencies with no libcrypto

### DIFF
--- a/tcpdump.c
+++ b/tcpdump.c
@@ -624,7 +624,19 @@ show_remote_devices_and_exit(void)
 #define z_FLAG_USAGE
 #endif
 
-#define SHORTOPTS "aAbB:c:C:dDeE:fF:G:hHi:I" j_FLAG J_FLAG "KlLm:M:nNOpqQ:r:s:StT:uUvV:w:W:xXy:Y" z_FLAG "Z:#"
+#ifdef HAVE_LIBCRYPTO
+#define E_FLAG		"E:"
+#define E_FLAG_USAGE    "[ -E algo:secret ] "
+#define M_FLAG		"M:"
+#define M_FLAG_USAGE	"[ -M secret ] "
+#else
+#define E_FLAG
+#define E_FLAG_USAGE
+#define M_FLAG
+#define M_FLAG_USAGE
+#endif
+
+#define SHORTOPTS "aAbB:c:C:dDe" E_FLAG "fF:G:hHi:I" j_FLAG J_FLAG "KlLm:" M_FLAG "nNOpqQ:r:s:StT:uUvV:w:W:xXy:Y" z_FLAG "Z:#"
 
 /*
  * Long options.
@@ -1775,12 +1787,11 @@ main(int argc, char **argv)
 			++ndo->ndo_eflag;
 			break;
 
+#ifdef HAVE_LIBCRYPTO
 		case 'E':
-#ifndef HAVE_LIBCRYPTO
-			warning("crypto code not compiled in");
-#endif
 			ndo->ndo_espsecret = optarg;
 			break;
+#endif
 
 		case 'f':
 			++ndo->ndo_fflag;
@@ -1866,13 +1877,12 @@ main(int argc, char **argv)
 			}
 			break;
 
+#ifdef HAVE_LIBCRYPTO
 		case 'M':
 			/* TCP-MD5 shared secret */
-#ifndef HAVE_LIBCRYPTO
-			warning("crypto code not compiled in");
-#endif
 			ndo->ndo_sigsecret = optarg;
 			break;
+#endif
 
 		case 'n':
 			++ndo->ndo_nflag;
@@ -3469,7 +3479,7 @@ print_usage(FILE *f)
 	(void)fprintf(f,
 "Usage: %s [-AbdDefhHI" J_FLAG "KlLnNOpqStuUvxX#] [ -B size ] [ -c count ] [--count]\n", program_name);
 	(void)fprintf(f,
-"\t\t[ -C file_size ] [ -E algo:secret ] [ -F file ] [ -G seconds ]\n");
+"\t\t[ -C file_size ] " E_FLAG_USAGE "[ -F file ] [ -G seconds ]\n");
 	(void)fprintf(f,
 "\t\t[ -i interface ]" IMMEDIATE_MODE_USAGE j_FLAG_USAGE "\n");
 	(void)fprintf(f,
@@ -3479,7 +3489,7 @@ print_usage(FILE *f)
 "\t\t" m_FLAG_USAGE "\n");
 #endif
 	(void)fprintf(f,
-"\t\t[ -M secret ] [ --number ] [ --print ]\n");
+"\t\t" M_FLAG_USAGE "[ --number ] [ --print ]\n");
 	(void)fprintf(f,
 "\t\t[ --print-sampling nth ] [ -Q in|out|inout ] [ -r file ]\n");
 	(void)fprintf(f,


### PR DESCRIPTION
The inconsistencies were:
-E
tcpdump: option requires an argument -- 'E'
-E xxx
tcpdump: WARNING: crypto code not compiled in

-M
tcpdump: option requires an argument -- 'M'
-M xxx
tcpdump: WARNING: crypto code not compiled in