### PR TITLE
print-bgp: account for TLV header bytes in L2VPN tlen tracking

### DIFF
--- a/print-bgp.c
+++ b/print-bgp.c
@@ -1367,6 +1367,7 @@ print_labeled_vpn_l2(netdissect_options *ndo, const u_char *pptr)
             tlv_len = GET_BE_U_2(pptr);  /* length, in *bits* */
             ttlv_len = (tlv_len + 7)/8;      /* length, in *bytes* */
             pptr += 2;
+            tlen -= 3;
 
             switch(tlv_type) {
             case 1:


### PR DESCRIPTION
print_labeled_vpn_l2() reads a 3-byte TLV header (1-byte type +
2-byte length) per iteration and advances pptr by 3, but does not
subtract the header bytes from tlen. Only the data portion is
subtracted via tlen -= ttlv_len (default case) or tlen-- per byte
(case 1).

After N TLVs, tlen is 3*N bytes too high, causing the
while (tlen != 0) loop to continue past the L2VPN attribute
boundary and interpret adjacent BGP path attribute data as TLV
structures.

Fix by subtracting the 3-byte TLV header from tlen immediately
after reading it.

Found by manual audit of commit 9ec6904.