### PR TITLE
Appveyor: Download npcap-sdk-1.15.zip from tcpdump-htdocs repository

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,8 +12,8 @@ matrix:
 install:
   - appveyor DownloadFile https://github.com/the-tcpdump-group/tcpdump-htdocs/raw/master/depends/WpdPack_4_1_2.zip
   - 7z x .\WpdPack_4_1_2.zip -oc:\projects\libpcap\Win32
-  - appveyor DownloadFile https://npcap.com/dist/npcap-sdk-1.13.zip
-  - 7z x .\npcap-sdk-1.13.zip -oc:\projects\libpcap\Win32\npcap-sdk-1.13
+  - appveyor DownloadFile https://github.com/the-tcpdump-group/tcpdump-htdocs/raw/master/depends/npcap-sdk-1.15.zip
+  - 7z x .\npcap-sdk-1.15.zip -oc:\projects\libpcap\Win32\npcap-sdk-1.15
 
 environment:
   matrix:
@@ -25,10 +25,10 @@ environment:
       SDK: WpdPack
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       GENERATOR: "Visual Studio 14 2015"
-      SDK: npcap-sdk-1.13
+      SDK: npcap-sdk-1.15
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       GENERATOR: "Visual Studio 14 2015 Win64"
-      SDK: npcap-sdk-1.13
+      SDK: npcap-sdk-1.15
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       GENERATOR: "Visual Studio 15 2017"
       SDK: WpdPack
@@ -37,10 +37,10 @@ environment:
       SDK: WpdPack
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       GENERATOR: "Visual Studio 15 2017"
-      SDK: npcap-sdk-1.13
+      SDK: npcap-sdk-1.15
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       GENERATOR: "Visual Studio 15 2017 Win64"
-      SDK: npcap-sdk-1.13
+      SDK: npcap-sdk-1.15
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       GENERATOR: "Visual Studio 16 2019"
       PLATFORM: Win32
@@ -52,11 +52,11 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       GENERATOR: "Visual Studio 16 2019"
       PLATFORM: Win32
-      SDK: npcap-sdk-1.13
+      SDK: npcap-sdk-1.15
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       GENERATOR: "Visual Studio 16 2019"
       PLATFORM: x64
-      SDK: npcap-sdk-1.13
+      SDK: npcap-sdk-1.15
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
       GENERATOR: "Visual Studio 17 2022"
       PLATFORM: Win32
@@ -68,11 +68,11 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
       GENERATOR: "Visual Studio 17 2022"
       PLATFORM: Win32
-      SDK: npcap-sdk-1.13
+      SDK: npcap-sdk-1.15
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
       GENERATOR: "Visual Studio 17 2022"
       PLATFORM: x64
-      SDK: npcap-sdk-1.13
+      SDK: npcap-sdk-1.15
 
 build_script:
   #


### PR DESCRIPTION
Upgrade SDK from 1.13 to 1.15.

As with libpcap.

(backported from commit fafbce84bf7ffe6f4c1ddfb7936a115663ff9920)

[skip ci]