### PR TITLE
a few QNX-specific backports

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,8 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       IP: Update the offload "presumed TSO" case for "BIG TCP".
     User interface:
        Print an error message about --count without -r or -V.
+    Building and testing:
+      Treat SA_RESTART as optional.
 
 Tuesday, December 30, 2025 / The Tcpdump Group
   Summary for 4.99.6 tcpdump release

--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
   Summary for 4.99.7 tcpdump release (so far!)
     Source code:
       NetFlow: Use tcp_flag_values[] for TCP flags.
+      Disregard setlinebuf(3), always use setvbuf(3).
     Refine protocol decoding for:
       MPTCP: parse MPC data_len field, print flags from MP_CAPABLE option,
         dissect the MP_TCPRST sub-option.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -608,7 +608,6 @@ else()
 endif()
 
 check_function_exists(getopt_long HAVE_GETOPT_LONG)
-check_function_exists(setlinebuf HAVE_SETLINEBUF)
 #
 # For Windows,  don't need to waste time checking for fork() or vfork().
 #

--- a/cmakeconfig.h.in
+++ b/cmakeconfig.h.in
@@ -165,9 +165,6 @@
 /* Define to 1 if you have the <rpc/rpc.h> header file. */
 #cmakedefine HAVE_RPC_RPC_H 1
 
-/* Define to 1 if you have the `setlinebuf' function. */
-#cmakedefine HAVE_SETLINEBUF 1
-
 /* Define to 1 if you have the <stdint.h> header file. */
 #cmakedefine HAVE_STDINT_H 1
 

--- a/configure.ac
+++ b/configure.ac
@@ -448,7 +448,6 @@ fi
 
 AC_REPLACE_FUNCS(strlcat strlcpy strdup strsep getservent getopt_long)
 AC_CHECK_FUNCS(fork vfork)
-AC_CHECK_FUNCS(setlinebuf)
 
 #
 # It became apparent at some point that using a suitable C99 compiler does not

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -3007,6 +3007,7 @@ static void
 
 	memset(&new, 0, sizeof(new));
 	new.sa_handler = func;
+# ifdef SA_RESTART
 	if ((sig == SIGCHLD)
 # ifdef SIGNAL_REQ_INFO
 		|| (sig == SIGNAL_REQ_INFO)
@@ -3016,6 +3017,7 @@ static void
 # endif
 		)
 		new.sa_flags = SA_RESTART;
+# endif // SA_RESTART
 	if (sigaction(sig, &new, &old) < 0)
 		/* The same workaround as for SIG_DFL above. */
 #ifdef __illumos__

--- a/tcpdump.c
+++ b/tcpdump.c
@@ -1962,11 +1962,7 @@ main(int argc, char **argv)
 			 */
 			setvbuf(stdout, NULL, _IONBF, 0);
 #else /* _WIN32 */
-#ifdef HAVE_SETLINEBUF
-			setlinebuf(stdout);
-#else
 			setvbuf(stdout, NULL, _IOLBF, 0);
-#endif
 #endif /* _WIN32 */
 			lflag = 1;
 			break;


### PR DESCRIPTION
This is the least amount of changes required to fix building the current tcpdump-4.99 on/for QNX. The build does not pass one of the tests due to rounding peculiarities, as discussed.