### PR TITLE
Fix some MSVC 14.0 warnings

### DIFF
--- a/netdissect.h
+++ b/netdissect.h
@@ -151,9 +151,9 @@ struct tok {
 };
 
 /* tok2str is deprecated */
-extern const char *tok2str(const struct tok *, const char *, u_int);
-extern char *bittok2str(const struct tok *, const char *, u_int);
-extern char *bittok2str_nosep(const struct tok *, const char *, u_int);
+extern const char *tok2str(const struct tok *, const char *, const u_int);
+extern char *bittok2str(const struct tok *, const char *, const u_int);
+extern char *bittok2str_nosep(const struct tok *, const char *, const u_int);
 
 /* Initialize netdissect. */
 extern int nd_init(char *, size_t);
@@ -507,7 +507,7 @@ extern int unaligned_memcmp(const void *, const void *, size_t);
 #define PLURAL_SUFFIX(n) \
 	(((n) != 1) ? "s" : "")
 
-extern const char *tok2strary_internal(const char **, int, const char *, int);
+extern const char *tok2strary_internal(const char **, int, const char *, const int);
 #define	tok2strary(a,f,i) tok2strary_internal(a, sizeof(a)/sizeof(a[0]),f,i)
 
 struct uint_tokary
@@ -798,7 +798,7 @@ extern void nd_print_protocol(netdissect_options *);
 extern void nd_print_protocol_caps(netdissect_options *);
 extern void nd_print_invalid(netdissect_options *);
 
-extern int mask2plen(uint32_t);
+extern int mask2plen(const uint32_t);
 extern int mask62plen(const u_char *);
 
 extern const char *dnnum_string(netdissect_options *, u_short);


### PR DESCRIPTION
The warnings were:
util-print.c(531): warning C4028: formal parameter 3 different from
  declaration
util-print.c(592): warning C4028: formal parameter 3 different from
  declaration
util-print.c(602): warning C4028: formal parameter 3 different from
  declaration
util-print.c(614): warning C4028: formal parameter 4 different from
  declaration
util-print.c(647): warning C4028: formal parameter 1 different from
  declaration

It is a follow-up to ab6ef17af878ab0c83f89e687665d44d878300f8.

(backported from commit d0defdf32bdc033eced9b816cbcc8c408015a00e)