### PR TITLE
Build on QNX.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -81,6 +81,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       Autoconf: Add QNX support to AC_LBL_LIBRARY_NET().
       Treat SA_RESTART as optional.
     Documentation:
+      Add a README.qnx.md file.
 
 DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
   Summary for 4.99.7 tcpdump release (so far!)

--- a/CHANGES
+++ b/CHANGES
@@ -79,6 +79,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       Reimplement the tests similarly to libpcap.
       CI: Implement cross-compiling with libpcap.
       Autoconf: Add QNX support to AC_LBL_LIBRARY_NET().
+      Treat SA_RESTART as optional.
     Documentation:
 
 DayOfTheWeek, Month DD, YYYY / The Tcpdump Group

--- a/CHANGES
+++ b/CHANGES
@@ -78,6 +78,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       tests: On HP-UX use "diff -c" by default.
       Reimplement the tests similarly to libpcap.
       CI: Implement cross-compiling with libpcap.
+      Autoconf: Add QNX support to AC_LBL_LIBRARY_NET().
     Documentation:
 
 DayOfTheWeek, Month DD, YYYY / The Tcpdump Group

--- a/Makefile.in
+++ b/Makefile.in
@@ -352,6 +352,7 @@ EXTRA_DIST = \
 	doc/README.aix.md \
 	doc/README.haiku.md \
 	doc/README.NetBSD.md \
+	doc/README.qnx.md \
 	doc/README.solaris.md \
 	doc/README.windows.md \
 	install-sh \

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ tcpdump compiles and works on at least the following platforms:
 * {Mac} OS X / macOS
 * [NetBSD](./doc/README.NetBSD.md)
 * OpenBSD
+* [QNX](./doc/README.qnx.md)
 * [Solaris](./doc/README.solaris.md)
 * [Windows](./doc/README.windows.md) (requires WinPcap or Npcap, and Visual
   Studio with CMake)
@@ -48,7 +49,6 @@ In the past tcpdump certainly or likely worked on the following platforms:
 * DOS
 * IRIX
 * LynxOS
-* QNX
 * SINIX
 * SunOS
 * Ultrix

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -861,7 +861,14 @@ AC_DEFUN(AC_LBL_LIBRARY_NET, [
 		LIBS="-lnetwork $LIBS"
 	    ],
 	    [
-		AC_MSG_ERROR([gethostbyaddr is required, but wasn't found])
+		AS_UNSET(ac_cv_lib_socket_gethostbyaddr)
+		AC_CHECK_LIB(socket, gethostbyaddr,
+		[
+		    LIBS="-lsocket $LIBS"
+		],
+		[
+		    AC_MSG_ERROR([gethostbyaddr is required, but wasn't found])
+		])
 	    ])
 	], -lnsl)
     ])

--- a/doc/README.qnx.md
+++ b/doc/README.qnx.md
@@ -1,0 +1,17 @@
+# Compiling tcpdump for QNX
+
+It is possible to cross-compile tcpdump from this source tree on a Linux host
+for a QNX 8.0 target as follows:
+1. Obtain a licence, download and install QNX Software Center.
+2. Using QNX Software Center, install a suitable version of QNX SDP (for
+   example, 8.0.3 works) and note the SDP installation directory (for example,
+   `~/qnx800`).  There is no need to install the Momentics IDE.
+3. If the SDP does not include a suitable version of libpcap, build libpcap
+   first in `../libpcap` relative to the tcpdump source tree.
+4. Initialize environment variables and cross-compile tcpdump for the required
+   target.  For example, for AArch64:
+   ```
+   . ~/qnx800/qnxsdp-env.sh
+   ./configure --host=aarch64-unknown-nto-qnx8.0.0
+   make
+   ```

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -3021,6 +3021,7 @@ static void
 
 	memset(&new, 0, sizeof(new));
 	new.sa_handler = func;
+# ifdef SA_RESTART
 	if ((sig == SIGCHLD)
 # ifdef SIGNAL_REQ_INFO
 		|| (sig == SIGNAL_REQ_INFO)
@@ -3030,6 +3031,7 @@ static void
 # endif
 		)
 		new.sa_flags = SA_RESTART;
+# endif // SA_RESTART
 	if (sigaction(sig, &new, &old) < 0)
 		/* The same workaround as for SIG_DFL above. */
 #ifdef __illumos__


### PR DESCRIPTION
The `SA_RESTART` workaround has not been tested in any regard, other than it unblocks building of tcpdump and the resulting executable seems to work as expected.