### PR TITLE
Cirrus CI: Bump FreeBSD up to 13.5.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,7 +11,7 @@ freebsd_task:
     # The number of CPU cores must be either 1 or a multiple of 2.
     cpu: 1
     memory: 2G
-    image_family: freebsd-13-4
+    image_family: freebsd-13-5
   env:
     IGNORE_OSVERSION: yes
     MATRIX_CC: clang17 gcc13


### PR DESCRIPTION
(cherry picked from commit 927639806dd3e6dd14b9ae4921e0fed610509068)