### PR TITLE
Avoid race condition when receiving signal during shutdown

### DIFF
--- a/tcpdump.c
+++ b/tcpdump.c
@@ -2783,6 +2783,7 @@ DIAG_ON_ASSIGN_ENUM
 			info(1);
 		}
 		pcap_close(pd);
+		pd = NULL;
 		if (VFileName != NULL) {
 			ret = get_next_file(VFile, VFileLine);
 			if (ret) {
@@ -3062,7 +3063,8 @@ cleanup(int signo _U_)
 	 * to do anything with standard I/O streams in a signal handler -
 	 * the ANSI C standard doesn't say it is).
 	 */
-	pcap_breakloop(pd);
+	if (pd)
+		pcap_breakloop(pd);
 }
 
 /*


### PR DESCRIPTION
If we receive a TERM signal while we're shutting down, we can access a free'd pcap_t while trying to call pcap_breakloop(). We avoid this by setting the "pd" to NULL after freeing it, and don't try to use it if it's NULL.

The backtrace of the failure (in tcpdump 4.99.5) appeared as follows:
```
(gdb) where
#0  pcap_breakloop_linux (handle=0x55bc681f00f0) at ./pcap-linux.c:947
#1  0x000055bc676c40c3 in cleanup (signo=<optimized out>) at ./tcpdump.c:2929
#2  save_state_and_cleanup (sgno=<optimized out>) at ./tcpdump.c:2982
#3  <signal handler called>
#4  0x00007fb6fab7a8b8 in _fini () from /lib64/libgcc_s.so.1
#5  0x00007fb6fb65b376 in _dl_fini () at dl-fini.c:147
#6  0x00007fb6fac1f2ae in __run_exit_handlers () from /lib64/libc.so.6
#7  0x00007fb6fac1f3de in exit () from /lib64/libc.so.6
#8  0x000055bc676c363a in exit_tcpdump (status=1) at ./tcpdump.c:424
#9  0x000055bc676c2096 in main (argc=<optimized out>, argv=<optimized out>) at ./tcpdump.c:2864
```
The bottom line is that we had already passed throughh `pcap_close(pd)` before receiving the signal, which of course frees `pd`, and then `cleanup()` uses `pd` to ask `pcap_breakloop_linux()` to break the loop.

Replication of the failure without the fix is straightforward: add a patch like this
```diff
--- a/tcpdump.c
+++ b/tcpdump.c
@@ -343,6 +343,11 @@ static void NORETURN
 exit_tcpdump(const int status)
 {
        nd_cleanup();
+       /* XXX */
+       printf( "Sleeping 30 seconds to extend race...\n" );
+       sleep( 30 );
+       printf( "...survived\n" );
+       /* XXX */
        exit(status);
 }
 
```
and run:
```
ip link add type dummy 
ip link set dev dummy0 up
tcpdump -i dummy0
```
and in another window, run
```
ip link del dev dummy0
```
and then hit ^C (or send a SIGTERM) during the sleep. It won't necessarily crash, but running under valgrind will show that it's accessing free'd memory.
