### PR TITLE
EGP: Fix printing with -v option

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -52,8 +52,8 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       Use %zu when printing a sizeof to squelch compiler warnings
       Remove unused missing/strdup.c.
       (FIXME: somebody please wrap the line below just before the release)
-      AODV, AppleTalk, BOOTP, CHDLC, DCCP, EAP, EGP, EIGRP, ForCES, Geneve, GRE, ICMP, Juniper, L2TP, LISP, mobile, MSDP, NetFlow, NFLOG, NTP, OLSR, pflog, PGM, RADIUS, RIP, RSVP, SCTP, SNMP, TCP, UDP, vsock: Modernize packet parsing style
-      DCCP, EGP: Replace custom code with tok2str()
+      AODV, AppleTalk, BOOTP, CHDLC, DCCP, EAP, EIGRP, ForCES, Geneve, GRE, ICMP, Juniper, L2TP, LISP, mobile, MSDP, NetFlow, NFLOG, NTP, OLSR, pflog, PGM, RADIUS, RIP, RSVP, SCTP, SNMP, TCP, UDP, vsock: Modernize packet parsing style
+      DCCP: Replace custom code with tok2str().
       UDP: Clean up address and port printing.
       AppleTalk: Declutter appletalk.h.
       IEEE 802.11: Simplify handle_action().
@@ -108,6 +108,8 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       IPv6 mobility: Modernize packet parsing and make fixes.
       IP6OPTS: Modernize packet parsing and make fixes.
       VXLAN: Add UDP port 8472 used by Linux as the default port.
+      EGP: Replace custom code with tok2str(); Modernize packet parsing and
+        fix printing with -v option.
     User interface:
       Add optional unit suffix on -C file size.
       Improve the handling of size suffixes for -C.

--- a/print-egp.c
+++ b/print-egp.c
@@ -256,30 +256,28 @@ egp_print(netdissect_options *ndo,
 	u_int status;
 
 	ndo->ndo_protocol = "egp";
+	nd_print_protocol_caps(ndo);
+
 	egp = (const struct egp_packet *)bp;
-	ND_ICHECKMSG_ZU("packet length", length, <, sizeof(*egp));
-	ND_TCHECK_SIZE(egp);
+	ND_ICHECK_ZU(length, <, sizeof(*egp));
 
 	version = GET_U_1(egp->egp_version);
-        if (!ndo->ndo_vflag) {
-            ND_PRINT("EGPv%u, AS %u, seq %u, length %u",
-                   version,
-                   GET_BE_U_2(egp->egp_as),
-                   GET_BE_U_2(egp->egp_sequence),
-                   length);
-            return;
-        } else
-            ND_PRINT("EGPv%u, length %u",
-                   version,
-                   length);
+	ND_ICHECK_U(version, !=, EGP_VERSION);
+	ND_TCHECK_SIZE(egp);
 
-	if (version != EGP_VERSION) {
-		ND_PRINT("[version %u]", version);
+	ND_PRINT("v%u", version);
+	if (ndo->ndo_vflag) {
+		ND_PRINT(", AS %u, seq %u, length %u",
+			 GET_BE_U_2(egp->egp_as),
+			 GET_BE_U_2(egp->egp_sequence),
+			 length);
+	} else {
+		ND_PRINT(", length %u", length);
 		return;
 	}
 
 	type = GET_U_1(egp->egp_type);
-	ND_PRINT(" %s", tok2str(egp_type_str, "[type %u]", type));
+	ND_PRINT(", %s", tok2str(egp_type_str, "[type %u]", type));
 	code = GET_U_1(egp->egp_code);
 	status = GET_U_1(egp->egp_status);
 


### PR DESCRIPTION
When -v option is set print more header fields, not less.

Print the protocol name before any check.
Use ND_ICHECK_U to check the version.
s/packet length/length/ in an error message as in other prints.
Print a comma before the type.