### PR TITLE
Add a header file that defines a "byte-swap a 32-bit integer" macro.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -269,6 +269,7 @@ HDR = \
 	appletalk.h \
 	ascii_strcasecmp.h \
 	atm.h \
+	byteswap.h \
 	chdlc.h \
 	compiler-tests.h \
 	cpack.h \

--- a/byteswap.h
+++ b/byteswap.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026
+ *	The Tcpdump Group and contributors.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * bAS ISb AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* \summary: macros to byte-swap integral quantities */
+
+#ifndef BYTESWAP_H
+#define BYTESWAP_H
+
+#include "netdissect-stdinc.h"
+
+/*
+ * Byte-swap a 32-bit number.
+ * ("htonl()" or "ntohl()" won't work - we want to byte-swap even on
+ * big-endian platforms.)
+ */
+#define ND_BSWAP_32(y) \
+    ((uint32_t)(((((uint32_t)(y)) & UINT32_C(0xff000000)) >> 24) | \
+                ((((uint32_t)(y)) & UINT32_C(0x00ff0000)) >> 8)  | \
+                ((((uint32_t)(y)) & UINT32_C(0x0000ff00)) << 8)  | \
+                ((((uint32_t)(y)) & UINT32_C(0x000000ff)) << 24)))
+
+#endif /* BYTESWAP_H */

--- a/print-enc.c
+++ b/print-enc.c
@@ -30,6 +30,7 @@
 #define ND_LONGJMP_FROM_TCHECK
 #include "netdissect.h"
 #include "extract.h"
+#include "byteswap.h"
 #include "af.h"
 
 /* From $OpenBSD: if_enc.h,v 1.8 2001/06/25 05:14:00 angelos Exp $ */
@@ -85,20 +86,12 @@ struct enchdr {
 		(wh) &= ~(xf); \
 	}
 
-/*
- * Byte-swap a 32-bit number.
- * ("htonl()" or "ntohl()" won't work - we want to byte-swap even on
- * big-endian platforms.)
- */
-#define	SWAPLONG(y) \
-((((y)&0xff)<<24) | (((y)&0xff00)<<8) | (((y)&0xff0000)>>8) | (((y)>>24)&0xff))
-
 void
 enc_if_print(netdissect_options *ndo,
              const struct pcap_pkthdr *h, const u_char *p)
 {
 	u_int length = h->len;
-	u_int af, flags;
+	uint32_t af, flags;
 	const struct enchdr *hdr;
 
 	ndo->ndo_protocol = "enc";
@@ -127,8 +120,8 @@ enc_if_print(netdissect_options *ndo,
 	UNALIGNED_MEMCPY(&af, &hdr->af, sizeof (af));
 	UNALIGNED_MEMCPY(&flags, &hdr->flags, sizeof (flags));
 	if ((af & 0xFFFF0000) != 0) {
-		af = SWAPLONG(af);
-		flags = SWAPLONG(flags);
+		af = ND_BSWAP_32(af);
+		flags = ND_BSWAP_32(flags);
 	}
 
 	if (flags == 0)

--- a/print-null.c
+++ b/print-null.c
@@ -28,6 +28,7 @@
 #define ND_LONGJMP_FROM_TCHECK
 #include "netdissect.h"
 #include "extract.h"
+#include "byteswap.h"
 #include "af.h"
 
 
@@ -42,14 +43,6 @@
  * is in network byte order.
  */
 #define	NULL_HDRLEN 4
-
-/*
- * Byte-swap a 32-bit number.
- * ("htonl()" or "ntohl()" won't work - we want to byte-swap even on
- * big-endian platforms.)
- */
-#define	SWAPLONG(y) \
-((((y)&0xff)<<24) | (((y)&0xff00)<<8) | (((y)&0xff0000)>>8) | (((y)>>24)&0xff))
 
 static void
 null_hdr_print(netdissect_options *ndo, uint32_t family, u_int length)
@@ -93,7 +86,7 @@ null_if_print(netdissect_options *ndo, const struct pcap_pkthdr *h, const u_char
 	 * If the upper 16 bits aren't all zero, assume it's byte-swapped.
 	 */
 	if ((family & 0xFFFF0000) != 0)
-		family = SWAPLONG(family);
+		family = ND_BSWAP_32(family);
 
 	if (ndo->ndo_eflag)
 		null_hdr_print(ndo, family, length);


### PR DESCRIPTION
Remove the macro from dissectors that use it, and have them include the header file.

Go with the renamed macro from libpcap, and declare the variables on which it's used to be uint32_t.