### PR TITLE
tcpdump: Fix a warning about use of a possibly-NULL pointer

### DIFF
--- a/tcpdump.c
+++ b/tcpdump.c
@@ -1662,6 +1662,9 @@ main(int argc, char **argv)
 		executable_name = argv[0];
 	/* Strip off trailing ".exe". */
 	program_name = strdup(executable_name);
+	if (program_name == NULL)
+		error("Unable to allocate memory for executable name '%s'",
+		      executable_name);
 	last_dot = strrchr(program_name, '.');
 	if (last_dot != NULL && ascii_strcasecmp(last_dot, ".exe") == 0)
 		*last_dot = '\0';


### PR DESCRIPTION
Found with GCC option -fanalyzer.

The error was:
```
tcpdump.c: In function 'main':
tcpdump.c:1665:20: warning: use of possibly-NULL 'program_name' where
  non-null expected [CWE-690] [-Wanalyzer-possible-null-argument]
 1665 |         last_dot = strrchr(program_name, '.');
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~
[...]
In file included from ../libpcap/pcap/pcap-inttypes.h:98,
                 from netdissect-stdinc.h:78,
                 from tcpdump.c:41:
/usr/include/string.h:273:14: note: argument 1 of 'strrchr' must be
  non-null
  273 | extern char *strrchr (const char *__s, int __c)
      |              ^~~~~~~
```