### PR TITLE
tcpdump(1): Document double quoting on Windows with cmd.exe

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -315,6 +315,7 @@ Friday, April 7, 2023 / The Tcpdump Group
       Update config.{guess,sub}, timestamps 2023-01-01,2023-01-21.
     Documentation:
       man: Document TCP flag names better.
+      man: Document double quoting on Windows with cmd.exe.
 
 Thursday, January 12, 2023 / The Tcpdump Group
   Summary for 4.99.3 tcpdump release

--- a/tcpdump.1.in
+++ b/tcpdump.1.in
@@ -1097,7 +1097,8 @@ implementations of
 .BR getopt_long (3)
 and regardless of whether the
 .B \%POSIXLY_CORRECT
-environment variable is set.
+environment variable is set. Exception: On Windows, with cmd.exe command line,
+single quoting must be replaced by double quoting.
 .LP
 For backward compatibility reasons
 .I tcpdump


### PR DESCRIPTION
The single quote has no special meaning in this context.

See: https://learn.microsoft.com/en-us/cpp/c-language/parsing-c-command-line-arguments?view=msvc-170