### PR TITLE
Replace an unnecessary comma operator in addrtostr6()

### DIFF
--- a/addrtostr.c
+++ b/addrtostr.c
@@ -127,9 +127,11 @@ addrtostr6 (const void *src, char *dst, size_t size)
   cur.base  = -1;
   for (i = 0; i < (IN6ADDRSZ / INT16SZ); i++) {
     if (words[i] == 0) {
-      if (cur.base == -1)
-           cur.base = i, cur.len = 1;
-      else cur.len++;
+      if (cur.base == -1) {
+         cur.base = i;
+         cur.len = 1;
+      } else
+         cur.len++;
     } else if (cur.base != -1) {
       if (best.base == -1 || cur.len > best.len)
          best = cur;


### PR DESCRIPTION
Use of comma as statement separator is discouraged and reported as warning by clang with -Wcomma.

the use of ';' to separate to assignments is more appropriate than ','.

The warning was:
addrtostr.c:131:24: warning: possible misuse of comma operator here [-Wcomma]
           cur.base = i, cur.len = 1;
                       ^