### PR TITLE
IPv6 mobility: Delete an useless custom check

### DIFF
--- a/print-mobility.c
+++ b/print-mobility.c
@@ -203,7 +203,6 @@ mobility_print(netdissect_options *ndo,
                const u_char *bp, const u_char *bp2 _U_)
 {
 	const struct ip6_mobility *mh;
-	const u_char *ep;
 	unsigned mhlen, hlen;
 	uint8_t pproto, type;
 
@@ -217,25 +216,6 @@ mobility_print(netdissect_options *ndo,
 		ND_PRINT("(payload protocol %u should be %u) ", pproto,
 			 IPPROTO_NONE);
 
-	/* 'ep' points to the end of available data. */
-	ep = ndo->ndo_snapend;
-
-	if (!ND_TTEST_1(mh->ip6m_len)) {
-		/*
-		 * There's not enough captured data to include the
-		 * mobility header length.
-		 *
-		 * Our caller expects us to return the length, however,
-		 * so return a value that will run to the end of the
-		 * captured data.
-		 *
-		 * XXX - "ip6_print()" doesn't do anything with the
-		 * returned length, however, as it breaks out of the
-		 * header-processing loop.
-		 */
-		mhlen = (unsigned)(ep - bp);
-		goto trunc;
-	}
 	mhlen = (GET_U_1(mh->ip6m_len) + 1) << 3;
 
 	/* XXX ip6m_cksum */


### PR DESCRIPTION
The truncation is handled by the GET_U_1().

In any case, after 66df248b49095c261138b5a5e34d341a6bf9ac7f, the 'mhlen = (unsigned)(ep - bp)' was useless, because:

    ...
    Also, change mobility_print() to return -1 if it runs up against the
    end of the packet, and stop dissecting if it does so.
    ...