### PR TITLE
autotools: don't link with -lcrypto twice.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -859,6 +859,26 @@ AC_ARG_WITH(crypto,
 ])
 if test "$want_libcrypto" != "no"; then
 	#
+	# Do we already *have* libcrypto, e.g. if we're using a
+	# version of libpcap that has rpcap-over-TLS support?
+	#
+	AC_MSG_CHECKING([whether we're already linking with libcrypto])
+	if $EGREP -s -q -e '-lcrypto|libcrypto' <<EOF
+$LIBS
+EOF
+	then
+		#
+		# Yes; we already *have* libcrypto, don't
+		# look for another one.
+		#
+		AC_MSG_RESULT([yes])
+		want_libcrypto=no
+	else
+		AC_MSG_RESULT([no])
+	fi
+fi
+if test "$want_libcrypto" != "no"; then
+	#
 	# Were we told where to look for libcrypto?
 	#
 	if test -z "$libcrypto_root"; then


### PR DESCRIPTION
In case some other library with which we're linking - for example, a version of libpcap that has rpcap-over-TLS support? - is causing us to link with libcrypto, don't look for libcrypto ourselves.