### PR TITLE
ICMPv6, IP6OPTS: Add dissectors for ILNPv6 Locator Update and Nonce O…

### DIFF
--- a/ip6.h
+++ b/ip6.h
@@ -145,10 +145,12 @@ struct ip6_dest {
 #define IP6OPT_HOME_ADDRESS	0xc9	/* 11 0 01001 */
 #define IP6OPT_HOMEADDR_MINLEN	18
 #define IP6OPT_EID		0x8a	/* 10 0 01010 */
-#define IP6OPT_ILNP_NOTICE	0x8b	/* 10 0 01011 */
+#define IP6OPT_ILNP_NONCE	0x8b	/* 10 0 01011 */
 #define IP6OPT_LINE_ID		0x8c	/* 10 0 01100 */
 #define IP6OPT_MPL		0x6d	/* 01 1 01101 */
 #define IP6OPT_IP_DFF		0xee	/* 11 1 01110 */
+
+#define IP6OPT_ILNP_NONCE_MINLEN 6	/* up to maximum dstopt length */
 
 #define IP6OPT_TYPE(o)		((o) & 0xC0)
 #define IP6OPT_TYPE_SKIP	0x00

--- a/print-ip6opts.c
+++ b/print-ip6opts.c
@@ -153,6 +153,22 @@ ip6_opt_process(netdissect_options *ndo, const u_char *bp, const u_int len,
 		}
 	    }
 	    break;
+	/*
+	 * IPv6 Nonce Destination Option for ILNPv6 (RFC 6744).
+	 */
+	case IP6OPT_ILNP_NONCE:
+	    if (len - i < IP6OPT_ILNP_NONCE_MINLEN) {
+		ND_PRINT("(nonce: trunc)");
+		goto invalid;
+	    }
+	    if (bp[i + 1] < IP6OPT_ILNP_NONCE_MINLEN - 2) {
+		printf("(nonce: len %u - < 4)", bp[i + 1]);
+		goto invalid;
+	    }
+	    ND_PRINT("(nonce: ");
+	    hex_print(ndo, " ", &bp[i + 2], (u_int)(bp[i + 1] - 2));
+	    ND_PRINT(") ");
+	    break;
         case IP6OPT_HOME_ADDRESS:
 	    ND_ICHECKMSG_U("(homeaddr) remaining length", (u_int)(len - i), <,
 			   IP6OPT_HOMEADDR_MINLEN);


### PR DESCRIPTION
…ption.

Refer to RFC 6743 and RFC 6744 respectively.

Ported to contemporary tcpdump, from the FreeBSD 8.4-RELEASE based private branch I host on SourceHut. Not tested against production traffic since then, but believed to be correct. Precedes the corresponding Wireshark contribution in time.

Full disclosure: I am the former maintainer of vendorized tcpdump and libcap in FreeBSD from the 2000s.

Sponsored by:	Cisco Systems, Inc.