### PR TITLE
SNMP: Fix a MSVC 17 warning

### DIFF
--- a/print-snmp.c
+++ b/print-snmp.c
@@ -1712,7 +1712,7 @@ v3msg_print(netdissect_options *ndo,
 	u_char flags;
 	int model;
 	const u_char *xnp = np;
-	int xlength = length;
+	u_int xlength = length;
 
 	/* Sequence */
 	if ((count = asn1_parse(ndo, np, length, &elem)) < 0)
@@ -1805,8 +1805,7 @@ v3msg_print(netdissect_options *ndo,
             return;
 	}
 
-	np = xnp + (np - xnp);
-	length = xlength - (np - xnp);
+	length = xlength - (u_int)(np - xnp);
 
 	/* msgSecurityParameters (OCTET STRING) */
 	if ((count = asn1_parse(ndo, np, length, &elem)) < 0)


### PR DESCRIPTION
Fix proposed by Bill.

The warning was:
print-snmp.c(1809,19): warning C4242: =: conversion from __int64 to
  u_int, possible loss of data