### PR TITLE
tcpdump: put the interface name into all open error messages.

### DIFF
--- a/tcpdump.c
+++ b/tcpdump.c
@@ -1362,7 +1362,7 @@ open_interface(const char *device, netdissect_options *ndo, char *ebuf)
 		 */
 		cp = pcap_geterr(pc);
 		if (status == PCAP_ERROR)
-			error("%s", cp);
+			error("%s: %s", device, cp);
 		else if (status == PCAP_ERROR_NO_SUCH_DEVICE) {
 			/*
 			 * Return an error for our caller to handle.


### PR DESCRIPTION
Don't assume that a libpcap error message will include the interface name.