### PR TITLE
Require config.h to be from the tcpdump build.

### DIFF
--- a/cmakeconfig.h.in
+++ b/cmakeconfig.h.in
@@ -1,5 +1,8 @@
 /* cmakeconfig.h.in */
 
+#ifndef TCPDUMP_CONFIG_H_
+#define TCPDUMP_CONFIG_H_
+
 /* Define to 1 if arpa/inet.h declares `ether_ntohost' */
 #cmakedefine ARPA_INET_H_DECLARES_ETHER_NTOHOST 1
 
@@ -288,3 +291,5 @@
 /* Define to the type of an unsigned integer type wide enough to hold a
    pointer, if such a type exists, and if the system does not define it. */
 #cmakedefine uintptr_t 1
+
+#endif // TCPDUMP_CONFIG_H_

--- a/configure.ac
+++ b/configure.ac
@@ -1293,6 +1293,13 @@ AC_SUBST(MAN_MISC_INFO)
 AC_PROG_INSTALL
 
 AC_CONFIG_HEADER(config.h)
+AH_TOP([
+#ifndef TCPDUMP_CONFIG_H_
+#define TCPDUMP_CONFIG_H_
+])
+AH_BOTTOM([
+#endif // TCPDUMP_CONFIG_H_
+])
 
 AC_CONFIG_COMMANDS([.devel],[[if test -f .devel; then
 	echo timestamp > stamp-h

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -34,6 +34,9 @@
  */
 
 #include <config.h>
+#ifndef TCPDUMP_CONFIG_H_
+#error "The included config.h header is not from the tcpdump build."
+#endif
 
 /*
  * Some older versions of Mac OS X ship pcap.h from libpcap 0.6 with a


### PR DESCRIPTION
This way the build will reliably fail if it happened to include the header from some other build (e.g. libpcap).  See GitHub bug report #1313.

(backported from commit 9beea81f673bd6267a536d9132ca06a3d20a0235)