### PR TITLE
IP: Improve a length check

### DIFF
--- a/print-ip.c
+++ b/print-ip.c
@@ -353,8 +353,11 @@ ip_print(netdissect_options *ndo,
 		/* we guess that it is a TSO send */
 		len = length;
 		presumed_tso = 1;
-	} else
-		ND_ICHECKMSG_U("total length", len, <, hlen);
+	}
+	if (len < hlen) {
+		ND_PRINT("[total length %u < header length %u]", len, hlen);
+		goto invalid;
+	}
 
 	ND_TCHECK_SIZE(ip);
 	/*

--- a/tests/ipv4_invalid_total_length_2.out
+++ b/tests/ipv4_invalid_total_length_2.out
@@ -1,1 +1,1 @@
-    1  2023-08-25 08:57:44.621711 IP  [total length 19 < 20] (invalid)
+    1  2023-08-25 08:57:44.621711 IP [total length 19 < header length 20] (invalid)


### PR DESCRIPTION
Also perform the check for the presumed TSO case.

Print "header length".

Update a test output accordingly.