### PR TITLE
print-isoclns: fix unsigned underflows in IS-IS sub-TLV parsing

### DIFF
--- a/print-isoclns.c
+++ b/print-isoclns.c
@@ -2334,6 +2334,10 @@ isis_print_extd_ip_reach(netdissect_options *ndo,
         while (sublen != 0) {
             subtlvtype=GET_U_1(tptr);
             subtlvlen=GET_U_1(tptr + 1);
+            if (subtlvlen + 2 > sublen) {
+                nd_print_invalid(ndo);
+                break;
+            }
             tptr+=2;
             /* prepend the indent string */
             snprintf(indent_buffer, sizeof(indent_buffer), "%s  ", indent);
@@ -2377,6 +2381,8 @@ isis_print_router_cap_subtlv(netdissect_options *ndo, const uint8_t *tptr, uint8
 		uint32_t range;
 		const uint8_t *sid_ptr;
 
+		if (subl < 4)
+		    break;
 		flags = GET_U_1(tptr);
 		range = GET_BE_U_3(tptr+1);
 		ND_PRINT(", Flags [%s], Range %u",


### PR DESCRIPTION
Two unsigned underflow issues in IS-IS sub-TLV parsing:

1. `isis_print_extd_ip_reach()`: the sub-TLV loop decrements
   `sublen` by `subtlvlen + 2` without first checking that
   `subtlvlen + 2 <= sublen`. A crafted sub-TLV with an
   oversized length wraps `sublen` (u_int) to ~UINT_MAX.

   Fix: add a bounds check before the subtraction. This is
   consistent with `isis_print_ext_is_reach()` (line 2006)
   which already has such a guard.

2. `isis_print_router_cap_subtlv()`: the SR Capabilities
   handler computes `sid_tlen = subl - 4` without checking
   `subl >= 4`. Since `sid_tlen` is `uint8_t`, the subtraction
   wraps (e.g., subl=2 → sid_tlen=254), causing the SID inner
   loop to read past the sub-TLV boundary.

   Fix: add `if (subl < 4) break;` before the subtraction.

Found by manual audit of commit 9ec6904.