### PR TITLE
BOOTP: Improve a bounds check

### DIFF
--- a/print-bootp.c
+++ b/print-bootp.c
@@ -641,7 +641,8 @@ rfc1048_print(netdissect_options *ndo,
 				ND_PRINT(", occurs %u", ntag);
 		}
 
-		ND_TCHECK_LEN(bp, len);
+		if (len != 0)
+			ND_TCHECK_LEN(bp, len);
 
 		if (tag == TAG_DHCP_MESSAGE && len == 1) {
 			ND_PRINT("%s",


### PR DESCRIPTION
No need to check if zero bytes were captured.