### PR TITLE
instrument functions: Satisfy bfd inclusion guard

### DIFF
--- a/instrument-functions.c
+++ b/instrument-functions.c
@@ -15,7 +15,15 @@
 #include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
+
+/*
+ * The binutils bfd header has a weird inclusion guard, requiring this
+ * macro to be defined. Some distributions patch the guard out, others
+ * don't.
+ */
+#define PACKAGE "binutils-bfd.h-guard-workaround"
 #include <bfd.h>
+#undef PACKAGE
 
 /*
  * Generate instrumentation calls for entry and exit to functions.


### PR DESCRIPTION
In [2012](https://sourceware.org/git/?p=binutils-gdb.git;a=blobdiff;f=bfd/bfd-in.h;h=ae8149a2;hp=d88bcb6c;hb=df7b86aa;hpb=134fa82e) binutils added an inclusion guard to `bfd.h`, requiring to include the automake `config.h` beforehand. This guard is triggered when enabling instrumentation and development mode:

```
% git clone https://github.com/the-tcpdump-group/tcpdump.git
% cd tcpdump
% touch .devel
% ./autogen.sh
% ./configure --enable-instrument-functions --enable-smb --quiet
./mkdep -c gcc -m -M -s . -DHAVE_CONFIG_H -I. fptype.c tcpdump.c print-smb.c smbutil.c instrument-functions.c <libnetdissect src list>
In file included from ./instrument-functions.c:18:
/usr/include/bfd.h:35:2: error: #error config.h must be included before this header
   35 | #error config.h must be included before this header
      |  ^~~~~
```

Note than this does \*not\* happen on Debian-based systems, because they [remove](https://salsa.debian.org/toolchain-team/binutils/-/blob/38415eb8/debian/rules#L1045-1048) that guard since [2012](https://code.launchpad.net/~doko/binutils/pkg-2.23-debian). That's also why the Ubuntu-based Linux CI is not affected. But on distributions using the vanilla source, like Arch Linux, it prevents the debug build.

Also a small update to the CONTRIBUTING docs, adding the required <del>automake</del> autoreconf invocation.