### PR TITLE
Install sysusers.d config for 'tcpdump' user/group

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -369,6 +369,7 @@ EXTRA_DIST = \
 	send-ack.awk \
 	smbutil.c \
 	stime.awk \
+	tcpdump-sysusers.conf \
 	tcpdump.1.in
 
 TEST_DIST= `git -C "$$DIR" ls-files tests`
@@ -405,11 +406,15 @@ install: all
 	[ -d $(DESTDIR)$(mandir)/man1 ] || \
 	    (mkdir -p $(DESTDIR)$(mandir)/man1; chmod 755 $(DESTDIR)$(mandir)/man1)
 	$(INSTALL_DATA) $(PROG).1 $(DESTDIR)$(mandir)/man1/$(PROG).1
+	[ -d $(DESTDIR)$(prefix)/lib/sysusers.d ] || \
+	    (mkdir -p $(DESTDIR)$(prefix)/lib/sysusers.d; chmod 755 $(DESTDIR)$(prefix)/lib/sysusers.d)
+	$(INSTALL_DATA) tcpdump-sysusers.conf $(DESTDIR)$(prefix)/lib/sysusers.d/tcpdump.conf
 
 uninstall:
 	rm -f $(DESTDIR)$(bindir)/$(PROG)
 	rm -f $(DESTDIR)$(bindir)/$(PROG).`cat ${srcdir}/VERSION`
 	rm -f $(DESTDIR)$(mandir)/man1/$(PROG).1
+	rm -f $(DESTDIR)$(prefix)/lib/sysusers.d/tcpdump.conf
 
 lint:
 	lint -hbxn $(SRC) $(LIBNETDISSECT_SRC) | \

--- a/tcpdump-sysusers.conf
+++ b/tcpdump-sysusers.conf
@@ -1,0 +1,1 @@
+u! tcpdump - "tcpdump" /nonexistent


### PR DESCRIPTION
Ubuntu, Fedora and other distro create the tcpdump user/group pair by default, to be used for unprivileged access to tcpdump:

https://git.launchpad.net/ubuntu/+source/tcpdump/tree/debian/tcpdump.postinst https://src.fedoraproject.org/rpms/tcpdump/blob/rawhide/f/tcpdump-sysusers.conf

Add a sysusers.d config file and install it. This configuration file will create the 'tcpdump' user/group pair on first boot/factory reset/package installation, without requiring manual scripts or actions. This is very important for image-based OSes, but it is useful in other cases too, to allow using declarative configuration instead of scripts.

RPM now has built-in support for sysusers.d too.

https://www.freedesktop.org/software/systemd/man/latest/sysusers.d.html

This is just a one-line config file, so if a system doesn't support sysusers.d, it is a harmless no-op (and can be deleted/not packaged too).