### PR TITLE
print-ospf: guard RI LSA TLV length before subtraction

### DIFF
--- a/print-ospf.c
+++ b/print-ospf.c
@@ -1120,6 +1120,10 @@ ospf_print_lsa(netdissect_options *ndo,
 
                     case LS_OPAQUE_RI_TLV_SID_LABEL_RANGE:
                     case LS_OPAQUE_RI_TLV_SR_LOCAL_BLOCK:
+                        if (tlv_length < 4) {
+                            ND_PRINT("\n\t    Bogus TLV length %u < 4", tlv_length);
+                            return(ls_end);
+                        }
                         ND_TCHECK_4(tptr);
                         ND_PRINT("\n\t      Range size: %u", GET_BE_U_3(tptr));
                         if (ospf_print_ri_lsa_sid_label_range_tlv(ndo, tptr + 4, tlv_length - 4) == -1) {


### PR DESCRIPTION
The RI LSA TLV dispatch passes `tlv_length - 4` to
`ospf_print_ri_lsa_sid_label_range_tlv()` for TLV types 9 (SID/Label
Range) and 14 (SR Local Block) without checking `tlv_length >= 4`.

When `tlv_length` is 0–3, the unsigned subtraction wraps to a large
value, causing the callee's `while (tlv_length != 0)` loop to read
past the TLV boundary into adjacent packet data.

The fix adds a `tlv_length < 4` guard that prints a bogus-length
diagnostic and returns, consistent with other TLV handlers in the
same function (e.g. lines 818/847).

Found by manual audit of commit 9ec6904.