### PR TITLE
tcpdump: Fix a warning about use of a possibly-NULL pointer

### DIFF
--- a/tcpdump.c
+++ b/tcpdump.c
@@ -2338,6 +2338,9 @@ main(int argc, char **argv)
 				error("no interfaces available for capture");
 			device = strdup(devlist->name);
 			pcap_freealldevs(devlist);
+			if (device == NULL)
+				error("Unable to allocate memory for device %s",
+				      devlist->name);
 		}
 
 		/*


### PR DESCRIPTION
Found with GCC option -fanalyzer.

The error was:
```
tcpdump.c: In function 'open_interface':
tcpdump.c:1251:13: warning: use of possibly-NULL 'device' where
  non-null expected [CWE-690] [-Wanalyzer-possible-null-argument]
 1251 |         if (strncmp(device, rpcap_prefix, sizeof(rpcap_prefix) \
                    - 1) == 0 ||
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[...]
In file included from ../libpcap/pcap/pcap-inttypes.h:98,
                 from netdissect-stdinc.h:78,
                 from tcpdump.c:41:
/usr/include/string.h:159:12: note: argument 1 of 'strncmp' must be
  non-null
  159 | extern int strncmp (const char *__s1, const char *__s2, size_t __n)
      |            ^~~~~~~
```